### PR TITLE
feat: 합격 신호·스레드 resolve + 워크플로 변경 PR 자동 스킵

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -3,6 +3,8 @@ name: Claude PR Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
+    paths-ignore:
+      - '.github/workflows/**'
   issue_comment:
     types: [created]
   pull_request_review_comment:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)
+            --allowedTools mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)
           prompt: |
             이 PR을 리뷰해 주세요. 사람 리뷰어를 대체하지 않는 1차 스크리닝입니다.
 
@@ -46,11 +46,24 @@ jobs:
             - **요약·총평 코멘트를 만들지 마세요.** 전체 평가를 PR 본문에 다는 코멘트는 금지.
             - 각 피드백은 **그 피드백이 적용되는 정확한 파일·라인에 inline review comment**로 달아주세요.
             - 여러 라인에 걸친 이슈는 해당 범위에 **단 하나**의 multi-line review comment로.
-            - **예외**: PR description 자체의 문제(목적·이유 누락 등)는 라인이 없으므로 PR 일반 코멘트 1개로만 게시.
+            - **예외 1**: PR description 자체의 문제(목적·이유 누락 등)는 라인이 없으므로 PR 일반 코멘트 1개로만 게시.
+            - **예외 2 (중요)**: 모든 체크 항목을 검토한 결과 게시할 inline 이슈가 **0개**라면, 짧은 합격 요약 코멘트 1개를 PR 일반 코멘트로 게시. 예: "주요 이슈 없음. 합격 기준 통과." 침묵하지 말 것 — 검토가 돌았는지 안 돌았는지 사용자가 구분할 수 있어야 함.
 
             **한 코멘트 형식 (한국어, 간결):**
             - 첫 줄: `[BLOCKING]` / `[ISSUE]` / `[NIT]` 태그 + 한 문장 요지
             - 필요하면 1-2줄 이유나 대안
+
+            **재리뷰 시 기존 스레드 처리 (중복 방지):**
+            먼저 이 PR의 기존 review thread를 조회해 각 지적이 현재 diff에서 해결됐는지 확인:
+            ```
+            gh api graphql -f query='query { repository(owner: "OWNER", name: "REPO") { pullRequest(number: PR_NUMBER) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { body path line } } } } } } }'
+            ```
+            - 해결된 스레드는 resolved 처리:
+              ```
+              gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<THREAD_ID>"}) { thread { isResolved } } }'
+              ```
+            - 미해결 스레드는 그대로 두고 **같은 이슈를 새 inline으로 다시 게시하지 말 것**.
+            - 신규 이슈만 새 inline 코멘트로 게시.
 
             **체크 우선순위:**
             1. PR description에 "무엇을 / 왜"가 명확한가?


### PR DESCRIPTION
## 무엇을
워크플로 프롬프트·트리거에 세 가지 동작 추가:

1. **합격 신호 코멘트**: 모든 체크 통과 후 게시할 inline 이슈가 0개라면, 짧은 "이상 없음" 요약을 PR 일반 코멘트로 1개 게시 (침묵 금지)
2. **기존 스레드 resolve**: 재리뷰 시 이전 review thread를 조회해 해결된 것은 GraphQL \`resolveReviewThread\`로 resolved 처리. 미해결은 그대로 두고 같은 이슈 중복 게시 금지
3. **워크플로 파일만 변경하는 PR은 자동 리뷰 스킵**: \`pull_request\`에 \`paths-ignore: '.github/workflows/**'\` 추가. 액션 자체 검증으로 어차피 거부되는 PR에서 빨간 X 표시 제거

\`claude_args\` 허용 도구에 \`Bash(gh api:*)\` 추가 (GraphQL 호출용).

## 왜
- PR #16 카나리에서 관찰된 사용성 문제: 워크플로가 돌고도 코멘트 0개면 "동작 안 함"과 구분 불가, 같은 이슈가 매 푸시마다 중복 누적
- PR #19 자체에서 발견된 이슈: 워크플로 파일만 변경한 PR도 리뷰 액션이 401로 실패해 빨간 X 표시됨 (액션의 보안 검증으로 의도된 동작이지만 시각적 거슬림)

## 알려진 한계
- 워크플로 + 다른 파일을 동시에 변경하는 PR은 여전히 액션이 트리거되며 검증으로 401 실패. 이런 경우는 드물고, "워크플로 변경은 별도 PR로" 분리 신호로 받아들임.

## Test plan
- [ ] 머지 후 다음 PR에서 합격 시 "이상 없음" 코멘트 1개 게시 확인
- [ ] 이슈 지적 → 수정 푸시 → 해당 스레드가 resolved로 바뀌는지 확인
- [ ] 같은 이슈 중복 게시 안 되는지 확인
- [ ] 워크플로 파일만 변경하는 PR에서 액션 트리거 안 되는지 확인 (이 PR 이후 스스로 검증됨)