### PR TITLE
chore: README 초기화 + .gitignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 node_modules/
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
 # Claude Plugins Marketplace
 
 Claude Code용 플러그인 마켓플레이스 저장소입니다.
-
-<!-- 위 줄은 이 저장소가 무엇인지 설명하는 헤더입니다 -->
-
-## 사용법
-
-TODO: 작성 예정.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# claude-plugins
+# Claude Plugins Marketplace
+
+Claude Code용 플러그인 마켓플레이스 저장소입니다.
+
+<!-- 위 줄은 이 저장소가 무엇인지 설명하는 헤더입니다 -->
+
+## 사용법
+
+TODO: 작성 예정.


### PR DESCRIPTION
## 무엇을
- **README.md**: 빈 상태(`# claude-plugins`)에서 마켓플레이스 소개 헤더 + 한 줄 설명으로 채움
- **.gitignore**: 다음 무시 규칙 추가
  - `.DS_Store` (macOS 시스템 파일)
  - `node_modules/` (Node 산출물)
  - `.env`, `.env.*` (환경 변수 파일 — 시크릿 보호)

## 왜
- 저장소가 마켓플레이스 용도임을 첫 진입자가 바로 알 수 있게
- 공동 작업 시 환경 산출물·시크릿이 의도치 않게 커밋되는 것 방지

## 카나리 검증 부산물
이 PR은 원래 \`Claude PR Review\` 워크플로 검증용 카나리였습니다(Phase B). 검증 결과 워크플로가 정상 동작 확인됐고, 지적된 이슈를 점진적으로 반영하며 수렴했습니다.