### PR TITLE
feat(autopilot/spec): EARS 작성 언어 default(ko) + ears_language frontmatter override (#78)

### DIFF
--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -126,6 +126,14 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 
 승인 안 받은 섹션은 다시 제시·수정. 한 번에 통째로 보여주지 않음.
 
+**EARS 작성 언어 해석 (`ears_language` frontmatter override).** 수용 기준(섹션 3) 산출
+시점에 SPEC frontmatter의 `ears_language` 키를 읽어 디폴트와 override를 일관 적용한다:
+- 값이 `en`·`ko`·`hybrid` 중 하나면 그 모드로 AC를 산출한다.
+- 키가 미명시이면 **디폴트 `ko`**(프로젝트 기본 언어)로 산출한다.
+- 사용자에게 작성 언어를 다시 묻지 않는다 — frontmatter 값 또는 default만으로 결정.
+- 3모드 형식 정의·5패턴 예시·자유 텍스트→EARS 변환 규칙은 `references/ears-patterns.md`의
+  "EARS 작성 언어" 절을 단일 출처(single source of truth)로 사용한다.
+
 `--resume` 모드: 마커가 박힌 섹션만.
 
 ### 7. SPEC.md 작성

--- a/plugins/autopilot/skills/spec/references/ears-patterns.md
+++ b/plugins/autopilot/skills/spec/references/ears-patterns.md
@@ -16,7 +16,9 @@ SPEC frontmatter `ears_language` 키로 개별 SPEC이 default를 override할 �
 - `en` — 본문·키워드 모두 영어. 표준 EARS 영어 키워드(`When` · `While` · `Where` · `If` · `shall`).
   예: "When a user submits an empty password, the system shall reject the request with a 400 status."
 - `hybrid` — EARS 영어 키워드(`When` · `While` · `Where` · `If` · `shall`)는 그대로 두고 본문만
-  한국어로 작성. 형식 정의: `<EARS 영어 키워드> <한국어 본문>, the system shall <한국어 응답>한다.`
+  한국어로 작성. 형식 정의:
+  - 트리거·조건·오류가 있는 패턴(Event/State/Optional/Unwanted): `<EARS 영어 키워드> <한국어 본문>, the system shall <한국어 응답>한다.`
+  - Ubiquitous(트리거 없음): `The system shall <한국어 응답>한다.`
   예시 라인: When 사용자가 빈 비밀번호를 제출하면, the system shall 400으로 요청을 거부한다.
 
 자유 텍스트→EARS 변환 시에도 동일 언어 규칙이 적용된다(아래 §변환 가이드).

--- a/plugins/autopilot/skills/spec/references/ears-patterns.md
+++ b/plugins/autopilot/skills/spec/references/ears-patterns.md
@@ -2,52 +2,93 @@
 
 EARS = Easy Approach to Requirements Syntax. 5개 패턴으로 모호성 없는 수용 기준을 작성.
 
+## EARS 작성 언어
+
+EARS 5패턴의 의미·구조(Mavin et al. 표준)는 언어와 무관하게 보존하되, 어휘만 작성 언어에
+맞춰 번역한다. **작성 언어 default는 프로젝트 기본 언어**다 — 현 레포의 경우 한국어(`ko`).
+
+SPEC frontmatter `ears_language` 키로 개별 SPEC이 default를 override할 수 있다. 허용 값은
+`ko` · `en` · `hybrid` 세 가지이며, 키 미명시 시 디폴트는 `ko`(프로젝트 기본 언어)다.
+
+3모드 정의:
+- `ko` — 본문·키워드 모두 한국어. 트리거는 "~할 때 / ~인 동안 / ~인 경우 / ~이면", 응답은
+  "시스템은 ~한다" 형태. 예: "사용자가 빈 비밀번호를 제출할 때, 시스템은 400으로 요청을 거부한다."
+- `en` — 본문·키워드 모두 영어. 표준 EARS 영어 키워드(`When` · `While` · `Where` · `If` · `shall`).
+  예: "When a user submits an empty password, the system shall reject the request with a 400 status."
+- `hybrid` — EARS 영어 키워드(`When` · `While` · `Where` · `If` · `shall`)는 그대로 두고 본문만
+  한국어로 작성. 형식 정의: `<EARS 영어 키워드> <한국어 본문>, the system shall <한국어 응답>한다.`
+  예시 라인: When 사용자가 빈 비밀번호를 제출하면, the system shall 400으로 요청을 거부한다.
+
+자유 텍스트→EARS 변환 시에도 동일 언어 규칙이 적용된다(아래 §변환 가이드).
+
 ## 5개 패턴
 
+각 패턴의 의미·구조는 모드 간 동일. 예시는 ko · en · hybrid 3모드를 함께 제시.
+
 ### 1. Ubiquitous (무조건)
-형식: `The system shall <응답>`
+형식:
+- en: `The system shall <응답>`
+- ko: `시스템은 <응답>한다`
+- hybrid: `The system shall <한국어 응답>한다`
 
 용례: 시스템의 *기본 행동*. 트리거나 조건 없이 항상 성립.
 
 예시:
-- The system shall log all authentication attempts.
-- The system shall expire idle sessions after 30 minutes.
+- (ko) 시스템은 모든 인증 시도를 로그에 기록한다.
+- (en) The system shall log all authentication attempts.
+- (hybrid) The system shall 모든 인증 시도를 로그에 기록한다.
 
 ### 2. Event-driven (이벤트 기반)
-형식: `When <트리거>, the system shall <응답>`
+형식:
+- en: `When <트리거>, the system shall <응답>`
+- ko: `<트리거>할 때, 시스템은 <응답>한다`
+- hybrid: `When <한국어 트리거>, the system shall <한국어 응답>한다`
 
 용례: 외부 입력·내부 이벤트로 촉발되는 행동.
 
 예시:
-- When a user submits an empty password, the system shall reject the request with a 400 status.
-- When the refresh token expires, the system shall invalidate the session.
+- (ko) 사용자가 빈 비밀번호를 제출할 때, 시스템은 400 상태로 요청을 거부한다.
+- (en) When a user submits an empty password, the system shall reject the request with a 400 status.
+- (hybrid) When 사용자가 빈 비밀번호를 제출하면, the system shall 400 상태로 요청을 거부한다.
 
 ### 3. State-driven (상태 기반)
-형식: `While <상태>, the system shall <지속 응답>`
+형식:
+- en: `While <상태>, the system shall <지속 응답>`
+- ko: `<상태>인 동안, 시스템은 <지속 응답>한다`
+- hybrid: `While <한국어 상태>인 동안, the system shall <한국어 지속 응답>한다`
 
 용례: 시스템이 특정 상태일 때만 *지속적으로* 성립.
 
 예시:
-- While the database is in read-only mode, the system shall reject all write operations with 503.
-- While a user is impersonated, the system shall include "X-Impersonated-By" in every response.
+- (ko) 데이터베이스가 read-only 모드인 동안, 시스템은 모든 쓰기 작업을 503으로 거부한다.
+- (en) While the database is in read-only mode, the system shall reject all write operations with 503.
+- (hybrid) While 데이터베이스가 read-only 모드인 동안, the system shall 모든 쓰기 작업을 503으로 거부한다.
 
 ### 4. Optional (조건부 기능)
-형식: `Where <조건>, the system shall <응답>`
+형식:
+- en: `Where <조건>, the system shall <응답>`
+- ko: `<조건>인 경우, 시스템은 <응답>한다`
+- hybrid: `Where <한국어 조건>인 경우, the system shall <한국어 응답>한다`
 
 용례: 특정 환경·feature flag·구성에서만 활성.
 
 예시:
-- Where the audit-log feature flag is enabled, the system shall record every state mutation.
-- Where MFA is configured, the system shall require a second factor on login.
+- (ko) audit-log feature flag가 활성화된 경우, 시스템은 모든 상태 변경을 기록한다.
+- (en) Where the audit-log feature flag is enabled, the system shall record every state mutation.
+- (hybrid) Where audit-log feature flag가 활성화된 경우, the system shall 모든 상태 변경을 기록한다.
 
 ### 5. Unwanted behavior (불가용·오류)
-형식: `If <불가용/오류>, then the system shall <복구·거부>`
+형식:
+- en: `If <불가용/오류>, then the system shall <복구·거부>`
+- ko: `<불가용/오류>이면, 시스템은 <복구·거부>한다`
+- hybrid: `If <한국어 불가용/오류>이면, then the system shall <한국어 복구·거부>한다`
 
 용례: 실패·예외 상황의 명시적 처리.
 
 예시:
-- If the database connection fails, then the system shall return 503 with a retry-after header.
-- If a webhook delivery fails three times, then the system shall mark the subscription as inactive.
+- (ko) 데이터베이스 연결이 실패하면, 시스템은 retry-after 헤더와 함께 503을 반환한다.
+- (en) If the database connection fails, then the system shall return 503 with a retry-after header.
+- (hybrid) If 데이터베이스 연결이 실패하면, then the system shall retry-after 헤더와 함께 503을 반환한다.
 
 ## 자유 텍스트 → EARS 변환 가이드
 

--- a/plugins/autopilot/skills/spec/references/self-review.md
+++ b/plugins/autopilot/skills/spec/references/self-review.md
@@ -47,6 +47,18 @@
 
 불가능하면 `[NEEDS CLARIFICATION: 검증 가능한 형태로 재작성 — 어떤 fail 시나리오?]`.
 
+### 자유 텍스트 → EARS 변환 가이드 (작성 언어별)
+
+자체 검토 단계에서 자유 텍스트가 발견되면 `references/ears-patterns.md` 변환 가이드를
+적용한다. 작성 언어는 SPEC frontmatter `ears_language`를 따른다(미명시 시 `ko`).
+
+ko EARS 패턴 예시 (Event-driven):
+- 자유 텍스트: "사용자가 빈 비밀번호를 제출하면 400으로 거부함"
+- ko 변환: 사용자가 빈 비밀번호를 제출할 때, 시스템은 400으로 요청을 거부한다.
+
+다른 모드(en·hybrid)와 5패턴 전체 예시는 `references/ears-patterns.md`의
+"EARS 작성 언어"·"5개 패턴" 절을 단일 출처로 참조한다.
+
 ## 검토 출력 형식
 
 자체 검토 후 사용자에게:

--- a/plugins/autopilot/skills/spec/references/spec-template.md
+++ b/plugins/autopilot/skills/spec/references/spec-template.md
@@ -22,6 +22,11 @@ verify: "{{verify_command}}"
 # test_sweep_paths:
 #   - "tests/legacy_to_remove/**"
 #   - "tests/test_specific_to_rename.py"
+#
+# ears_language (선택): "수용 기준 (EARS)" 산출 시 사용할 작성 언어. 허용 값:
+#   `ko` · `en` · `hybrid`. 미명시 시 디폴트는 `ko`(프로젝트 기본 언어).
+#   3모드 정의·예시는 references/ears-patterns.md "EARS 작성 언어" 절 참조.
+# ears_language: ko
 ---
 
 # {{task_title}}
@@ -37,6 +42,11 @@ verify: "{{verify_command}}"
   - State-driven: "While <상태>, the system shall <지속 응답>"
   - Optional: "Where <조건>, the system shall <응답>"
   - Unwanted: "If <불가용/오류>, then the system shall <복구·거부>"
+
+작성 언어 default는 `ko`(프로젝트 기본 언어). frontmatter `ears_language` 키로
+개별 SPEC이 `en`·`ko`·`hybrid` 중 하나를 override할 수 있다. 언어 정책·3모드
+형식·예시는 references/ears-patterns.md "EARS 작성 언어" 절 참조.
+
 각 기준이 verify 명령 안에서 *어떤 형태로든* fail 가능해야 합니다 (Independent-Test 규칙). 불가능한 기준은 [NEEDS CLARIFICATION: <질문>]으로 표시. -->
 {{acceptance_criteria}}
 

--- a/plugins/autopilot/skills/spec/references/spec-template.md
+++ b/plugins/autopilot/skills/spec/references/spec-template.md
@@ -37,15 +37,16 @@ verify: "{{verify_command}}"
 
 ## 수용 기준 (EARS)
 <!-- 5개 EARS 패턴 중 하나로 작성. 자세한 사례는 references/ears-patterns.md 참조.
-  - Ubiquitous: "The system shall <응답>"
-  - Event-driven: "When <트리거>, the system shall <응답>"
-  - State-driven: "While <상태>, the system shall <지속 응답>"
-  - Optional: "Where <조건>, the system shall <응답>"
-  - Unwanted: "If <불가용/오류>, then the system shall <복구·거부>"
+  작성 언어 default는 `ko`(프로젝트 기본 언어). 아래 형식은 ko 기준 — en·hybrid는
+  references/ears-patterns.md "EARS 작성 언어" 절 참조.
+  - Ubiquitous: "시스템은 <응답>한다"
+  - Event-driven: "<트리거>할 때, 시스템은 <응답>한다"
+  - State-driven: "<상태>인 동안, 시스템은 <지속 응답>한다"
+  - Optional: "<조건>인 경우, 시스템은 <응답>한다"
+  - Unwanted: "<불가용/오류>이면, 시스템은 <복구·거부>한다"
 
-작성 언어 default는 `ko`(프로젝트 기본 언어). frontmatter `ears_language` 키로
-개별 SPEC이 `en`·`ko`·`hybrid` 중 하나를 override할 수 있다. 언어 정책·3모드
-형식·예시는 references/ears-patterns.md "EARS 작성 언어" 절 참조.
+frontmatter `ears_language` 키로 개별 SPEC이 `en`·`ko`·`hybrid` 중 하나를
+override할 수 있다(미명시 시 ko).
 
 각 기준이 verify 명령 안에서 *어떤 형태로든* fail 가능해야 합니다 (Independent-Test 규칙). 불가능한 기준은 [NEEDS CLARIFICATION: <질문>]으로 표시. -->
 {{acceptance_criteria}}


### PR DESCRIPTION
Closes #78.

## Summary
- `references/ears-patterns.md` 상단에 "EARS 작성 언어" 신규 절 — default를 프로젝트 기본 언어(ko)로 선언, `ears_language: en|ko|hybrid` override 규칙, hybrid(EARS 영어 키워드 + 한국어 본문) 형식 정의 라인 포함. 5패턴(Ubiquitous·Event/State/Optional/Unwanted) 각각 ko·en·hybrid 3모드 예시.
- `SKILL.md` step 6에 "EARS 작성 언어 해석" 절 추가 — frontmatter 값 읽기·디폴트(ko)·재질문 금지·`ears-patterns.md`를 single source of truth로 명시.
- `references/spec-template.md` frontmatter 주석 블록에 `ears_language`(선택, 허용 값, 디폴트 ko) 키 추가, AC 주석에 언어 정책 문서 포인터 추가.
- `references/self-review.md` 자유 텍스트→EARS 변환 가이드에 작성 언어별 서브섹션 + ko Event-driven 예시 1건 추가.
- 기존 #66 영어 EARS SPEC 등은 grandfather (회귀 없음).

EARS 5패턴 Mavin 표준의 트리거·조건·응답 구조는 모든 언어 모드에서 보존, 어휘만 번역.

## Test plan
- [x] `bash -c '...'` verify 명령(9개 grep) 0 exit으로 종료
  - `ears-patterns.md`: "EARS 작성 언어"·"프로젝트 기본 언어" 문구, ko Event-driven 예시("할 때, 시스템은 ~한다"), en 예시(보존), hybrid 라인
  - `spec-template.md`: `ears_language` 키
  - `SKILL.md`: `ears_language` 키 + `ears_language`와 default/디폴트/기본이 한 줄에 등장
  - `self-review.md`: ko Event-driven 예시
- [x] `loop.sh`는 frontmatter에서 `scope`·`verify`·`test_paths`·`test_sweep_paths`만 yq로 읽음 — `ears_language` 추가가 loop 파싱에 영향 없음 확인
- [ ] spec 스킬 실호출로 새 SPEC을 작성해 ko EARS AC가 산출되는지(또는 `ears_language: en` 시 영어 산출) 회귀 확인 — 다음 SPEC 작성 시점에서 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)