### PR TITLE
refactor(autopilot/spec): SPEC.md 출력 경로를 milestones/<m>/loops/<c>/로 정렬

### DIFF
--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -369,10 +369,11 @@ diff_vs_scope() {
 
 grep_new_suppressors() {
   # 커밋된 diff + working tree 변경 양쪽 검사 (미커밋 suppressor도 catch)
+  # .loop/는 워커 메모리(헌법 인용 등 false positive 발생)이므로 검사 제외
   cd "$WT" || return
   {
-    git diff HEAD~1 HEAD 2>/dev/null
-    git diff HEAD 2>/dev/null
+    git diff HEAD~1 HEAD -- ':(exclude).loop/**' 2>/dev/null
+    git diff HEAD -- ':(exclude).loop/**' 2>/dev/null
   } \
     | grep -E '^\+' \
     | grep -E '#[[:space:]]*noqa|@ts-ignore|eslint-disable|#pragma[[:space:]]+warning[[:space:]]+disable' \

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: spec
-description: "autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. 호출 'Skill(skill=\"spec\", args=\"<task-id>\")' 또는 '<task-id> --resume'."
+description: "autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. 호출 'Skill(skill=\"spec\", args=\"<task-id> [--milestone <m>] [--resume]\")'. milestone 미지정 시 `regular`(catch-all)을 default로 적용."
 ---
 
 # spec
 
-`autopilot:loop` 스킬이 입력으로 받는 `.loops/<task-id>/SPEC.md`를 대화형으로 생성. 자율 loop이 도중 질문 없이 완수할 수 있는 자기완결적 SPEC이 목표.
+`autopilot:loop` 스킬이 입력으로 받는 `milestones/<m>/loops/<c>/SPEC.md`를 대화형으로 생성. 자율 loop이 도중 질문 없이 완수할 수 있는 자기완결적 SPEC이 목표.
 
 ## 호출 방법
 
-- 새 SPEC: `Skill(skill: "spec", args: "<task-id>")`
-- 마커 해결 모드: `Skill(skill: "spec", args: "<task-id> --resume")`
+- 새 SPEC: `Skill(skill: "spec", args: "<task-id> [--milestone <m>]")`
+- 마커 해결 모드: `Skill(skill: "spec", args: "<task-id> [--milestone <m>] --resume")`
+
+milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `autopilot:loop`이 단일 컴포넌트 task-id를 `regular/<task-id>`로 정규화하는 컨벤션과 일치. `autopilot:dispatch` 등 milestone 분해 컨텍스트에서 호출할 때는 `--milestone <m>`을 명시.
 
 또는 사용자가 자연어로 의도 전달 시 모델이 자동 호출.
 
@@ -20,9 +22,10 @@ description: "autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 �
 
 ### 1. 사전 검사
 
-- task-id 형식 검증 (loop.sh의 `validate_task_id`와 동일 규칙): 비어 있거나, `..` 포함, `.` 단독 컴포넌트(`.`·`./foo`·`foo/.`·`a/./b`), `__` 포함, 공백 포함 시 abort. 슬래시(`/`)는 허용 — loop.sh가 lock 파일명에서 `__`로 인코딩하며 nested task-id(`goal-x/sub-task` 등)가 정상 사용 사례. spec 스킬과 loop이 같은 task-id를 받아들여야 `--resume` 라운드트립이 성립.
-- **일반 모드**: `.loops/<task-id>/` 존재 시 abort + `AskUserQuestion`으로 3옵션 (다른 task-id / `--resume` / 백업 후 새로)
-- **--resume 모드**: `.loops/<task-id>/SPEC.md` 부재 시 abort. 잔존 `[NEEDS CLARIFICATION` 마커 0개 시 "해결할 마커 없음" 안내 후 종료
+- task-id 형식 검증 (loop.sh의 `validate_task_id`와 동일 규칙): 비어 있거나, `..` 포함, `.` 단독 컴포넌트(`.`·`./foo`·`foo/.`·`a/./b`), `__` 포함, 공백 포함 시 abort. 슬래시(`/`)는 허용 — milestone이 별도 인자로 분리된 뒤의 nested task-id(`sub-area/child` 등)가 정상 사용 사례. spec 스킬과 loop이 같은 (milestone, task-id) 쌍을 받아들여야 `--resume` 라운드트립이 성립.
+- milestone 인자 파싱: `--milestone <m>` 명시 시 `<m>`을 milestone으로 사용. 미지정 시 `regular`(catch-all)을 default로 적용. milestone 자체에도 task-id와 동일한 형식 검증을 적용 (단, milestone은 단일 컴포넌트 — `/` 미허용).
+- **일반 모드**: `milestones/<m>/loops/<c>/` 존재 시 abort + `AskUserQuestion`으로 3옵션 (다른 task-id / `--resume` / 백업 후 새로). 본 절 이후 `<c>`는 task-id를 지칭.
+- **--resume 모드**: `milestones/<m>/loops/<c>/SPEC.md` 부재 시 abort. 잔존 `[NEEDS CLARIFICATION` 마커 0개 시 "해결할 마커 없음" 안내 후 종료
 
 ### 2. 컨텍스트 탐색
 
@@ -89,11 +92,11 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 - `{{scope_include}}` → frontmatter `scope.include` (YAML inline flow list 형식, 예: `["src/**", "tests/**"]`. 본문 `{{scope_in}}`과 같은 내용을 YAML 문법으로)
 - `{{verify_command}}` → 본문 섹션 5 + frontmatter `verify` (둘 다 같은 placeholder)
 - `{{constraints}}` / `{{risks}}` → 섹션 6/7. 빈 값이면 빈 줄 한 줄로 치환 (헤더는 남김)
-- frontmatter `scope.exclude`는 고정 default(`rules/**`, `.loops/**`, `CLAUDE.md`) — 치환 대상 아님
+- frontmatter `scope.exclude`는 고정 default(`rules/**`, `milestones/**`, `CLAUDE.md`) — 치환 대상 아님
 
 미해결 항목은 `[NEEDS CLARIFICATION: <구체 질문>]` 마커로 박은 채 작성.
 
-`mkdir -p .loops/<task-id>` 후 SPEC.md 기록.
+`mkdir -p milestones/<m>/loops/<c>` 후 `milestones/<m>/loops/<c>/SPEC.md`에 기록.
 
 ### 8. 자체 검토
 
@@ -102,7 +105,7 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 ### 9. 사용자 최종 검토
 
 SPEC.md 경로·요약 안내 + `AskUserQuestion`으로 검토 결과 수집:
-- 승인: 다음 단계 안내 출력 — *"SPEC 완성: .loops/<task-id>/SPEC.md\n다음 단계: Skill(skill: \"loop\", args: \"start <task-id>\")"*
+- 승인: 다음 단계 안내 출력 — *"SPEC 완성: milestones/<m>/loops/<c>/SPEC.md\n다음 단계: Skill(skill: \"loop\", args: \"start <m>/<c>\")"* (milestone이 default `regular`이면 `start <c>` 단축형도 동등 — loop.sh가 자동 정규화)
 - 변경: 어느 섹션을 변경할지 묻고 단계 6/7 재진입
 
 ## --resume 모드 요약
@@ -125,7 +128,7 @@ SPEC.md 경로·요약 안내 + `AskUserQuestion`으로 검토 결과 수집:
 
 ## 규칙
 
-- 본 스킬은 target 프로젝트의 `.loops/<task-id>/SPEC.md`만 작성한다. 다른 파일 생성·수정 안 함.
+- 본 스킬은 target 프로젝트의 `milestones/<m>/loops/<c>/SPEC.md`만 작성한다. 다른 파일 생성·수정 안 함.
 - 모든 결정·선택·확인은 `AskUserQuestion`으로. 자유 텍스트 끝에 질문 종결구 다는 방식 금지 (CLAUDE.md 규칙).
 - 한 주제씩 (한 `AskUserQuestion` 호출에 관련 소문항 최대 4개 허용).
 - `[NEEDS CLARIFICATION` 마커는 `loop start`에서 차단됨. 사용자에게 명시적으로 마커가 박혔음을 알리고 `--resume`으로 해결하도록 안내.

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -22,7 +22,7 @@ milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `a
 
 ### 1. 사전 검사
 
-- task-id 형식 검증 (loop.sh의 `validate_task_id`와 동일 규칙): 비어 있거나, `..` 포함, `.` 단독 컴포넌트(`.`·`./foo`·`foo/.`·`a/./b`), `__` 포함, 공백 포함 시 abort. 슬래시(`/`)는 허용 — milestone이 별도 인자로 분리된 뒤의 nested task-id(`sub-area/child` 등)가 정상 사용 사례. spec 스킬과 loop이 같은 (milestone, task-id) 쌍을 받아들여야 `--resume` 라운드트립이 성립.
+- task-id 형식 검증 (loop.sh의 `validate_task_id`와 동일 규칙): 비어 있거나, `..` 포함, `.` 단독 컴포넌트(`.`·`./foo`·`foo/.`·`a/./b`), `__` 포함, 공백 포함 시 abort. 슬래시(`/`)는 `--milestone <m>`이 명시된 경우에만 허용 — milestone이 별도 인자로 분리된 뒤의 nested task-id(`sub-area/child` 등)가 정상 사용 사례. `--milestone` 미지정 + 슬래시 포함 task-id는 abort — loop.sh의 `normalize_task_id`가 슬래시 있는 task-id의 첫 컴포넌트를 milestone으로 해석하므로 spec의 default(`regular`)와 어긋나 `--resume` 라운드트립이 깨짐. 슬래시 포함 task-id를 쓰려면 `--milestone <m>`을 명시. spec 스킬과 loop이 같은 (milestone, task-id) 쌍을 받아들여야 `--resume` 라운드트립이 성립.
 - milestone 인자 파싱: `--milestone <m>` 명시 시 `<m>`을 milestone으로 사용. 미지정 시 `regular`(catch-all)을 default로 적용. milestone 자체에도 task-id와 동일한 형식 검증을 적용 (단, milestone은 단일 컴포넌트 — `/` 미허용).
 - **일반 모드**: `milestones/<m>/loops/<c>/` 존재 시 abort + `AskUserQuestion`으로 3옵션 (다른 task-id / `--resume` / 백업 후 새로). 본 절 이후 `<c>`는 task-id를 지칭.
 - **--resume 모드**: `milestones/<m>/loops/<c>/SPEC.md` 부재 시 abort. 잔존 `[NEEDS CLARIFICATION` 마커 0개 시 "해결할 마커 없음" 안내 후 종료

--- a/plugins/autopilot/skills/spec/references/spec-template.md
+++ b/plugins/autopilot/skills/spec/references/spec-template.md
@@ -3,7 +3,7 @@ scope:
   include: {{scope_include}}
   exclude:
     - rules/**
-    - .loops/**
+    - milestones/**
     - CLAUDE.md
 verify: "{{verify_command}}"
 # test_paths (선택): 테스트 약화 게이트가 추적할 경로/파일명 패턴 (git pathspec).

--- a/tests/autopilot/test-loop-sh.sh
+++ b/tests/autopilot/test-loop-sh.sh
@@ -2082,6 +2082,8 @@ output54=$(PATH="$MOCK54:$PATH" MAX_ITERATIONS=2 WALL_CLOCK_MINUTES=5 loop start
 set -e
 echo "$output54" | grep -q "Suppressor 신규 추가" \
   && { echo "FAIL: .loop/PLAN.md의 suppressor 패턴 인용이 false positive halt 트리거"; echo "$output54"; exit 1; }
+echo "$output54" | grep -q "이터 상한 도달" \
+  || { echo "FAIL: loop이 MAX_ITERATIONS까지 정상 진행 못함 — false positive 부재만으로 OK 판정하면 mock·환경 이슈에서 false OK 발생"; echo "$output54"; exit 1; }
 loop cleanup "$TEST54_TASK" --force > /dev/null 2>&1 || true
 echo "OK"
 

--- a/tests/autopilot/test-loop-sh.sh
+++ b/tests/autopilot/test-loop-sh.sh
@@ -2044,5 +2044,46 @@ EOF
 )
 echo "OK"
 
+echo "=== TEST 54: suppressor 게이트가 .loop/ 워커 메모리는 검사 제외 ==="
+# 워커가 PLAN.md 등에 헌법 본문 인용 시 suppressor 패턴 문자열이 들어감 — false positive 방지
+TEST54_TASK="gate-suppressor-loop-dir"
+mkdir -p "$PROJECT/milestones/regular/loops/$TEST54_TASK"
+cat > "$PROJECT/milestones/regular/loops/$TEST54_TASK/SPEC.md" <<'EOF'
+---
+scope:
+  include:
+    - "**/*"
+  exclude: []
+verify: 'true'
+---
+
+# Gate Test — .loop/ Excluded from Suppressor Scan
+EOF
+
+MOCK54="$WORK_DIR/mock54-bin"
+mkdir -p "$MOCK54"
+cat > "$MOCK54/claude" <<'MOCKEOF'
+#!/usr/bin/env bash
+cat > /dev/null
+# 워커가 PLAN.md에 헌법 본문 인용 (suppressor 패턴 문자열 포함) + commit
+# 헌법 §3.1 출력 요건: 메모리 파일 갱신은 commit과 함께
+mkdir -p .loop
+cat > .loop/PLAN.md <<'PLAN_EOF'
+- `# noqa`, `@ts-ignore`, `eslint-disable`, `#pragma warning disable` 등 경고 억제 지시어 신규 추가 금지
+PLAN_EOF
+git add .loop/PLAN.md
+git commit -q -m "feat: cite suppressor rules in PLAN.md"
+echo '{"result": "mock54", "usage": {"input_tokens": 1, "output_tokens": 1}}'
+MOCKEOF
+chmod +x "$MOCK54/claude"
+
+set +e
+output54=$(PATH="$MOCK54:$PATH" MAX_ITERATIONS=2 WALL_CLOCK_MINUTES=5 loop start "$TEST54_TASK" 2>&1)
+set -e
+echo "$output54" | grep -q "Suppressor 신규 추가" \
+  && { echo "FAIL: .loop/PLAN.md의 suppressor 패턴 인용이 false positive halt 트리거"; echo "$output54"; exit 1; }
+loop cleanup "$TEST54_TASK" --force > /dev/null 2>&1 || true
+echo "OK"
+
 echo ""
 echo "=== 모든 테스트 통과 ==="


### PR DESCRIPTION
## Summary

**spec 경로 정렬** (issue #80):
- spec 스킬이 작성하는 SPEC.md 경로를 sibling loop 스킬의 새 경로 컨벤션 `milestones/<m>/loops/<c>/SPEC.md`로 정렬 (`4a4cc9c`)
- 호출 인터페이스에 `--milestone <m>` 플래그 추가, 미지정 시 default `regular`(catch-all)
- legacy `.loops/<task-id>/` 경로 spec 스킬 트리에서 완전 제거
- `spec-template.md` frontmatter `scope.exclude` default 갱신 (`.loops/**` → `milestones/**`)
- 후속: `--milestone` 미지정 + 슬래시 포함 task-id abort 규칙 (`acec20e`, review #1)

**loop.sh suppressor 게이트 false positive 수정** (별개 fix, 워크트리 base 경유 동봉):
- 워커 메모리(`.loop/` 디렉토리)에 들어간 헌법 인용·suppressor 패턴 문자열이 false positive halt를 트리거하던 문제 해결 (`4e864a7`)
- 테스트: `.loop/PLAN.md`에 suppressor 패턴 문자열이 들어가도 정상 진행 검증 (`4e864a7`, 보완 `0cc86f0` — review #2)

## Test plan
- [ ] SPEC verify 0 exit 확인: `! grep -rEq '[.]loops/<task-id>|mkdir -p [.]loops' plugins/autopilot/skills/spec/ && grep -qE 'milestones/<m>/loops/<c>/' plugins/autopilot/skills/spec/SKILL.md && grep -qE 'regular' plugins/autopilot/skills/spec/SKILL.md && grep -qE 'milestones/[*][*]' plugins/autopilot/skills/spec/references/spec-template.md && ! grep -qE '[.]loops/[*][*]' plugins/autopilot/skills/spec/references/spec-template.md`
- [ ] spec 스킬 새로 호출 시 `milestones/<m>/loops/<c>/SPEC.md`에 작성되는지
- [ ] spec `--resume` 호출 시 새 경로에서 명확화 마커 해결되는지
- [ ] `--milestone` 미지정 + 슬래시 task-id 입력 시 abort 안내되는지
- [ ] `tests/autopilot/test-loop-sh.sh` 실행 후 suppressor 테스트가 "이터 상한 도달" 시그널까지 검증하는지

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)