### PR TITLE
autopilot/spec+loop: SPEC commit → worktree 자연 포함 + main archive 오염 제거

### DIFF
--- a/plugins/autopilot/skills/loop/references/agent-prompts.md
+++ b/plugins/autopilot/skills/loop/references/agent-prompts.md
@@ -28,9 +28,9 @@ Agent({
 ```
 당신은 자율 루프의 현재 이터레이션에서 만든 변경이 작업 명세에 부합하는지 검증합니다.
 
-## 요구사항 (.loop/SPEC.md에서)
+## 요구사항 (SPEC.md에서)
 
-[`<worktree>/.loop/SPEC.md`의 작업 정의 섹션 전체 텍스트 — 작업 정의·수용 기준·범위·검증 명령을 그대로 paste. 파일을 다시 읽게 하지 말 것]
+[워크트리의 SPEC.md(신규 contract: `<worktree>/milestones/<m>/loops/<c>/SPEC.md` / legacy: `<worktree>/.loop/SPEC.md`)의 작업 정의 섹션 전체 텍스트 — 작업 정의·수용 기준·범위·검증 명령을 그대로 paste. 파일을 다시 읽게 하지 말 것]
 
 ## 이번 이터가 한 작업 (자기 보고)
 
@@ -111,7 +111,7 @@ Agent({
 
 ## 작업 정의 / 평가 기준
 
-이터의 작업 정의는 `<worktree>/.loop/SPEC.md`에 있음. 평가 기준은 헌법(`<worktree>/CLAUDE.md`) §3.5 Self-Review 4축.
+이터의 작업 정의는 워크트리의 SPEC.md(신규: `<worktree>/milestones/<m>/loops/<c>/SPEC.md` / legacy: `<worktree>/.loop/SPEC.md`)에 있음. 평가 기준은 헌법(`<worktree>/CLAUDE.md`) §3.5 Self-Review 4축.
 
 ## Git 범위
 

--- a/plugins/autopilot/skills/loop/references/constitution.md
+++ b/plugins/autopilot/skills/loop/references/constitution.md
@@ -32,14 +32,14 @@
 
 - **콜드 스타트**: 매 이터레이션은 새 프로세스다. 직전 이터의 추론 과정·중간 상태는 다음 이터가 보지 못한다 — 결과물(코드·테스트·메모리 파일)만 본다.
 - **워크트리 격리**: 모든 작업은 워크트리 안(`milestones/<m>/loops/<c>/.worktree/` — 단일 task는 `<m>=regular`로 정규화)에서 일어난다. 워크트리 밖 파일은 수정 대상이 아니다.
-- **입력**: `<worktree>/CLAUDE.md`(헌법), `.loop/SPEC.md`(작업 정의), 디스크 상태(코드·git 히스토리), `.loop/{PLAN,NOTES,HANDOFF,RUN_LOG}.md`(메모리 파일).
+- **입력**: `<worktree>/CLAUDE.md`(헌법), `milestones/<m>/loops/<c>/SPEC.md`(작업 정의 — worktree 안의 단일 canonical 경로. 신규 contract에선 feat 브랜치 commit으로 자연 포함, legacy에선 셋업 시 `.loop/SPEC.md`로 cp), 디스크 상태(코드·git 히스토리), `.loop/{PLAN,NOTES,HANDOFF,RUN_LOG}.md`(메모리 파일).
 - **출력**: 코드 변경 + 자기 분류 prefix를 가진 git commit + `.loop/` 메모리 파일 갱신 + (선택) `DONE` 또는 `.loop/ESCALATION.md` 신호 파일.
 
 ## 3. 작업 흐름
 
 ### 3.1 수용 기준 확인
 
-작업 시작 시점에 `.loop/SPEC.md`의 작업 정의·수용 기준을 먼저 읽는다. 수용 기준이 모호하면 즉시 에스컬레이션한다 — 추측으로 진행하지 않는다.
+작업 시작 시점에 `milestones/<m>/loops/<c>/SPEC.md`의 작업 정의·수용 기준을 먼저 읽는다 (legacy contract는 `.loop/SPEC.md`). 수용 기준이 모호하면 즉시 에스컬레이션한다 — 추측으로 진행하지 않는다.
 
 ### 3.2 한 이터레이션의 6단계
 
@@ -233,7 +233,7 @@ revert 시 commit message는 `chore: revert <짧은 SHA> — fix:symptom 자체 
 - `.git` 히스토리 조작, force push, 리베이스
 - "작동하는 것처럼 보이게 하는" 모든 종류의 위장
 - 워크트리 밖 파일 수정 (모든 작업은 워크트리 안에서)
-- 워크트리 루트의 `CLAUDE.md`(헌법), `.loop/SPEC.md` 수정
+- 워크트리 루트의 `CLAUDE.md`(헌법), 워크트리의 SPEC.md(신규: `milestones/<m>/loops/<c>/SPEC.md` / legacy: `.loop/SPEC.md`) 수정
 - 거짓 `DONE` 또는 거짓 `.loop/ESCALATION.md` 작성
 
 다음 항목은 드라이버가 객관 검증한다 — 위반 시 자동 halt + 에스컬레이션:

--- a/plugins/autopilot/skills/loop/references/escalation-template.md
+++ b/plugins/autopilot/skills/loop/references/escalation-template.md
@@ -32,7 +32,7 @@
 ## 카테고리 선택 가이드
 
 - `config-gap` — 환경 설정·도구 버전·자격증명 부재. 사람이 환경 조정.
-- `spec-gap` — `.loop/SPEC.md` 자체 결함. 사람이 명세 수정.
+- `spec-gap` — SPEC.md 자체 결함 (신규: `milestones/<m>/loops/<c>/SPEC.md` / legacy: `.loop/SPEC.md`). 사람이 명세 수정.
 - `architecture-gap` — 현재 코드 구조로 해결 불가. 사람의 architecture 결정.
 - `environment-gap` — 외부 시스템 일시적 문제. 사람의 환경 점검.
 - `other` — 위에 안 맞을 때.

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -216,7 +216,7 @@ find_feat_branch() {
   if [[ -z "$matches" ]]; then
     return 1
   fi
-  count=$(printf '%s\n' "$matches" | grep -c . 2>/dev/null || echo 0)
+  count=$(printf '%s\n' "$matches" | grep -c .)
   if [[ $count -ge 2 ]]; then
     die "여러 feat 브랜치가 task-id '$task_id'와 매칭됨 (모호):\n$matches\n수동으로 하나 남기고 다른 것 정리 후 재시도."
   fi

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -192,10 +192,36 @@ compute_paths() {
   local milestone="${task_id%%/*}"
   local child="${task_id#*/}"
   LOOPS_DIR="$PROJECT_ROOT/milestones/$milestone/loops/$child"
+  # LOOPS_DIR_REL: worktree 안의 SPEC.md canonical 경로 prefix (신규 contract).
+  # 신규 contract에선 SPEC.md가 feat 브랜치에 commit되어 worktree에서
+  # <wt>/$LOOPS_DIR_REL/SPEC.md 경로로 자연 노출된다.
+  LOOPS_DIR_REL="milestones/$milestone/loops/$child"
   WT="$LOOPS_DIR/.worktree"
   LOCK_FILE="$LOOPS_DIR/.lock"
   # 정규화된 task-id를 caller에게 노출 (cmd_start에서 TASK_ID로 사용)
   TASK_ID_NORMALIZED="$task_id"
+}
+
+# 신규 contract 감지: feat/<task-id> 또는 feat/<task-id>-<slug> 브랜치 검색.
+# 0개 매칭이면 빈 출력 + return 1 (legacy 분기로 fallback).
+# 정확히 1개 매칭이면 브랜치 이름 출력 + return 0.
+# 2개 이상이면 die (모호성).
+find_feat_branch() {
+  local task_id="$1"
+  local matches count
+  matches=$(git -C "$PROJECT_ROOT" for-each-ref \
+    --format='%(refname:short)' \
+    "refs/heads/feat/$task_id" \
+    "refs/heads/feat/$task_id-*" 2>/dev/null)
+  if [[ -z "$matches" ]]; then
+    return 1
+  fi
+  count=$(printf '%s\n' "$matches" | grep -c . 2>/dev/null || echo 0)
+  if [[ $count -ge 2 ]]; then
+    die "여러 feat 브랜치가 task-id '$task_id'와 매칭됨 (모호):\n$matches\n수동으로 하나 남기고 다른 것 정리 후 재시도."
+  fi
+  printf '%s\n' "$matches"
+  return 0
 }
 
 # ----- 동시성 락 -----
@@ -346,11 +372,20 @@ hash_deps() {
 }
 
 read_scope_yaml() {
+  # SPEC.md 위치 자동 감지:
+  #   - 신규 contract: <WT>/<LOOPS_DIR_REL>/SPEC.md (feat 브랜치 commit으로 자연 포함)
+  #   - legacy: <WT>/.loop/SPEC.md (셋업 시 cp)
+  local spec_path
+  if [[ -n "${LOOPS_DIR_REL:-}" ]] && [[ -f "$WT/$LOOPS_DIR_REL/SPEC.md" ]]; then
+    spec_path="$WT/$LOOPS_DIR_REL/SPEC.md"
+  else
+    spec_path="$WT/.loop/SPEC.md"
+  fi
   sed -n '1,/^---$/{
     1d
     /^---$/d
     p
-  }' "$WT/.loop/SPEC.md" 2>/dev/null
+  }' "$spec_path" 2>/dev/null
 }
 
 diff_vs_scope() {
@@ -531,6 +566,12 @@ iterate() {
 
   # 비동기 실행 + wait — bash trap은 동기 명령 안에서 deferred되므로 wait를 써야
   # SIGTERM/SIGINT가 즉시 처리돼 자식 트리 정리 가능 (orphan 방지)
+  # SPEC.md stdin 경로: 신규 contract는 worktree의 milestones/<m>/loops/<c>/SPEC.md,
+  # legacy는 .loop/SPEC.md (셋업 시 cp). 둘 다 worktree 안의 단일 canonical 경로.
+  local spec_stdin_path=".loop/SPEC.md"
+  if [[ -n "${LOOPS_DIR_REL:-}" ]] && [[ -f "$WT/$LOOPS_DIR_REL/SPEC.md" ]]; then
+    spec_stdin_path="$LOOPS_DIR_REL/SPEC.md"
+  fi
   local exit_code=0
   (
     cd "$WT"
@@ -541,7 +582,7 @@ iterate() {
       --system-prompt-file CLAUDE.md \
       --add-dir . \
       --output-format json \
-      < .loop/SPEC.md \
+      < "$spec_stdin_path" \
       > ".loop/iterations/$n.log" 2>&1
   ) &
   local claude_pid=$!
@@ -658,7 +699,7 @@ cmd_start() {
   MAX_CONCURRENT="${MAX_CONCURRENT:-3}"
   WATCH_MODE="$watch_mode"
 
-  # 1. --spec 외부 SPEC 전달 처리
+  # 1. --spec 외부 SPEC 전달 처리 (legacy 진입로 — main 작업트리에 SPEC을 직접 둠)
   if [[ -n "$spec_path" ]]; then
     [[ -f "$spec_path" ]] || die "외부 SPEC 파일을 찾을 수 없음: $spec_path"
     mkdir -p "$LOOPS_DIR"
@@ -666,22 +707,44 @@ cmd_start() {
     echo "외부 SPEC 파일 복사: $spec_path → $LOOPS_DIR/SPEC.md"
   fi
 
-  # 2. SPEC.md 존재 확인 (milestones/<m>/loops/<c>/SPEC.md 단일 경로 — legacy fallback 없음)
-  local spec_path_local="$LOOPS_DIR/SPEC.md"
-  if [[ ! -f "$spec_path_local" ]]; then
-    die "SPEC.md가 없습니다 (기대 경로: $spec_path_local).\n먼저 실행하세요: Skill(skill: \"spec\", args: \"$task_id\")"
+  # 1.5. 신규 contract 감지: feat/<task-id>[-<slug>] 브랜치가 main repo에 있으면
+  # 그 브랜치를 worktree base로 사용하고 SPEC은 worktree에서 자연 노출되는 경로로 읽음.
+  # 없으면 legacy 분기 (LOOPS_DIR/SPEC.md를 .loop/로 cp).
+  NEW_CONTRACT=0
+  local feat_branch=""
+  if feat_branch=$(find_feat_branch "$task_id"); then
+    if [[ -n "$feat_branch" ]]; then
+      NEW_CONTRACT=1
+      BRANCH="$feat_branch"
+    fi
   fi
 
-  # 2.5. [NEEDS CLARIFICATION] 마커 검사 (락 획득 전)
-  if grep -q '\[NEEDS CLARIFICATION' "$spec_path_local"; then
+  # 2. SPEC.md 존재·내용 검증 — 신규 contract와 legacy 분기.
+  local spec_content=""
+  if [[ $NEW_CONTRACT -eq 1 ]]; then
+    # 신규 contract: SPEC을 feat 브랜치 commit에서 읽음 (main 작업트리는 무시).
+    # 브랜치는 있는데 SPEC commit이 없으면 fail-fast.
+    spec_content=$(git -C "$PROJECT_ROOT" show "${BRANCH}:${LOOPS_DIR_REL}/SPEC.md" 2>/dev/null) \
+      || die "feat 브랜치 '${BRANCH}'의 HEAD에 SPEC.md(${LOOPS_DIR_REL}/SPEC.md) 부재 — spec 스킬로 SPEC 작성·commit 필요."
+  else
+    # legacy: main 작업트리의 LOOPS_DIR/SPEC.md를 읽음.
+    local spec_path_local="$LOOPS_DIR/SPEC.md"
+    if [[ ! -f "$spec_path_local" ]]; then
+      die "SPEC.md가 없습니다 (기대 경로: $spec_path_local 또는 feat/${task_id}[-<slug>] 브랜치).\n먼저 실행하세요: Skill(skill: \"spec\", args: \"$task_id\")"
+    fi
+    spec_content=$(cat "$spec_path_local")
+  fi
+
+  # 2.5. [NEEDS CLARIFICATION] 마커 검사 (락 획득 전, 양 contract 공통)
+  if grep -q '\[NEEDS CLARIFICATION' <<< "$spec_content"; then
     die "SPEC.md에 미해결 [NEEDS CLARIFICATION] 마커가 있습니다.\n해결: Skill(skill: \"spec\", args: \"$task_id --resume\")"
   fi
 
   # 3. placeholder 검사
   local placeholders
-  placeholders=$(grep -oE '\{\{[^}]+\}\}' "$spec_path_local" 2>/dev/null || true)
+  placeholders=$(grep -oE '\{\{[^}]+\}\}' <<< "$spec_content" 2>/dev/null || true)
   if [[ -n "$placeholders" ]]; then
-    die "채워지지 않은 placeholder가 있습니다: $(echo "$placeholders" | tr '\n' ' ')\n$spec_path_local 를 편집하세요."
+    die "채워지지 않은 placeholder가 있습니다: $(echo "$placeholders" | tr '\n' ' ')\nSPEC.md를 편집하세요."
   fi
 
   # 4. scope.include 비어있으면 거부 (start에서)
@@ -690,7 +753,7 @@ cmd_start() {
     1d
     /^---$/d
     p
-  }' "$spec_path_local" 2>/dev/null | yq '.scope.include | length' 2>/dev/null)
+  }' <<< "$spec_content" | yq '.scope.include | length' 2>/dev/null)
   if [[ "${include_count:-0}" -eq 0 ]]; then
     die "SPEC.md의 scope.include가 비어 있습니다. 최소 한 패턴 명시 필요 (예: 'src/**'·'**/*')"
   fi
@@ -705,8 +768,20 @@ cmd_start() {
     # 새 nested 정책: WT 부모(loops_dir)는 이미 SPEC.md 존재 시 만들어짐.
     # 일관성을 위해 mkdir -p로 보장.
     mkdir -p "$(dirname "$WT")"
-    git -C "$PROJECT_ROOT" worktree add "$WT" -b "$BRANCH" \
-      || die "git worktree add 실패: $WT"
+
+    # 신규 contract: 기존 feat 브랜치를 base로 worktree 체크아웃 (-b 없음).
+    # legacy: 새 autonomous-loop 브랜치를 만들며 worktree 생성.
+    if [[ $NEW_CONTRACT -eq 1 ]]; then
+      git -C "$PROJECT_ROOT" worktree add "$WT" "$BRANCH" \
+        || die "git worktree add 실패 (feat 브랜치 체크아웃): $WT (브랜치: $BRANCH)"
+      # 사후 검증: worktree HEAD에 SPEC.md 자연 노출 확인 (spec 스킬이 commit했어야)
+      if [[ ! -f "$WT/$LOOPS_DIR_REL/SPEC.md" ]]; then
+        die "feat 브랜치 ${BRANCH} 워크트리 HEAD에 SPEC.md 부재 (기대: $WT/$LOOPS_DIR_REL/SPEC.md)"
+      fi
+    else
+      git -C "$PROJECT_ROOT" worktree add "$WT" -b "$BRANCH" \
+        || die "git worktree add 실패: $WT"
+    fi
 
     # 워크트리 baseline empty commit — iter 1의 HEAD~1..HEAD diff가 부모 브랜치의
     # ensure_loops_setup chore commit 등 setup history를 worker 변경으로 오인하지
@@ -728,9 +803,12 @@ cmd_start() {
         || die "skip-worktree 설정 실패: $WT/CLAUDE.md"
     fi
 
-    # 메타 파일 시드
+    # 메타 파일 시드 — 신규 contract는 SPEC을 worktree에서 자연 포함하므로 cp 안 함.
+    # legacy만 LOOPS_DIR/SPEC.md → .loop/SPEC.md로 cp.
     mkdir -p "$WT/.loop/iterations"
-    cp "$LOOPS_DIR/SPEC.md" "$WT/.loop/SPEC.md"
+    if [[ $NEW_CONTRACT -eq 0 ]]; then
+      cp "$LOOPS_DIR/SPEC.md" "$WT/.loop/SPEC.md"
+    fi
     cp "$SCRIPT_DIR/plan-template.md" "$WT/.loop/PLAN.md"
     cp "$SCRIPT_DIR/notes-template.md" "$WT/.loop/NOTES.md"
     cp "$SCRIPT_DIR/handoff-template.md" "$WT/.loop/HANDOFF.md"
@@ -1061,12 +1139,27 @@ cmd_cleanup() {
     die "task $task_id 에 DONE 신호가 없습니다.\n--force 없이 cleanup하려면 먼저 DONE 파일이 필요합니다: $0 cleanup $task_id --force"
   fi
 
-  # 4. 메타 파일 archive (milestones/<m>/loops/<c>/ 로 이동)
-  mkdir -p "$LOOPS_DIR"
-  for f in PLAN.md NOTES.md HANDOFF.md RUN_LOG.md ESCALATION.md; do
-    cp "$WT/.loop/$f" "$LOOPS_DIR/$f" 2>/dev/null || true
-  done
-  echo "메타 파일 보관: $LOOPS_DIR"
+  # 3.5. 신규 contract 감지 — worktree HEAD 브랜치가 feat/... 이면 신규.
+  # 신규 contract는 메모리 파일 archive를 폐기하고 feat 브랜치를 PR base로 남긴다.
+  local current_branch=""
+  current_branch=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  local cleanup_new_contract=0
+  if [[ "$current_branch" == feat/* ]]; then
+    cleanup_new_contract=1
+    BRANCH="$current_branch"
+  fi
+
+  # 4. 메타 파일 archive — legacy contract만 수행.
+  # 신규 contract: worker 메모리 파일을 main 작업트리로 복사하지 않음 (worktree 제거와 함께 폐기).
+  if [[ $cleanup_new_contract -eq 0 ]]; then
+    mkdir -p "$LOOPS_DIR"
+    for f in PLAN.md NOTES.md HANDOFF.md RUN_LOG.md ESCALATION.md; do
+      cp "$WT/.loop/$f" "$LOOPS_DIR/$f" 2>/dev/null || true
+    done
+    echo "메타 파일 보관: $LOOPS_DIR"
+  else
+    echo "신규 contract: 메모리 파일 archive 건너뜀 (feat 브랜치 ${BRANCH}이 PR base)"
+  fi
 
   # 5. 워크트리 제거
   local wt_remove_flags=""
@@ -1074,15 +1167,22 @@ cmd_cleanup() {
   git -C "$PROJECT_ROOT" worktree remove $wt_remove_flags "$WT" \
     || die "git worktree remove 실패. 수동 제거: git worktree remove --force $WT"
 
-  # 6. 브랜치 삭제
-  local branch_delete_flag="-d"
-  [[ $force -eq 1 ]] && branch_delete_flag="-D"
-  git -C "$PROJECT_ROOT" branch $branch_delete_flag "$BRANCH" 2>/dev/null \
-    || echo "WARN: 브랜치 삭제 실패 (이미 머지됐거나 없을 수 있음): $BRANCH"
+  # 6. 브랜치 삭제 — legacy contract만 수행.
+  # 신규 contract: feat 브랜치는 PR base로 남겨야 하므로 삭제하지 않음.
+  if [[ $cleanup_new_contract -eq 0 ]]; then
+    local branch_delete_flag="-d"
+    [[ $force -eq 1 ]] && branch_delete_flag="-D"
+    git -C "$PROJECT_ROOT" branch $branch_delete_flag "$BRANCH" 2>/dev/null \
+      || echo "WARN: 브랜치 삭제 실패 (이미 머지됐거나 없을 수 있음): $BRANCH"
+  else
+    echo "feat 브랜치 보존: $BRANCH (PR base로 사용)"
+  fi
 
   echo ""
   echo "정리 완료: $task_id"
-  echo "보관된 메타 파일: $LOOPS_DIR"
+  if [[ $cleanup_new_contract -eq 0 ]]; then
+    echo "보관된 메타 파일: $LOOPS_DIR"
+  fi
 }
 
 # ----- subcommand: logs -----

--- a/plugins/autopilot/skills/loop/references/operational-guide.md
+++ b/plugins/autopilot/skills/loop/references/operational-guide.md
@@ -118,7 +118,7 @@ bash "$LOOP_SH" logs auth-refactor [--tail | --iter N]
 ```bash
 cat milestones/<m>/loops/<c>/.worktree/.loop/ESCALATION.md  # 사유 확인
 cd milestones/<m>/loops/<c>/.worktree
-$EDITOR .loop/SPEC.md && $EDITOR .loop/NOTES.md             # 명세·학습 조정
+$EDITOR milestones/<m>/loops/<c>/SPEC.md && $EDITOR .loop/NOTES.md   # 명세·학습 조정 (legacy는 .loop/SPEC.md)
 rm .loop/ESCALATION.md                                      # 보고 해제
 cd <project-root> && bash "$LOOP_SH" start <task-id>        # 재시작
 # --watch 모드면 ESCALATION.md 정리만으로 자동 재개 (60초 polling)

--- a/plugins/autopilot/skills/loop/references/operational-guide.md
+++ b/plugins/autopilot/skills/loop/references/operational-guide.md
@@ -118,7 +118,10 @@ bash "$LOOP_SH" logs auth-refactor [--tail | --iter N]
 ```bash
 cat milestones/<m>/loops/<c>/.worktree/.loop/ESCALATION.md  # 사유 확인
 cd milestones/<m>/loops/<c>/.worktree
-$EDITOR milestones/<m>/loops/<c>/SPEC.md && $EDITOR .loop/NOTES.md   # 명세·학습 조정 (legacy는 .loop/SPEC.md)
+# 신규 contract: SPEC은 worktree 안 milestones/<m>/loops/<c>/SPEC.md
+$EDITOR milestones/<m>/loops/<c>/SPEC.md && $EDITOR .loop/NOTES.md
+# legacy contract: SPEC은 worktree 안 .loop/SPEC.md (위 명령에서 SPEC 경로만 교체)
+# $EDITOR .loop/SPEC.md && $EDITOR .loop/NOTES.md
 rm .loop/ESCALATION.md                                      # 보고 해제
 cd <project-root> && bash "$LOOP_SH" start <task-id>        # 재시작
 # --watch 모드면 ESCALATION.md 정리만으로 자동 재개 (60초 polling)

--- a/plugins/autopilot/skills/loop/references/troubleshooting.md
+++ b/plugins/autopilot/skills/loop/references/troubleshooting.md
@@ -18,7 +18,7 @@ ESCALATION.md의 `**카테고리**` 필드 별 사람의 처리 권장 흐름.
 
 처리:
 1. ESCALATION.md의 "필요한 결정" 섹션 검토
-2. 워크트리의 SPEC.md 직접 수정 (신규 contract: `milestones/<m>/loops/<c>/.worktree/milestones/<m>/loops/<c>/SPEC.md` / legacy: `milestones/<m>/loops/<c>/.worktree/.loop/SPEC.md`. SPEC 작성은 spec 스킬 사용: Skill(skill: "spec", args: "<task-id>"))
+2. 워크트리의 SPEC.md 직접 수정. 워크트리 루트는 `milestones/<m>/loops/<c>/.worktree`이고 그 안 SPEC 위치는 contract에 따라 다름 — 신규 contract: `milestones/<m>/loops/<c>/SPEC.md`, legacy: `.loop/SPEC.md`. (SPEC 작성은 spec 스킬 사용: Skill(skill: "spec", args: "<task-id>"))
 3. ESCALATION.md 정리 후 재시작
 
 ## architecture-gap (코드 구조 변경 필요)

--- a/plugins/autopilot/skills/loop/references/troubleshooting.md
+++ b/plugins/autopilot/skills/loop/references/troubleshooting.md
@@ -18,7 +18,7 @@ ESCALATION.md의 `**카테고리**` 필드 별 사람의 처리 권장 흐름.
 
 처리:
 1. ESCALATION.md의 "필요한 결정" 섹션 검토
-2. `milestones/<m>/loops/<c>/.worktree/.loop/SPEC.md` 직접 수정 (prepare 서브커맨드는 deprecated이며 SPEC 작성은 spec 스킬 사용: Skill(skill: "spec", args: "<task-id>"))
+2. 워크트리의 SPEC.md 직접 수정 (신규 contract: `milestones/<m>/loops/<c>/.worktree/milestones/<m>/loops/<c>/SPEC.md` / legacy: `milestones/<m>/loops/<c>/.worktree/.loop/SPEC.md`. SPEC 작성은 spec 스킬 사용: Skill(skill: "spec", args: "<task-id>"))
 3. ESCALATION.md 정리 후 재시작
 
 ## architecture-gap (코드 구조 변경 필요)

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
-description: "autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. 호출 'Skill(skill=\"spec\", args=\"<task-id> [--milestone <m>] [--resume]\")'. milestone 미지정 시 `regular`(catch-all)을 default로 적용."
-allowed-tools: AskUserQuestion, Read, Write, Skill, Bash(git log:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(echo:*), Bash(head:*), Bash(gh issue view:*)
+description: "autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. SPEC.md 작성 후 결정적 슬러그화 규칙(ASCII 영숫자·하이픈만)으로 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·SPEC.md를 commit해 loop·PR 흐름이 단일 feature 브랜치로 통합되게 합니다. 호출 'Skill(skill=\"spec\", args=\"<task-id> [--milestone <m>] [--resume]\")'. milestone 미지정 시 `regular`(catch-all)을 default로 적용."
+allowed-tools: AskUserQuestion, Read, Write, Skill, Bash(git log:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git show-ref:*), Bash(git for-each-ref:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(echo:*), Bash(head:*), Bash(tr:*), Bash(sed:*), Bash(gh issue view:*)
 ---
 
 # spec
@@ -147,6 +147,54 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 ### 8. 자체 검토
 
 `references/self-review.md` 5항목 체크 (placeholder · 모순 · 범위 · 모호성 · EARS fail-가능성). 발견 시 인라인 수정 또는 `[NEEDS CLARIFICATION]` 마커만 — 사용자 Q&A 없음(단계 9에서 일괄 해결). 재루프 없음. 수정·마커 후 SPEC.md 재기록.
+
+### 8.5. feat 브랜치 + SPEC.md commit (자동, main 작업트리 무손상)
+
+SPEC.md 작성과 자체 검토가 끝나면, sibling `autopilot:loop`이 worktree base로 사용할 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·생성하고 SPEC.md를 그 브랜치에 commit한다. main 작업트리 상태(staged/unstaged/untracked)는 변경되지 않아야 한다.
+
+이 단계를 단계 9의 사용자 최종 검토 *전*에 수행해 SPEC.md가 이미 git history에 반영된 상태에서 사용자가 결정을 내리도록 한다. 사용자가 단계 9에서 "변경" 옵션을 선택하면 단계 6/7 재진입 후 본 단계의 commit을 amend하거나 새 commit을 쌓는다 (자동 처리).
+
+#### 8.5.1 슬러그화 규칙 (결정적)
+
+SPEC §1 제목(첫 H1, `# ` 다음 텍스트)에서 `<slug>`를 도출:
+
+1. ASCII 소문자로 변환
+2. `[a-z0-9-]`가 아닌 모든 문자를 `-`로 치환 (UTF-8 멀티바이트는 바이트별 치환)
+3. 연속된 `-`를 단일 `-`로 압축
+4. 시작·끝의 `-` 제거
+
+결과가 빈 문자열이면 `<slug>` 없이 `feat/<task-id>` 단독으로 fallback. 같은 SPEC 제목은 항상 같은 slug를 만든다.
+
+구현 예 (bash):
+
+```bash
+title=$(sed -n '/^---$/,/^---$/!{/^# /{s/^# //p; q;}}' "milestones/<m>/loops/<c>/SPEC.md")
+slug=$(printf '%s' "$title" \
+  | LC_ALL=C tr '[:upper:]' '[:lower:]' \
+  | LC_ALL=C tr -c 'a-z0-9-' '-' \
+  | sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//')
+```
+
+#### 8.5.2 브랜치 생성·commit 절차
+
+1. `git status --porcelain`으로 main 작업트리 상태 스냅샷 캡처. unstaged·untracked가 있으면 그 사실을 인지 (다음 단계의 git 동작이 영향 안 주도록 명시적 경로 사용).
+2. 현재 브랜치 이름 보존: `orig_branch=$(git rev-parse --abbrev-ref HEAD)`.
+3. 브랜치 이름 결정:
+   - `branch="feat/<task-id>-<slug>"` (slug 비-empty 시)
+   - `branch="feat/<task-id>"` (slug fallback)
+4. `git show-ref --verify --quiet "refs/heads/$branch"`로 충돌 확인. 이미 존재하면 사용자에게 알리고 `AskUserQuestion`으로 (덮어쓰기 / 새 이름 / 종료) 선택.
+5. `git checkout -b "$branch"`로 분기 (main에서). main 작업트리의 다른 변경은 그대로 따라옴 (이를 의도). SPEC.md만 add·commit하므로 다른 파일은 새 commit에 들어가지 않는다.
+6. `git add "milestones/<m>/loops/<c>/SPEC.md"`로 명시적으로 SPEC.md만 staging (`git add .` 절대 금지).
+7. `git commit -m "feat(spec): <task-id> — <title>" -- "milestones/<m>/loops/<c>/SPEC.md"`로 SPEC만 commit. `-- <pathspec>` 형식이 다른 staged 파일을 commit에서 격리.
+8. `git checkout "$orig_branch"`로 원래 브랜치 복귀.
+9. 복귀 후 `git status --porcelain` 결과가 step 1과 동일한지 검증. 다르면 사용자에게 경고.
+
+#### 8.5.3 실패 처리
+
+위 절차 중 어떤 단계라도 실패하면:
+- 부분 결과 정리: 생성된 feat 브랜치가 있으면 `git branch -D "$branch"`로 삭제 (단, 그 브랜치에 다른 commit이 없을 때만; 의심스러우면 사용자에게 알리고 수동 정리 안내).
+- 원래 브랜치 복귀: `git checkout "$orig_branch"`.
+- 사용자에게 명시적으로 실패 사유와 복구 방법 안내. SPEC.md는 `milestones/<m>/loops/<c>/SPEC.md`에 그대로 남기되, loop 진행은 다음 단계에서 사용자가 결정.
 
 ### 9. 사용자 최종 검토
 

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -183,7 +183,7 @@ slug=$(printf '%s' "$title" \
    - `branch="feat/<task-id>-<slug>"` (slug 비-empty 시)
    - `branch="feat/<task-id>"` (slug fallback)
 4. `git show-ref --verify --quiet "refs/heads/$branch"`로 충돌 확인. 이미 존재하면 사용자에게 알리고 `AskUserQuestion`으로 (덮어쓰기 / 새 이름 / 종료) 선택.
-5. `git checkout -b "$branch"`로 분기 (main에서). main 작업트리의 다른 변경은 그대로 따라옴 (이를 의도). SPEC.md만 add·commit하므로 다른 파일은 새 commit에 들어가지 않는다.
+5. `git checkout -b "$branch" main`으로 main에서 명시적으로 분기. base를 명시하지 않으면 호출 시점 HEAD에서 분기되어 비-main 브랜치에서 호출 시 엉뚱한 base로 feat 브랜치가 만들어진다. main 작업트리의 다른 변경은 그대로 따라옴 (이를 의도). SPEC.md만 add·commit하므로 다른 파일은 새 commit에 들어가지 않는다.
 6. `git add "milestones/<m>/loops/<c>/SPEC.md"`로 명시적으로 SPEC.md만 staging (`git add .` 절대 금지).
 7. `git commit -m "feat(spec): <task-id> — <title>" -- "milestones/<m>/loops/<c>/SPEC.md"`로 SPEC만 commit. `-- <pathspec>` 형식이 다른 staged 파일을 commit에서 격리.
 8. `git checkout "$orig_branch"`로 원래 브랜치 복귀.

--- a/tests/autopilot/test-loop-sh.sh
+++ b/tests/autopilot/test-loop-sh.sh
@@ -2301,5 +2301,150 @@ chmod +x "$MOCK58/claude"
 )
 echo "OK"
 
+echo "=== TEST 59: 신규 contract — feat 브랜치 + 커밋된 SPEC를 worktree가 자연 포함 (외부 cp 없음) ==="
+# 새 라이프사이클: spec 스킬이 feat/<task-id>-<slug> 브랜치에 SPEC.md를 commit. loop start는
+# 그 브랜치를 직접 체크아웃해 worktree를 만들며 worktree 외부에서 SPEC를 추가 복사하지 않는다.
+T59_PROJECT="$WORK_DIR/new-contract-feat"
+mkdir -p "$T59_PROJECT"
+git -C "$T59_PROJECT" init -q
+git -C "$T59_PROJECT" config user.email "t@e.com"
+git -C "$T59_PROJECT" config user.name "Test"
+git -C "$T59_PROJECT" commit --allow-empty -m "initial" -q
+
+# spec 스킬을 시뮬레이션: feat 브랜치 + SPEC commit (main 작업 트리는 변경하지 않음)
+T59_BRANCH="feat/regular/n59-my-feature"
+T59_LOOPS_REL="milestones/regular/loops/n59"
+T59_DEFAULT_BRANCH=$(git -C "$T59_PROJECT" rev-parse --abbrev-ref HEAD)
+git -C "$T59_PROJECT" checkout -q -b "$T59_BRANCH"
+mkdir -p "$T59_PROJECT/$T59_LOOPS_REL"
+cat > "$T59_PROJECT/$T59_LOOPS_REL/SPEC.md" <<'EOF'
+---
+scope:
+  include:
+    - "**/*"
+  exclude: []
+verify: 'true'
+---
+
+# My Feature
+EOF
+git -C "$T59_PROJECT" add "$T59_LOOPS_REL/SPEC.md"
+git -C "$T59_PROJECT" commit -q -m "feat(spec): n59 — My Feature"
+# 원래 브랜치로 복귀 (main 트리 상태)
+git -C "$T59_PROJECT" checkout -q "$T59_DEFAULT_BRANCH"
+# 워킹 트리에는 SPEC.md가 없어야 (spec 스킬이 main 트리를 더럽히지 않았다는 가정)
+[[ ! -f "$T59_PROJECT/$T59_LOOPS_REL/SPEC.md" ]] \
+  || { echo "FAIL: setup 단계에서 main 작업 트리에 SPEC.md가 남아 있음 (test setup 오류)"; exit 1; }
+
+(
+  cd "$T59_PROJECT"
+  set +e
+  output59=$(MAX_ITERATIONS=1 WALL_CLOCK_MINUTES=5 bash "$LOOP_SH_SRC" start "regular/n59" 2>&1)
+  result59=$?
+  set -e
+  WT59="$T59_PROJECT/$T59_LOOPS_REL/.worktree"
+  [[ $result59 -eq 0 ]] || { echo "FAIL: 신규 contract start 실패. exit=$result59. got: $output59"; exit 1; }
+  [[ -d "$WT59" ]] || { echo "FAIL: 워크트리 미생성: $WT59"; exit 1; }
+  # SPEC.md는 worktree에서 자연 경로로 존재해야 (feat 브랜치 commit)
+  [[ -f "$WT59/$T59_LOOPS_REL/SPEC.md" ]] \
+    || { echo "FAIL: 워크트리 canonical 경로에 SPEC.md 없음 ($WT59/$T59_LOOPS_REL/SPEC.md)"; exit 1; }
+  # 워크트리의 브랜치가 feat/<task-id>-<slug>여야
+  CURR_BR=$(git -C "$WT59" rev-parse --abbrev-ref HEAD)
+  [[ "$CURR_BR" == "$T59_BRANCH" ]] \
+    || { echo "FAIL: 워크트리 브랜치가 feat가 아님 (got: $CURR_BR, expected: $T59_BRANCH)"; exit 1; }
+)
+echo "OK"
+
+echo "=== TEST 60: 신규 contract cleanup — 메모리 파일 archive 안 함 + feat 브랜치 유지 ==="
+# 동일 setup 재사용. --force는 mock의 untracked DONE/.loop/CLAUDE.md를 정리하기 위함
+# (TEST 8과 동일 사유 — 정상 worker는 commit으로 정리)
+(
+  cd "$T59_PROJECT"
+  bash "$LOOP_SH_SRC" cleanup "regular/n59" --force > /dev/null 2>&1
+  WT60="$T59_PROJECT/$T59_LOOPS_REL/.worktree"
+  [[ ! -d "$WT60" ]] || { echo "FAIL: cleanup 후 워크트리 잔존"; exit 1; }
+  # 신규 contract: 메모리 파일이 archive되지 않아야
+  ARCHIVE60="$T59_PROJECT/$T59_LOOPS_REL"
+  [[ ! -f "$ARCHIVE60/PLAN.md" ]] \
+    || { echo "FAIL: 신규 contract인데 PLAN.md가 main 작업트리로 archive됨"; exit 1; }
+  [[ ! -f "$ARCHIVE60/NOTES.md" ]] \
+    || { echo "FAIL: 신규 contract인데 NOTES.md가 archive됨"; exit 1; }
+  [[ ! -f "$ARCHIVE60/HANDOFF.md" ]] \
+    || { echo "FAIL: 신규 contract인데 HANDOFF.md가 archive됨"; exit 1; }
+  [[ ! -f "$ARCHIVE60/RUN_LOG.md" ]] \
+    || { echo "FAIL: 신규 contract인데 RUN_LOG.md가 archive됨"; exit 1; }
+  # feat 브랜치는 보존되어야 (PR base)
+  git -C "$T59_PROJECT" show-ref --verify --quiet "refs/heads/$T59_BRANCH" \
+    || { echo "FAIL: cleanup 후 feat 브랜치가 사라짐: $T59_BRANCH"; exit 1; }
+)
+echo "OK"
+
+echo "=== TEST 61: 신규 contract fail-fast — feat 브랜치 부재 + legacy SPEC 부재 ==="
+T61_PROJECT="$WORK_DIR/new-contract-missing"
+mkdir -p "$T61_PROJECT"
+git -C "$T61_PROJECT" init -q
+git -C "$T61_PROJECT" config user.email "t@e.com"
+git -C "$T61_PROJECT" config user.name "Test"
+git -C "$T61_PROJECT" commit --allow-empty -m "initial" -q
+# SPEC 부재 + feat 브랜치 부재 상태에서 start
+(
+  cd "$T61_PROJECT"
+  set +e
+  output61=$(MAX_ITERATIONS=1 WALL_CLOCK_MINUTES=5 bash "$LOOP_SH_SRC" start "regular/missing" 2>&1)
+  result61=$?
+  set -e
+  [[ $result61 -ne 0 ]] || { echo "FAIL: SPEC·feat 브랜치 둘 다 없는데 start 성공"; exit 1; }
+  echo "$output61" | grep -qE "SPEC\.md|feat" \
+    || { echo "FAIL: fail-fast 메시지에 SPEC·feat 안내 없음. got: $output61"; exit 1; }
+  WT61="$T61_PROJECT/milestones/regular/loops/missing/.worktree"
+  [[ ! -d "$WT61" ]] || { echo "FAIL: fail-fast인데 워크트리 생성됨"; exit 1; }
+)
+echo "OK"
+
+echo "=== TEST 62: 신규 contract slug-fallback — feat/<task-id> (slug 없는 단독 브랜치) 동작 ==="
+# 비-ASCII 제목 등으로 슬러그가 빈 경우 spec 스킬이 feat/<task-id>로 fallback. loop가 그것도 인식해야
+T62_PROJECT="$WORK_DIR/new-contract-fallback"
+mkdir -p "$T62_PROJECT"
+git -C "$T62_PROJECT" init -q
+git -C "$T62_PROJECT" config user.email "t@e.com"
+git -C "$T62_PROJECT" config user.name "Test"
+git -C "$T62_PROJECT" commit --allow-empty -m "initial" -q
+
+T62_BRANCH="feat/regular/n62"      # slug 없음 — fallback
+T62_LOOPS_REL="milestones/regular/loops/n62"
+T62_DEFAULT_BRANCH=$(git -C "$T62_PROJECT" rev-parse --abbrev-ref HEAD)
+git -C "$T62_PROJECT" checkout -q -b "$T62_BRANCH"
+mkdir -p "$T62_PROJECT/$T62_LOOPS_REL"
+cat > "$T62_PROJECT/$T62_LOOPS_REL/SPEC.md" <<'EOF'
+---
+scope:
+  include:
+    - "**/*"
+  exclude: []
+verify: 'true'
+---
+
+# 비-ASCII 제목 작업 (한국어)
+EOF
+git -C "$T62_PROJECT" add "$T62_LOOPS_REL/SPEC.md"
+git -C "$T62_PROJECT" commit -q -m "feat(spec): n62 fallback"
+git -C "$T62_PROJECT" checkout -q "$T62_DEFAULT_BRANCH"
+
+(
+  cd "$T62_PROJECT"
+  set +e
+  output62=$(MAX_ITERATIONS=1 WALL_CLOCK_MINUTES=5 bash "$LOOP_SH_SRC" start "regular/n62" 2>&1)
+  result62=$?
+  set -e
+  WT62="$T62_PROJECT/$T62_LOOPS_REL/.worktree"
+  [[ $result62 -eq 0 ]] || { echo "FAIL: slug-fallback start 실패. exit=$result62. got: $output62"; exit 1; }
+  [[ -d "$WT62" ]] || { echo "FAIL: 워크트리 미생성"; exit 1; }
+  CURR_BR=$(git -C "$WT62" rev-parse --abbrev-ref HEAD)
+  [[ "$CURR_BR" == "$T62_BRANCH" ]] \
+    || { echo "FAIL: 워크트리 브랜치가 feat/<task-id>(fallback)가 아님 (got: $CURR_BR)"; exit 1; }
+  bash "$LOOP_SH_SRC" cleanup "regular/n62" --force > /dev/null 2>&1
+)
+echo "OK"
+
 echo ""
 echo "=== 모든 테스트 통과 ==="

--- a/tests/autopilot/test-skill-install.sh
+++ b/tests/autopilot/test-skill-install.sh
@@ -95,6 +95,13 @@ echo "OK: [NEEDS CLARIFICATION] 마커"
 grep -q -- '--resume' "$SPEC_SKILL_MD" \
   || { echo "FAIL: spec/SKILL.md description에 '--resume' 마커 없음"; exit 1; }
 echo "OK: --resume 마커"
+# 신규 contract: feat 브랜치 자동 생성·SPEC.md commit 단계가 명시되어야 함
+grep -q 'feat/<task-id>' "$SPEC_SKILL_MD" \
+  || { echo "FAIL: spec/SKILL.md에 'feat/<task-id>' 브랜치 명세 없음 (신규 contract 미반영)"; exit 1; }
+echo "OK: feat/<task-id> 브랜치 명세"
+grep -qE '슬러그|slug' "$SPEC_SKILL_MD" \
+  || { echo "FAIL: spec/SKILL.md에 슬러그화 규칙 명세 없음"; exit 1; }
+echo "OK: 슬러그화 규칙 명세"
 
 echo ""
 echo "=== prd 스킬 구조 검증 ==="


### PR DESCRIPTION
## Summary

autopilot의 SPEC·구현 라이프사이클을 task당 한 개의 feature branch로 통합하는 dual-mode contract 도입. 기존 legacy 흐름(LOOPS_DIR/SPEC.md cp + archive + autonomous-loop branch)은 새 패턴 감지 실패 시 fallback으로 유지.

자율 loop `regular/79`가 1 iter에 전 마일스톤을 단일 commit으로 squash 완료.

## 변경 (9 files, +339/-39)

- `plugins/autopilot/skills/loop/references/loop.sh` (+156): `find_feat_branch` 헬퍼, `LOOPS_DIR_REL` 노출, `cmd_start`/`cmd_cleanup`/`iterate`/`read_scope_yaml` dual-mode 분기
- `plugins/autopilot/skills/spec/SKILL.md` (+52): step 8.5 (feat 브랜치 자동 생성 + SPEC commit) + 슬러그화 규칙 + allowed-tools 보완
- `plugins/autopilot/skills/loop/references/constitution.md` + 부수 4 파일 (agent-prompts·escalation-template·operational-guide·troubleshooting): `.loop/SPEC.md` 참조 dual-mode 갱신
- `tests/autopilot/test-loop-sh.sh` (+145): TEST 59-62 추가 (신규 contract worktree·cleanup·fail-fast·slug-fallback)
- `tests/autopilot/test-skill-install.sh` (+7): `feat/<task-id>` 브랜치 명세·슬러그화 키워드 검증

## 검증

- `bash tests/autopilot/test-loop-sh.sh` — TEST 1-62 PASS (신규 4개 RED→GREEN 포함)
- `bash tests/autopilot/test-skill-install.sh` — PASS

## 호환성

- 신규 task는 새 contract (`feat/<task-id>-<slug>` worktree base, archive 폐기) 자동 적용
- 기존 in-flight legacy loop은 `cmd_start`·`cmd_cleanup`이 브랜치명으로 모드 감지해 영향 없음
- main의 v0.2 nested 정책(`milestones/<m>/loops/<c>/.worktree/`)과 양립

## Test plan

- [x] test-loop-sh.sh 62 케이스 자동 PASS
- [x] test-skill-install.sh PASS
- [ ] (사용자) 머지 후 신규 task가 dual-mode contract로 자동 분기 확인
- [ ] (사용자) 진행 중 legacy loop이 영향 받지 않는지 확인

Closes #79