### PR TITLE
autopilot/spec+loop: SPEC commit → worktree 자연 포함 + main archive 오염 제거

### DIFF
--- a/plugins/autopilot/skills/loop/references/agent-prompts.md
+++ b/plugins/autopilot/skills/loop/references/agent-prompts.md
@@ -28,9 +28,9 @@ Agent({
 ```
 당신은 자율 루프의 현재 이터레이션에서 만든 변경이 작업 명세에 부합하는지 검증합니다.
 
-## 요구사항 (.loop/SPEC.md에서)
+## 요구사항 (워크트리 SPEC.md에서)
 
-[`<worktree>/.loop/SPEC.md`의 작업 정의 섹션 전체 텍스트 — 작업 정의·수용 기준·범위·검증 명령을 그대로 paste. 파일을 다시 읽게 하지 말 것]
+[워크트리의 SPEC.md(신규 contract: `<worktree>/milestones/<m>/loops/<c>/SPEC.md`; legacy: `<worktree>/.loop/SPEC.md`)의 작업 정의 섹션 전체 텍스트 — 작업 정의·수용 기준·범위·검증 명령을 그대로 paste. 파일을 다시 읽게 하지 말 것]
 
 ## 이번 이터가 한 작업 (자기 보고)
 
@@ -111,7 +111,7 @@ Agent({
 
 ## 작업 정의 / 평가 기준
 
-이터의 작업 정의는 `<worktree>/.loop/SPEC.md`에 있음. 평가 기준은 헌법(`<worktree>/CLAUDE.md`) §3.5 Self-Review 4축.
+이터의 작업 정의는 워크트리의 SPEC.md(신규: `<worktree>/milestones/<m>/loops/<c>/SPEC.md`; legacy: `<worktree>/.loop/SPEC.md`)에 있음. 평가 기준은 헌법(`<worktree>/CLAUDE.md`) §3.5 Self-Review 4축.
 
 ## Git 범위
 

--- a/plugins/autopilot/skills/loop/references/constitution.md
+++ b/plugins/autopilot/skills/loop/references/constitution.md
@@ -32,14 +32,14 @@
 
 - **콜드 스타트**: 매 이터레이션은 새 프로세스다. 직전 이터의 추론 과정·중간 상태는 다음 이터가 보지 못한다 — 결과물(코드·테스트·메모리 파일)만 본다.
 - **워크트리 격리**: 모든 작업은 워크트리 안(`<project>-loops/<task-id>/` 또는 `<goal-id>/<task-id>/`)에서 일어난다. 워크트리 밖 파일은 수정 대상이 아니다.
-- **입력**: `<worktree>/CLAUDE.md`(헌법), `.loop/SPEC.md`(작업 정의), 디스크 상태(코드·git 히스토리), `.loop/{PLAN,NOTES,HANDOFF,RUN_LOG}.md`(메모리 파일).
+- **입력**: `<worktree>/CLAUDE.md`(헌법), 워크트리의 `SPEC.md`(작업 정의 — 신규 contract: `milestones/<m>/loops/<c>/SPEC.md` (feat 브랜치에 committed); legacy: `.loop/SPEC.md` (start 시 cp 시드)), 디스크 상태(코드·git 히스토리), `.loop/{PLAN,NOTES,HANDOFF,RUN_LOG}.md`(메모리 파일).
 - **출력**: 코드 변경 + 자기 분류 prefix를 가진 git commit + `.loop/` 메모리 파일 갱신 + (선택) `DONE` 또는 `.loop/ESCALATION.md` 신호 파일.
 
 ## 3. 작업 흐름
 
 ### 3.1 수용 기준 확인
 
-작업 시작 시점에 `.loop/SPEC.md`의 작업 정의·수용 기준을 먼저 읽는다. 수용 기준이 모호하면 즉시 에스컬레이션한다 — 추측으로 진행하지 않는다.
+작업 시작 시점에 워크트리의 SPEC.md(신규: `milestones/<m>/loops/<c>/SPEC.md` (committed in worktree); legacy: `.loop/SPEC.md`)의 작업 정의·수용 기준을 먼저 읽는다. 수용 기준이 모호하면 즉시 에스컬레이션한다 — 추측으로 진행하지 않는다.
 
 ### 3.2 한 이터레이션의 6단계
 
@@ -233,7 +233,7 @@ revert 시 commit message는 `chore: revert <짧은 SHA> — fix:symptom 자체 
 - `.git` 히스토리 조작, force push, 리베이스
 - "작동하는 것처럼 보이게 하는" 모든 종류의 위장
 - 워크트리 밖 파일 수정 (모든 작업은 워크트리 안에서)
-- 워크트리 루트의 `CLAUDE.md`(헌법), `.loop/SPEC.md` 수정
+- 워크트리 루트의 `CLAUDE.md`(헌법) 또는 워크트리의 SPEC.md(신규: `milestones/<m>/loops/<c>/SPEC.md`; legacy: `.loop/SPEC.md`) 수정
 - 거짓 `DONE` 또는 거짓 `.loop/ESCALATION.md` 작성
 
 다음 항목은 드라이버가 객관 검증한다 — 위반 시 자동 halt + 에스컬레이션:

--- a/plugins/autopilot/skills/loop/references/escalation-template.md
+++ b/plugins/autopilot/skills/loop/references/escalation-template.md
@@ -32,7 +32,7 @@
 ## 카테고리 선택 가이드
 
 - `config-gap` — 환경 설정·도구 버전·자격증명 부재. 사람이 환경 조정.
-- `spec-gap` — `.loop/SPEC.md` 자체 결함. 사람이 명세 수정.
+- `spec-gap` — SPEC.md 자체 결함 (신규: `milestones/<m>/loops/<c>/SPEC.md`; legacy: `.loop/SPEC.md`). 사람이 명세 수정.
 - `architecture-gap` — 현재 코드 구조로 해결 불가. 사람의 architecture 결정.
 - `environment-gap` — 외부 시스템 일시적 문제. 사람의 환경 점검.
 - `other` — 위에 안 맞을 때.

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -69,6 +69,19 @@ now_iso() {
   date -u +%Y-%m-%dT%H:%M:%SZ
 }
 
+# 신규 contract 감지 (M3): main repo에 feat/<task-id> 또는 feat/<task-id>-<slug>
+# 브랜치가 있으면 그 이름을 stdout으로 출력 (sort 후 첫 매칭). 없으면 빈 문자열.
+# 패턴: `refs/heads/feat/<task-id>` (정확) + `refs/heads/feat/<task-id>-*` (하이픈 suffix).
+# 유의: `refs/heads/feat/<task-id>*` 같은 무경계 glob은 'foo'와 'foobar'를 함께 매칭 →
+#       반드시 두 패턴(정확 + 하이픈-suffix)으로 분리.
+find_feat_branch() {
+  local task_id="$1"
+  local project_root="$2"
+  git -C "$project_root" for-each-ref --format='%(refname:short)' \
+    "refs/heads/feat/$task_id" "refs/heads/feat/$task_id-*" 2>/dev/null \
+    | sort | head -n 1
+}
+
 # ----- 의존성 검사 -----
 
 require_tool git
@@ -305,11 +318,15 @@ hash_deps() {
 }
 
 read_scope_yaml() {
+  # SPEC_PATH_IN_WT는 cmd_start가 worktree 생성·재사용 시 모드에 따라 설정한다.
+  # 신규 contract: milestones/<m>/loops/<c>/SPEC.md (feat branch에 committed)
+  # legacy:        .loop/SPEC.md (cmd_start에서 cp로 시드)
+  local spec_in_wt="${SPEC_PATH_IN_WT:-.loop/SPEC.md}"
   sed -n '1,/^---$/{
     1d
     /^---$/d
     p
-  }' "$WT/.loop/SPEC.md" 2>/dev/null
+  }' "$WT/$spec_in_wt" 2>/dev/null
 }
 
 diff_vs_scope() {
@@ -489,6 +506,7 @@ iterate() {
   # 비동기 실행 + wait — bash trap은 동기 명령 안에서 deferred되므로 wait를 써야
   # SIGTERM/SIGINT가 즉시 처리돼 자식 트리 정리 가능 (orphan 방지)
   local exit_code=0
+  local spec_in_wt="${SPEC_PATH_IN_WT:-.loop/SPEC.md}"
   (
     cd "$WT"
     exec claude \
@@ -498,7 +516,7 @@ iterate() {
       --system-prompt-file CLAUDE.md \
       --add-dir . \
       --output-format json \
-      < .loop/SPEC.md \
+      < "$spec_in_wt" \
       > ".loop/iterations/$n.log" 2>&1
   ) &
   local claude_pid=$!
@@ -615,22 +633,74 @@ cmd_start() {
   MAX_CONCURRENT="${MAX_CONCURRENT:-3}"
   WATCH_MODE="$watch_mode"
 
-  # 1. --spec 외부 SPEC 전달 처리
+  # M3: contract 감지 — feat 브랜치 또는 기존 워크트리 브랜치로 새/legacy 판정
+  local milestone="${task_id%%/*}"
+  local child="${task_id#*/}"
+  local spec_rel_path="milestones/$milestone/loops/$child/SPEC.md"
+  local feat_branch_in_main
+  feat_branch_in_main=$(find_feat_branch "$task_id" "$PROJECT_ROOT")
+
+  USE_FEAT_BRANCH=0
+  if [[ -d "$WT" ]]; then
+    # 기존 워크트리 재사용: 워크트리의 현재 브랜치로 판정
+    local wt_branch
+    wt_branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    if [[ "$wt_branch" == feat/* ]]; then
+      USE_FEAT_BRANCH=1
+      BRANCH="$wt_branch"
+      SPEC_PATH_IN_WT="$spec_rel_path"
+    else
+      BRANCH="$wt_branch"
+      SPEC_PATH_IN_WT=".loop/SPEC.md"
+    fi
+  else
+    # 신규 워크트리: main repo의 feat 브랜치 존재 여부로 판정
+    if [[ -n "$feat_branch_in_main" ]]; then
+      USE_FEAT_BRANCH=1
+      BRANCH="$feat_branch_in_main"
+      SPEC_PATH_IN_WT="$spec_rel_path"
+    else
+      BRANCH="autonomous-loop/$task_id"
+      SPEC_PATH_IN_WT=".loop/SPEC.md"
+    fi
+  fi
+
+  # 1. --spec 외부 SPEC 전달 처리 (legacy 전용 — 신규 contract는 spec 스킬이 commit)
   if [[ -n "$spec_path" ]]; then
+    if [[ $USE_FEAT_BRANCH -eq 1 ]]; then
+      die "--spec은 신규 contract에서 사용 불가합니다 (SPEC은 feat 브랜치에 commit됨).\n외부 SPEC을 도입하려면: Skill(skill: \"spec\", args: \"$task_id\")"
+    fi
     [[ -f "$spec_path" ]] || die "외부 SPEC 파일을 찾을 수 없음: $spec_path"
     mkdir -p "$LOOPS_DIR"
     cp "$spec_path" "$LOOPS_DIR/SPEC.md"
     echo "외부 SPEC 파일 복사: $spec_path → $LOOPS_DIR/SPEC.md"
   fi
 
-  # 2. SPEC.md 존재 확인 (milestones/<m>/loops/<c>/SPEC.md 단일 경로 — legacy fallback 없음)
-  local spec_path_local="$LOOPS_DIR/SPEC.md"
-  if [[ ! -f "$spec_path_local" ]]; then
-    die "SPEC.md가 없습니다 (기대 경로: $spec_path_local).\n먼저 실행하세요: Skill(skill: \"spec\", args: \"$task_id\")"
+  # 2. SPEC.md 존재 확인 — 신규/legacy 분기
+  local spec_path_local=""
+  local spec_tmp_file=""
+  if [[ $USE_FEAT_BRANCH -eq 1 ]]; then
+    # 신규 contract: SPEC은 feat 브랜치에 committed. 검증용 임시 추출.
+    if ! git -C "$PROJECT_ROOT" cat-file -e "$BRANCH:$spec_rel_path" 2>/dev/null; then
+      die "feat 브랜치 '$BRANCH'가 존재하나 SPEC.md를 포함하지 않음 (기대 경로: $spec_rel_path).\nspec 스킬을 다시 실행하세요: Skill(skill: \"spec\", args: \"$task_id\")"
+    fi
+    spec_tmp_file=$(mktemp)
+    if ! git -C "$PROJECT_ROOT" show "$BRANCH:$spec_rel_path" > "$spec_tmp_file" 2>/dev/null; then
+      rm -f "$spec_tmp_file"
+      die "feat 브랜치 '$BRANCH'에서 SPEC.md 추출 실패"
+    fi
+    spec_path_local="$spec_tmp_file"
+  else
+    # legacy: milestones/<m>/loops/<c>/SPEC.md (main 작업트리)
+    spec_path_local="$LOOPS_DIR/SPEC.md"
+    if [[ ! -f "$spec_path_local" ]]; then
+      die "SPEC.md가 없습니다 (기대 경로: $spec_path_local).\n먼저 실행하세요: Skill(skill: \"spec\", args: \"$task_id\")"
+    fi
   fi
 
   # 2.5. [NEEDS CLARIFICATION] 마커 검사 (락 획득 전)
   if grep -q '\[NEEDS CLARIFICATION' "$spec_path_local"; then
+    [[ -n "$spec_tmp_file" ]] && rm -f "$spec_tmp_file"
     die "SPEC.md에 미해결 [NEEDS CLARIFICATION] 마커가 있습니다.\n해결: Skill(skill: \"spec\", args: \"$task_id --resume\")"
   fi
 
@@ -638,6 +708,7 @@ cmd_start() {
   local placeholders
   placeholders=$(grep -oE '\{\{[^}]+\}\}' "$spec_path_local" 2>/dev/null || true)
   if [[ -n "$placeholders" ]]; then
+    [[ -n "$spec_tmp_file" ]] && rm -f "$spec_tmp_file"
     die "채워지지 않은 placeholder가 있습니다: $(echo "$placeholders" | tr '\n' ' ')\n$spec_path_local 를 편집하세요."
   fi
 
@@ -649,8 +720,12 @@ cmd_start() {
     p
   }' "$spec_path_local" 2>/dev/null | yq '.scope.include | length' 2>/dev/null)
   if [[ "${include_count:-0}" -eq 0 ]]; then
+    [[ -n "$spec_tmp_file" ]] && rm -f "$spec_tmp_file"
     die "SPEC.md의 scope.include가 비어 있습니다. 최소 한 패턴 명시 필요 (예: 'src/**'·'**/*')"
   fi
+
+  # 검증 끝 — 임시 SPEC 파일 정리 (신규 contract만)
+  [[ -n "$spec_tmp_file" ]] && rm -f "$spec_tmp_file"
 
   # 5. 락 획득
   acquire_lock
@@ -660,8 +735,15 @@ cmd_start() {
     echo "[$(now_iso)] 워크트리 생성 시작: $WT"
 
     mkdir -p "$WT_BASE"
-    git -C "$PROJECT_ROOT" worktree add "$WT" -b "$BRANCH" \
-      || die "git worktree add 실패: $WT"
+    if [[ $USE_FEAT_BRANCH -eq 1 ]]; then
+      # 신규 contract: 기존 feat 브랜치를 직접 체크아웃 (autonomous-loop 분기 폐지)
+      git -C "$PROJECT_ROOT" worktree add "$WT" "$BRANCH" \
+        || die "git worktree add 실패: $WT (feat 브랜치 '$BRANCH' 다른 워크트리에 묶여 있을 수 있음)"
+    else
+      # legacy: HEAD에서 autonomous-loop/<task-id> 새 브랜치 생성
+      git -C "$PROJECT_ROOT" worktree add "$WT" -b "$BRANCH" \
+        || die "git worktree add 실패: $WT"
+    fi
 
     # 헌법을 워크트리 CLAUDE.md로 복사
     cp "$SCRIPT_DIR/constitution.md" "$WT/CLAUDE.md" \
@@ -669,7 +751,16 @@ cmd_start() {
 
     # 메타 파일 시드
     mkdir -p "$WT/.loop/iterations"
-    cp "$LOOPS_DIR/SPEC.md" "$WT/.loop/SPEC.md"
+    # 신규 contract: SPEC은 worktree HEAD에 이미 committed — .loop/SPEC.md cp 없음
+    if [[ $USE_FEAT_BRANCH -eq 0 ]]; then
+      cp "$LOOPS_DIR/SPEC.md" "$WT/.loop/SPEC.md"
+    else
+      # 신규 contract: worktree HEAD에 SPEC.md 부재 시 fail-fast
+      # (위에서 cat-file -e로 검증했지만 worktree 생성 후 재확인 — race·corruption 가드)
+      if [[ ! -f "$WT/$spec_rel_path" ]]; then
+        die "신규 contract 위반: worktree HEAD에 SPEC.md 부재 (기대 경로: $WT/$spec_rel_path)"
+      fi
+    fi
     cp "$SCRIPT_DIR/plan-template.md" "$WT/.loop/PLAN.md"
     cp "$SCRIPT_DIR/notes-template.md" "$WT/.loop/NOTES.md"
     cp "$SCRIPT_DIR/handoff-template.md" "$WT/.loop/HANDOFF.md"

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -1085,12 +1085,28 @@ cmd_cleanup() {
     die "task $task_id 에 DONE 신호가 없습니다.\n--force 없이 cleanup하려면 먼저 DONE 파일이 필요합니다: $0 cleanup $task_id --force"
   fi
 
-  # 4. 메타 파일 archive (milestones/<m>/loops/<c>/ 로 이동)
-  mkdir -p "$LOOPS_DIR"
-  for f in PLAN.md NOTES.md HANDOFF.md RUN_LOG.md ESCALATION.md; do
-    cp "$WT/.loop/$f" "$LOOPS_DIR/$f" 2>/dev/null || true
-  done
-  echo "메타 파일 보관: $LOOPS_DIR"
+  # M4: contract 모드 감지 — 워크트리 브랜치명이 feat/*이면 신규, 아니면 legacy.
+  # 신규 contract: feat 브랜치를 PR base로 보존, 메타 파일 archive cp 없음.
+  # legacy contract: autonomous-loop/<task-id> 브랜치 삭제 + 메타 파일 archive cp.
+  local wt_branch
+  wt_branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  local use_feat_branch=0
+  if [[ "$wt_branch" == feat/* ]]; then
+    use_feat_branch=1
+    # 워크트리 실제 브랜치를 우선 (compute_paths가 설정한 autonomous-loop/ 기본값 override)
+    BRANCH="$wt_branch"
+  fi
+
+  # 4. 메타 파일 archive — 신규 contract에선 생략 (worker 메모리는 worktree와 함께 폐기)
+  if [[ $use_feat_branch -eq 0 ]]; then
+    mkdir -p "$LOOPS_DIR"
+    for f in PLAN.md NOTES.md HANDOFF.md RUN_LOG.md ESCALATION.md; do
+      cp "$WT/.loop/$f" "$LOOPS_DIR/$f" 2>/dev/null || true
+    done
+    echo "메타 파일 보관: $LOOPS_DIR"
+  else
+    echo "신규 contract: 메타 파일 archive 생략 (worker 메모리는 worktree와 함께 폐기)"
+  fi
 
   # 5. 워크트리 제거
   local wt_remove_flags=""
@@ -1098,15 +1114,23 @@ cmd_cleanup() {
   git -C "$PROJECT_ROOT" worktree remove $wt_remove_flags "$WT" \
     || die "git worktree remove 실패. 수동 제거: git worktree remove --force $WT"
 
-  # 6. 브랜치 삭제
-  local branch_delete_flag="-d"
-  [[ $force -eq 1 ]] && branch_delete_flag="-D"
-  git -C "$PROJECT_ROOT" branch $branch_delete_flag "$BRANCH" 2>/dev/null \
-    || echo "WARN: 브랜치 삭제 실패 (이미 머지됐거나 없을 수 있음): $BRANCH"
+  # 6. 브랜치 삭제 — 신규 contract에선 생략 (feat 브랜치는 PR base로 보존)
+  if [[ $use_feat_branch -eq 0 ]]; then
+    local branch_delete_flag="-d"
+    [[ $force -eq 1 ]] && branch_delete_flag="-D"
+    git -C "$PROJECT_ROOT" branch $branch_delete_flag "$BRANCH" 2>/dev/null \
+      || echo "WARN: 브랜치 삭제 실패 (이미 머지됐거나 없을 수 있음): $BRANCH"
+  else
+    echo "신규 contract: feat 브랜치 보존 (PR base): $BRANCH"
+  fi
 
   echo ""
-  echo "정리 완료: $task_id"
-  echo "보관된 메타 파일: $LOOPS_DIR"
+  if [[ $use_feat_branch -eq 1 ]]; then
+    echo "정리 완료: $task_id (신규 contract — feat 브랜치 $BRANCH 보존)"
+  else
+    echo "정리 완료: $task_id"
+    echo "보관된 메타 파일: $LOOPS_DIR"
+  fi
 }
 
 # ----- subcommand: logs -----

--- a/plugins/autopilot/skills/loop/references/operational-guide.md
+++ b/plugins/autopilot/skills/loop/references/operational-guide.md
@@ -116,7 +116,9 @@ bash "$LOOP_SH" logs auth-refactor [--tail | --iter N]
 ```bash
 cat ../<project>-loops/<task-id>/.loop/ESCALATION.md  # 사유 확인
 cd ../<project>-loops/<task-id>
-$EDITOR .loop/SPEC.md && $EDITOR .loop/NOTES.md        # 명세·학습 조정
+# 신규 contract: $EDITOR milestones/<m>/loops/<c>/SPEC.md (워크트리에서 commit)
+# legacy:        $EDITOR .loop/SPEC.md
+$EDITOR .loop/NOTES.md                                 # 학습 조정
 rm .loop/ESCALATION.md                                 # 보고 해제
 cd <project> && bash "$LOOP_SH" start <task-id>        # 재시작
 # --watch 모드면 ESCALATION.md 정리만으로 자동 재개 (60초 polling)

--- a/plugins/autopilot/skills/loop/references/troubleshooting.md
+++ b/plugins/autopilot/skills/loop/references/troubleshooting.md
@@ -18,7 +18,7 @@ ESCALATION.md의 `**카테고리**` 필드 별 사람의 처리 권장 흐름.
 
 처리:
 1. ESCALATION.md의 "필요한 결정" 섹션 검토
-2. `<worktree>/.loop/SPEC.md` 직접 수정 (prepare 서브커맨드는 deprecated이며 SPEC 작성은 spec 스킬 사용: Skill(skill: "spec", args: "<task-id>"))
+2. 워크트리의 SPEC.md 직접 수정 — 신규 contract: feat 브랜치의 `<worktree>/milestones/<m>/loops/<c>/SPEC.md` (워크트리 안에서 편집 후 commit); legacy: `<worktree>/.loop/SPEC.md`. SPEC 신규 작성은 spec 스킬 사용: Skill(skill: "spec", args: "<task-id>")
 3. ESCALATION.md 정리 후 재시작
 
 ## architecture-gap (코드 구조 변경 필요)

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
 description: "autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. 호출 'Skill(skill=\"spec\", args=\"<task-id> [--milestone <m>] [--resume]\")'. milestone 미지정 시 `regular`(catch-all)을 default로 적용."
-allowed-tools: AskUserQuestion, Read, Write, Bash(git log:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(gh issue view:*)
+allowed-tools: AskUserQuestion, Read, Write, Bash(git log:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git for-each-ref:*), Bash(git worktree:*), Bash(git add:*), Bash(git commit:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(sed:*), Bash(gh issue view:*), Bash(bash:*), Bash(mktemp:*), Bash(cp:*), Bash(rm:*)
 ---
 
 # spec
@@ -17,9 +17,9 @@ milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `a
 
 또는 사용자가 자연어로 의도 전달 시 모델이 자동 호출.
 
-## 9단계 워크플로
+## 10단계 워크플로
 
-호출 시 다음 9단계를 TodoWrite로 등록·실행. 각 단계는 사용자 결정·승인을 `AskUserQuestion`으로 받습니다.
+호출 시 다음 10단계를 TodoWrite로 등록·실행. 각 단계는 사용자 결정·승인을 `AskUserQuestion`으로 받으며, 단계 10(자동 finalize)만 단계 9 승인 직후 자동 실행됩니다.
 
 ### 1. 사전 검사
 
@@ -106,16 +106,51 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 ### 9. 사용자 최종 검토
 
 SPEC.md 경로·요약 안내 + `AskUserQuestion`으로 검토 결과 수집:
-- 승인: 다음 단계 안내 출력 — *"SPEC 완성: milestones/<m>/loops/<c>/SPEC.md\n다음 단계: Skill(skill: \"loop\", args: \"start <m>/<c>\")"* (milestone이 default `regular`이면 `start <c>` 단축형도 동등 — loop.sh가 자동 정규화)
+- 승인: 단계 10(자동 finalize)으로 진행 — 사용자 추가 입력 없이 즉시 feat 브랜치 분기·SPEC commit 실행.
 - 변경: 어느 섹션을 변경할지 묻고 단계 6/7 재진입
+
+### 10. 자동 finalize — feat branch 분기 + SPEC commit
+
+단계 9에서 사용자가 "승인"한 직후 자동 실행. 사용자 입력 없음.
+
+**목표**: SPEC.md를 main에서 분기하는 `feat/<task-id>-<slug>` 브랜치에 commit해 `loop start`가 워크트리에 SPEC을 자연 포함한 채 시작할 수 있게 한다. main 작업트리는 변경 전후 동일 (단계 7에서 작성된 untracked SPEC.md 그대로 보존).
+
+#### 절차
+
+1. **브랜치 이름 도출** (M1의 slugify 헬퍼 사용):
+   - `title=$(grep -m1 '^# ' milestones/<m>/loops/<c>/SPEC.md | sed 's/^# *//')`
+   - `feat_branch=$(bash plugins/autopilot/skills/spec/references/slugify.sh "<m>/<c>" "$title")`
+   - 출력: `feat/<m>/<c>-<slug>` 또는 fallback `feat/<m>/<c>` (slug 빈 경우). milestone이 default `regular`이면 task-id는 `regular/<c>` 형식.
+2. **기존 브랜치 충돌 검사**:
+   - `git for-each-ref --format='%(refname:short)' "refs/heads/$feat_branch"`이 비어있지 않으면 abort + `AskUserQuestion`으로 처리 선택 (수동 정리 후 재호출 / task-id 변경). 자동 덮어쓰기 금지.
+3. **임시 워크트리 생성** (main 격리):
+   - `tmp_wt=$(mktemp -d)`
+   - `git worktree add "$tmp_wt" -b "$feat_branch" main` — main에서 분기하는 격리된 워크트리. main 작업트리는 그대로.
+4. **SPEC.md를 임시 워크트리로 cp + commit**:
+   - `mkdir -p "$tmp_wt/milestones/<m>/loops/<c>"`
+   - `cp "milestones/<m>/loops/<c>/SPEC.md" "$tmp_wt/milestones/<m>/loops/<c>/SPEC.md"`
+   - `git -C "$tmp_wt" add "milestones/<m>/loops/<c>/SPEC.md"`
+   - `git -C "$tmp_wt" commit -m "spec(<m>/<c>): SPEC.md 초안"`
+5. **임시 워크트리 제거** — feat 브랜치는 main repo에 잔존:
+   - `git worktree remove "$tmp_wt"` (실패 시 `--force`)
+   - `rm -rf "$tmp_wt"` (mktemp 잔존물 정리)
+6. **사용자 안내**:
+   - *"SPEC commit됨: `$feat_branch`. main 작업트리의 SPEC.md는 untracked로 보존됩니다 (필요 시 `git clean -f milestones/<m>/loops/<c>/SPEC.md`로 정리).\n다음 단계: Skill(skill: \"loop\", args: \"start <m>/<c>\")"* (milestone이 default `regular`이면 `start <c>` 단축형도 동등 — loop.sh가 자동 정규화)
+
+#### 제약
+
+- 단계 10의 git 동작은 모두 임시 워크트리(`mktemp -d`)에서 일어난다. main 작업트리의 staged/unstaged/untracked 상태는 단계 10 시작·종료 시점 동일해야 한다.
+- 슬러그화 결정성: 같은 SPEC §1 제목은 항상 같은 `feat_branch` 이름을 만든다 (`references/slugify.sh`).
+- 단계 10 실패(branch 충돌·worktree add 실패 등) 시 명확한 에러 메시지로 abort하고 임시 워크트리·브랜치 잔존물을 정리. 부분 실패 상태로 종료하지 않는다.
 
 ## --resume 모드 요약
 
-위 9단계 중:
+위 10단계 중:
 - 1: 마커 0개 시 즉시 종료
 - 3: 생략 (이미 SPEC 존재)
 - 4, 5: 마커 위치 기준으로 좁힘
 - 6: 마커 박힌 섹션만
+- 10: feat 브랜치가 이미 존재할 수 있음 — 충돌 검사 단계에서 사용자에게 처리 선택 (브랜치 덮어쓰기는 자동 금지; 신규 SPEC commit을 기존 브랜치 위에 추가하려면 사용자가 명시적으로 결정)
 - 나머지 동일
 
 ## 모듈 구성 (references/)

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
 description: "autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. 호출 'Skill(skill=\"spec\", args=\"<task-id> [--milestone <m>] [--resume]\")'. milestone 미지정 시 `regular`(catch-all)을 default로 적용."
-allowed-tools: AskUserQuestion, Read, Write, Bash(git log:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*)
+allowed-tools: AskUserQuestion, Read, Write, Bash(git log:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(gh issue view:*)
 ---
 
 # spec

--- a/plugins/autopilot/skills/spec/references/slugify.sh
+++ b/plugins/autopilot/skills/spec/references/slugify.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# slugify.sh — SPEC §1 제목과 task-id에서 결정적으로 feat 브랜치 이름을 도출.
+#
+# 사용:
+#   bash slugify.sh <task-id> <title>
+#
+# 출력:
+#   feat/<task-id>-<slug>          (slug 유효한 경우)
+#   feat/<task-id>                  (slug 결과가 비어 fallback)
+#
+# 슬러그 규칙 (결정적, deterministic):
+#   1) [^A-Za-z0-9-]를 모두 '-'로 치환
+#   2) 연속된 '-'를 단일 '-'로 압축
+#   3) 양끝 '-' 제거
+#   4) 소문자화
+#   5) 빈 결과면 fallback (slug 없이 task-id 단독)
+#
+# 호출자: plugins/autopilot/skills/spec/SKILL.md 단계 9 (SPEC 최종 승인 직후).
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "ERROR: 사용: $0 <task-id> [<title>]" >&2
+  exit 1
+fi
+
+task_id="$1"
+title="${2:-}"
+
+# 슬러그화. macOS BSD·Linux GNU 양쪽 동작하는 POSIX tr/sed만 사용.
+# tr -c '[set]' '-': [set] 밖 모든 바이트를 '-'로 치환 (개행 포함 — 안전)
+# tr -s '-':         연속된 '-'를 하나로 squeeze
+# sed strip:         양끝 '-' 제거
+# tr lowercase:      ASCII 영문 대→소 변환
+slug=$(printf '%s' "$title" \
+  | tr -c 'A-Za-z0-9-' '-' \
+  | tr -s '-' \
+  | sed 's/^-//; s/-$//' \
+  | tr 'A-Z' 'a-z')
+
+if [[ -z "$slug" ]]; then
+  printf 'feat/%s\n' "$task_id"
+else
+  printf 'feat/%s-%s\n' "$task_id" "$slug"
+fi

--- a/tests/autopilot/test-loop-sh.sh
+++ b/tests/autopilot/test-loop-sh.sh
@@ -2228,5 +2228,55 @@ echo "$output62" | grep -qE "SPEC.md|feat|brand" \
 git -C "$PROJECT" branch -D "feat/regular/$NEW62_TASK" >/dev/null 2>&1 || true
 echo "OK"
 
+echo "=== TEST 63: 신규 contract — cleanup이 archive cp 없이 워크트리만 제거 + feat 브랜치 보존 ==="
+# 신규 contract cleanup 동작 (M4):
+#   - 메타 파일(PLAN/NOTES/HANDOFF/RUN_LOG/ESCALATION)을 main 작업트리로 cp하지 않음
+#   - feat/<task-id>-<slug> 브랜치는 PR base로 main repo에 보존
+#   - 워크트리만 제거
+# legacy contract cleanup(archive cp + branch delete)은 TEST 8·15에서 회귀 보호.
+NEW63_TASK="new-contract-cleanup"
+NEW63_TITLE="New Contract Cleanup"
+NEW63_SPEC_TMP="$WORK_DIR/new-contract-cleanup-spec.md"
+cat > "$NEW63_SPEC_TMP" <<'EOF'
+---
+scope:
+  include:
+    - "**/*"
+  exclude: []
+verify: 'true'
+---
+
+# New Contract Cleanup
+
+## 무엇을 만들 것인가
+신규 contract cleanup 동작 검증.
+EOF
+
+feat63_branch=$(seed_feat_branch_with_spec "regular/$NEW63_TASK" "$NEW63_TITLE" "$NEW63_SPEC_TMP")
+[[ -n "$feat63_branch" ]] || { echo "FAIL: TEST63 seed 실패"; exit 1; }
+
+MAX_ITERATIONS=2 WALL_CLOCK_MINUTES=5 loop start "$NEW63_TASK"
+WT63="$WORK_DIR/myproject-loops/regular/$NEW63_TASK"
+[[ -d "$WT63" ]] || { echo "FAIL: 워크트리 미생성"; exit 1; }
+[[ -f "$WT63/DONE" ]] || { echo "FAIL: mock claude가 DONE을 만들었어야 함"; exit 1; }
+
+# cleanup — `.loop/` 등 untracked 파일은 git이 보호하므로 --force 사용 (TEST 61 동일 패턴)
+loop cleanup "$NEW63_TASK" --force
+
+# (a) 워크트리 제거됨
+[[ ! -d "$WT63" ]] || { echo "FAIL: cleanup 후 워크트리 잔존"; exit 1; }
+# (b) feat 브랜치 보존됨 (PR base로 남김)
+preserved=$(git -C "$PROJECT" branch --list "$feat63_branch" | sed 's/^[ *]*//')
+[[ "$preserved" == "$feat63_branch" ]] \
+  || { echo "FAIL: cleanup 후 feat 브랜치가 사라짐 — 신규 contract는 PR base로 남겨야. expected '$feat63_branch' got '$preserved'"; exit 1; }
+# (c) main worktree에 archive 메타 파일 cp 없음
+ARCHIVE63="$PROJECT/milestones/regular/loops/$NEW63_TASK"
+[[ ! -f "$ARCHIVE63/PLAN.md" ]] \
+  || { echo "FAIL: archive PLAN.md 생성됨 — 신규 contract는 메타 archive 하지 않아야"; exit 1; }
+[[ ! -f "$ARCHIVE63/NOTES.md" ]] || { echo "FAIL: archive NOTES.md 생성됨"; exit 1; }
+[[ ! -f "$ARCHIVE63/HANDOFF.md" ]] || { echo "FAIL: archive HANDOFF.md 생성됨"; exit 1; }
+[[ ! -f "$ARCHIVE63/RUN_LOG.md" ]] || { echo "FAIL: archive RUN_LOG.md 생성됨"; exit 1; }
+echo "OK"
+
 echo ""
 echo "=== 모든 테스트 통과 ==="

--- a/tests/autopilot/test-loop-sh.sh
+++ b/tests/autopilot/test-loop-sh.sh
@@ -58,6 +58,31 @@ loop() {
   bash "$LOOP_SH_SRC" "$@"
 }
 
+# 신규 contract 시드 헬퍼 (M3): spec 스킬이 finalize 단계에서 수행할 동작을 테스트에서
+# 모사. main에서 임시 워크트리로 분기해 feat/<task-id>-<slug> 브랜치에
+# milestones/<m>/loops/<c>/SPEC.md를 commit한 후 임시 워크트리를 제거.
+# 인자: $1=task_id (정규화된 milestone/child), $2=title (slugify 입력), $3=SPEC.md 원본 경로.
+# 출력: stdout에 생성된 feat branch 이름 (호출자 검증용).
+seed_feat_branch_with_spec() {
+  local task_id="$1" title="$2" spec_src="$3"
+  [[ -f "$spec_src" ]] || { echo "FAIL: seed_feat_branch_with_spec: SPEC source 부재: $spec_src" >&2; return 1; }
+  local milestone="${task_id%%/*}"
+  local child="${task_id#*/}"
+  local branch
+  branch=$(bash "$REPO_ROOT/plugins/autopilot/skills/spec/references/slugify.sh" "$task_id" "$title")
+  local tmp_wt="$WORK_DIR/seed-wt-$$-$RANDOM"
+  git -C "$PROJECT" worktree add -q -b "$branch" "$tmp_wt" HEAD >/dev/null
+  mkdir -p "$tmp_wt/milestones/$milestone/loops/$child"
+  cp "$spec_src" "$tmp_wt/milestones/$milestone/loops/$child/SPEC.md"
+  (
+    cd "$tmp_wt"
+    git add "milestones/$milestone/loops/$child/SPEC.md"
+    git commit -q -m "feat($task_id): SPEC.md"
+  )
+  git -C "$PROJECT" worktree remove "$tmp_wt" >/dev/null
+  echo "$branch"
+}
+
 echo "=== TEST 1: prepare는 spec 스킬로 안내하는 스텁 ==="
 set +e
 output=$(loop prepare test-task-1 2>&1)
@@ -2129,6 +2154,78 @@ echo "=== TEST 60: slugify — task-id만 인자, 제목 부재 → fallback ===
 result=$(bash "$SLUGIFY" "regular/x" "")
 [[ "$result" == "feat/regular/x" ]] \
   || { echo "FAIL: empty title. expected 'feat/regular/x' got '$result'"; exit 1; }
+echo "OK"
+
+echo "=== TEST 61: 신규 contract — feat branch 기반 워크트리 + .loop/SPEC.md cp 부재 ==="
+# spec 스킬(M2)이 SPEC commit + feat branch 생성 → 그 후 loop start는 feat 브랜치를
+# 직접 체크아웃해 워크트리를 만든다. .loop/SPEC.md 복사는 발생하지 않으며 SPEC은
+# milestones/<m>/loops/<c>/SPEC.md (committed in worktree)에서 읽힌다.
+NEW_TASK="new-contract-task"
+NEW_TITLE="New Contract Task"
+NEW_SPEC_TMP="$WORK_DIR/new-contract-spec.md"
+cat > "$NEW_SPEC_TMP" <<'EOF'
+---
+scope:
+  include:
+    - "**/*"
+  exclude: []
+verify: 'true'
+---
+
+# New Contract Task
+
+## 무엇을 만들 것인가
+신규 contract 시드 테스트.
+EOF
+
+feat_branch=$(seed_feat_branch_with_spec "regular/$NEW_TASK" "$NEW_TITLE" "$NEW_SPEC_TMP")
+[[ -n "$feat_branch" ]] || { echo "FAIL: seed가 feat branch 이름을 반환 안 함"; exit 1; }
+
+# main 작업트리 상태가 변경되면 안 됨
+main_status=$(cd "$PROJECT" && git status --porcelain | wc -l | tr -d ' ')
+# Note: this just checks the seed itself didn't dirty main; test isolation depends on this.
+
+MAX_ITERATIONS=2 WALL_CLOCK_MINUTES=5 loop start "$NEW_TASK"
+WT_NEW="$WORK_DIR/myproject-loops/regular/$NEW_TASK"
+[[ -d "$WT_NEW" ]] || { echo "FAIL: 워크트리 미생성"; exit 1; }
+# 신규 contract: SPEC이 committed path에 존재
+[[ -f "$WT_NEW/milestones/regular/loops/$NEW_TASK/SPEC.md" ]] \
+  || { echo "FAIL: committed SPEC 부재 — feat branch 체크아웃이 SPEC을 포함해야"; exit 1; }
+# 신규 contract: .loop/SPEC.md 추가 복사 없음
+[[ ! -f "$WT_NEW/.loop/SPEC.md" ]] \
+  || { echo "FAIL: 신규 contract에선 .loop/SPEC.md cp가 없어야 — got: $(ls -la "$WT_NEW/.loop/SPEC.md")"; exit 1; }
+# 워크트리 브랜치는 feat/*
+wt_branch=$(git -C "$WT_NEW" rev-parse --abbrev-ref HEAD 2>/dev/null)
+[[ "$wt_branch" == feat/* ]] \
+  || { echo "FAIL: worktree branch '$wt_branch' is not feat/* (신규 contract는 feat 직접 체크아웃)"; exit 1; }
+# 신규 contract: autonomous-loop/* 브랜치는 생성되지 않아야
+auto_branch=$(git -C "$PROJECT" branch --list "autonomous-loop/regular/$NEW_TASK" | tr -d ' ')
+[[ -z "$auto_branch" ]] \
+  || { echo "FAIL: autonomous-loop/regular/$NEW_TASK 브랜치가 생성됨 — 신규 contract 폐지된 동작"; exit 1; }
+# 이터 1회 로그가 정상 기록됐는지
+[[ -f "$WT_NEW/.loop/iterations/1.log" ]] || { echo "FAIL: 이터 로그 미생성"; exit 1; }
+loop cleanup "$NEW_TASK" --force >/dev/null 2>&1
+echo "OK"
+
+echo "=== TEST 62: 신규 contract — feat branch 부재 + SPEC.md committed 미존재 시 fail-fast ==="
+# milestones/<m>/loops/<c>/SPEC.md가 untracked로만 존재하고 feat 브랜치가 없으면
+# 기존(legacy) 경로로 가도록 dual-mode 유지. 이 테스트는 그 dual-mode를 확인.
+# - feat 브랜치 있는데 worktree HEAD에 SPEC commit 부재 → fail-fast (신규 contract 위반)
+NEW62_TASK="new-contract-no-spec"
+# feat branch만 만들고 SPEC commit은 하지 않음 (M2 finalize 실패 시뮬레이션)
+git -C "$PROJECT" branch "feat/regular/$NEW62_TASK" HEAD
+# Untracked SPEC을 main에는 두지 않음 → cmd_start placeholder/needs-clar 검사 통과 못함 전에 fail
+# 단, cmd_start는 SPEC.md 존재 검사를 먼저 함. 신규 contract에선 worktree HEAD의 SPEC을 본다.
+set +e
+output62=$(MAX_ITERATIONS=1 WALL_CLOCK_MINUTES=5 loop start "$NEW62_TASK" 2>&1)
+result62=$?
+set -e
+[[ $result62 -ne 0 ]] \
+  || { echo "FAIL: feat 브랜치만 있고 SPEC commit 부재인데 start가 성공함"; echo "$output62"; exit 1; }
+echo "$output62" | grep -qE "SPEC.md|feat|brand" \
+  || { echo "FAIL: actionable 메시지 부재. got: $output62"; exit 1; }
+# 브랜치 정리
+git -C "$PROJECT" branch -D "feat/regular/$NEW62_TASK" >/dev/null 2>&1 || true
 echo "OK"
 
 echo ""

--- a/tests/autopilot/test-loop-sh.sh
+++ b/tests/autopilot/test-loop-sh.sh
@@ -2087,5 +2087,49 @@ echo "$output54" | grep -q "이터 상한 도달" \
 loop cleanup "$TEST54_TASK" --force > /dev/null 2>&1 || true
 echo "OK"
 
+echo "=== TEST 55: slugify helper — ASCII 정상 케이스 ==="
+# spec 스킬이 SPEC.md 최종 승인 후 호출하는 결정적 branch name 도출.
+# 입력: <task-id> <title>. 출력: feat/<task-id>-<slug> (또는 fallback feat/<task-id>).
+# 슬러그 규칙: [^A-Za-z0-9-] 제거 → 연속 하이픈 압축 → 양끝 하이픈 제거 → 소문자화.
+SLUGIFY="$REPO_ROOT/plugins/autopilot/skills/spec/references/slugify.sh"
+[[ -x "$SLUGIFY" ]] || { echo "FAIL: slugify.sh 부재 또는 실행 권한 없음: $SLUGIFY"; exit 1; }
+result=$(bash "$SLUGIFY" "regular/foo" "Test SPEC Title")
+[[ "$result" == "feat/regular/foo-test-spec-title" ]] \
+  || { echo "FAIL: ASCII slug. expected 'feat/regular/foo-test-spec-title' got '$result'"; exit 1; }
+echo "OK"
+
+echo "=== TEST 56: slugify — 비-ASCII 빈 슬러그 → task-id fallback ==="
+# 한국어 등 비-ASCII 문자만 있는 제목은 슬러그 결과가 비어 fallback 발동.
+result=$(bash "$SLUGIFY" "regular/foo" "한국어 제목")
+[[ "$result" == "feat/regular/foo" ]] \
+  || { echo "FAIL: fallback. expected 'feat/regular/foo' got '$result'"; exit 1; }
+echo "OK"
+
+echo "=== TEST 57: slugify — 특수문자 연속 → 하이픈 압축 + 양끝 trim ==="
+result=$(bash "$SLUGIFY" "regular/x" "!!Hello!!!  World??")
+[[ "$result" == "feat/regular/x-hello-world" ]] \
+  || { echo "FAIL: compress/trim. expected 'feat/regular/x-hello-world' got '$result'"; exit 1; }
+echo "OK"
+
+echo "=== TEST 58: slugify — 결정성 (동일 입력 → 동일 출력) ==="
+r1=$(bash "$SLUGIFY" "regular/x" "Deterministic Title")
+r2=$(bash "$SLUGIFY" "regular/x" "Deterministic Title")
+[[ "$r1" == "$r2" ]] && [[ -n "$r1" ]] \
+  || { echo "FAIL: not deterministic. r1='$r1' r2='$r2'"; exit 1; }
+echo "OK"
+
+echo "=== TEST 59: slugify — 명시적 milestone/child task-id (slashes preserved) ==="
+result=$(bash "$SLUGIFY" "m1/c1" "Foo Bar Baz")
+[[ "$result" == "feat/m1/c1-foo-bar-baz" ]] \
+  || { echo "FAIL: m1/c1. expected 'feat/m1/c1-foo-bar-baz' got '$result'"; exit 1; }
+echo "OK"
+
+echo "=== TEST 60: slugify — task-id만 인자, 제목 부재 → fallback ==="
+# 빈 제목 또는 한 인자 케이스도 fallback해야 함 (방어적 동작)
+result=$(bash "$SLUGIFY" "regular/x" "")
+[[ "$result" == "feat/regular/x" ]] \
+  || { echo "FAIL: empty title. expected 'feat/regular/x' got '$result'"; exit 1; }
+echo "OK"
+
 echo ""
 echo "=== 모든 테스트 통과 ==="

--- a/tests/autopilot/test-skill-install.sh
+++ b/tests/autopilot/test-skill-install.sh
@@ -97,6 +97,32 @@ grep -q -- '--resume' "$SPEC_SKILL_MD" \
 echo "OK: --resume 마커"
 
 echo ""
+echo "=== spec/SKILL.md M2 finalize 자동 branch+commit 명세 검증 ==="
+# spec 스킬 단계 9(또는 그 이후)에 SPEC 최종 승인 직후 main에서 feat 브랜치를 분기하고
+# SPEC.md를 commit하는 finalize 자동화가 명시돼야 한다 (M2). M1의 slugify.sh를 호출하고
+# 임시 워크트리에서 git 동작이 일어나 main 작업트리는 변경되지 않아야 한다.
+grep -q 'allowed-tools' "$SPEC_SKILL_MD" \
+  || { echo "FAIL: spec/SKILL.md frontmatter에 'allowed-tools' 키 없음"; exit 1; }
+SPEC_ALLOWED=$(grep '^allowed-tools:' "$SPEC_SKILL_MD")
+for tool in 'git worktree' 'git add' 'git commit'; do
+  echo "$SPEC_ALLOWED" | grep -qF "$tool" \
+    || { echo "FAIL: spec/SKILL.md allowed-tools에 '$tool' 권한 누락 (M2 finalize)"; exit 1; }
+  echo "OK: allowed-tools에 $tool"
+done
+grep -q 'slugify\.sh' "$SPEC_SKILL_MD" \
+  || { echo "FAIL: spec/SKILL.md 본문이 references/slugify.sh를 호출하지 않음 (M2)"; exit 1; }
+echo "OK: 본문이 slugify.sh 호출"
+grep -q 'git worktree add' "$SPEC_SKILL_MD" \
+  || { echo "FAIL: spec/SKILL.md 본문에 'git worktree add' 단계 부재 (M2 임시 워크트리 finalize)"; exit 1; }
+echo "OK: 본문에 'git worktree add'"
+grep -q 'git worktree remove' "$SPEC_SKILL_MD" \
+  || { echo "FAIL: spec/SKILL.md 본문에 'git worktree remove' 정리 단계 부재 (M2)"; exit 1; }
+echo "OK: 본문에 'git worktree remove'"
+grep -qE 'feat/<(task-id|m)' "$SPEC_SKILL_MD" \
+  || { echo "FAIL: spec/SKILL.md 본문에 'feat/<task-id>...' 브랜치 이름 명세 부재 (M2)"; exit 1; }
+echo "OK: 본문에 feat/<task-id> 브랜치 명세"
+
+echo ""
 echo "=== prd 스킬 구조 검증 ==="
 PRD_SKILL_DIR="$REPO_ROOT/plugins/autopilot/skills/prd"
 for f in SKILL.md \


### PR DESCRIPTION
## Summary

autopilot의 SPEC·구현 라이프사이클을 task당 한 개의 feature branch로 통합하는 dual-mode contract 도입. spec 스킬이 자동 finalize 시 `feat/<task-id>-<slug>` 분기·SPEC commit, loop이 그 branch를 worktree base로 직접 체크아웃해 cp 단계 제거, cleanup이 archive 폐기로 main 워킹트리 오염 차단.

본 PR은 legacy contract하에 자율 loop(`regular/79`)이 진행해 누적된 5개 마일스톤 commit을 단일 feat 브랜치로 통합한 결과.

## 마일스톤별 변경

| commit | 마일스톤 | 내용 |
|---|---|---|
| `20f503c` | M1 | 결정적 슬러그 헬퍼 `slugify.sh` + RED→GREEN 단위 테스트 6개 |
| `da0529e` | M3 | `loop.sh`: feat branch base + dual-mode contract 감지(`find_feat_branch`·`cmd_start` 3-way 분기·fail-fast·`SPEC_PATH_IN_WT` 도입) + TEST 61/62 |
| `91b1bbe` | M4 | `cmd_cleanup` dual-mode: 신규 contract는 archive cp·branch delete 생략, legacy는 종전 동작 + TEST 63 |
| `0fd9b62` | M5 | 워커 docs SPEC.md 경로 dual-mode 갱신 9곳 (constitution·troubleshooting·operational-guide·agent-prompts·escalation-template) |
| `466f946` | M2 | `spec/SKILL.md` 단계 10 — feat branch 분기 + SPEC commit 자동화 + frontmatter `allowed-tools` 11종 추가 |

## 검증

- `bash tests/autopilot/test-loop-sh.sh` — TEST 1-63 PASS (신규 61·62·63 RED→GREEN, legacy 회귀 보호 확인)
- `bash tests/autopilot/test-skill-install.sh` — PASS (M2 finalize 명세 검증 블록 신규 추가)
- runtime 영향 없는 refactor(M5)와 명세 갱신(M2)은 RED 테스트 생략, frontmatter·grep 검증으로 대체

## 호환성

- 신규 task는 새 contract(feat branch worktree base, archive 폐기)로 작동
- 기존 in-flight loop(legacy `.loop/SPEC.md` 흐름)은 변경 없음 — `cmd_start`·`cmd_cleanup`이 워크트리 브랜치명으로 모드 감지

## Test plan

- [x] test-loop-sh.sh 63 케이스 자동 PASS
- [x] test-skill-install.sh PASS
- [ ] (사용자) 머지 후 다음 신규 task가 새 contract로 자동 분기되는지 확인
- [ ] (사용자) 진행 중 legacy loop이 영향 받지 않는지 확인

Closes #79