### PR TITLE
fix: claude_args에 inline 코멘트·gh pr 도구 허용

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,6 +37,8 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
           prompt: |
             이 PR을 리뷰해 주세요. 사람 리뷰어를 대체하지 않는 1차 스크리닝입니다.
 


### PR DESCRIPTION
## Summary
PR #16 카나리에서 워크플로가 통과했으나 코멘트 0개. 원인: Claude가 \`mcp__github_inline_comment__create_inline_comment\` 도구에 접근 권한이 없어 "No buffered inline comments"로 종료.

\`claude_args: --allowedTools\`로 다음 허용:
- \`mcp__github_inline_comment__create_inline_comment\` (inline 게시)
- \`Bash(gh pr comment:*)\` (description 이슈는 일반 코멘트로)
- \`Bash(gh pr diff:*)\` / \`Bash(gh pr view:*)\` (PR 컨텍스트 읽기)

공식 \`pr-review-comprehensive.yml\` 예제 패턴 참조.

## Test plan
- [ ] 머지 후 PR #16 카나리에 main 다시 머지 → 워크플로 재실행
- [ ] inline review comment 게시 확인 (디스크립션 모호 / 스코프 초과 / 불필요 주석 등)