### PR TITLE
feat(autopilot/spec): SKILL.md 단계 2 — task 상태 정합 (#95)

### DIFF
--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
 description: "autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. SPEC.md 작성 후 결정적 슬러그화 규칙(ASCII 영숫자·하이픈만)으로 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·SPEC.md를 commit해 loop·PR 흐름이 단일 feature 브랜치로 통합되게 합니다. 호출 'Skill(skill=\"spec\", args=\"<task-id> [--milestone <m>] [--resume]\")'. milestone 미지정 시 `regular`(catch-all)을 default로 적용."
-allowed-tools: AskUserQuestion, Read, Write, Skill, Bash(git log:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git show-ref:*), Bash(git for-each-ref:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(echo:*), Bash(head:*), Bash(tr:*), Bash(sed:*), Bash(gh issue view:*)
+allowed-tools: AskUserQuestion, Read, Write, Skill, Bash(git log:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git show-ref:*), Bash(git for-each-ref:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(echo:*), Bash(head:*), Bash(tr:*), Bash(sed:*), Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh issue create:*), Bash(gh project item-list:*), Bash(gh project item-edit:*), Bash(gh project item-add:*), Bash(gh api:*)
 ---
 
 # spec
@@ -17,9 +17,9 @@ milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `a
 
 또는 사용자가 자연어로 의도 전달 시 모델이 자동 호출.
 
-## 9단계 워크플로
+## 10단계 워크플로
 
-호출 시 다음 9단계를 TodoWrite로 등록·실행. 각 단계는 사용자 결정·승인을 `AskUserQuestion`으로 받습니다.
+호출 시 다음 10단계를 TodoWrite로 등록·실행. 각 단계는 사용자 결정·승인을 `AskUserQuestion`으로 받습니다.
 
 ### 1. 사전 검사
 
@@ -35,14 +35,14 @@ milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `a
 task-id 형식 검증 실패 또는 자연어 입력 감지 시, 즉시 종료하지 않고 `AskUserQuestion`으로 사용자 의도를 분류하는 3옵션을 제시한다 (프로젝트 CLAUDE.md의 "사용자에게 결정·승인·선택·해명을 요청할 때는 예외 없이 AskUserQuestion 도구를 사용" 규칙과 동일 정신):
 
 - **(a) 올바른 task-id 재입력 후 검증 재시도** — 사용자가 새 task-id를 입력하면 step 1 검증을 재실행. 통과 시 정상 spec 흐름(일반/--resume 분기)으로 복귀.
-- **(b) 사전 명확화 라운드 진입** — 아직 task-id가 확보되지 않은 상태로 step 4 명확화 라운드 메커니즘을 *앞당겨* 적용 (별도 phase 신설 없음, 동일 메커니즘 재사용). 자세한 흐름은 §1.2.
+- **(b) 사전 명확화 라운드 진입** — 아직 task-id가 확보되지 않은 상태로 step 5 명확화 라운드 메커니즘을 *앞당겨* 적용 (별도 phase 신설 없음, 동일 메커니즘 재사용). 자세한 흐름은 §1.2.
 - **(c) 종료** — SPEC.md를 작성하지 않고 종료. 어떠한 산출물도 남기지 않는다. 라우팅 AskUserQuestion에 응답 없이 종결될 경우도 동일.
 
 옵션 표기는 본문에서 `(a)`/`(b)`/`(c)` 형식을 유지한다. "다음 단계: Skill(...)" 형식의 자유 텍스트 안내는 출력하지 않는다 — 후속 스킬 호출은 항상 AskUserQuestion 확인 후 invoke한다.
 
-#### 1.2 사전 명확화 라운드 (step 4 앞당김)
+#### 1.2 사전 명확화 라운드 (step 5 앞당김)
 
-(b) 선택 시 진입. 핵심 원칙: spec의 기존 step 4 명확화 라운드를 task-id 확보 *전* 단계로 앞당긴 것이다. 별도 phase·신규 모듈을 만들지 않고 같은 인터랙션 규칙을 그대로 적용한다.
+(b) 선택 시 진입. 핵심 원칙: spec의 기존 step 5 명확화 라운드를 task-id 확보 *전* 단계로 앞당긴 것이다. 별도 phase·신규 모듈을 만들지 않고 같은 인터랙션 규칙을 그대로 적용한다.
 
 - 한 번에 한 질문(`AskUserQuestion`, 가능하면 멀티초이스). 답변이 다음 질문 형태를 결정. 한 호출에 관련 소문항 최대 4개.
 - 수집 항목:
@@ -51,7 +51,7 @@ task-id 형식 검증 실패 또는 자연어 입력 감지 시, 즉시 종료�
   - 범위: 포함 영역과 비-목표
   - 제약: 환경·도구·호환성·이미 시도한 dead-end
 
-  (step 4는 task가 이미 정의된 상태에서 `핵심 목적·성공 기준·알려진 제약·알려진 위험`을 묻지만, §1.2는 task 자체를 아직 정의하지 않은 상태이므로 `문제·목표·범위·제약`으로 폭을 넓힌다. 메커니즘은 동일하지만 수집 항목은 단계 목적에 맞춰 달리한다.)
+  (step 5는 task가 이미 정의된 상태에서 `핵심 목적·성공 기준·알려진 제약·알려진 위험`을 묻지만, §1.2는 task 자체를 아직 정의하지 않은 상태이므로 `문제·목표·범위·제약`으로 폭을 넓힌다. 메커니즘은 동일하지만 수집 항목은 단계 목적에 맞춰 달리한다.)
 - 매 라운드 사용자 측 "충분" 종결 옵션을 `AskUserQuestion`에 포함해 무한 Q&A를 방지한다.
 - 사용자가 라운드 중 명시적으로 **취소**를 선택하면 task를 생성하지 않고 어떠한 산출물도 남기지 않고 종료한다 (§1.1 (c)와 동일 안전 종료).
 
@@ -61,7 +61,7 @@ task-id 형식 검증 실패 또는 자연어 입력 감지 시, 즉시 종료�
 
 수집된 문제·목표·범위·제약이 단일 task 규모로 정리되면, **프로젝트의 태스크 관련 지침**(예: `CLAUDE.md`·`rules/`의 issue 생성 컨벤션, GitHub project 운영 규칙 등)에 따라 task를 생성해 task-id를 확보한다. 본 스킬은 그 구조를 재정의하지 않고 프로젝트 지침의 issue body 구조(목표·배경·제안·검증 계획·DoD 등)를 그대로 따른다.
 
-task-id 확보 후 spec의 **step 2(컨텍스트 탐색)부터 그 task-id로 재개**한다. 라운드에서 합의된 문제·목표·범위·제약은 step 2 이후 단계의 섹션 초안으로 손실 없이 이어진다 (step 6 섹션별 SPEC 제시 시 사전 합의 내용을 초안으로 사용).
+task-id 확보 후 spec의 **step 2(task 상태 정합)부터 그 task-id로 재개**한다. 라운드에서 합의된 문제·목표·범위·제약은 step 3 이후 단계의 섹션 초안으로 손실 없이 이어진다 (step 7 섹션별 SPEC 제시 시 사전 합의 내용을 초안으로 사용).
 
 task 생성 자체는 외부 도구(`gh` CLI, GitHub project 접근 등 프로젝트 지침이 정한 경로)에 의존한다. 실패 시 사용자에게 명시적으로 알리고 부분 산출물을 남기지 않고 안전하게 종료한다 — `milestones/<m>/loops/<c>/` 디렉터리도 생성하지 않는다.
 
@@ -73,7 +73,36 @@ PRD 스킬은 `milestone-id`를 요구하므로, spec은 PRD 스킬을 invoke하
 
 승인이 없으면 PRD를 invoke하지 않고 종료. SPEC.md도 작성하지 않는다 — 산출은 단일 경로의 SPEC.md 또는 마일스톤 경로의 PRD.md 하나뿐이다.
 
-### 2. 컨텍스트 탐색
+### 2. task 상태 정합 (일반·--resume 두 모드 공통)
+
+**사전 검사 통과 직후** 실행. task-id로 식별되는 외부 task를 조회하고 4갈래 분기로 상태를 설계 상태(`In Design`)로 정합한다. 본 단계는 일반 모드와 `--resume` 모드 모두에 동일하게 적용된다.
+
+**백킹 시스템 매핑**: 본 프로젝트는 `rules/context.md`에 따라 **GitHub Project + Issue** 백엔드를 사용한다. 추상 상태 → 구체 매핑:
+
+| 추상 상태 (SPEC) | GitHub Project Status field |
+|---|---|
+| 설계 상태 | `In Design` |
+| 설계 이전 상태 | `Backlog` |
+| 설계 이후 상태 | `In Progress`, `Review`, `Done`, `Blocked`, `Cancelled` 등 그 외 |
+
+task-id ↔ Issue 매핑은 task-id 자체가 issue number(`#42` 또는 `42` 형식)이거나, task-id를 검색 키로 `gh issue list --search`로 단일 매칭을 찾는다. 본 프로젝트 컨벤션 외 다른 프로젝트에서 호출 시 `rules/context.md` 매핑을 재확인.
+
+**조회 절차**:
+- `gh issue view <task-id>` 또는 `gh issue list --search "<task-id>"`로 task 존재 확인.
+- 존재 시 `gh project item-list <project>`로 해당 issue의 Status field 값 읽기.
+
+**4갈래 분기**:
+
+1. **(a) task 부재** (issue 조회 결과 없음): 새 issue를 `gh issue create`로 생성하고 `gh project item-add`로 Project에 추가 + Status를 `In Design`으로 설정. 새 issue number를 새 task-id로 사용하며 — 이후 워크플로의 `<c>`는 새 task-id로 **교체**한다. `AskUserQuestion`으로 사용자에게 새 task-id를 명시적으로 안내한 후 진행. 새 task-id에 대해 사전 검사(단계 1)의 폴더 존재 검사·형식 검증을 다시 적용한다 (위험: 새 task-id의 `milestones/<m>/loops/<c>/` 폴더가 이미 있을 수 있음).
+2. **(b) 기존 task가 설계 상태(`In Design`)**: 상태를 변경하지 않고 다음 단계로 진행 (resume 케이스).
+3. **(c) 기존 task가 설계 이전 상태(`Backlog`)**: `gh project item-edit`로 Status field를 `In Design`으로 전이한 뒤 다음 단계로 진행.
+4. **(d) 기존 task가 설계 이후 상태(`In Progress`·`Review`·`Done` 등)**: 새 issue를 `gh issue create`로 생성·Project 추가·Status를 `In Design`으로 설정. 새 issue number로 task-id를 **교체**하고 `AskUserQuestion`으로 사용자에게 새 task-id를 명시적으로 안내한 후 진행. (a)와 동일하게 새 task-id에 대해 사전 검사를 재적용.
+
+**호출 실패 시 abort**: task 조회·생성·상태 전이 호출(`gh issue view`·`gh issue create`·`gh project item-list`·`gh project item-edit`·`gh project item-add`) 중 어느 하나라도 0이 아닌 exit으로 실패하면 명확한 에러 메시지와 함께 abort. 자동 roll-back은 수행하지 않으며 부분 실패 상태로 다음 단계로 진행하지 않는다.
+
+**범위 외 (비-목표)**: loop `start` 시점의 `In Design → In Progress` 전이, SPEC 승인 후 자동 후속 전이는 본 단계의 책임이 아니다 (다른 스킬·이벤트가 담당).
+
+### 3. 컨텍스트 탐색
 
 다음 명령으로 프로젝트 컨텍스트 자동 수집 (사용자에게 요약만):
 ```
@@ -84,15 +113,15 @@ ls rules/      # 있으면
 find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__' -o -name 'spec' \) 2>/dev/null | head -5
 ```
 
-목적: 테스트 컨벤션·CLAUDE.md 룰·디렉터리 구조 파악. 모노레포여도 단계 4에서 좁힐 것이므로 깊이 탐색 안 함.
+목적: 테스트 컨벤션·CLAUDE.md 룰·디렉터리 구조 파악. 모노레포여도 단계 5에서 좁힐 것이므로 깊이 탐색 안 함.
 
-### 3. 범위 분해 게이트
+### 4. 범위 분해 게이트
 
 `references/decomposition-gate.md` 휴리스틱으로 다중 서브시스템 검사. 감지 시 사용자에게 분해 제안.
 
 `--resume` 모드: 이 단계 생략 (이미 SPEC 존재).
 
-### 4. 명확화 라운드
+### 5. 명확화 라운드
 
 한 번에 한 질문 (`AskUserQuestion`, 가능하면 멀티초이스). 답변이 다음 질문 형태를 결정.
 
@@ -104,7 +133,7 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 
 `--resume` 모드: 마커가 박힌 섹션 관련 질문만.
 
-### 5. 접근법 비교 (조건부)
+### 6. 접근법 비교 (조건부)
 
 명확화에서 task가 비-자명한 설계 결정을 포함한다고 판단되면 2-3 접근법 + 트레이드오프 + 추천 제시. 자명하면 생략.
 
@@ -113,7 +142,7 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 - 영향 받는 코드 영역이 둘 이상의 명확히 다른 패턴 사이에서 선택을 요구
 - 외부 의존성·라이브러리 선택이 task 결과에 큰 영향
 
-### 6. 섹션별 SPEC 제시·승인
+### 7. 섹션별 SPEC 제시·승인
 
 다음 순서로 한 섹션씩 사용자에게 제시 → `AskUserQuestion`으로 "이 섹션 OK?" 확인:
 1. 제목
@@ -136,10 +165,10 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 
 `--resume` 모드: 마커가 박힌 섹션만.
 
-### 7. SPEC.md 작성
+### 8. SPEC.md 작성
 
 `references/spec-template.md` 읽어 placeholder 치환:
-- `{{task_title}}` → 단계 6에서 합의된 제목 (없으면 task-id 그대로)
+- `{{task_title}}` → 단계 7에서 합의된 제목 (없으면 task-id 그대로)
 - `{{task_description}}` → 섹션 2 합의 내용
 - `{{acceptance_criteria}}` → 섹션 3 합의 내용 (EARS 포맷)
 - `{{scope_in}}` / `{{scope_out}}` → 본문 섹션 4 (사람이 읽는 형식)
@@ -152,17 +181,17 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 
 `mkdir -p milestones/<m>/loops/<c>` 후 `milestones/<m>/loops/<c>/SPEC.md`에 기록.
 
-### 8. 자체 검토
+### 9. 자체 검토
 
-`references/self-review.md` 5항목 체크 (placeholder · 모순 · 범위 · 모호성 · EARS fail-가능성). 발견 시 인라인 수정 또는 `[NEEDS CLARIFICATION]` 마커만 — 사용자 Q&A 없음(단계 9에서 일괄 해결). 재루프 없음. 수정·마커 후 SPEC.md 재기록.
+`references/self-review.md` 5항목 체크 (placeholder · 모순 · 범위 · 모호성 · EARS fail-가능성). 발견 시 인라인 수정 또는 `[NEEDS CLARIFICATION]` 마커만 — 사용자 Q&A 없음(단계 10에서 일괄 해결). 재루프 없음. 수정·마커 후 SPEC.md 재기록.
 
-### 8.5. feat 브랜치 + SPEC.md commit (자동, main 작업트리 무손상)
+### 9.5. feat 브랜치 + SPEC.md commit (자동, main 작업트리 무손상)
 
 SPEC.md 작성과 자체 검토가 끝나면, sibling `autopilot:loop`이 worktree base로 사용할 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·생성하고 SPEC.md를 그 브랜치에 commit한다. main 작업트리 상태(staged/unstaged/untracked)는 변경되지 않아야 한다.
 
-이 단계를 단계 9의 사용자 최종 검토 *전*에 수행해 SPEC.md가 이미 git history에 반영된 상태에서 사용자가 결정을 내리도록 한다. 사용자가 단계 9에서 "변경" 옵션을 선택하면 단계 6/7 재진입 후 본 단계의 commit을 amend하거나 새 commit을 쌓는다 (자동 처리).
+이 단계를 단계 10의 사용자 최종 검토 *전*에 수행해 SPEC.md가 이미 git history에 반영된 상태에서 사용자가 결정을 내리도록 한다. 사용자가 단계 10에서 "변경" 옵션을 선택하면 단계 7/8 재진입 후 본 단계의 commit을 amend하거나 새 commit을 쌓는다 (자동 처리).
 
-#### 8.5.1 슬러그화 규칙 (결정적)
+#### 9.5.1 슬러그화 규칙 (결정적)
 
 SPEC §1 제목(첫 H1, `# ` 다음 텍스트)에서 `<slug>`를 도출:
 
@@ -183,7 +212,7 @@ slug=$(printf '%s' "$title" \
   | sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')
 ```
 
-#### 8.5.2 브랜치 생성·commit 절차
+#### 9.5.2 브랜치 생성·commit 절차
 
 1. `git status --porcelain`으로 main 작업트리 상태 스냅샷 캡처. unstaged·untracked가 있으면 그 사실을 인지 (다음 단계의 git 동작이 영향 안 주도록 명시적 경로 사용).
 2. 현재 브랜치 이름 보존: `orig_branch=$(git rev-parse --abbrev-ref HEAD)`.
@@ -197,30 +226,31 @@ slug=$(printf '%s' "$title" \
 8. `git checkout "$orig_branch"`로 원래 브랜치 복귀.
 9. 복귀 후 `git status --porcelain` 결과가 step 1과 동일한지 검증. 다르면 사용자에게 경고.
 
-#### 8.5.3 실패 처리
+#### 9.5.3 실패 처리
 
 위 절차 중 어떤 단계라도 실패하면:
 - 부분 결과 정리: 생성된 feat 브랜치가 있으면 `git branch -D "$branch"`로 삭제 (단, 그 브랜치에 다른 commit이 없을 때만; 의심스러우면 사용자에게 알리고 수동 정리 안내).
 - 원래 브랜치 복귀: `git checkout "$orig_branch"`.
 - 사용자에게 명시적으로 실패 사유와 복구 방법 안내. SPEC.md는 `milestones/<m>/loops/<c>/SPEC.md`에 그대로 남기되, loop 진행은 다음 단계에서 사용자가 결정.
 
-### 9. 사용자 최종 검토
+### 10. 사용자 최종 검토
 
 SPEC.md 경로(`milestones/<m>/loops/<c>/SPEC.md`)와 요약을 먼저 안내한 뒤, `AskUserQuestion`으로 **명시적 결정 입력**을 받는다 (자유 텍스트 안내·자유 텍스트 끝 질문 종결구 금지 — CLAUDE.md 규칙). 옵션은 다음 3개:
 
 - **지금 loop start 호출** (Recommended) — 동일 task-id로 sibling 스킬을 자동 연계 호출: `Skill(skill: "loop", args: "start <m>/<c>")`. 사용자가 이 옵션을 선택하면 모델은 즉시 본 Skill 호출을 발행하며, 추가 모니터 결정 질문은 묻지 않고 loop 기본 동작(자동 Monitor 가설 포함, `plugins/autopilot/skills/loop/SKILL.md` 참조)을 그대로 적용한다. milestone이 default `regular`인 경우 `start <c>` 단축형도 동등 (loop.sh가 자동 정규화).
 - **SPEC만 확정** — 경로만 안내하고 종료. 사용자가 이후 별도 시점에 `Skill(skill: "loop", args: "start <m>/<c>")`를 직접 호출.
-- **변경** — 어느 섹션을 변경할지 묻고 단계 6/7 재진입.
+- **변경** — 어느 섹션을 변경할지 묻고 단계 7/8 재진입.
 
 세 옵션은 상호배타. "지금 loop start 호출"이라는 옵션 라벨에서 본 결정의 효과가 곧 sibling loop 스킬 호출임이 명확해야 한다.
 
 ## --resume 모드 요약
 
-위 9단계 중:
+위 10단계 중:
 - 1: 마커 0개 시 즉시 종료
-- 3: 생략 (이미 SPEC 존재)
-- 4, 5: 마커 위치 기준으로 좁힘
-- 6: 마커 박힌 섹션만
+- 2: 일반 모드와 동일하게 적용 — 사전 검사 통과 직후 task 상태 정합(4갈래 분기·abort) 수행. `--resume`은 보통 (b) 설계 상태 분기로 떨어져 상태 변경 없이 통과한다.
+- 4: 생략 (이미 SPEC 존재)
+- 5, 6: 마커 위치 기준으로 좁힘
+- 7: 마커 박힌 섹션만
 - 나머지 동일
 
 ## 모듈 구성 (references/)

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -98,6 +98,18 @@ task-id ↔ Issue 매핑은 task-id 자체가 issue number(`#42` 또는 `42` 형
 3. **(c) 기존 task가 설계 이전 상태(`Backlog`)**: `gh project item-edit`로 Status field를 `In Design`으로 전이한 뒤 다음 단계로 진행.
 4. **(d) 기존 task가 설계 이후 상태(`In Progress`·`Review`·`Done` 등)**: 새 issue를 `gh issue create`로 생성·Project 추가·Status를 `In Design`으로 설정. 새 issue number로 task-id를 **교체**하고 `AskUserQuestion`으로 사용자에게 새 task-id를 명시적으로 안내한 후 진행. (a)와 동일하게 새 task-id에 대해 사전 검사를 재적용.
 
+**(a)·(d) 새 issue 생성 시 title/body 수집**: step 2 시점에는 아직 명확화 라운드(step 5) 전이라 issue 본문에 쓸 문제·목표·범위가 수집되지 않은 상태다. 임의 값으로 채우면 실행 일관성이 깨지므로 다음 절차로 최소 정보를 명시적으로 확보한다:
+
+- **Title**: `AskUserQuestion`으로 한 줄 제목을 수집 (1문항, 자유 입력 옵션 포함). 사용자가 "그대로 task-id 사용"을 선택하거나 입력이 비어 있으면 원래 task-id 문자열을 fallback 제목으로 사용한다.
+- **Body**: 최소 본문은 다음 두 줄로 고정 — 임의 확장 금지:
+  ```
+  spec 워크플로우 step 2에서 자동 생성. 본문은 SPEC.md 작성·승인 후 갱신될 예정.
+  SPEC: milestones/<m>/loops/<new-task-id>/SPEC.md
+  ```
+  명확화 라운드(step 5) 완료 시점에 본 issue 본문을 update할지 여부는 본 SPEC 범위 밖이며, 필요하면 사용자가 수동으로 보강한다.
+
+본 절차로 입력이 결정된 뒤에만 `gh issue create --title <title> --body <body>`를 호출한다. 사용자가 title 수집 단계에서 명시적 취소를 선택하면 (a)·(d) 분기는 abort로 처리한다 — `milestones/` 디렉터리도 생성하지 않는다.
+
 **호출 실패 시 abort**: task 조회·생성·상태 전이 호출(`gh issue view`·`gh issue create`·`gh project item-list`·`gh project item-edit`·`gh project item-add`) 중 어느 하나라도 0이 아닌 exit으로 실패하면 명확한 에러 메시지와 함께 abort. 자동 roll-back은 수행하지 않으며 부분 실패 상태로 다음 단계로 진행하지 않는다.
 
 **범위 외 (비-목표)**: loop `start` 시점의 `In Design → In Progress` 전이, SPEC 승인 후 자동 후속 전이는 본 단계의 책임이 아니다 (다른 스킬·이벤트가 담당).

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -106,7 +106,10 @@ task-id ↔ Issue 매핑은 task-id 자체가 issue number(`#42` 또는 `42` 형
   spec 워크플로우 step 2에서 자동 생성. 본문은 SPEC.md 작성·승인 후 갱신될 예정.
   SPEC: milestones/<m>/loops/<new-task-id>/SPEC.md
   ```
-  `<new-task-id>` 플레이스홀더는 `gh issue create` 호출 시점엔 새 issue 번호를 모르므로 다음 절차로 처리한다 — `gh issue create`로 임시 body(`<new-task-id>` 리터럴 포함)를 올리고, 반환된 issue number(`N`)로 즉시 `gh issue edit N --body <substituted-body>`를 호출해 리터럴을 실제 번호로 치환한다. edit 실패 시 abort 규칙은 다른 `gh` 호출과 동일하다.
+  본문 템플릿의 플레이스홀더 처리는 **두 단계로 나뉜다**:
+  - **`<m>` (milestone)**: step 1에서 이미 결정된 값(`--milestone <m>` 또는 default `regular`). `gh issue create` 호출 *전에* 실제 milestone 문자열로 치환한다.
+  - **`<new-task-id>` (issue number)**: `gh issue create` 호출 시점엔 아직 발급되지 않은 값. `<m>`만 치환한 임시 body(`<new-task-id>`는 리터럴로 남김)로 `gh issue create`를 호출하고, 반환된 issue number(`N`)로 즉시 `gh issue edit N --body <substituted-body>`를 호출해 리터럴을 실제 번호로 치환한다.
+  edit 실패 시 abort 규칙은 다른 `gh` 호출과 동일하다.
 
   명확화 라운드(step 5) 완료 시점에 본 issue 본문을 update할지 여부는 본 SPEC 범위 밖이며, 필요하면 사용자가 수동으로 보강한다.
 

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
 description: "autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. SPEC.md 작성 후 결정적 슬러그화 규칙(ASCII 영숫자·하이픈만)으로 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·SPEC.md를 commit해 loop·PR 흐름이 단일 feature 브랜치로 통합되게 합니다. 호출 'Skill(skill=\"spec\", args=\"<task-id> [--milestone <m>] [--resume]\")'. milestone 미지정 시 `regular`(catch-all)을 default로 적용."
-allowed-tools: AskUserQuestion, Read, Write, Skill, Bash(git log:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git show-ref:*), Bash(git for-each-ref:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(echo:*), Bash(head:*), Bash(tr:*), Bash(sed:*), Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh issue create:*), Bash(gh project item-list:*), Bash(gh project item-edit:*), Bash(gh project item-add:*), Bash(gh api:*)
+allowed-tools: AskUserQuestion, Read, Write, Skill, Bash(git log:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git show-ref:*), Bash(git for-each-ref:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(echo:*), Bash(head:*), Bash(tr:*), Bash(sed:*), Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh issue create:*), Bash(gh issue edit:*), Bash(gh project item-list:*), Bash(gh project item-edit:*), Bash(gh project item-add:*), Bash(gh api:*)
 ---
 
 # spec
@@ -106,11 +106,13 @@ task-id ↔ Issue 매핑은 task-id 자체가 issue number(`#42` 또는 `42` 형
   spec 워크플로우 step 2에서 자동 생성. 본문은 SPEC.md 작성·승인 후 갱신될 예정.
   SPEC: milestones/<m>/loops/<new-task-id>/SPEC.md
   ```
+  `<new-task-id>` 플레이스홀더는 `gh issue create` 호출 시점엔 새 issue 번호를 모르므로 다음 절차로 처리한다 — `gh issue create`로 임시 body(`<new-task-id>` 리터럴 포함)를 올리고, 반환된 issue number(`N`)로 즉시 `gh issue edit N --body <substituted-body>`를 호출해 리터럴을 실제 번호로 치환한다. edit 실패 시 abort 규칙은 다른 `gh` 호출과 동일하다.
+
   명확화 라운드(step 5) 완료 시점에 본 issue 본문을 update할지 여부는 본 SPEC 범위 밖이며, 필요하면 사용자가 수동으로 보강한다.
 
 본 절차로 입력이 결정된 뒤에만 `gh issue create --title <title> --body <body>`를 호출한다. 사용자가 title 수집 단계에서 명시적 취소를 선택하면 (a)·(d) 분기는 abort로 처리한다 — `milestones/` 디렉터리도 생성하지 않는다.
 
-**호출 실패 시 abort**: task 조회·생성·상태 전이 호출(`gh issue view`·`gh issue create`·`gh project item-list`·`gh project item-edit`·`gh project item-add`) 중 어느 하나라도 0이 아닌 exit으로 실패하면 명확한 에러 메시지와 함께 abort. 자동 roll-back은 수행하지 않으며 부분 실패 상태로 다음 단계로 진행하지 않는다.
+**호출 실패 시 abort**: task 조회·생성·편집·상태 전이 호출(`gh issue view`·`gh issue create`·`gh issue edit`·`gh project item-list`·`gh project item-edit`·`gh project item-add`) 중 어느 하나라도 0이 아닌 exit으로 실패하면 명확한 에러 메시지와 함께 abort. 자동 roll-back은 수행하지 않으며 부분 실패 상태로 다음 단계로 진행하지 않는다.
 
 **범위 외 (비-목표)**: loop `start` 시점의 `In Design → In Progress` 전이, SPEC 승인 후 자동 후속 전이는 본 단계의 책임이 아니다 (다른 스킬·이벤트가 담당).
 

--- a/tests/autopilot/test-spec-status-transition.sh
+++ b/tests/autopilot/test-spec-status-transition.sh
@@ -102,7 +102,6 @@ echo "OK: 10단계 헤더"
 
 echo ""
 echo "=== TEST 10: SKILL.md (a)·(d) 새 issue 생성 시 title/body 수집 절차 명시 ==="
-# PR #96 review (claude[bot]): step 2 (a)/(d) gh issue create title/body 명시 부재.
 # 모델이 임의 값으로 채우는 것을 방지하기 위해 title은 AskUserQuestion 1문항 + task-id fallback,
 # body는 고정 placeholder임을 명시해야 한다.
 grep -qE 'title.*AskUserQuestion|AskUserQuestion.*title|한 줄 제목.*수집' "$SKILL_MD" \
@@ -117,8 +116,6 @@ echo "OK: body 최소/고정"
 
 echo ""
 echo "=== TEST 11: SKILL.md <new-task-id> 플레이스홀더 치환 절차 명시 ==="
-# PR #96 review NIT (claude[bot]): body의 <new-task-id> placeholder가 issue 생성 전엔
-# 값이 없으므로 create 후 즉시 edit으로 치환하는 절차를 명시해야 한다.
 grep -qE 'gh issue edit.*body|edit.*치환|치환.*edit|반환된 issue number.*edit' "$SKILL_MD" \
   || { echo "FAIL: <new-task-id> 치환 절차(create 후 edit) 명시 없음"; exit 1; }
 echo "OK: create 후 edit 치환 절차"

--- a/tests/autopilot/test-spec-status-transition.sh
+++ b/tests/autopilot/test-spec-status-transition.sh
@@ -101,4 +101,19 @@ grep -qE '^## 10단계 워크플로|^## 10-step|총 10단계' "$SKILL_MD" \
 echo "OK: 10단계 헤더"
 
 echo ""
+echo "=== TEST 10: SKILL.md (a)·(d) 새 issue 생성 시 title/body 수집 절차 명시 ==="
+# PR #96 review (claude[bot]): step 2 (a)/(d) gh issue create title/body 명시 부재.
+# 모델이 임의 값으로 채우는 것을 방지하기 위해 title은 AskUserQuestion 1문항 + task-id fallback,
+# body는 고정 placeholder임을 명시해야 한다.
+grep -qE 'title.*AskUserQuestion|AskUserQuestion.*title|한 줄 제목.*수집' "$SKILL_MD" \
+  || { echo "FAIL: (a)/(d) title 수집 절차(AskUserQuestion) 명시 없음"; exit 1; }
+echo "OK: title 수집 절차"
+grep -qE 'task-id.*fallback|fallback.*task-id|task-id 문자열.*fallback' "$SKILL_MD" \
+  || { echo "FAIL: title fallback (task-id 사용) 명시 없음"; exit 1; }
+echo "OK: title fallback"
+grep -qE 'body.*최소|최소 본문|body.*고정|placeholder' "$SKILL_MD" \
+  || { echo "FAIL: body 최소/고정 placeholder 명시 없음"; exit 1; }
+echo "OK: body 최소/고정"
+
+echo ""
 echo "=== 모든 spec 상태 전이 테스트 통과 ==="

--- a/tests/autopilot/test-spec-status-transition.sh
+++ b/tests/autopilot/test-spec-status-transition.sh
@@ -4,8 +4,8 @@
 # SPEC: spec 워크플로우(일반·--resume)가 사전 검사 통과 직후 task-id로
 # 식별되는 외부 task의 상태를 설계 상태로 정합(reconcile)하는지 검사.
 #
-# 검사는 SKILL.md(+ references)에 4갈래 분기·abort·양 모드 적용·사용자
-# 안내·백킹 시스템 매핑이 명시되었는지 grep으로 정적 확인한다.
+# 검사는 SKILL.md에 4갈래 분기·abort·양 모드 적용·사용자 안내·백킹 시스템
+# 매핑이 명시되었는지 grep으로 정적 확인한다 (references/ 디렉터리는 미검사).
 
 set -euo pipefail
 

--- a/tests/autopilot/test-spec-status-transition.sh
+++ b/tests/autopilot/test-spec-status-transition.sh
@@ -116,4 +116,16 @@ grep -qE 'body.*최소|최소 본문|body.*고정|placeholder' "$SKILL_MD" \
 echo "OK: body 최소/고정"
 
 echo ""
+echo "=== TEST 11: SKILL.md <new-task-id> 플레이스홀더 치환 절차 명시 ==="
+# PR #96 review NIT (claude[bot]): body의 <new-task-id> placeholder가 issue 생성 전엔
+# 값이 없으므로 create 후 즉시 edit으로 치환하는 절차를 명시해야 한다.
+grep -qE 'gh issue edit.*body|edit.*치환|치환.*edit|반환된 issue number.*edit' "$SKILL_MD" \
+  || { echo "FAIL: <new-task-id> 치환 절차(create 후 edit) 명시 없음"; exit 1; }
+echo "OK: create 후 edit 치환 절차"
+# allowed-tools에 gh issue edit 추가
+grep -m1 '^allowed-tools:' "$SKILL_MD" | grep -q 'gh issue edit' \
+  || { echo "FAIL: allowed-tools에 'gh issue edit' 없음"; exit 1; }
+echo "OK: allowed-tools에 gh issue edit"
+
+echo ""
 echo "=== 모든 spec 상태 전이 테스트 통과 ==="

--- a/tests/autopilot/test-spec-status-transition.sh
+++ b/tests/autopilot/test-spec-status-transition.sh
@@ -126,6 +126,10 @@ echo "OK: create 후 edit 치환 절차"
 grep -m1 '^allowed-tools:' "$SKILL_MD" | grep -q 'gh issue edit' \
   || { echo "FAIL: allowed-tools에 'gh issue edit' 없음"; exit 1; }
 echo "OK: allowed-tools에 gh issue edit"
+# <m>은 create 전 치환 (이미 알려진 값이므로 리터럴로 남기지 않음)
+grep -qE 'create 호출.*전.*치환|create.*전에.*치환|create 호출 전' "$SKILL_MD" \
+  || { echo "FAIL: <m> milestone 치환 시점(create 전) 명시 없음"; exit 1; }
+echo "OK: <m> create 전 치환"
 
 echo ""
 echo "=== 모든 spec 상태 전이 테스트 통과 ==="

--- a/tests/autopilot/test-spec-status-transition.sh
+++ b/tests/autopilot/test-spec-status-transition.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# autopilot:spec 스킬 — task 상태 전이 단계 정적 검증 테스트
+#
+# SPEC: spec 워크플로우(일반·--resume)가 사전 검사 통과 직후 task-id로
+# 식별되는 외부 task의 상태를 설계 상태로 정합(reconcile)하는지 검사.
+#
+# 검사는 SKILL.md(+ references)에 4갈래 분기·abort·양 모드 적용·사용자
+# 안내·백킹 시스템 매핑이 명시되었는지 grep으로 정적 확인한다.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SKILL_DIR="$REPO_ROOT/plugins/autopilot/skills/spec"
+SKILL_MD="$SKILL_DIR/SKILL.md"
+
+[[ -f "$SKILL_MD" ]] || { echo "FAIL: SKILL.md 부재"; exit 1; }
+
+echo "=== TEST 1: SKILL.md에 task 상태 정합 단계 헤더 존재 ==="
+# 새 단계 헤더 (정합/전이/reconcile 중 어느 표현이든 허용; '상태' + '정합|전이|reconcile')
+grep -qE '^###? .*(상태 정합|상태 전이|status reconcil|status transition)' "$SKILL_MD" \
+  || { echo "FAIL: SKILL.md에 'task 상태 정합/전이' 단계 헤더 부재"; exit 1; }
+echo "OK: 단계 헤더"
+
+echo ""
+echo "=== TEST 2: SKILL.md에 사전 검사 통과 직후 실행 명시 ==="
+# "사전 검사 통과 직후" 또는 "preflight 직후" 같은 표현으로 위치 명시
+grep -qE '사전 검사 (통과 )?직후|preflight (통과 )?직후|after preflight' "$SKILL_MD" \
+  || { echo "FAIL: 사전 검사 통과 직후 실행 위치 명시 없음"; exit 1; }
+echo "OK: 사전 검사 직후 실행"
+
+echo ""
+echo "=== TEST 3: SKILL.md에 4갈래 분기 모두 명시 ==="
+# (a) task 부재 → 새 task 생성
+grep -qE '부재|없으면|존재하지 않|absent' "$SKILL_MD" \
+  || { echo "FAIL: (a) task 부재 분기 명시 없음"; exit 1; }
+echo "OK: (a) 부재 분기"
+
+# (b) 설계 상태(In Design) → 변경 없음 / 그대로
+grep -qE '설계 상태|In Design' "$SKILL_MD" \
+  || { echo "FAIL: (b) 설계 상태(In Design) 분기 명시 없음"; exit 1; }
+echo "OK: (b) 설계 상태 분기"
+
+# (c) 설계 이전 상태(Backlog) → 설계 상태로 전이
+grep -qE '설계 이전|Backlog' "$SKILL_MD" \
+  || { echo "FAIL: (c) 설계 이전(Backlog) 분기 명시 없음"; exit 1; }
+echo "OK: (c) 설계 이전 분기"
+
+# (d) 설계 이후 상태 → 새 task 생성
+grep -qE '설계 이후|In Progress|Review|Done' "$SKILL_MD" \
+  || { echo "FAIL: (d) 설계 이후 분기 명시 없음"; exit 1; }
+echo "OK: (d) 설계 이후 분기"
+
+echo ""
+echo "=== TEST 4: SKILL.md에 task-id 교체 + 사용자 안내 명시 ==="
+grep -qE '교체|새 task-id|새 task의 식별자' "$SKILL_MD" \
+  || { echo "FAIL: task-id 교체 명시 없음"; exit 1; }
+echo "OK: task-id 교체"
+grep -qE '사용자에게.*안내|새 task-id를.*안내|AskUserQuestion.*새 task' "$SKILL_MD" \
+  || { echo "FAIL: 사용자에게 새 task-id 안내 명시 없음"; exit 1; }
+echo "OK: 사용자 안내"
+
+echo ""
+echo "=== TEST 5: SKILL.md에 호출 실패 시 abort 명시 ==="
+# 조회·생성·전이 호출 중 하나라도 실패하면 abort
+grep -qE '실패.*abort|abort.*실패|호출 실패' "$SKILL_MD" \
+  || { echo "FAIL: 호출 실패 시 abort 동작 명시 없음"; exit 1; }
+echo "OK: 실패 시 abort"
+
+echo ""
+echo "=== TEST 6: SKILL.md에 일반 모드·--resume 모드 모두 적용 명시 ==="
+# 새 단계가 양 모드에 적용된다는 명시 (--resume 모드 요약 섹션에 본 단계 언급)
+# 단계 헤더부터 끝까지 추출해 일반·--resume 두 키워드 동시 등장 확인
+grep -qE -- '일반 모드.*--?resume|--?resume.*일반 모드|일반·--?resume|두 모드' "$SKILL_MD" \
+  || { echo "FAIL: 일반/--resume 두 모드 적용 명시 없음"; exit 1; }
+echo "OK: 양 모드 적용"
+
+echo ""
+echo "=== TEST 7: SKILL.md에 백킹 시스템(GitHub Project/Issue) 매핑 명시 ==="
+# rules/context.md 어휘에 정렬: Issue + Project Status field
+grep -qE 'GitHub (Project|Issue)|gh (issue|project)' "$SKILL_MD" \
+  || { echo "FAIL: GitHub Project/Issue 백킹 시스템 매핑 명시 없음"; exit 1; }
+echo "OK: 백킹 시스템 매핑"
+
+echo ""
+echo "=== TEST 8: SKILL.md allowed-tools에 task 상태 전이용 gh 명령 추가 ==="
+ALLOWED_LINE=$(grep -m1 '^allowed-tools:' "$SKILL_MD" || true)
+[[ -n "$ALLOWED_LINE" ]] || { echo "FAIL: allowed-tools 라인 없음"; exit 1; }
+# 신규 task 생성 + 상태 전이 호출에 필요한 gh 명령
+echo "$ALLOWED_LINE" | grep -q 'gh issue create' \
+  || { echo "FAIL: allowed-tools에 'gh issue create' 없음"; exit 1; }
+echo "OK: gh issue create"
+echo "$ALLOWED_LINE" | grep -qE 'gh project (item-list|item-edit|item-add)' \
+  || { echo "FAIL: allowed-tools에 'gh project item-*' 없음"; exit 1; }
+echo "OK: gh project item-*"
+
+echo ""
+echo "=== TEST 9: SKILL.md 워크플로 번호가 새 단계 반영 ==="
+# 단계 추가 후 워크플로 헤더 번호가 10으로 갱신됐는지 (main의 9단계 + 단계 2 task 상태 정합)
+grep -qE '^## 10단계 워크플로|^## 10-step|총 10단계' "$SKILL_MD" \
+  || { echo "FAIL: 워크플로 헤더가 10단계로 갱신되지 않음"; exit 1; }
+echo "OK: 10단계 헤더"
+
+echo ""
+echo "=== 모든 spec 상태 전이 테스트 통과 ==="


### PR DESCRIPTION
Closes #95

## Summary
- spec 워크플로우(일반·`--resume`)가 사전 검사 통과 직후 task-id로 외부 task를 조회·정합
- 4갈래 분기: (a) 부재→생성+ID 교체 (b) `In Design`→무변경 (c) `Backlog`→전이 (d) 그 외→생성+ID 교체
- 정적 검사 `tests/autopilot/test-spec-status-transition.sh` 추가 (TEST 1-11 통과)

## 본 PR의 신규 커밋
- `feat(autopilot/spec): SKILL.md 단계 2 — task 상태 정합 (4갈래 분기 + GitHub Project 매핑)`
- `fix(autopilot/spec): PR #96 review — step 2 (a)/(d) gh issue create title/body 수집 절차 명시`
- `fix(autopilot/spec): PR #96 review NIT — <new-task-id> placeholder 치환 절차 명시`
- `fix(autopilot/spec): PR #96 review NIT — <m> milestone placeholder도 치환 명시`

## Test plan
- [x] `bash tests/autopilot/test-spec-status-transition.sh` → 0 exit (TEST 1-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)