### PR TITLE
fix: OAuth 토큰을 claude_code_oauth_token input으로 전달

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             이 PR을 리뷰해 주세요. 사람 리뷰어를 대체하지 않는 1차 스크리닝입니다.
 


### PR DESCRIPTION
## Summary
OAuth 토큰을 `anthropic_api_key` input으로 통과시키면 SDK가 "Invalid API key"로 거부함. 액션의 전용 input `claude_code_oauth_token`으로 전달해야 정상 인증.

PR #16 카나리에서 발견됨 (Run 24934227381).

## Test plan
- [ ] 머지 후 PR #16 카나리 워크플로 재실행 → 인증 통과 + Claude 리뷰 게시 확인