### PR TITLE
feat(autopilot/loop): test_sweep_paths로 합법적 sweep 허용 (#66)

### DIFF
--- a/plugins/autopilot/skills/loop/references/constitution.md
+++ b/plugins/autopilot/skills/loop/references/constitution.md
@@ -237,7 +237,7 @@ revert 시 commit message는 `chore: revert <짧은 SHA> — fix:symptom 자체 
 - 거짓 `DONE` 또는 거짓 `.loop/ESCALATION.md` 작성
 
 다음 항목은 드라이버가 객관 검증한다 — 위반 시 자동 halt + 에스컬레이션:
-- 테스트 약화 → `tests/**` 해시 비교
+- 테스트 약화 → `tests/**` 해시 비교 (SPEC frontmatter `test_sweep_paths` 선언 경로는 해시 비교에서 제외 — 합법적 sweep을 사용자 승인 시점에 화이트리스트화)
 - 의존성 변경 → 매니페스트 해시
 - scope 위반 → `git diff --name-only` vs `scope.include`
 - suppressor 신규 → `git diff` grep

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -219,7 +219,56 @@ list_test_files() {
     )
   fi
 
+  local tracked
+  tracked=$(cd "$WT" 2>/dev/null && git ls-files -- "${pathspecs[@]}" 2>/dev/null | sort -u)
+
+  # test_sweep_paths 선언 시 매칭 파일을 weakening 비교 셋에서 제외 (issue #66).
+  # 합법적 sweep(예: 단순 rename, 광범위 cleanup 후 신규 파일 추가)을 SPEC 작성 시점에
+  # 사용자 승인으로 화이트리스트화. 워커가 워크트리의 SPEC.md를 수정하면 scope.exclude
+  # 게이트가 차단(헌법 §7) — 안전.
+  local sweep_files
+  sweep_files=$(list_sweep_files)
+  if [[ -z "$sweep_files" ]]; then
+    echo "$tracked"
+  else
+    # subtract sweep_files from tracked. awk associative array로 O(n+m) 비교.
+    awk -v s="$sweep_files" '
+      BEGIN { n = split(s, lines, "\n"); for (i=1; i<=n; i++) if (lines[i] != "") seen[lines[i]] = 1 }
+      !seen[$0]
+    ' <<< "$tracked"
+  fi
+}
+
+list_sweep_files() {
+  # SPEC.md frontmatter test_sweep_paths에 매칭되는 git-tracked 파일 (sorted unique).
+  # 미선언·매칭 0건 시 빈 출력.
+  local sweep_paths
+  sweep_paths=$(read_scope_yaml | yq '.test_sweep_paths[]' 2>/dev/null || true)
+  [[ -z "${sweep_paths// }" ]] && return 0
+
+  local pathspecs=()
+  while IFS= read -r p; do
+    [[ -z "$p" ]] && continue
+    pathspecs+=("$p")
+  done <<< "$sweep_paths"
+  [[ ${#pathspecs[@]} -eq 0 ]] && return 0
+
+  # bash 3.2: 빈 배열 우회는 위에서 ${#pathspecs[@]} -eq 0 가드로 이미 처리.
   cd "$WT" 2>/dev/null && git ls-files -- "${pathspecs[@]}" 2>/dev/null | sort -u
+}
+
+# test_sweep_paths가 선언됐으나 이터 시작 시점에 매칭 파일이 0건이면 stderr 경고.
+# halt하지 않음 — 패턴 오타·신규 파일 추가 전 상태 등 정당한 케이스 보존.
+warn_sweep_no_match() {
+  local sweep_declared
+  sweep_declared=$(read_scope_yaml | yq 'has("test_sweep_paths")' 2>/dev/null || echo "false")
+  [[ "$sweep_declared" != "true" ]] && return 0
+
+  local sweep_files
+  sweep_files=$(list_sweep_files)
+  if [[ -z "$sweep_files" ]]; then
+    echo "[$(now_iso)] WARN: SPEC.md의 test_sweep_paths가 선언됐으나 매칭 파일 없음 — 패턴 오타 또는 신규 파일 추가 전 상태 가능" >&2
+  fi
 }
 
 # 주어진 파일 목록의 결합 해시. 누락된 파일은 sha256sum이 silent 실패하므로 자연스레
@@ -422,8 +471,13 @@ iterate() {
 
   echo "[$(now_iso)] 이터 #$n 시작"
 
+  # test_sweep_paths 선언됐으나 매칭 0건이면 경고 (issue #66, AC2).
+  warn_sweep_no_match
+
   # 시작 시점의 테스트 파일 set 캡처. 종료 시점에 같은 set만 다시 해시해 비교 →
   # 삭제·수정만 감지, 신규 추가는 통과 (TDD RED 단계 보호).
+  # list_test_files()는 test_sweep_paths 매칭 파일을 결과에서 제외하므로
+  # 자동으로 weakening 비교 셋에서 sweep 영역이 빠진다 (AC1·5).
   local start_test_files start_hash_tests start_hash_deps
   start_test_files=$(list_test_files)
   start_hash_tests=$(hash_listed_files "$start_test_files")

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -232,8 +232,10 @@ list_test_files() {
     echo "$tracked"
   else
     # subtract sweep_files from tracked. awk associative array로 O(n+m) 비교.
-    awk -v s="$sweep_files" '
-      BEGIN { n = split(s, lines, "\n"); for (i=1; i<=n; i++) if (lines[i] != "") seen[lines[i]] = 1 }
+    # ENVIRON 경유: awk -v는 값의 백슬래시를 이스케이프로 해석(예: '\b'→backspace)해
+    # 백슬래시 포함 경로(Linux 합법)에서 오동작. ENVIRON은 원시 문자열 전달.
+    sweep_files="$sweep_files" awk '
+      BEGIN { n = split(ENVIRON["sweep_files"], lines, "\n"); for (i=1; i<=n; i++) if (lines[i] != "") seen[lines[i]] = 1 }
       !seen[$0]
     ' <<< "$tracked"
   fi

--- a/plugins/autopilot/skills/loop/references/operational-guide.md
+++ b/plugins/autopilot/skills/loop/references/operational-guide.md
@@ -152,7 +152,7 @@ MAX_CONCURRENT=5 bash "$LOOP_SH" start new-task &   # 캡 상향
 |---|---|
 | 이터 상한 | `MAX_ITERATIONS` (기본 30) |
 | 시계 캡 | `WALL_CLOCK_MINUTES` (기본 120) |
-| 테스트 약화 | 이터 시작 시점의 테스트 파일 set만 종료 후 다시 해시 비교 — **삭제·수정만 감지, 신규 추가는 통과** (TDD RED 단계 보호, 헌법 §0). 기본 추적: `tests/`·`test/`·`__tests__/`·`spec/`·`src/test/` 디렉토리 + co-located 파일명 (`*.test.{js,ts,jsx,tsx,py}`·`*.spec.{js,ts,rb}`·`*_test.{go,py,rb}`·`test_*.py`·`*_spec.rb`). 비표준 컨벤션은 SPEC.md frontmatter `test_paths` (git pathspec 배열)로 override. `git ls-files`로 추적 파일만 검사 (gitignored 제외). |
+| 테스트 약화 | 이터 시작 시점의 테스트 파일 set만 종료 후 다시 해시 비교 — **삭제·수정만 감지, 신규 추가는 통과** (TDD RED 단계 보호, 헌법 §0). 기본 추적: `tests/`·`test/`·`__tests__/`·`spec/`·`src/test/` 디렉토리 + co-located 파일명 (`*.test.{js,ts,jsx,tsx,py}`·`*.spec.{js,ts,rb}`·`*_test.{go,py,rb}`·`test_*.py`·`*_spec.rb`). 비표준 컨벤션은 SPEC.md frontmatter `test_paths` (git pathspec 배열)로 override. `git ls-files`로 추적 파일만 검사 (gitignored 제외). 합법적 sweep(rename·cleanup 등)은 SPEC frontmatter `test_sweep_paths` (git pathspec 배열) 선언으로 해시 비교 셋에서 제외 — sweep 밖 기존 테스트는 여전히 보호. 선언됐으나 매칭 파일 0건이면 stderr 경고만 (halt 없음). |
 | 의존성 동결 | `package.json`·`requirements.txt`·`Cargo.toml` 등 매니페스트 해시 |
 | Scope 위반 | git diff (커밋된 + working tree 미커밋) vs SPEC.md frontmatter의 scope.include·exclude. 미커밋 변경도 검사해 claude 비정상 종료 gap 차단. 미추적 신규 파일은 미커버 — halt 시 `git add -A && git stash`로 보호. |
 | Suppressor 신규 | `noqa`·`@ts-ignore`·`eslint-disable`·`#pragma warning disable` 신규 추가 (커밋된 diff + working tree 미커밋 양쪽). |

--- a/plugins/autopilot/skills/spec/references/spec-template.md
+++ b/plugins/autopilot/skills/spec/references/spec-template.md
@@ -13,6 +13,15 @@ verify: "{{verify_command}}"
 # test_paths:
 #   - "custom/test/**"
 #   - "**/*.t.cpp"
+#
+# test_sweep_paths (선택): 합법적 sweep(대규모 rename·cleanup 등)을 SPEC 작성 시점에
+#   화이트리스트화. 매칭되는 파일은 weakening 해시 비교 셋에서 제외된다 — 수정·삭제해도
+#   "테스트 약화" halt 발생 안 함. 매칭 규칙은 test_paths와 동일한 git pathspec.
+#   선언 후 매칭 파일이 0건이면 stderr 경고만 (halt 없음 — 패턴 오타·미생성 상태 보존).
+#   주의: sweep 밖의 기존 테스트 변경은 여전히 halt — sweep은 화이트리스트 면제.
+# test_sweep_paths:
+#   - "tests/legacy_to_remove/**"
+#   - "tests/test_specific_to_rename.py"
 ---
 
 # {{task_title}}

--- a/tests/autopilot/test-loop-sh.sh
+++ b/tests/autopilot/test-loop-sh.sh
@@ -1874,5 +1874,175 @@ echo "$output50" | grep -q "SPEC.md가 없습니다\|milestones/" \
 rm -rf "$PROJECT/.loops/$LEGACY_ID"
 echo "OK"
 
+echo "=== TEST 51: test_sweep_paths 선언 시 해당 경로 테스트 수정·삭제는 weakening halt 안 함 ==="
+# AC1+5: sweep 경로 안 파일은 약화 검사에서 제외.
+SWEEP_OK_PROJECT="$WORK_DIR/sweep-ok-project"
+mkdir -p "$SWEEP_OK_PROJECT/tests"
+git -C "$SWEEP_OK_PROJECT" init -q
+git -C "$SWEEP_OK_PROJECT" config user.email "t@e.com"
+git -C "$SWEEP_OK_PROJECT" config user.name "Test"
+# 기본 컨벤션 매칭(tests/**)이지만 sweep으로 선언되므로 수정해도 halt 안 돼야
+echo "def test_sweep(): assert True" > "$SWEEP_OK_PROJECT/tests/test_sweep_target.py"
+git -C "$SWEEP_OK_PROJECT" add tests/test_sweep_target.py
+git -C "$SWEEP_OK_PROJECT" commit -q -m "init sweep target"
+
+COUNTER51="$WORK_DIR/iter-count-51.txt"
+echo "0" > "$COUNTER51"
+export COUNTER51_PATH="$COUNTER51"
+
+MOCK51="$WORK_DIR/mock51-bin"
+mkdir -p "$MOCK51"
+cat > "$MOCK51/claude" <<'MOCKEOF'
+#!/usr/bin/env bash
+cat > /dev/null
+n=$(cat "${COUNTER51_PATH}")
+n=$((n + 1))
+echo "$n" > "${COUNTER51_PATH}"
+if [[ $n -eq 1 ]]; then
+  # iter 1: 기존 sweep 대상 파일 수정 (sweep 안이므로 weakening halt 없어야)
+  # DONE은 만들지 않음 → 이터 종료 후 weakening 게이트가 반드시 실행됨
+  echo "def test_sweep(): assert True  # sweep modified" > tests/test_sweep_target.py
+  git add tests/test_sweep_target.py
+  git commit -q -m "test: sweep modify"
+else
+  # iter 2: 정상 종료 (weakening 게이트가 iter 1을 통과했음을 입증)
+  touch DONE
+fi
+echo '{"result": "mock51", "usage": {"input_tokens": 1, "output_tokens": 1}}'
+MOCKEOF
+chmod +x "$MOCK51/claude"
+
+(
+  cd "$SWEEP_OK_PROJECT"
+  mkdir -p "milestones/regular/loops/sweep-ok"
+  cat > "milestones/regular/loops/sweep-ok/SPEC.md" <<'EOF'
+---
+scope:
+  include:
+    - "**/*"
+  exclude: []
+verify: 'true'
+test_sweep_paths:
+  - "tests/test_sweep_target.py"
+---
+
+# Sweep Allow Test
+EOF
+  set +e
+  output51=$(PATH="$MOCK51:$PATH" MAX_ITERATIONS=2 WALL_CLOCK_MINUTES=5 \
+    bash "$LOOP_SH_SRC" start "sweep-ok" 2>&1)
+  result51=$?
+  set -e
+  [[ $result51 -eq 0 ]] || { echo "FAIL: sweep 경로 수정이 weakening halt 트리거. exit=$result51"; echo "$output51"; exit 1; }
+  if echo "$output51" | grep -q "테스트 약화"; then
+    echo "FAIL: sweep 경로 수정에 '테스트 약화' 메시지 발생"
+    echo "$output51"
+    exit 1
+  fi
+  WT51="$WORK_DIR/sweep-ok-project-loops/regular/sweep-ok"
+  [[ -f "$WT51/DONE" ]] || { echo "FAIL: DONE 미생성"; exit 1; }
+)
+echo "OK"
+
+echo "=== TEST 52: test_sweep_paths 선언됐으나 매칭 파일 0건 → stderr 경고 + halt 없음 ==="
+# AC2: 패턴 오타·미생성 시 경고만, 진행 차단 안 함.
+SWEEP_WARN_PROJECT="$WORK_DIR/sweep-warn-project"
+mkdir -p "$SWEEP_WARN_PROJECT"
+git -C "$SWEEP_WARN_PROJECT" init -q
+git -C "$SWEEP_WARN_PROJECT" config user.email "t@e.com"
+git -C "$SWEEP_WARN_PROJECT" config user.name "Test"
+git -C "$SWEEP_WARN_PROJECT" commit --allow-empty -q -m "init"
+
+MOCK52="$WORK_DIR/mock52-bin"
+mkdir -p "$MOCK52"
+cat > "$MOCK52/claude" <<'MOCKEOF'
+#!/usr/bin/env bash
+cat > /dev/null
+touch DONE
+echo '{"result": "mock52", "usage": {"input_tokens": 1, "output_tokens": 1}}'
+MOCKEOF
+chmod +x "$MOCK52/claude"
+
+(
+  cd "$SWEEP_WARN_PROJECT"
+  mkdir -p "milestones/regular/loops/sweep-warn"
+  cat > "milestones/regular/loops/sweep-warn/SPEC.md" <<'EOF'
+---
+scope:
+  include:
+    - "**/*"
+  exclude: []
+verify: 'true'
+test_sweep_paths:
+  - "nonexistent-dir/**"
+---
+
+# Sweep Empty Match Test
+EOF
+  set +e
+  output52=$(PATH="$MOCK52:$PATH" MAX_ITERATIONS=1 WALL_CLOCK_MINUTES=5 \
+    bash "$LOOP_SH_SRC" start "sweep-warn" 2>&1)
+  result52=$?
+  set -e
+  [[ $result52 -eq 0 ]] || { echo "FAIL: sweep 매칭 0건이 halt 트리거. exit=$result52"; echo "$output52"; exit 1; }
+  echo "$output52" | grep -q "test_sweep_paths" \
+    || { echo "FAIL: sweep 매칭 0건 경고 없음. got: $output52"; exit 1; }
+  WT52="$WORK_DIR/sweep-warn-project-loops/regular/sweep-warn"
+  [[ -f "$WT52/DONE" ]] || { echo "FAIL: DONE 미생성"; exit 1; }
+)
+echo "OK"
+
+echo "=== TEST 53: test_sweep_paths 선언 시 sweep 밖 기존 테스트 수정은 여전히 weakening halt ==="
+# AC4: sweep은 화이트리스트 면제 — 밖의 파일은 보호된다.
+SWEEP_BOUND_PROJECT="$WORK_DIR/sweep-bound-project"
+mkdir -p "$SWEEP_BOUND_PROJECT/tests"
+git -C "$SWEEP_BOUND_PROJECT" init -q
+git -C "$SWEEP_BOUND_PROJECT" config user.email "t@e.com"
+git -C "$SWEEP_BOUND_PROJECT" config user.name "Test"
+echo "def test_protected(): assert True" > "$SWEEP_BOUND_PROJECT/tests/test_protected.py"
+echo "def test_sweep(): assert True" > "$SWEEP_BOUND_PROJECT/tests/test_sweep_zone.py"
+git -C "$SWEEP_BOUND_PROJECT" add tests/test_protected.py tests/test_sweep_zone.py
+git -C "$SWEEP_BOUND_PROJECT" commit -q -m "init both"
+
+MOCK53="$WORK_DIR/mock53-bin"
+mkdir -p "$MOCK53"
+cat > "$MOCK53/claude" <<'MOCKEOF'
+#!/usr/bin/env bash
+cat > /dev/null
+# sweep 밖 파일 수정 (보호되어야 → halt 발생해야)
+echo "def test_protected(): assert False  # weakened" > tests/test_protected.py
+git add tests/test_protected.py
+git commit -q -m "weaken: protected"
+echo '{"result": "mock53", "usage": {"input_tokens": 1, "output_tokens": 1}}'
+MOCKEOF
+chmod +x "$MOCK53/claude"
+
+(
+  cd "$SWEEP_BOUND_PROJECT"
+  mkdir -p "milestones/regular/loops/sweep-bound"
+  cat > "milestones/regular/loops/sweep-bound/SPEC.md" <<'EOF'
+---
+scope:
+  include:
+    - "**/*"
+  exclude: []
+verify: 'true'
+test_sweep_paths:
+  - "tests/test_sweep_zone.py"
+---
+
+# Sweep Boundary Test
+EOF
+  set +e
+  output53=$(PATH="$MOCK53:$PATH" MAX_ITERATIONS=2 WALL_CLOCK_MINUTES=5 \
+    bash "$LOOP_SH_SRC" start "sweep-bound" 2>&1)
+  result53=$?
+  set -e
+  [[ $result53 -ne 0 ]] || { echo "FAIL: sweep 밖 파일 수정이 halt 안 됨 (AC4 위반). exit=$result53"; echo "$output53"; exit 1; }
+  echo "$output53" | grep -q "테스트 약화" \
+    || { echo "FAIL: sweep 밖 약화 halt 메시지 없음. got: $output53"; exit 1; }
+)
+echo "OK"
+
 echo ""
 echo "=== 모든 테스트 통과 ==="


### PR DESCRIPTION
## Summary
- weakening 게이트가 합법적 test sweep(대규모 rename·cleanup 등)을 약화로 오분류하던 구조적 한계 해소.
- SPEC.md frontmatter `test_sweep_paths`(git pathspec list)에 선언된 경로의 테스트 파일은 weakening 해시 비교 셋에서 제외. 선언 밖 기존 테스트는 여전히 보호.
- default-off 하위 호환: 선언 없는 SPEC은 동작 변경 없음.

## Test plan
- [x] `bash tests/autopilot/test-loop-sh.sh` 53/53 통과 (TEST 51/52/53 신규: sweep 안 수정 허용·매칭 0건 경고·sweep 밖 halt 유지)
- [ ] reviewer 수동 확인 — frontmatter 선언 → driver list_test_files() 차감 흐름

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)