### PR TITLE
feat(review): 인라인 답글 분기 추가 (#27)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,11 +24,14 @@ jobs:
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
       || (github.event_name == 'issue_comment'
           && github.event.issue.pull_request != null
-          && contains(github.event.comment.body, '@claude'))
+          && contains(github.event.comment.body, '@claude')
+          && github.event.comment.user.login != 'claude[bot]')
       || (github.event_name == 'pull_request_review_comment'
-          && contains(github.event.comment.body, '@claude'))
+          && contains(github.event.comment.body, '@claude')
+          && github.event.comment.user.login != 'claude[bot]')
       || (github.event_name == 'pull_request_review'
-          && contains(github.event.review.body, '@claude'))
+          && contains(github.event.review.body, '@claude')
+          && github.event.review.user.login != 'claude[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -37,11 +40,26 @@ jobs:
           fetch-depth: 0
 
       - uses: anthropics/claude-code-action@v1
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_IN_REPLY_TO_ID: ${{ github.event.comment.in_reply_to_id }}
+          COMMENT_PATH: ${{ github.event.comment.path }}
+          COMMENT_LINE: ${{ github.event.comment.line }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
-            --allowedTools mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)
+            --allowedTools mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(gh api graphql:*)
           prompt: |
+            이 워크플로는 두 가지 모드로 동작합니다. 입력 컨텍스트를 보고 어느 분기인지 먼저 판별하세요.
+
+            - **(A) 전체 리뷰 패스**: `EVENT_NAME` 이 `pull_request` / `issue_comment` / `pull_request_review` 거나, `pull_request_review_comment` 이지만 `COMMENT_IN_REPLY_TO_ID` 가 비어 있는 경우. → 아래 "전체 리뷰 패스" 섹션 수행.
+            - **(B) 인라인 스레드 답글 처리**: `EVENT_NAME == 'pull_request_review_comment'` 이고 `COMMENT_IN_REPLY_TO_ID` 가 비어 있지 않은 경우 (= 작성자가 기존 인라인 스레드에 `@claude` 멘션과 함께 답글을 달았음). → 아래 "스레드 답글 처리" 섹션만 수행하고 그 외 작업 금지.
+
+            ---
+
+            ## (A) 전체 리뷰 패스
+
             이 PR을 리뷰해 주세요. 사람 리뷰어를 대체하지 않는 1차 스크리닝입니다.
 
             **출력 방식 — 중요:**
@@ -60,10 +78,11 @@ jobs:
             ```
             gh api graphql -f query='query { repository(owner: "OWNER", name: "REPO") { pullRequest(number: PR_NUMBER) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 1) { nodes { body path line } } } } } } }'
             ```
-            - 해결된 스레드는 resolved 처리:
+            - 해결된 스레드(= 코드 변경으로 지적이 무효화된 경우)는 resolved 처리:
               ```
               gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<THREAD_ID>"}) { thread { isResolved } } }'
               ```
+            - **이 분기에서는 작성자의 자연어 답글만으로는 resolve 하지 마세요.** 자연어 해명 기반 resolve는 (B) 분기 전용입니다.
             - 미해결 스레드는 그대로 두고 **같은 이슈를 새 inline으로 다시 게시하지 말 것**.
             - 신규 이슈만 새 inline 코멘트로 게시.
 
@@ -80,3 +99,53 @@ jobs:
             - 추측성 "future-proofing" 권장.
 
             이 리뷰는 참고 의견입니다. 최종 판단은 사람 리뷰어가 합니다.
+
+            ---
+
+            ## (B) 스레드 답글 처리
+
+            작성자가 기존 인라인 리뷰 스레드에 `@claude` 멘션 + 답글을 단 상황입니다. 트리거된 답글 자체는 환경 변수로 노출됩니다:
+            - `COMMENT_IN_REPLY_TO_ID`: 답글이 달린 원본 인라인 코멘트의 ID
+            - `COMMENT_PATH` / `COMMENT_LINE`: 스레드가 가리키는 파일·라인
+            - `COMMENT_BODY`: 트리거된 답글 본문
+
+            **출력은 반드시 그 스레드 내부에서만.** 신규 인라인 생성 금지, PR 일반 코멘트 작성 금지, 다른 스레드 건드리기 금지.
+
+            **수행 절차:**
+            1. GraphQL 로 해당 스레드의 모든 코멘트(원본 봇 지적 + 작성자 답글들)를 읽으세요. `COMMENT_IN_REPLY_TO_ID` 가 가리키는 코멘트가 속한 thread 를 찾고 thread ID 와 그 안의 코멘트 본문들을 확보:
+               ```
+               gh api graphql -f query='query { repository(owner: "OWNER", name: "REPO") { pullRequest(number: PR_NUMBER) { reviewThreads(first: 100) { nodes { id isResolved comments(first: 50) { nodes { databaseId body author { login } } } } } } } }'
+               ```
+               그중 `comments.nodes` 안에 `databaseId == COMMENT_IN_REPLY_TO_ID` 또는 답글의 직계 부모인 코멘트가 포함된 스레드를 선택.
+
+            2. 다음 셋 중 정확히 하나만 수행:
+
+               **(B-1) 해명 수용 → 스레드 resolve.**
+               다음 모두를 만족할 때만:
+                 - 작성자 답글이 코드 변경 없이 의도/맥락만으로 지적을 무효화함
+                 - 지적 카테고리가 **컨벤션·명명·의도성** 중 하나 (예: "이 네이밍은 의도적", "이건 공유용", "이 패턴은 팀 컨벤션")
+                 - 보안·정확성·논리 버그 류는 자연어만으로 resolve **금지**
+               동작:
+                 - 같은 스레드에 한 줄 답글: "의도 확인. resolved." 정도로만.
+                   ```
+                   gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: "<THREAD_ID>", body: "의도 확인. resolved."}) { comment { id } } }'
+                   ```
+                 - 그 다음 스레드 resolve:
+                   ```
+                   gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<THREAD_ID>"}) { thread { isResolved } } }'
+                   ```
+
+               **(B-2) 반론 / 추가 정보 요청.**
+               해명이 부족하거나 보안·정확성·논리 카테고리이면, 같은 스레드에 짧은 답글만:
+                 ```
+                 gh api graphql -f query='mutation { addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: "<THREAD_ID>", body: "<짧은 반론 또는 질문>"}) { comment { id } } }'
+                 ```
+               resolve 하지 않음.
+
+               **(B-3) 침묵.**
+               이미 같은 스레드에 봇이 동일한 취지의 답글을 단 적이 있으면 아무것도 하지 않음.
+
+            **답글 본문 규칙:**
+            - 한국어, 1–2 문장.
+            - **`@claude` 멘션을 절대 포함하지 말 것** (자기 자신을 다시 트리거함).
+            - 일반 코멘트나 신규 인라인을 만들지 말 것.


### PR DESCRIPTION
Closes #27

## 무엇을

`@claude` 멘션이 포함된 **인라인 리뷰 답글**(`pull_request_review_comment` + `in_reply_to_id`)이 올 때, 봇이 *전체 재리뷰 패스* 대신 **해당 스레드 안에서만 응답**하도록 워크플로를 확장합니다.

## 왜

PR #25 의 `.claude/settings.json` 인라인 스레드 사례에서, 작성자가 `@claude` 멘션과 함께 의도 해명 답글을 달았는데 봇은 전체 재리뷰 패스로만 동작해 PR 일반 코멘트로 한 줄만 게시하고 정작 그 스레드는 그대로 두는 갭이 관찰됨.

## 변경 내용

- **`if` 조건에 `claude[bot]` 사용자 가드 추가** — 봇 자기 답글로 워크플로가 다시 트리거되어 무한 루프 도는 것 차단.
- **분기 판별용 환경 변수 노출** (`EVENT_NAME`, `COMMENT_IN_REPLY_TO_ID`, `COMMENT_PATH`, `COMMENT_LINE`, `COMMENT_BODY`).
- **프롬프트를 두 분기로 분리:**
  - **(A) 전체 리뷰 패스** — `pull_request` / `issue_comment` / `pull_request_review` 이벤트, 또는 `in_reply_to_id` 가 빈 인라인 코멘트. 기존 동작 유지.
  - **(B) 인라인 스레드 답글 처리** — `pull_request_review_comment` + `in_reply_to_id` 가 채워진 경우. 해당 스레드 안에서만 답글/resolve 수행, PR 일반 코멘트나 신규 인라인 생성 금지.
- **(B) 분기 휴리스틱**: 작성자 답글이 코드 변경 없이 의도/맥락만으로 무효화 가능하고 카테고리가 **컨벤션·명명·의도성** 중 하나일 때만 resolve. 보안·정확성·논리 버그류는 자연어만으로 resolve 금지하고 같은 스레드에 반론·질문만.
- **`allowedTools` 에 `Bash(gh api graphql:*)` 명시 추가** — `addPullRequestReviewThreadReply`, `resolveReviewThread` 뮤테이션 사용.
- **봇 답글 본문에 `@claude` 멘션 포함 금지** 룰을 프롬프트에 명시 — `if` 조건과 이중 가드.

## 의식적으로 빠진 것

- **(A) 전체 재리뷰 패스에서의 자연어 해명 기반 resolve**: 도입하지 않음. 리뷰어 통제력 보존을 위해 (B) 전용으로 한정 (이슈 #27 미해결 질문 #3 결정).
- **synchronize 시 마지막 push diff 만 리뷰하도록 (A) 동작 변경**: 본 PR 스코프 밖. 필요 시 별도 이슈로 분리 권장.

## 검증 계획

본 PR 머지 후 별도 테스트 PR에서:
1. 봇 인라인 지적 → 작성자 `@claude` 멘션 + 의도 해명 답글 → 봇이 같은 스레드 안에 짧은 답글 + resolve 처리되는지.
2. PR 본문에 일반 코멘트가 추가로 달리지 않는지.
3. 작성자 답글이 부족할 때 봇이 추가 정보 요청으로 응답하는지.
4. 봇 답글이 다시 워크플로를 트리거해 무한 루프 발생하지 않는지 Actions 탭 확인.
5. 외부 컨트리뷰터 PR 시나리오에서 `claude[bot]` 가 OWNER 의 스레드를 resolve 할 수 있는지 (이슈 #27 미해결 질문 #1).

## Test plan

- [ ] 봇 인라인 지적 + 작성자 의도 해명 답글 → 같은 스레드에 답글 + resolve
- [ ] PR 일반 코멘트 추가 게시 없음
- [ ] 부족한 해명 시 같은 스레드에 반론/질문 답글
- [ ] 봇 답글이 자기 자신을 재트리거하지 않음
- [ ] resolve 권한 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)