### PR TITLE
autopilot:loop — DONE 이후 PR 리뷰 자동 fix 루프 + Monitor 가설

### DIFF
--- a/milestones/regular/loops/123/SPEC.md
+++ b/milestones/regular/loops/123/SPEC.md
@@ -1,0 +1,218 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/loop/**"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "S=plugins/autopilot/skills/loop; test -f $S/references/rebase-phase.sh && test -f $S/references/review-fix-phase.sh && test -f $S/references/cleanup-phase.sh && grep -qE 'merged|closed' $S/references/review-fix-phase.sh && grep -qE 'APPROVED' $S/references/review-fix-phase.sh && grep -qE '/done|합격|통과' $S/references/review-fix-phase.sh && grep -q 'sleep' $S/references/review-fix-phase.sh && grep -q 'rebase' $S/references/rebase-phase.sh && grep -q 'worktree remove' $S/references/cleanup-phase.sh && grep -qE 'branch -D|push --delete' $S/references/cleanup-phase.sh && grep -qE 'review-fix-phase|rebase-phase|cleanup-phase' $S/references/loop.sh && grep -q 'gh project item-edit' $S/references/loop.sh $S/references/review-fix-phase.sh $S/references/cleanup-phase.sh && grep -q 'gh pr merge' $S/references/review-fix-phase.sh && grep -q 'gh pr comment' $S/references/review-fix-phase.sh && grep -qE '반박|dispute' $S/references/review-fix-phase.sh && grep -qE 'allowed-tools|--allowed-tools' $S/references/loop.sh && grep -qE 'review-fix|rebase|cleanup' $S/SKILL.md && grep -qE '상태 전이|Status' $S/SKILL.md && grep -qE '자동 머지|auto[- ]?merge' $S/SKILL.md"
+ears_language: ko
+request_review: true
+---
+
+# autopilot:loop — DONE 이후 PR 리뷰 자동 fix 루프 + Monitor 가설
+
+## 무엇을 만들 것인가
+
+autopilot:loop의 PR 관련 phase를 확장해 DONE 이후 PR 생애주기 전체를 자동화한다.
+SPEC frontmatter `request_review: true` opt-in이 활성화되면 다음 sub-phase들이
+순차·일부 background로 구동된다:
+
+1. **pre-PR rebase** — default에서 feat 브랜치 rebase. conflict 시 claude CLI
+   자동 해소 시도, 실패 시 ESCALATION abort.
+2. **PR 생성** — push, 신규 PR 생성 또는 동일 head의 open PR 갱신.
+3. **태스크 상태 전이 (→ 리뷰 관련 상태)** — PR 생성·재사용 성공 시 외부 태스크
+   추적 시스템의 *추상 상태*를 "리뷰 관련 상태"로 전이. 구체 값·백킹
+   시스템·매핑은 `rules/context.md` 단일 출처에 의존.
+4. **review-fix 루프 (background)** — 30초 주기 폴링 (PR-level comments ·
+   review threads · review summary). 새 이벤트마다: 매 fix iter 직전 default
+   재-rebase, claude CLI 세션으로 fix, 코드 변경 시 commit+push, "리뷰어 틀렸다"
+   판명 시 반박 코멘트 1개 게시 (그 외 일체 게시 금지), 새 이벤트·종료 신호를
+   stdout 으로 emit.
+5. **자동 머지 (조건부)** — 종료 신호가 merged가 *아닌* PR 승인 또는 owner의
+   종료 코멘트(`/done`·`합격`·`통과`)로 들어오면 시스템이 `gh pr merge`로
+   직접 머지.
+6. **cleanup** — 로컬 worktree 제거 + 로컬 feat 삭제 + origin feat 삭제.
+7. **태스크 상태 전이 (→ 완료 관련 상태)** — cleanup 0 exit 이후 추상 상태를
+   "완료 관련 상태"로 전이. 구체 값·매핑 `rules/context.md` 의존.
+
+PR이 closed (merge 안 됨)로 전이한 경우 review-fix 이후 모든 단계(자동 머지·
+cleanup·상태 전이)를 생략한다 — 사용자 판단 대기.
+
+본 phase 그룹의 명령 실행에 필요한 도구 권한은 autopilot 워커의 allowed-tools에
+**범위 최소화 원칙**으로 등록된다:
+
+- **GitHub CLI**: 본 phase가 실제 호출하는 PR 관련 서브커맨드만 허용 —
+  `gh pr merge`, `gh pr comment`, `gh pr view`, `gh api repos/.../pulls/*` ·
+  `repos/.../issues/*/comments` (폴링용). `gh issue *`, `gh repo *` 등
+  PR과 무관한 명령은 등록 안 함.
+- **GitHub Project**: 본 phase가 사용하는 정확한 명령(`gh project item-edit`)
+  만 포인트로 허용.
+- **Git**: 본 phase가 호출하는 정확한 서브커맨드만 — `git rebase`,
+  `git push --delete`, `git branch -D`, `git worktree remove`. 그 외 일체
+  와일드카드 등록 금지.
+
+등록 범위는 autopilot 워커의 실행 컨텍스트에만 한정되며 사용자 대화형
+세션의 settings.json은 건드리지 않는다 (메모리 feedback_allowlist_exclude_github
+유지).
+
+## 수용 기준 (EARS)
+
+1. (Event-driven) PR phase 진입 직전, 시스템은 default 브랜치에서 워크트리의
+   현재 feat 브랜치를 rebase한다.
+
+2. (Unwanted) rebase가 conflict로 실패하면, 시스템은 claude CLI 세션을 호출해
+   자동 해소를 시도한다. 세션이 해소에 실패하면 ESCALATION을 stdout으로
+   기록하고 phase를 중단한다.
+
+3. (Event-driven) pre-PR rebase가 0 exit으로 끝나면, 시스템은 push → PR
+   생성·재사용 단계를 그대로 수행한다.
+
+4. (Event-driven) PR 생성·재사용이 성공하면, 시스템은 review-fix 루프를
+   background로 시작한다.
+
+5. (State-driven) review-fix 루프가 가동 중인 동안, 시스템은 30초 주기로
+   PR-level comments · review threads (inline) · review summary 세 소스를
+   폴링해 이전에 본 적 없는 항목을 새 이벤트로 분류한다.
+
+6. (Event-driven) 새 이벤트가 분류되면, 시스템은 그 이벤트의 요약 한 줄을
+   stdout으로 출력한다.
+
+7. (Event-driven) 새 이벤트가 분류되면, 시스템은 fix iter 직전에 default
+   브랜치에서 워크트리의 feat 브랜치를 재-rebase한다 (AC#1·#2 절차 동일).
+
+8. (Event-driven) 재-rebase가 끝나면, 시스템은 수집된 입력을 claude CLI에
+   전달해 fix 세션을 시작한다.
+
+9. (Event-driven) fix 세션이 코드 변경을 남기면, 시스템은 변경을
+   commit + push한다.
+
+10. (Event-driven) fix 세션이 "리뷰어가 틀렸다" 판명 시, 시스템은 그 판단
+    본문을 1개의 반박 코멘트로 PR에 게시한다.
+
+11. (Ubiquitous) 시스템은 AC#10 외 어떤 GitHub 게시도 수행하지 않는다
+    (inline reply, summary comment, title/description 편집, review reply 등).
+
+12. (Event-driven) PR 생성·재사용 성공 시, 시스템은 외부 태스크 추적
+    시스템의 *추상 상태*를 "리뷰 관련 상태"로 전이한다. 구체 값·
+    시스템 매핑은 `rules/context.md` 단일 출처에 의존한다.
+
+13. (Unwanted) PR이 merged로 전이하면, 시스템은 review-fix 루프를
+    종료하고 자동 머지를 건너뛰어 cleanup으로 진입한다.
+
+14. (Event-driven) 종료 신호가 PR 승인 상태 또는 owner 코멘트
+    `/done`·`합격`·`통과` 중 하나이고 PR이 merged가 아닌 상태면,
+    시스템은 `gh pr merge`로 PR을 머지한다.
+
+15. (Unwanted) PR이 closed (merge 안 됨)로 전이하면, 시스템은 review-fix
+    이후 모든 단계(자동 머지·cleanup·상태 전이)를 생략한다.
+
+16. (Event-driven) PR이 merged 상태가 되면 (자동 머지 포함), 시스템은
+    cleanup phase에서 로컬 worktree, 로컬 feat 브랜치, origin feat 브랜치를
+    차례로 제거한다.
+
+17. (Event-driven) cleanup이 0 exit으로 끝나면, 시스템은 추상 상태를
+    "완료 관련 상태"로 전이한다. 구체 값·매핑은 `rules/context.md`
+    단일 출처에 의존한다.
+
+18. (Ubiquitous) 시스템은 본 phase 그룹의 도구 권한을 autopilot 워커의
+    allowed-tools에 **범위 최소화 원칙**으로 등록한다 — PR 관련
+    gh 서브커맨드(`gh pr merge`·`gh pr comment`·`gh pr view`·
+    `gh api repos/.../pulls/*` · `repos/.../issues/*/comments`),
+    `gh project item-edit`, `git rebase`·`git push --delete`·`git branch -D`·
+    `git worktree remove`만 등록하고 그 외 와일드카드 등록을 금지한다.
+
+19. (Unwanted) 본 phase 그룹의 어느 명령이 비-zero exit으로 실패하면,
+    시스템은 "ESCALATION" prefix 한 줄을 stdout으로 출력하고 해당
+    phase를 중단한다.
+
+## 범위
+
+포함:
+- `plugins/autopilot/skills/loop/references/rebase-phase.sh` 신규 —
+  default에서 feat 브랜치 rebase + conflict claude 자동 해소 시도.
+- `plugins/autopilot/skills/loop/references/review-fix-phase.sh` 신규 —
+  폴링·이벤트 분류·재-rebase 호출·fix iter dispatch·반박 코멘트
+  게시·자동 머지·종료 검사·stdout event emit.
+- `plugins/autopilot/skills/loop/references/cleanup-phase.sh` 신규 —
+  로컬 worktree 제거 + 로컬 feat 삭제 + origin feat 삭제.
+- 상태 전이 (→ 리뷰/완료 관련) 구현: 독립 스크립트로 분리하거나
+  공용 셸 함수로. 구체 값·매핑은 `rules/context.md` 읽어 해석.
+- `plugins/autopilot/skills/loop/references/loop.sh` 갱신 — `request_review:
+  true` opt-in 시 rebase→PR→상태:리뷰→review-fix→(조건부 merge)→cleanup→
+  상태:완료 자동 연결.
+- `plugins/autopilot/skills/loop/references/pr-phase.sh` 갱신 — pre-PR rebase
+  호출 연결 (또는 caller(loop.sh) 책임).
+- `plugins/autopilot/skills/loop/SKILL.md` 갱신 — 상태 전이 규제·
+  새 phase 구조·allowed-tools 목록 문서화.
+- autopilot 워커의 allowed-tools 설정 소스 갱신 — 구현자가 현행
+  loop.sh 구조에서 소스 위치(claude CLI 호출 플래그 또는 설정 파일)
+  를 식별해 그 곳에 AC#18 목록 정확 등록.
+
+비-목표 / 제외:
+- SPEC frontmatter 추가 opt-in 키 (`request_review: true` 단일).
+- 리뷰 코멘트 분류기 — 새 이벤트 일괄 fix dispatch.
+- PR closed (merge 안) 자동 cleanup·상태 전이 — 사용자 판단.
+- review-fix wall-clock·iter 한계 (추후 개선).
+- branch protection bypass, force-push (필요 시 `--force-with-lease` 한정).
+- AC#10 이외 어떤 코멘트·게시.
+- 사용자 대화형 세션의 settings.json `permissions.allow` 권한 변경 —
+  메모리 feedback_allowlist_exclude_github 유지 (별도 경로).
+- `rules/context.md`의 상태 어휘 갱신 — 메타 상태는 이미 정의되어 있음.
+- 본 저장소의 `rules/`·`milestones/`·`CLAUDE.md` (default exclude).
+
+## 검증
+이 명령이 0 exit으로 끝나야 합니다:
+```bash
+S=plugins/autopilot/skills/loop
+test -f $S/references/rebase-phase.sh \
+ && test -f $S/references/review-fix-phase.sh \
+ && test -f $S/references/cleanup-phase.sh \
+ && grep -qE 'merged|closed'             $S/references/review-fix-phase.sh \
+ && grep -qE 'APPROVED'                  $S/references/review-fix-phase.sh \
+ && grep -qE '/done|합격|통과'           $S/references/review-fix-phase.sh \
+ && grep -q  'sleep'                     $S/references/review-fix-phase.sh \
+ && grep -q  'rebase'                    $S/references/rebase-phase.sh \
+ && grep -q  'worktree remove'           $S/references/cleanup-phase.sh \
+ && grep -qE 'branch -D|push --delete'   $S/references/cleanup-phase.sh \
+ && grep -qE 'review-fix-phase|rebase-phase|cleanup-phase' $S/references/loop.sh \
+ && grep -q  'gh project item-edit'      $S/references/loop.sh \
+       $S/references/review-fix-phase.sh \
+       $S/references/cleanup-phase.sh \
+ && grep -q  'gh pr merge'               $S/references/review-fix-phase.sh \
+ && grep -q  'gh pr comment'             $S/references/review-fix-phase.sh \
+ && grep -qE '반박|dispute'              $S/references/review-fix-phase.sh \
+ && grep -qE 'allowed-tools|--allowed-tools' $S/references/loop.sh \
+ && grep -qE 'review-fix|rebase|cleanup' $S/SKILL.md \
+ && grep -qE '상태 전이|Status'          $S/SKILL.md \
+ && grep -qE '자동 머지|auto[- ]?merge'  $S/SKILL.md
+```
+
+## 제약
+- 의존성: `gh` CLI + OAuth (push:write·repo:status 스코프), `claude` CLI,
+  `jq` (gh JSON 파싱 — 신규 의존성 추가 가능).
+- 폴링 주기 30초; 환경 변수(예: `LOOP_REVIEW_POLL_SECS`) override 권장.
+- review-fix 루프는 background process (loop.sh의 자식·disown·`&`).
+- 코멘트 게시는 AC#10의 반박 1건 외 일체 금지.
+- allowed-tools 등록 범위: PR 관련 gh 서브커맨드 + 명시된 gh project/git
+  서브커맨드만, 와일드카드(`gh *`, `git *`) 금지.
+- 메모리 갱신 (별도 follow-up 작업으로 처리):
+  - `feedback_pr_review_no_reply` → "반박 1건 예외 허용"으로
+  - `feedback_allowlist_exclude_github` → "사용자 대화형 세션 한정;
+    autopilot 워커는 범위 최소로 허용"으로
+
+## 위험
+- **무한 루프**: 종료 4조건 모두 실패 + 새 코멘트가 계속 도착하면 무한
+  fix 가능. fail-safe로 wall-clock cutoff·iter 최대치 추후 추가.
+- **폴링 중복 트리거**: 동일 코멘트가 매 폴링마다 재등장하지 않도록
+  last-seen ID dedup 필수.
+- **conflict 자동 해소 의도 밖 변경**: claude 세션이 rebase 충돌
+  해소 중 무관한 코드를 만질 가능성. 해소 후 verify 게이트 재실행 권장.
+- **반박 false-positive**: claude 세션이 잘못 반박해 부적절 코멘트
+  게시. owner의 명시 cancel signal 매커니즘 후속 개선.
+- **자동 머지 실패**: conflict·CI 실패·branch protection 수부로 실패
+  가능. 실패 시 review-fix를 그대로 유지하면 사용자가 수동 머지 가능.
+- **cleanup 손실**: 워크트리에 미커밋 변경 있을 때 cleanup 손실 위험.
+  cleanup 전 `git status --porcelain` 검사 후 비-empty면 abort 필요.
+- **권한 확장 세고**: allowed-tools가 사용자 대화형 세션 settings.json
+  으로 새지 않도록 계층 분리 명확·구현자가 수동 확인 필요.

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -74,7 +74,50 @@ task가 `DONE`에 도달한 직후 같은 워크트리에서 PR 생성(또는 �
 
 `--no-pr` 플래그는 셸 드라이버(`loop.sh`)에 직접 전달되며, PR phase 진입 자체를 차단합니다. 이전 버전에서 `request_review: true`로 opt-in을 사용하던 호출자는 별도 마이그레이션이 필요 없습니다(default가 ON으로 변경됐으므로 동일 동작). 이전 버전에서 `request_review: false`(또는 키 미지정)로 PR을 차단하던 호출자는 `--no-pr`로 동일 동작을 재현해야 합니다.
 
-기존 PR body의 사용자 수기 편집 보호를 위해 자동 영역은 `<!-- autopilot:pr-body:begin --> ... <!-- autopilot:pr-body:end -->` marker fence 안에만 작성됩니다. 후속 단계(리뷰 모니터·자동 fix·worktree 정리)는 별도 task에서 다룹니다.
+기존 PR body의 사용자 수기 편집 보호를 위해 자동 영역은 `<!-- autopilot:pr-body:begin --> ... <!-- autopilot:pr-body:end -->` marker fence 안에만 작성됩니다.
+
+#### DONE 이후 PR 리뷰 자동 fix 루프 (SPEC 123, `request_review: true` opt-in)
+
+SPEC frontmatter에 `request_review: true`가 지정된 task만 본 흐름을 진입합니다. PR 생성·재사용이 성공한 직후 다음 sub-phase가 차례·일부 background로 실행됩니다:
+
+| 단계 | 스크립트 | 역할 |
+|---|---|---|
+| pre-PR rebase | `references/rebase-phase.sh` | default 브랜치로부터 워크트리 feat 브랜치 rebase. 충돌 시 claude CLI 1회 자동 해소, 실패 시 ESCALATION abort. |
+| review-fix 루프 (background) | `references/review-fix-phase.sh` | 30초 주기 폴링 (PR comments · review threads · summary). 새 이벤트마다 재-rebase → claude CLI fix → commit+push → (필요 시) 1개 반박 코멘트. |
+| 자동 머지 (auto-merge) | `references/review-fix-phase.sh` 내부 | reviewDecision `APPROVED` 또는 owner의 종료 코멘트(`/done`·`합격`·`통과`)로 `gh pr merge --squash` 수행. PR이 이미 `merged`이면 자동 머지 건너뜀. |
+| cleanup | `references/cleanup-phase.sh` | PR `merged` 후 worktree 제거 + 로컬 feat `branch -D` + origin feat `push --delete`. |
+
+##### 상태 전이 (Status field)
+
+`rules/context.md`의 추상 상태 어휘에 따라 외부 태스크 추적 시스템(GitHub Project)의 Status 필드를 다음 시점에 전이합니다:
+
+- PR 생성·재사용 성공 직후 → **Review** (review-fix-phase 진입 시점)
+- cleanup 성공 직후 → **Done**
+
+전이는 `gh project item-edit`로 수행하며, 환경 변수(`LOOP_PROJECT_ID` 등) 부재 시 무음 skip되어 phase 자체는 진행됩니다. 구체 값·매핑은 `rules/context.md` 단일 출처에 의존합니다.
+
+##### 종료 조건
+
+review-fix 루프는 다음 중 하나가 감지되면 종료합니다:
+
+1. PR `merged` → cleanup 진입 (자동 머지 skip — 이미 merged)
+2. PR `closed` (unmerged) → cleanup·상태 전이 모두 skip (사용자 판단 대기)
+3. reviewDecision `APPROVED` → 자동 머지 → cleanup
+4. owner 코멘트 `/done`·`합격`·`통과` → 자동 머지 → cleanup
+
+##### 게시 제약
+
+리뷰어가 틀렸다고 판명된 경우 1개의 반박(dispute) 코멘트만 PR에 게시합니다. inline reply, summary comment, title/description 편집 등 다른 어떤 GitHub 게시도 수행하지 않습니다.
+
+##### allowed-tools
+
+본 phase 그룹은 autopilot 워커의 새 claude CLI 세션 호출에 다음 도구만 허용합니다 (범위 최소화, 와일드카드 금지):
+
+- GitHub CLI: `gh pr merge`, `gh pr comment`, `gh pr view`, `gh api repos/.../pulls/*`·`repos/.../issues/*/comments`, `gh project item-edit`
+- Git: `git rebase`, `git push --delete`, `git branch -D`, `git worktree remove`, `git add`/`git commit`/`git status`/`git diff` (fix iter 본 작업)
+- Read·Edit·Write·Glob·Grep
+
+상수는 `loop.sh`의 `AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS` / `AUTOPILOT_REBASE_ALLOWED_TOOLS` 에 정의되며, 환경 변수로 자식 phase 스크립트에 export됩니다. 사용자 대화형 세션의 `settings.json`은 본 등록의 영향을 받지 않습니다 — autopilot 워커 컨텍스트에만 한정됩니다.
 
 요구: `gh` CLI 설치 + OAuth 인증.
 

--- a/plugins/autopilot/skills/loop/references/cleanup-phase.sh
+++ b/plugins/autopilot/skills/loop/references/cleanup-phase.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# cleanup-phase.sh — SPEC 123 M3
+#
+# PR이 MERGED 상태로 전이된 직후 호출되어 워크트리·로컬 feat·원격 feat 브랜치를
+# 차례로 정리하고, 추상 상태를 "Done"으로 전이한다.
+#
+# 사용:
+#   bash cleanup-phase.sh <worktree> <branch> <task-id> <project-root>
+#
+# 동작 (SPEC 123 AC16·AC17):
+#   1. 사전 검사: 워크트리에 미커밋 변경 없음 (git status --porcelain 비어 있음)
+#   2. git worktree remove <wt>
+#   3. git branch -D <branch>            (로컬 feat 삭제)
+#   4. git push --delete origin <branch> (원격 feat 삭제)
+#   5. 추상 상태 "완료 관련 상태" (Done) 전이 — gh project item-edit
+#      (환경변수 LOOP_PROJECT_ID·LOOP_STATUS_FIELD_ID·LOOP_STATUS_DONE_OPTION_ID 부재 시
+#       무음 skip하여 phase 자체는 계속 진행)
+#   6. 어떤 단계가 비-zero exit이면 stdout에 "ESCALATION cleanup-phase: ..." emit
+#      후 비-zero exit (SPEC 123 AC19).
+
+set -euo pipefail
+
+WT="${1:-}"
+BRANCH="${2:-}"
+TASK_ID="${3:-}"
+PROJECT_ROOT="${4:-}"
+
+if [[ -z "$WT" || -z "$BRANCH" || -z "$TASK_ID" || -z "$PROJECT_ROOT" ]]; then
+  echo "사용: $0 <worktree> <branch> <task-id> <project-root>" >&2
+  exit 2
+fi
+
+emit_escalation() { echo "ESCALATION cleanup-phase: $*"; }
+
+[[ -d "$WT" ]] || { emit_escalation "워크트리 없음: $WT"; exit 1; }
+[[ -d "$PROJECT_ROOT" ]] || { emit_escalation "project-root 없음: $PROJECT_ROOT"; exit 1; }
+
+# ----- 1. 미커밋 변경 사전 검사 (위험: cleanup 손실 차단) -----
+# 워크트리에 staged·unstaged·untracked가 남아 있으면 worktree remove 시 손실 위험.
+# untracked는 본 task의 .iterations/·CLAUDE.md·DONE 등 info/exclude로 가려져 있어
+# 보통 status에 안 나타난다. 그래도 safety-net으로 staged·unstaged만 검사.
+dirty=$( cd "$WT" && git status --porcelain --untracked-files=no 2>/dev/null || true )
+if [[ -n "$dirty" ]]; then
+  emit_escalation "워크트리에 미커밋 변경 있음 — cleanup 거부\n$dirty"
+  exit 1
+fi
+
+# ----- 2. worktree remove -----
+# autopilot 워크트리는 info/exclude된 ephemeral 파일(.iterations/·DONE·CLAUDE.md)을
+# 항상 보유한다. 위 사전 검사로 staged/unstaged 변경 부재를 이미 확인했으므로
+# --force로 ephemeral 파일도 함께 정리. (사용자 수기 변경은 untracked로 들어와도
+# `--untracked-files=no`를 통과하므로 사전 검사가 catch하지 못함. 사용자가 워크트리
+# 안에 임시 파일을 둔 경우 --force는 그것까지 삭제 — 본 phase는 PR merged 후 호출되므로
+# 정상 흐름에선 사용자가 워크트리에 별도 작업을 두지 않는다는 가정.)
+echo "[cleanup-phase] git worktree remove --force $WT"
+if ! ( cd "$PROJECT_ROOT" && git worktree remove --force "$WT" 2>&1 ); then
+  emit_escalation "git worktree remove 실패 — 수동: git worktree remove --force $WT"
+  exit 1
+fi
+
+# ----- 3. 로컬 feat 브랜치 삭제 -----
+echo "[cleanup-phase] git branch -D $BRANCH"
+if ! ( cd "$PROJECT_ROOT" && git branch -D "$BRANCH" 2>&1 ); then
+  emit_escalation "로컬 브랜치 삭제 실패: $BRANCH"
+  exit 1
+fi
+
+# ----- 4. origin feat 브랜치 삭제 -----
+echo "[cleanup-phase] git push --delete origin $BRANCH"
+if ! ( cd "$PROJECT_ROOT" && git push --delete origin "$BRANCH" 2>&1 ); then
+  # 원격 삭제 실패는 보통 이미 삭제됐거나 네트워크 일시 — escalation 아닌 WARN.
+  echo "WARN: origin/$BRANCH 삭제 실패 (이미 삭제됐거나 네트워크 오류). 수동 확인 필요." >&2
+fi
+
+# ----- 5. 추상 상태 'Done' 전이 (gh project item-edit) -----
+# 구체 값·매핑은 rules/context.md 단일 출처에 의존. 환경 변수로 주입.
+#   LOOP_PROJECT_ID         GitHub Project node ID (예: PVT_xxx)
+#   LOOP_STATUS_FIELD_ID    Status single-select field node ID
+#   LOOP_STATUS_DONE_OPTION_ID  "Done" option ID
+#   LOOP_PROJECT_ITEM_ID    이 task가 추가된 project item ID (issue → item)
+# 위 4 변수가 모두 set일 때만 호출. 하나라도 부재면 무음 skip.
+if command -v gh >/dev/null 2>&1 \
+   && [[ -n "${LOOP_PROJECT_ID:-}" && -n "${LOOP_STATUS_FIELD_ID:-}" \
+         && -n "${LOOP_STATUS_DONE_OPTION_ID:-}" && -n "${LOOP_PROJECT_ITEM_ID:-}" ]]; then
+  echo "[cleanup-phase] 상태 전이: Done (gh project item-edit)"
+  if ! gh project item-edit \
+       --project-id "$LOOP_PROJECT_ID" \
+       --id "$LOOP_PROJECT_ITEM_ID" \
+       --field-id "$LOOP_STATUS_FIELD_ID" \
+       --single-select-option-id "$LOOP_STATUS_DONE_OPTION_ID" >/dev/null 2>&1; then
+    echo "WARN: 상태 전이(Done) 실패 — 수동 처리 필요" >&2
+  fi
+else
+  echo "[cleanup-phase] 상태 전이 환경변수 부재 — Done 전이 skip (rules/context.md 백엔드 비활성)"
+fi
+
+echo "[cleanup-phase] 정리 완료: task=$TASK_ID branch=$BRANCH"
+exit 0

--- a/plugins/autopilot/skills/loop/references/cleanup-phase.sh
+++ b/plugins/autopilot/skills/loop/references/cleanup-phase.sh
@@ -41,7 +41,8 @@ emit_escalation() { echo "ESCALATION cleanup-phase: $*"; }
 # 보통 status에 안 나타난다. 그래도 safety-net으로 staged·unstaged만 검사.
 dirty=$( cd "$WT" && git status --porcelain --untracked-files=no 2>/dev/null || true )
 if [[ -n "$dirty" ]]; then
-  emit_escalation "워크트리에 미커밋 변경 있음 — cleanup 거부\n$dirty"
+  # `echo`는 `\n`을 리터럴로 출력 — printf로 실제 개행 처리.
+  emit_escalation "$(printf '워크트리에 미커밋 변경 있음 — cleanup 거부\n%s' "$dirty")"
   exit 1
 fi
 

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -24,6 +24,46 @@ set -euo pipefail
 # ----- 스크립트 자신의 디렉토리 (references/) -----
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# ----- allowed-tools (SPEC 123 AC18) -----
+#
+# DONE 이후 PR 생애주기 자동화 phase 그룹(rebase·review-fix·cleanup)의 명령 실행에
+# 필요한 도구 권한. autopilot 워커가 새 claude CLI 세션을 띄울 때(rebase 충돌 자동 해소,
+# review-fix iter) `--allowed-tools "$AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS"` 형태로
+# 전달된다. 범위 최소화 원칙:
+#   - GitHub CLI: PR 관련 서브커맨드만 (gh pr merge·comment·view, gh api repos/.../pulls/* ·
+#     issues/*/comments). gh issue *·gh repo * 등 PR 무관 명령은 허용 안 함.
+#   - GitHub Project: 정확히 gh project item-edit만.
+#   - Git: rebase·push --delete·branch -D·worktree remove만. git add·commit은
+#     fix iter 본 작업에 필요.
+# 와일드카드(gh *, git *) 사용 금지. 본 변수는 워커 phase 스크립트가 export해 자식
+# claude CLI 호출에 환경 변수로 주입한다.
+AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS="\
+Bash(gh pr merge:*),\
+Bash(gh pr comment:*),\
+Bash(gh pr view:*),\
+Bash(gh api repos/*),\
+Bash(gh project item-edit:*),\
+Bash(git rebase:*),\
+Bash(git push --delete:*),\
+Bash(git branch -D:*),\
+Bash(git worktree remove:*),\
+Bash(git add:*),\
+Bash(git commit:*),\
+Bash(git status:*),\
+Bash(git diff:*),\
+Read,Edit,Write,Glob,Grep"
+export AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS
+
+# 충돌 자동 해소 세션 전용(rebase-phase): 더 좁은 범위.
+AUTOPILOT_REBASE_ALLOWED_TOOLS="\
+Bash(git add:*),\
+Bash(git status:*),\
+Bash(git diff:*),\
+Bash(cat:*),\
+Bash(ls:*),\
+Read,Edit,Write,Glob,Grep"
+export AUTOPILOT_REBASE_ALLOWED_TOOLS
+
 # ----- 헬퍼 -----
 
 die() {
@@ -920,6 +960,44 @@ cmd_start() {
         if ! bash "$SCRIPT_DIR/pr-phase.sh" "$WT" "$BRANCH" "$TASK_ID" "$PROJECT_ROOT"; then
           echo "ERROR: PR phase 실패 — worktree·branch는 보존됨. 진단 후 재시도하세요." >&2
           exit 1
+        fi
+
+        # ----- SPEC 123: request_review opt-in 감지 + review-fix 루프 dispatch -----
+        # PR 생성·재사용이 성공한 후 SPEC frontmatter에서 request_review: true를 검사.
+        # 활성 시 background로 review-fix-phase.sh를 띄워 폴링·자동 fix·자동 머지·
+        # cleanup·상태 전이를 자율 처리. loop.sh 자체는 정상 종료한다.
+        #
+        # 본 분기는 새 phase 3종(rebase-phase·review-fix-phase·cleanup-phase)을 참조한다.
+        # review-fix-phase 내부에서 rebase-phase·cleanup-phase를 호출하므로 loop.sh는
+        # 진입점인 review-fix-phase만 dispatch한다.
+        local spec_md="$WT/$LOOPS_DIR_REL/SPEC.md"
+        local request_review_val=""
+        if [[ -f "$spec_md" ]]; then
+          request_review_val=$(sed -n '1,/^---$/{
+            1d
+            /^---$/d
+            p
+          }' "$spec_md" | yq '.request_review // false' 2>/dev/null | tr -d '[:space:]')
+        fi
+
+        if [[ "$request_review_val" == "true" ]]; then
+          # PR 번호 추출 (head 브랜치로 조회)
+          local pr_num
+          pr_num=$( cd "$WT" && gh pr list --head "$BRANCH" --state all \
+                      --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [[ -z "$pr_num" ]]; then
+            echo "WARN: request_review: true 인데 PR 번호 조회 실패 — review-fix 루프 dispatch skip" >&2
+          else
+            echo "[$(now_iso)] request_review: true — review-fix-phase.sh background dispatch (PR #$pr_num)"
+            # review-fix-phase.sh는 PR이 MERGED/CLOSED/APPROVED 또는 owner cmd(/done·합격·통과)
+            # 가 들어올 때까지 background로 폴링하며, 종료 시 자체적으로 cleanup-phase.sh를
+            # 호출해 worktree·feat 로컬·feat origin을 정리한다. allowed-tools 환경 변수는
+            # 이미 위에서 export됨.
+            nohup bash "$SCRIPT_DIR/review-fix-phase.sh" \
+                  "$WT" "$BRANCH" "$TASK_ID" "$PROJECT_ROOT" "$pr_num" \
+                  > "$WT/.iterations/review-fix-phase.log" 2>&1 < /dev/null &
+            disown $!
+          fi
         fi
       fi
 

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -26,31 +26,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ----- allowed-tools (SPEC 123 AC18) -----
 #
-# DONE 이후 PR 생애주기 자동화 phase 그룹(rebase·review-fix·cleanup)의 명령 실행에
-# 필요한 도구 권한. autopilot 워커가 새 claude CLI 세션을 띄울 때(rebase 충돌 자동 해소,
-# review-fix iter) `--allowed-tools "$AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS"` 형태로
-# 전달된다. 범위 최소화 원칙:
-#   - GitHub CLI: PR 관련 서브커맨드만 (gh pr merge·comment·view, gh api repos/.../pulls/* ·
-#     issues/*/comments). gh issue *·gh repo * 등 PR 무관 명령은 허용 안 함.
-#   - GitHub Project: 정확히 gh project item-edit만.
-#   - Git: rebase·push --delete·branch -D·worktree remove만. git add·commit은
-#     fix iter 본 작업에 필요.
-# 와일드카드(gh *, git *) 사용 금지. 본 변수는 워커 phase 스크립트가 export해 자식
-# claude CLI 호출에 환경 변수로 주입한다.
+# DONE 이후 PR 생애주기 자동화 phase 그룹(rebase·review-fix·cleanup)의 *자식 claude CLI
+# 세션*(rebase 충돌 자동 해소, review-fix iter) 전용 도구 권한. review-fix-phase가
+# `--allowed-tools "$AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS"` 형태로 전달한다.
+#
+# 범위 최소화 원칙 (claude 세션 관점):
+#   - phase 셸 스크립트가 직접 실행하는 파괴적 명령(gh pr merge·gh pr comment·
+#     gh project item-edit·git rebase·git commit·git push·git push --delete·
+#     git branch -D·git worktree remove)은 claude 세션이 사용해선 안 되므로 *제거*.
+#   - claude 세션은 fix 코드 변경(Read·Edit·Write) + staging/진단(git add·status·diff)
+#     + PR 컨텍스트 조회(gh pr view·gh api repos/) 만 필요.
+#   - 와일드카드(gh *, git *) 사용 금지.
 AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS="\
-Bash(gh pr merge:*),\
-Bash(gh pr comment:*),\
-Bash(gh pr view:*),\
-Bash(gh api repos/:*),\
-Bash(gh project item-edit:*),\
-Bash(git rebase:*),\
-Bash(git push --delete:*),\
-Bash(git branch -D:*),\
-Bash(git worktree remove:*),\
 Bash(git add:*),\
-Bash(git commit:*),\
 Bash(git status:*),\
 Bash(git diff:*),\
+Bash(gh pr view:*),\
+Bash(gh api repos/:*),\
 Read,Edit,Write,Glob,Grep"
 export AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS
 

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -956,30 +956,41 @@ cmd_start() {
       if (( no_pr == 1 )); then
         echo "[$(now_iso)] --no-pr 플래그 감지 — PR phase 건너뜀"
       else
+        # ----- SPEC 123: request_review opt-in 감지 (PR phase 진입 *전*에 확정) -----
+        # AC#1·#3: opt-in 활성 시 PR phase 진입 *직전*에 pre-PR rebase 실행.
+        # AC#4·#12·#16·#17: opt-in 활성 시 PR phase 직후 review-fix-phase background dispatch.
+        local spec_md="$WT/$LOOPS_DIR_REL/SPEC.md"
+        local request_review_val=""
+        if [[ -f "$spec_md" ]]; then
+          if command -v yq >/dev/null 2>&1; then
+            request_review_val=$(sed -n '1,/^---$/{
+              1d
+              /^---$/d
+              p
+            }' "$spec_md" | yq '.request_review // false' 2>/dev/null | tr -d '[:space:]')
+          else
+            echo "WARN: yq 미설치 — SPEC frontmatter request_review 파싱 불가, opt-in 비활성으로 처리" >&2
+          fi
+        fi
+
+        # ----- AC#1·#3: pre-PR rebase (request_review opt-in 시) -----
+        if [[ "$request_review_val" == "true" ]]; then
+          echo "[$(now_iso)] request_review opt-in — pre-PR rebase (AC#1·#3)"
+          if ! bash "$SCRIPT_DIR/rebase-phase.sh" "$WT" "$BRANCH" "$PROJECT_ROOT"; then
+            echo "ERROR: pre-PR rebase 실패 — PR phase 건너뜀, 워크트리·브랜치 보존" >&2
+            exit 1
+          fi
+        fi
+
         echo "[$(now_iso)] PR phase 진입 (default — 건너뛰려면 --no-pr 사용)"
         if ! bash "$SCRIPT_DIR/pr-phase.sh" "$WT" "$BRANCH" "$TASK_ID" "$PROJECT_ROOT"; then
           echo "ERROR: PR phase 실패 — worktree·branch는 보존됨. 진단 후 재시도하세요." >&2
           exit 1
         fi
 
-        # ----- SPEC 123: request_review opt-in 감지 + review-fix 루프 dispatch -----
-        # PR 생성·재사용이 성공한 후 SPEC frontmatter에서 request_review: true를 검사.
-        # 활성 시 background로 review-fix-phase.sh를 띄워 폴링·자동 fix·자동 머지·
-        # cleanup·상태 전이를 자율 처리. loop.sh 자체는 정상 종료한다.
-        #
-        # 본 분기는 새 phase 3종(rebase-phase·review-fix-phase·cleanup-phase)을 참조한다.
+        # ----- AC#4: PR 생성 성공 후 review-fix 루프 background dispatch -----
         # review-fix-phase 내부에서 rebase-phase·cleanup-phase를 호출하므로 loop.sh는
         # 진입점인 review-fix-phase만 dispatch한다.
-        local spec_md="$WT/$LOOPS_DIR_REL/SPEC.md"
-        local request_review_val=""
-        if [[ -f "$spec_md" ]]; then
-          request_review_val=$(sed -n '1,/^---$/{
-            1d
-            /^---$/d
-            p
-          }' "$spec_md" | yq '.request_review // false' 2>/dev/null | tr -d '[:space:]')
-        fi
-
         if [[ "$request_review_val" == "true" ]]; then
           # PR 번호 추출 (head 브랜치로 조회)
           local pr_num

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -41,7 +41,7 @@ AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS="\
 Bash(gh pr merge:*),\
 Bash(gh pr comment:*),\
 Bash(gh pr view:*),\
-Bash(gh api repos/*),\
+Bash(gh api repos/:*),\
 Bash(gh project item-edit:*),\
 Bash(git rebase:*),\
 Bash(git push --delete:*),\

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -986,7 +986,9 @@ cmd_start() {
         if [[ "$request_review_val" == "true" ]]; then
           # PR 번호 추출 (head 브랜치로 조회)
           local pr_num
-          pr_num=$( cd "$WT" && gh pr list --head "$BRANCH" --state all \
+          # pr-phase.sh가 방금 생성·재사용한 open PR만 매칭 — `--state all`은
+          # 동일 head 브랜치의 과거 closed PR을 잘못 반환할 위험.
+          pr_num=$( cd "$WT" && gh pr list --head "$BRANCH" --state open \
                       --json number --jq '.[0].number' 2>/dev/null || echo "")
           if [[ -z "$pr_num" ]]; then
             echo "WARN: request_review: true 인데 PR 번호 조회 실패 — review-fix 루프 dispatch skip" >&2

--- a/plugins/autopilot/skills/loop/references/rebase-phase.sh
+++ b/plugins/autopilot/skills/loop/references/rebase-phase.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# rebase-phase.sh — SPEC 123 M1
+#
+# PR 생성·재사용 직전, 그리고 review-fix 루프의 각 fix iter 직전에 호출되어
+# 워크트리의 feat 브랜치를 default 브랜치로 rebase한다.
+#
+# 사용:
+#   bash rebase-phase.sh <worktree> <branch> <project-root>
+#
+# 동작:
+#   1. default 브랜치 감지 (gh repo view → git symbolic-ref → 실패 abort)
+#   2. origin/<default> fetch
+#   3. git rebase origin/<default>
+#   4. 성공 시 0 exit (fast-forward·동일 history 포함).
+#   5. 실패(충돌) 시 claude CLI 세션 1회로 자동 해소 시도 (SPEC 123 AC2).
+#      - claude CLI 미설치·실패 시 보수적 좌절 (rebase --abort + non-zero exit).
+#   6. 자동 해소 후 `git rebase --continue` 시도, 그래도 실패하면 abort.
+#   7. 어떤 단계든 비-zero exit 시 stdout 첫 줄에 "ESCALATION" prefix를 출력해
+#      caller(loop.sh·review-fix-phase.sh)가 종료 신호로 감지하게 한다 (SPEC 123 AC19).
+
+set -euo pipefail
+
+WT="${1:-}"
+BRANCH="${2:-}"
+PROJECT_ROOT="${3:-}"
+
+if [[ -z "$WT" || -z "$BRANCH" || -z "$PROJECT_ROOT" ]]; then
+  echo "사용: $0 <worktree> <branch> <project-root>" >&2
+  exit 2
+fi
+[[ -d "$WT" ]] || { echo "ERROR: 워크트리 없음: $WT" >&2; exit 1; }
+
+emit_escalation() {
+  # caller 감지용 단일 라인 — stdout(또는 caller가 redirect한 stream).
+  echo "ESCALATION rebase-phase: $*"
+}
+
+detect_default_branch() {
+  local b=""
+  if command -v gh >/dev/null 2>&1; then
+    b=$(cd "$WT" && gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)
+  fi
+  if [[ -z "$b" ]]; then
+    local ref
+    ref=$(cd "$WT" && git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)
+    [[ -n "$ref" ]] && b="${ref#refs/remotes/origin/}"
+  fi
+  printf '%s' "$b"
+}
+
+DEFAULT_BRANCH="$(detect_default_branch)"
+if [[ -z "$DEFAULT_BRANCH" ]]; then
+  emit_escalation "default 브랜치 감지 실패 (gh repo view / git symbolic-ref 모두 실패)"
+  exit 1
+fi
+
+echo "[rebase-phase] origin/$DEFAULT_BRANCH fetch"
+if ! ( cd "$WT" && git fetch origin "$DEFAULT_BRANCH" 2>&1 ); then
+  emit_escalation "git fetch origin $DEFAULT_BRANCH 실패"
+  exit 1
+fi
+
+echo "[rebase-phase] rebase onto origin/$DEFAULT_BRANCH"
+if ( cd "$WT" && git rebase "origin/$DEFAULT_BRANCH" 2>&1 ); then
+  echo "[rebase-phase] rebase 성공 (충돌 없음)"
+  exit 0
+fi
+
+# ----- 충돌 — claude CLI 1회 자동 해소 시도 -----
+echo "[rebase-phase] rebase 충돌 감지 — claude CLI 자동 해소 시도 (1회)"
+
+if ! command -v claude >/dev/null 2>&1; then
+  ( cd "$WT" && git rebase --abort 2>/dev/null || true )
+  emit_escalation "claude CLI 미설치 — 충돌 자동 해소 불가"
+  exit 1
+fi
+
+# claude 세션에 conflict marker가 있는 파일 목록 + diff를 stdin으로 넘긴다.
+# allowed-tools는 caller(loop.sh)에서 export한 환경 변수 또는 본 스크립트 기본값.
+ALLOWED_TOOLS_REBASE="${AUTOPILOT_REBASE_ALLOWED_TOOLS:-Bash(git:*),Bash(cat:*),Bash(ls:*),Read,Edit,Write}"
+
+# claude 세션이 충돌을 해소할 수 있도록 작업 디렉토리·헌법(워크트리 CLAUDE.md)을 제공.
+# --dangerously-skip-permissions는 사용하지 않고 allowed-tools로 명시 범위 제한.
+conflict_files=$( cd "$WT" && git diff --name-only --diff-filter=U 2>/dev/null || true )
+
+claude_prompt=$(cat <<EOF
+You are inside a git rebase conflict on branch '$BRANCH' onto 'origin/$DEFAULT_BRANCH'.
+Conflicted files:
+$conflict_files
+
+Goal: resolve each conflict in-place, preferring the intent of branch '$BRANCH' (feat
+branch) but keeping any non-conflicting changes from base. Edit each file to remove
+the '<<<<<<<', '=======', '>>>>>>>' markers. Then run 'git add' on each resolved
+file. DO NOT run 'git rebase --continue' yourself — the caller will do that. DO NOT
+push, commit, or create branches.
+
+When done, output a single line: 'RESOLVED'.
+EOF
+)
+
+claude_exit=0
+( cd "$WT" && printf '%s' "$claude_prompt" | claude \
+    --print \
+    --no-session-persistence \
+    --add-dir . \
+    --allowed-tools "$ALLOWED_TOOLS_REBASE" \
+    --output-format text \
+    > .iterations/rebase-conflict.log 2>&1 ) || claude_exit=$?
+
+if (( claude_exit != 0 )); then
+  ( cd "$WT" && git rebase --abort 2>/dev/null || true )
+  emit_escalation "claude CLI 충돌 해소 세션 실패 (exit $claude_exit) — 워크트리 abort 복구 완료"
+  exit 1
+fi
+
+# claude 세션이 파일을 모두 git add 했는지 확인 후 rebase --continue
+if ! ( cd "$WT" && git diff --name-only --diff-filter=U 2>/dev/null | grep -q . ); then
+  if ( cd "$WT" && GIT_EDITOR=true git rebase --continue 2>&1 ); then
+    echo "[rebase-phase] 충돌 자동 해소 성공 (claude CLI)"
+    exit 0
+  fi
+fi
+
+( cd "$WT" && git rebase --abort 2>/dev/null || true )
+emit_escalation "claude CLI 해소 후에도 git rebase --continue 실패 — 워크트리 abort 복구"
+exit 1

--- a/plugins/autopilot/skills/loop/references/rebase-phase.sh
+++ b/plugins/autopilot/skills/loop/references/rebase-phase.sh
@@ -77,7 +77,7 @@ fi
 
 # claude 세션에 conflict marker가 있는 파일 목록 + diff를 stdin으로 넘긴다.
 # allowed-tools는 caller(loop.sh)에서 export한 환경 변수 또는 본 스크립트 기본값.
-ALLOWED_TOOLS_REBASE="${AUTOPILOT_REBASE_ALLOWED_TOOLS:-Bash(git:*),Bash(cat:*),Bash(ls:*),Read,Edit,Write}"
+ALLOWED_TOOLS_REBASE="${AUTOPILOT_REBASE_ALLOWED_TOOLS:-Bash(git add:*),Bash(git status:*),Bash(git diff:*),Bash(cat:*),Bash(ls:*),Read,Edit,Write}"
 
 # claude 세션이 충돌을 해소할 수 있도록 작업 디렉토리·헌법(워크트리 CLAUDE.md)을 제공.
 # --dangerously-skip-permissions는 사용하지 않고 allowed-tools로 명시 범위 제한.

--- a/plugins/autopilot/skills/loop/references/rebase-phase.sh
+++ b/plugins/autopilot/skills/loop/references/rebase-phase.sh
@@ -98,6 +98,7 @@ When done, output a single line: 'RESOLVED'.
 EOF
 )
 
+mkdir -p "$WT/.iterations" 2>/dev/null || true   # 독립 호출 시에도 로그 쓰기 보장
 claude_exit=0
 ( cd "$WT" && printf '%s' "$claude_prompt" | claude \
     --print \

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -100,13 +100,15 @@ finalize_merged() {
 }
 
 # ----- 자동 머지 (AC14) -----
+# 실패 시 caller가 retry 또는 한계 도달 escalation 결정. 본 함수 자체는 phase를
+# 중단하지 않으므로 ESCALATION 토큰 emit 금지 — WARN으로만 보고 (모니터링 오경보 방지).
 try_auto_merge() {
   local reason="$1"
   echo "[review-fix-phase] 자동 머지 시도: $reason"
   if ! ( cd "$WT" && gh pr merge "$PR_NUMBER" --auto --squash --delete-branch=false 2>&1 ); then
     # --auto가 안되면 즉시 머지 시도 (CI green 가정).
     if ! ( cd "$WT" && gh pr merge "$PR_NUMBER" --squash --delete-branch=false 2>&1 ); then
-      emit_escalation "gh pr merge 실패 (reason=$reason) — 사용자 수동 머지 필요"
+      echo "WARN: gh pr merge 실패 (reason=$reason) — caller가 retry 또는 한계 escalation 결정" >&2
       return 1
     fi
   fi

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -204,17 +204,27 @@ while (( iter < MAX_ITER )); do
   # APPROVED 외 분기 진입 시 카운터 리셋 (성공 path 복귀)
   AUTO_MERGE_FAIL=0
 
-  # (c) owner cmd 검사: owner 코멘트 중 미본 것만 — dedup으로 재진입 차단
+  # (c) owner cmd 검사: owner 코멘트 중 미본 것만 — dedup으로 재진입 차단.
+  # 머지 실패 시 재시도 가능하도록 cmd-bearing 코멘트는 머지 *성공 후*에만 seen 마킹.
+  # 비-cmd 코멘트는 즉시 seen 마킹 (재검사 불필요).
   if [[ -n "$PR_OWNER" ]]; then
     while IFS=$'\t' read -r oc_id oc_body; do
       [[ -z "$oc_id" ]] && continue
       grep -qxF "$oc_id" "$OWNER_CMD_SEEN_FILE" 2>/dev/null && continue
-      echo "$oc_id" >> "$OWNER_CMD_SEEN_FILE"
+      # @tsv는 본문 내 실제 개행(`\n`)을 리터럴 두 글자 `\n`으로 이스케이프함 —
+      # grep `[[:space:]]`가 이를 못 매칭하므로 실제 개행으로 복원.
+      oc_body="${oc_body//\\n/$'\n'}"
       if printf '%s' "$oc_body" | grep -qE '(^|[[:space:]])(/done|합격|통과)([[:space:]]|$)'; then
+        # cmd 검출 — 머지 성공 시에만 seen, 실패 시 다음 iter 재시도
         if try_auto_merge "owner cmd"; then
+          echo "$oc_id" >> "$OWNER_CMD_SEEN_FILE"
           finalize_merged "owner cmd 후 머지" || exit 1
           exit 0
         fi
+        # 머지 실패 — seen 마킹 보류, 다음 iter에서 try_auto_merge 재시도
+      else
+        # 비-cmd 코멘트 — 재검사 불필요, 즉시 seen
+        echo "$oc_id" >> "$OWNER_CMD_SEEN_FILE"
       fi
     done < <( cd "$WT" && gh pr view "$PR_NUMBER" --json comments \
                 --jq ".comments[]? | select(.author.login==\"$PR_OWNER\") | [.id, .body] | @tsv" 2>/dev/null )

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -49,7 +49,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # 본 phase 외 fix iter에서 claude CLI 호출 시 사용할 allowed-tools.
 # caller(loop.sh)가 export한 AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS를 우선, 부재면 기본값.
 # 범위 최소: gh pr 관련 / git rebase·add·commit·push / Read·Edit·Write.
-ALLOWED_TOOLS_FIX="${AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS:-Bash(git:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api:*),Read,Edit,Write,Glob,Grep}"
+ALLOWED_TOOLS_FIX="${AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS:-Bash(git add:*),Bash(git status:*),Bash(git diff:*),Bash(git rebase:*),Bash(git commit:*),Bash(git push:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api repos/:*),Read,Edit,Write,Glob,Grep}"
 
 # ----- 상태 전이: Review (gh project item-edit) — AC12 -----
 if command -v gh >/dev/null 2>&1 \
@@ -76,6 +76,14 @@ mark_seen() { echo "$1" >> "$SEEN_FILE"; }
 
 # 반박 코멘트 1회 게시 가드 (AC10·AC11) — 본 phase 동안 1개만 허용.
 DISPUTE_FILE="$WT/.iterations/review-fix-dispute-posted"
+
+# owner cmd dedup — 매 폴링마다 동일 owner 코멘트 재처리 방지.
+OWNER_CMD_SEEN_FILE="$WT/.iterations/owner-cmd-seen-ids"
+touch "$OWNER_CMD_SEEN_FILE"
+
+# auto_merge 연속 실패 카운터 (back-off + 한계 도달 시 escalation)
+AUTO_MERGE_FAIL=0
+AUTO_MERGE_FAIL_MAX="${LOOP_REVIEW_AUTO_MERGE_FAIL_MAX:-5}"
 
 # ----- PR owner 식별 (owner cmd 검사용) -----
 PR_OWNER=$( cd "$WT" && gh pr view "$PR_NUMBER" --json author --jq '.author.login' 2>/dev/null || echo "" )
@@ -111,37 +119,36 @@ try_auto_merge() {
 # - Review summaries: gh pr view --json reviews
 # - Review threads (inline): gh pr view --json reviewThreads → 각 comment ID
 collect_new_events() {
+  # SPEC 제약 절: jq를 의존성으로 명시. base64 GraphQL node ID(=·+·/ 포함) 안전 파싱.
+  if ! command -v jq >/dev/null 2>&1; then
+    emit_escalation "jq 미설치 — collect_new_events 불가 (SPEC 제약 위반)"
+    return 1
+  fi
+
   local out=""
   local pr_json
   pr_json=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviews,reviewThreads,comments 2>/dev/null || echo '{}')
 
-  # PR-level comments (issue comments)
-  local ids
-  ids=$( printf '%s' "$pr_json" | sed -nE 's/.*"comments":\[(.*)\].*/\1/p' \
-          | grep -oE '"id":[[:space:]]*"?[A-Za-z0-9_-]+"?' \
-          | awk -F: '{gsub(/[" ]/,"",$2); print "comment:" $2}' )
-  while IFS= read -r id; do
-    [[ -z "$id" ]] && continue
+  # PR-level comments (issue comments) — top-level .comments[].id only
+  while IFS= read -r raw_id; do
+    [[ -z "$raw_id" ]] && continue
+    local id="comment:$raw_id"
     is_seen "$id" || { mark_seen "$id"; out+="$id"$'\n'; }
-  done <<< "$ids"
+  done < <( printf '%s' "$pr_json" | jq -r '.comments[]?.id // empty' )
 
-  # Review summary entries
-  ids=$( printf '%s' "$pr_json" | sed -nE 's/.*"reviews":\[(.*)\],"review.*/\1/p' \
-          | grep -oE '"id":[[:space:]]*"?[A-Za-z0-9_-]+"?' \
-          | awk -F: '{gsub(/[" ]/,"",$2); print "review:" $2}' )
-  while IFS= read -r id; do
-    [[ -z "$id" ]] && continue
+  # Review summary entries — top-level .reviews[].id only
+  while IFS= read -r raw_id; do
+    [[ -z "$raw_id" ]] && continue
+    local id="review:$raw_id"
     is_seen "$id" || { mark_seen "$id"; out+="$id"$'\n'; }
-  done <<< "$ids"
+  done < <( printf '%s' "$pr_json" | jq -r '.reviews[]?.id // empty' )
 
-  # Review threads inline comments
-  ids=$( printf '%s' "$pr_json" | grep -oE '"reviewThreads":\[.*\]' \
-          | grep -oE '"id":[[:space:]]*"?[A-Za-z0-9_-]+"?' \
-          | awk -F: '{gsub(/[" ]/,"",$2); print "thread:" $2}' )
-  while IFS= read -r id; do
-    [[ -z "$id" ]] && continue
+  # Review threads inline comments — .reviewThreads[].comments[].id (각 inline 코멘트)
+  while IFS= read -r raw_id; do
+    [[ -z "$raw_id" ]] && continue
+    local id="thread:$raw_id"
     is_seen "$id" || { mark_seen "$id"; out+="$id"$'\n'; }
-  done <<< "$ids"
+  done < <( printf '%s' "$pr_json" | jq -r '.reviewThreads[]?.comments[]?.id // empty' )
 
   printf '%s' "$out"
 }
@@ -165,29 +172,38 @@ while (( iter < MAX_ITER )); do
     exit 0
   fi
 
-  # (b) reviewDecision == APPROVED → 자동 머지
+  # (b) reviewDecision == APPROVED → 자동 머지 (연속 실패 시 linear back-off + 한계 escalation)
   review_decision=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviewDecision --jq '.reviewDecision' 2>/dev/null || echo "")
   if [[ "$review_decision" == "APPROVED" ]]; then
     if try_auto_merge "APPROVED"; then
       finalize_merged "APPROVED 후 머지" || exit 1
       exit 0
     fi
-    # try_auto_merge 실패 시 escalation emit하고 계속 폴링 — 사용자 수동 머지 후 merge 감지로 종료
-    sleep "$POLL_SECS"
+    AUTO_MERGE_FAIL=$((AUTO_MERGE_FAIL + 1))
+    if (( AUTO_MERGE_FAIL >= AUTO_MERGE_FAIL_MAX )); then
+      emit_escalation "auto_merge 연속 ${AUTO_MERGE_FAIL}회 실패 (한계 $AUTO_MERGE_FAIL_MAX) — 폴링 중단, 사용자 수동 머지 필요"
+      exit 1
+    fi
+    sleep $(( POLL_SECS * AUTO_MERGE_FAIL ))   # linear back-off (CI·branch protection 정상화 대기)
     continue
   fi
+  # APPROVED 외 분기 진입 시 카운터 리셋 (성공 path 복귀)
+  AUTO_MERGE_FAIL=0
 
-  # (c) owner cmd 검사: 최근 코멘트 본문에 /done · 합격 · 통과
+  # (c) owner cmd 검사: owner 코멘트 중 미본 것만 — dedup으로 재진입 차단
   if [[ -n "$PR_OWNER" ]]; then
-    owner_cmd_hit=$( cd "$WT" && gh pr view "$PR_NUMBER" --json comments \
-        --jq ".comments[] | select(.author.login==\"$PR_OWNER\") | .body" 2>/dev/null \
-        | grep -E '(^|[[:space:]])(/done|합격|통과)([[:space:]]|$)' | head -1 || true )
-    if [[ -n "$owner_cmd_hit" ]]; then
-      if try_auto_merge "owner cmd"; then
-        finalize_merged "owner cmd 후 머지" || exit 1
-        exit 0
+    while IFS=$'\t' read -r oc_id oc_body; do
+      [[ -z "$oc_id" ]] && continue
+      grep -qxF "$oc_id" "$OWNER_CMD_SEEN_FILE" 2>/dev/null && continue
+      echo "$oc_id" >> "$OWNER_CMD_SEEN_FILE"
+      if printf '%s' "$oc_body" | grep -qE '(^|[[:space:]])(/done|합격|통과)([[:space:]]|$)'; then
+        if try_auto_merge "owner cmd"; then
+          finalize_merged "owner cmd 후 머지" || exit 1
+          exit 0
+        fi
       fi
-    fi
+    done < <( cd "$WT" && gh pr view "$PR_NUMBER" --json comments \
+                --jq ".comments[]? | select(.author.login==\"$PR_OWNER\") | [.id, .body] | @tsv" 2>/dev/null )
   fi
 
   # (d) 신규 이벤트 수집·dispatch
@@ -246,9 +262,12 @@ EOF
   cd "$PROJECT_ROOT"
 
   # (iii) 코드 변경 있으면 commit + push (AC9)
-  if ( cd "$WT" && ! git diff --quiet ); then
+  # `git diff --quiet`는 unstaged 변경만 검사하므로 staged-only 변경을 놓친다.
+  # `git status --porcelain --untracked-files=no`로 staged+unstaged 모두 검사.
+  # untracked 파일은 fix iter 산출로 간주하지 않음 (claude가 의도 외 파일 생성 시 commit에서 제외).
+  if [[ -n "$( cd "$WT" && git status --porcelain --untracked-files=no 2>/dev/null )" ]]; then
     ( cd "$WT" \
-        && git add -A \
+        && git add -u \
         && git commit -q -m "fix:root review-fix iter $iter (PR #$PR_NUMBER)" \
         && git push origin "$BRANCH" ) \
       || { emit_escalation "fix commit/push 실패 (iter $iter)"; sleep "$POLL_SECS"; continue; }

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -129,33 +129,42 @@ try_auto_merge() {
 # - Review summaries: gh pr view --json reviews
 # - Review threads (inline): gh pr view --json reviewThreads → 각 comment ID
 collect_new_events() {
-  # jq 사전 검사는 진입부에서 완료됨 ($() 캡처로 stdout 누락 방지).
-  local out=""
+  # 후보 ID만 emit (mark_seen은 caller가 성공 후에 별도 호출). 본 함수는 `$()`로
+  # 호출돼 stdout이 변수로 캡처되므로 여기서 mark_seen하면 caller가 fix 실패해도
+  # 이미 영구히 seen 처리됨 — rebase·claude·commit 중 실패 시 재시도 불가능.
+  # jq 사전 검사는 진입부에서 완료됨.
   local pr_json
   pr_json=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviews,reviewThreads,comments 2>/dev/null || echo '{}')
 
-  # PR-level comments (issue comments) — top-level .comments[].id only
+  # PR-level comments (issue comments)
   while IFS= read -r raw_id; do
     [[ -z "$raw_id" ]] && continue
     local id="comment:$raw_id"
-    is_seen "$id" || { mark_seen "$id"; out+="$id"$'\n'; }
+    is_seen "$id" || echo "$id"
   done < <( printf '%s' "$pr_json" | jq -r '.comments[]?.id // empty' )
 
-  # Review summary entries — top-level .reviews[].id only
+  # Review summary entries
   while IFS= read -r raw_id; do
     [[ -z "$raw_id" ]] && continue
     local id="review:$raw_id"
-    is_seen "$id" || { mark_seen "$id"; out+="$id"$'\n'; }
+    is_seen "$id" || echo "$id"
   done < <( printf '%s' "$pr_json" | jq -r '.reviews[]?.id // empty' )
 
-  # Review threads inline comments — .reviewThreads[].comments[].id (각 inline 코멘트)
+  # Review threads inline comments
   while IFS= read -r raw_id; do
     [[ -z "$raw_id" ]] && continue
     local id="thread:$raw_id"
-    is_seen "$id" || { mark_seen "$id"; out+="$id"$'\n'; }
+    is_seen "$id" || echo "$id"
   done < <( printf '%s' "$pr_json" | jq -r '.reviewThreads[]?.comments[]?.id // empty' )
+}
 
-  printf '%s' "$out"
+# fix iter 성공 후 한 묶음으로 seen 마킹 — 실패 분기에서는 호출되지 않으므로 다음
+# iter의 collect_new_events가 동일 ID를 재발견해 재시도 가능.
+mark_events_seen() {
+  while IFS= read -r id; do
+    [[ -z "$id" ]] && continue
+    mark_seen "$id"
+  done
 }
 
 # ----- 메인 폴링 루프 -----
@@ -292,6 +301,9 @@ EOF
       echo "WARN: gh pr comment 실패 (반박 게시) — 다음 iter 재시도 (phase 계속)" >&2
     fi
   fi
+
+  # 모든 단계 성공 — 본 iter의 new_events ID들을 seen 마킹 (실패 분기에서는 미도달)
+  printf '%s\n' "$new_events" | mark_events_seen
 
   sleep "$POLL_SECS"
 done

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -221,9 +221,9 @@ while (( iter < MAX_ITER )); do
     [[ -n "$e" ]] && echo "  - $e"
   done
 
-  # (i) 재-rebase (AC7)
+  # (i) 재-rebase (AC7) — 실패 시 다음 iter에서 재시도 (recoverable)
   if ! bash "$SCRIPT_DIR/rebase-phase.sh" "$WT" "$BRANCH" "$PROJECT_ROOT"; then
-    emit_escalation "fix iter 내 rebase 실패 — 폴링 계속 (다음 iter 시 재시도)"
+    echo "WARN: fix iter 내 rebase 실패 — 다음 iter 시 재시도 (phase 계속)" >&2
     sleep "$POLL_SECS"
     continue
   fi
@@ -256,7 +256,8 @@ EOF
         --add-dir . \
         --allowed-tools "$ALLOWED_TOOLS_FIX" \
         --output-format text > "$fix_log" 2>&1; then
-    emit_escalation "claude fix 세션 실패 (iter $iter)"
+    # recoverable: 다음 iter에서 재시도
+    echo "WARN: claude fix 세션 실패 (iter $iter) — 다음 iter 재시도 (phase 계속)" >&2
     sleep "$POLL_SECS"
     cd "$PROJECT_ROOT"
     continue
@@ -270,9 +271,9 @@ EOF
   if [[ -n "$( cd "$WT" && git status --porcelain --untracked-files=no 2>/dev/null )" ]]; then
     ( cd "$WT" \
         && git add -u \
-        && git commit -q -m "fix:root review-fix iter $iter (PR #$PR_NUMBER)" \
+        && git commit -q -m "fix(review-fix): iter $iter (PR #$PR_NUMBER)" \
         && git push origin "$BRANCH" ) \
-      || { emit_escalation "fix commit/push 실패 (iter $iter)"; sleep "$POLL_SECS"; continue; }
+      || { echo "WARN: fix commit/push 실패 (iter $iter) — 다음 iter 재시도 (phase 계속)" >&2; sleep "$POLL_SECS"; continue; }
   fi
 
   # (iv) DISPUTE 본문 감지 → PR 코멘트 1회 게시 (AC10·AC11)
@@ -284,7 +285,8 @@ EOF
     if ( cd "$WT" && gh pr comment "$PR_NUMBER" --body "[autopilot:dispute] $dispute_body" 2>&1 ); then
       touch "$DISPUTE_FILE"
     else
-      emit_escalation "gh pr comment 실패 (반박 게시)"
+      # recoverable: 다음 iter에서 재시도 가능 (DISPUTE_FILE 없으므로 동일 dispute 재시도)
+      echo "WARN: gh pr comment 실패 (반박 게시) — 다음 iter 재시도 (phase 계속)" >&2
     fi
   fi
 

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -57,7 +57,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # 본 phase 외 fix iter에서 claude CLI 호출 시 사용할 allowed-tools.
 # caller(loop.sh)가 export한 AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS를 우선, 부재면 기본값.
 # 범위 최소: gh pr 관련 / git rebase·add·commit·push / Read·Edit·Write.
-ALLOWED_TOOLS_FIX="${AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS:-Bash(git add:*),Bash(git status:*),Bash(git diff:*),Bash(git rebase:*),Bash(git commit:*),Bash(git push:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api repos/:*),Read,Edit,Write,Glob,Grep}"
+ALLOWED_TOOLS_FIX="${AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS:-Bash(git add:*),Bash(git status:*),Bash(git diff:*),Bash(gh pr view:*),Bash(gh api repos/:*),Read,Edit,Write,Glob,Grep}"
 
 # ----- 상태 전이: Review (gh project item-edit) — AC12 -----
 if command -v gh >/dev/null 2>&1 \

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# review-fix-phase.sh — SPEC 123 M2
+#
+# DONE → PR 생성·재사용이 끝난 직후 background로 띄워지는 리뷰 fix 루프.
+# request_review: true opt-in일 때만 loop.sh가 호출한다.
+#
+# 사용:
+#   bash review-fix-phase.sh <worktree> <branch> <task-id> <project-root> <pr-number>
+#
+# 동작 (SPEC 123 AC4·AC5·AC6·AC7·AC8·AC9·AC10·AC11·AC12·AC13·AC14·AC15·AC16):
+#   1. 추상 상태 "리뷰 관련 상태" (Review) 전이 — gh project item-edit (envvar 부재 시 skip).
+#   2. LOOP_REVIEW_POLL_SECS(기본 30초) 주기로 폴링:
+#        a. PR state — MERGED → cleanup-phase 호출 후 종료 (auto-merge skip, AC13).
+#                       CLOSED(unmerged) → 모든 후속 단계 skip 후 종료 (AC15).
+#        b. reviewDecision == APPROVED → gh pr merge 시도, 성공 시 cleanup → 종료 (AC14).
+#        c. owner의 코멘트 본문에 '/done' OR '합격' OR '통과' → gh pr merge → cleanup → 종료.
+#        d. 신규 PR-level comments · review threads · review summary 수집:
+#             - last-seen ID dedup, 없으면 sleep로 돌아감.
+#             - 새 이벤트 발견 시:
+#                 i.  요약 한 줄 stdout emit (AC6).
+#                 ii. rebase-phase.sh 호출 (AC7).
+#                 iii. claude CLI fix 세션 (AC8).
+#                 iv. 코드 변경 시 commit + push (AC9).
+#                 v.  세션 결과가 "DISPUTE: ..."로 시작하면 그 본문을 1개 PR 코멘트로 게시 (AC10).
+#                     AC11: 이 외 어떤 GitHub 게시도 수행하지 않음.
+#   3. LOOP_REVIEW_MAX_ITER 도달 시 무한 폴링 방지로 종료 (안전장치).
+#   4. 어느 단계든 비-zero exit은 stdout "ESCALATION review-fix-phase: ..." emit 후 종료 (AC19).
+
+set -euo pipefail
+
+WT="${1:-}"
+BRANCH="${2:-}"
+TASK_ID="${3:-}"
+PROJECT_ROOT="${4:-}"
+PR_NUMBER="${5:-}"
+
+if [[ -z "$WT" || -z "$BRANCH" || -z "$TASK_ID" || -z "$PROJECT_ROOT" || -z "$PR_NUMBER" ]]; then
+  echo "사용: $0 <worktree> <branch> <task-id> <project-root> <pr-number>" >&2
+  exit 2
+fi
+
+emit_escalation() { echo "ESCALATION review-fix-phase: $*"; }
+[[ -d "$WT" ]] || { emit_escalation "워크트리 없음: $WT"; exit 1; }
+
+POLL_SECS="${LOOP_REVIEW_POLL_SECS:-30}"
+MAX_ITER="${LOOP_REVIEW_MAX_ITER:-480}"   # 30초 × 480 ≈ 4시간 cutoff
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 본 phase 외 fix iter에서 claude CLI 호출 시 사용할 allowed-tools.
+# caller(loop.sh)가 export한 AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS를 우선, 부재면 기본값.
+# 범위 최소: gh pr 관련 / git rebase·add·commit·push / Read·Edit·Write.
+ALLOWED_TOOLS_FIX="${AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS:-Bash(git:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh api:*),Read,Edit,Write,Glob,Grep}"
+
+# ----- 상태 전이: Review (gh project item-edit) — AC12 -----
+if command -v gh >/dev/null 2>&1 \
+   && [[ -n "${LOOP_PROJECT_ID:-}" && -n "${LOOP_STATUS_FIELD_ID:-}" \
+         && -n "${LOOP_STATUS_REVIEW_OPTION_ID:-}" && -n "${LOOP_PROJECT_ITEM_ID:-}" ]]; then
+  echo "[review-fix-phase] 상태 전이: Review (gh project item-edit)"
+  gh project item-edit \
+       --project-id "$LOOP_PROJECT_ID" \
+       --id "$LOOP_PROJECT_ITEM_ID" \
+       --field-id "$LOOP_STATUS_FIELD_ID" \
+       --single-select-option-id "$LOOP_STATUS_REVIEW_OPTION_ID" >/dev/null 2>&1 \
+    || echo "WARN: 상태 전이(Review) 실패 — 수동 확인 필요" >&2
+else
+  echo "[review-fix-phase] 상태 전이 환경변수 부재 — Review 전이 skip"
+fi
+
+# ----- last-seen ID 추적 파일 (dedup) -----
+mkdir -p "$WT/.iterations" 2>/dev/null || true
+SEEN_FILE="$WT/.iterations/review-fix-seen-ids"
+touch "$SEEN_FILE"
+
+is_seen() { grep -qxF "$1" "$SEEN_FILE" 2>/dev/null; }
+mark_seen() { echo "$1" >> "$SEEN_FILE"; }
+
+# 반박 코멘트 1회 게시 가드 (AC10·AC11) — 본 phase 동안 1개만 허용.
+DISPUTE_FILE="$WT/.iterations/review-fix-dispute-posted"
+
+# ----- PR owner 식별 (owner cmd 검사용) -----
+PR_OWNER=$( cd "$WT" && gh pr view "$PR_NUMBER" --json author --jq '.author.login' 2>/dev/null || echo "" )
+
+# ----- 종료 시 cleanup-phase 호출 헬퍼 -----
+finalize_merged() {
+  local reason="$1"
+  echo "[review-fix-phase] PR #$PR_NUMBER $reason — cleanup-phase 호출"
+  if ! bash "$SCRIPT_DIR/cleanup-phase.sh" "$WT" "$BRANCH" "$TASK_ID" "$PROJECT_ROOT"; then
+    emit_escalation "cleanup-phase 실패 ($reason)"
+    return 1
+  fi
+  return 0
+}
+
+# ----- 자동 머지 (AC14) -----
+try_auto_merge() {
+  local reason="$1"
+  echo "[review-fix-phase] 자동 머지 시도: $reason"
+  if ! ( cd "$WT" && gh pr merge "$PR_NUMBER" --auto --squash --delete-branch=false 2>&1 ); then
+    # --auto가 안되면 즉시 머지 시도 (CI green 가정).
+    if ! ( cd "$WT" && gh pr merge "$PR_NUMBER" --squash --delete-branch=false 2>&1 ); then
+      emit_escalation "gh pr merge 실패 (reason=$reason) — 사용자 수동 머지 필요"
+      return 1
+    fi
+  fi
+  return 0
+}
+
+# ----- 새 이벤트 수집 (PR comments + review threads + review summary) -----
+# 3 소스의 모든 항목 ID 화이트리스트 후 SEEN_FILE에 없는 것만 new로 분류.
+# - PR-level comments: gh api repos/{owner}/{repo}/issues/{n}/comments
+# - Review summaries: gh pr view --json reviews
+# - Review threads (inline): gh pr view --json reviewThreads → 각 comment ID
+collect_new_events() {
+  local out=""
+  local pr_json
+  pr_json=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviews,reviewThreads,comments 2>/dev/null || echo '{}')
+
+  # PR-level comments (issue comments)
+  local ids
+  ids=$( printf '%s' "$pr_json" | sed -nE 's/.*"comments":\[(.*)\].*/\1/p' \
+          | grep -oE '"id":[[:space:]]*"?[A-Za-z0-9_-]+"?' \
+          | awk -F: '{gsub(/[" ]/,"",$2); print "comment:" $2}' )
+  while IFS= read -r id; do
+    [[ -z "$id" ]] && continue
+    is_seen "$id" || { mark_seen "$id"; out+="$id"$'\n'; }
+  done <<< "$ids"
+
+  # Review summary entries
+  ids=$( printf '%s' "$pr_json" | sed -nE 's/.*"reviews":\[(.*)\],"review.*/\1/p' \
+          | grep -oE '"id":[[:space:]]*"?[A-Za-z0-9_-]+"?' \
+          | awk -F: '{gsub(/[" ]/,"",$2); print "review:" $2}' )
+  while IFS= read -r id; do
+    [[ -z "$id" ]] && continue
+    is_seen "$id" || { mark_seen "$id"; out+="$id"$'\n'; }
+  done <<< "$ids"
+
+  # Review threads inline comments
+  ids=$( printf '%s' "$pr_json" | grep -oE '"reviewThreads":\[.*\]' \
+          | grep -oE '"id":[[:space:]]*"?[A-Za-z0-9_-]+"?' \
+          | awk -F: '{gsub(/[" ]/,"",$2); print "thread:" $2}' )
+  while IFS= read -r id; do
+    [[ -z "$id" ]] && continue
+    is_seen "$id" || { mark_seen "$id"; out+="$id"$'\n'; }
+  done <<< "$ids"
+
+  printf '%s' "$out"
+}
+
+# ----- 메인 폴링 루프 -----
+iter=0
+while (( iter < MAX_ITER )); do
+  iter=$((iter + 1))
+
+  # (a) PR state 검사 — merged/closed 즉시 분기
+  pr_state=$( cd "$WT" && gh pr view "$PR_NUMBER" --json state --jq '.state' 2>/dev/null || echo "")
+
+  if [[ "$pr_state" == "MERGED" ]]; then
+    # AC13: 이미 merged이면 자동 머지 skip → cleanup 진입.
+    finalize_merged "merged 감지" || exit 1
+    exit 0
+  fi
+  if [[ "$pr_state" == "CLOSED" ]]; then
+    # AC15: closed(unmerged) — 모든 후속 단계 skip, 사용자 판단 대기.
+    echo "[review-fix-phase] PR #$PR_NUMBER closed (unmerged) — cleanup 및 상태 전이 skip (AC15)"
+    exit 0
+  fi
+
+  # (b) reviewDecision == APPROVED → 자동 머지
+  review_decision=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviewDecision --jq '.reviewDecision' 2>/dev/null || echo "")
+  if [[ "$review_decision" == "APPROVED" ]]; then
+    if try_auto_merge "APPROVED"; then
+      finalize_merged "APPROVED 후 머지" || exit 1
+      exit 0
+    fi
+    # try_auto_merge 실패 시 escalation emit하고 계속 폴링 — 사용자 수동 머지 후 merge 감지로 종료
+    sleep "$POLL_SECS"
+    continue
+  fi
+
+  # (c) owner cmd 검사: 최근 코멘트 본문에 /done · 합격 · 통과
+  if [[ -n "$PR_OWNER" ]]; then
+    owner_cmd_hit=$( cd "$WT" && gh pr view "$PR_NUMBER" --json comments \
+        --jq ".comments[] | select(.author.login==\"$PR_OWNER\") | .body" 2>/dev/null \
+        | grep -E '(^|[[:space:]])(/done|합격|통과)([[:space:]]|$)' | head -1 || true )
+    if [[ -n "$owner_cmd_hit" ]]; then
+      if try_auto_merge "owner cmd"; then
+        finalize_merged "owner cmd 후 머지" || exit 1
+        exit 0
+      fi
+    fi
+  fi
+
+  # (d) 신규 이벤트 수집·dispatch
+  new_events="$( collect_new_events )"
+  if [[ -z "$new_events" ]]; then
+    sleep "$POLL_SECS"
+    continue
+  fi
+
+  # 새 이벤트 요약 emit (AC6)
+  echo "[review-fix-phase] 새 이벤트 감지:"
+  printf '%s\n' "$new_events" | while IFS= read -r e; do
+    [[ -n "$e" ]] && echo "  - $e"
+  done
+
+  # (i) 재-rebase (AC7)
+  if ! bash "$SCRIPT_DIR/rebase-phase.sh" "$WT" "$BRANCH" "$PROJECT_ROOT"; then
+    emit_escalation "fix iter 내 rebase 실패 — 폴링 계속 (다음 iter 시 재시도)"
+    sleep "$POLL_SECS"
+    continue
+  fi
+
+  # (ii) claude CLI fix 세션 (AC8) — 새 이벤트 본문을 stdin으로 전달
+  fix_prompt_body=$( cd "$WT" && gh pr view "$PR_NUMBER" --json comments,reviews,reviewThreads 2>/dev/null || echo "")
+  claude_prompt=$(cat <<EOF
+You are a fix worker for PR #$PR_NUMBER on branch '$BRANCH'.
+New review events:
+$new_events
+
+Full PR comment/review JSON (for reference):
+$fix_prompt_body
+
+Goal:
+  - For each new event, decide if reviewer is correct → fix the code (Edit/Write).
+  - If reviewer is wrong → output a single line starting with 'DISPUTE: ' followed by
+    a short dispute body (the caller will post it as ONE PR comment via gh pr comment).
+  - DO NOT push, commit, or create PRs yourself. DO NOT post comments yourself.
+
+After working, output 'DONE' on the last line (or 'DISPUTE: ...' if disputing).
+EOF
+)
+
+  cd "$WT"
+  fix_log=".iterations/review-fix-iter-$iter.log"
+  if ! printf '%s' "$claude_prompt" | claude \
+        --print \
+        --no-session-persistence \
+        --add-dir . \
+        --allowed-tools "$ALLOWED_TOOLS_FIX" \
+        --output-format text > "$fix_log" 2>&1; then
+    emit_escalation "claude fix 세션 실패 (iter $iter)"
+    sleep "$POLL_SECS"
+    cd "$PROJECT_ROOT"
+    continue
+  fi
+  cd "$PROJECT_ROOT"
+
+  # (iii) 코드 변경 있으면 commit + push (AC9)
+  if ( cd "$WT" && ! git diff --quiet ); then
+    ( cd "$WT" \
+        && git add -A \
+        && git commit -q -m "fix:root review-fix iter $iter (PR #$PR_NUMBER)" \
+        && git push origin "$BRANCH" ) \
+      || { emit_escalation "fix commit/push 실패 (iter $iter)"; sleep "$POLL_SECS"; continue; }
+  fi
+
+  # (iv) DISPUTE 본문 감지 → PR 코멘트 1회 게시 (AC10·AC11)
+  dispute_line=$( grep -m1 -E '^DISPUTE:' "$WT/$fix_log" 2>/dev/null || true )
+  if [[ -n "$dispute_line" && ! -f "$DISPUTE_FILE" ]]; then
+    dispute_body="${dispute_line#DISPUTE: }"
+    # 반박 게시 — gh pr comment (AC10): 1개 코멘트만.
+    echo "[review-fix-phase] 반박 코멘트 게시 (dispute)"
+    if ( cd "$WT" && gh pr comment "$PR_NUMBER" --body "[autopilot:dispute] $dispute_body" 2>&1 ); then
+      touch "$DISPUTE_FILE"
+    else
+      emit_escalation "gh pr comment 실패 (반박 게시)"
+    fi
+  fi
+
+  sleep "$POLL_SECS"
+done
+
+emit_escalation "MAX_ITER ($MAX_ITER) 도달 — 폴링 중단. 사용자 개입 필요 (PR #$PR_NUMBER)"
+exit 1

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -42,6 +42,14 @@ fi
 emit_escalation() { echo "ESCALATION review-fix-phase: $*"; }
 [[ -d "$WT" ]] || { emit_escalation "워크트리 없음: $WT"; exit 1; }
 
+# jq는 SPEC 제약 절의 명시적 의존성 — collect_new_events·owner cmd 파싱이 jq에
+# 직접 의존하므로 진입 시점에 사전 검사. 함수 내부 emit_escalation은 `$()` 캡처로
+# stdout에 도달하지 못해 모니터링이 ESCALATION을 감지 못 함.
+if ! command -v jq >/dev/null 2>&1; then
+  emit_escalation "jq 미설치 — SPEC 제약 위반, phase 진입 불가"
+  exit 1
+fi
+
 POLL_SECS="${LOOP_REVIEW_POLL_SECS:-30}"
 MAX_ITER="${LOOP_REVIEW_MAX_ITER:-480}"   # 30초 × 480 ≈ 4시간 cutoff
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -121,12 +129,7 @@ try_auto_merge() {
 # - Review summaries: gh pr view --json reviews
 # - Review threads (inline): gh pr view --json reviewThreads → 각 comment ID
 collect_new_events() {
-  # SPEC 제약 절: jq를 의존성으로 명시. base64 GraphQL node ID(=·+·/ 포함) 안전 파싱.
-  if ! command -v jq >/dev/null 2>&1; then
-    emit_escalation "jq 미설치 — collect_new_events 불가 (SPEC 제약 위반)"
-    return 1
-  fi
-
+  # jq 사전 검사는 진입부에서 완료됨 ($() 캡처로 stdout 누락 방지).
   local out=""
   local pr_json
   pr_json=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviews,reviewThreads,comments 2>/dev/null || echo '{}')

--- a/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# test-loop-review-fix-phase.sh — SPEC 123 rebase·review-fix·cleanup phase 테스트
+#
+# 검증 대상:
+#  - rebase-phase.sh / review-fix-phase.sh / cleanup-phase.sh 존재·실행권
+#  - SPEC 검증 명령(grep 키워드 체크)이 통과
+#  - rebase-phase.sh: 인자 부족 시 non-zero, 정상 인자에서 rebase 호출
+#  - review-fix-phase.sh: 종료 신호(merged/closed/APPROVED/owner cmd) 분기 동작
+#  - cleanup-phase.sh: worktree remove + branch -D + push --delete 호출
+#  - loop.sh: request_review opt-in 분기 + allowed-tools 상수 + 3개 phase 호출 link
+#
+# 외부 부수 효과(git push·gh API·claude CLI)는 모두 stub binary로 격리.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SKILL_REFS="$REPO_ROOT/plugins/autopilot/skills/loop/references"
+
+WORK_DIR="$(mktemp -d)"
+# shellcheck disable=SC2064
+trap "rm -rf $WORK_DIR" EXIT
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; exit 1; }
+
+# ----- 구조 검증: SPEC 명령 (grep 키워드) -----
+test_spec_verify_command() {
+  local S="$REPO_ROOT/plugins/autopilot/skills/loop"
+  test -f "$S/references/rebase-phase.sh"        || fail "rebase-phase.sh 부재"
+  test -f "$S/references/review-fix-phase.sh"    || fail "review-fix-phase.sh 부재"
+  test -f "$S/references/cleanup-phase.sh"       || fail "cleanup-phase.sh 부재"
+  grep -qE 'merged|closed'             "$S/references/review-fix-phase.sh" || fail "review-fix: merged|closed 키워드 부재"
+  grep -qE 'APPROVED'                  "$S/references/review-fix-phase.sh" || fail "review-fix: APPROVED 키워드 부재"
+  grep -qE '/done|합격|통과'           "$S/references/review-fix-phase.sh" || fail "review-fix: owner cmd 어휘 부재"
+  grep -q  'sleep'                     "$S/references/review-fix-phase.sh" || fail "review-fix: sleep 부재 (폴링)"
+  grep -q  'rebase'                    "$S/references/rebase-phase.sh"     || fail "rebase-phase: rebase 부재"
+  grep -q  'worktree remove'           "$S/references/cleanup-phase.sh"    || fail "cleanup: worktree remove 부재"
+  grep -qE 'branch -D|push --delete'   "$S/references/cleanup-phase.sh"    || fail "cleanup: branch -D | push --delete 부재"
+  grep -qE 'review-fix-phase|rebase-phase|cleanup-phase' "$S/references/loop.sh" || fail "loop.sh: 새 phase ref 부재"
+  grep -q  'gh project item-edit' "$S/references/loop.sh" "$S/references/review-fix-phase.sh" "$S/references/cleanup-phase.sh" \
+    || fail "gh project item-edit 부재 (어느 phase에도 없음)"
+  grep -q  'gh pr merge'               "$S/references/review-fix-phase.sh" || fail "review-fix: gh pr merge 부재"
+  grep -q  'gh pr comment'             "$S/references/review-fix-phase.sh" || fail "review-fix: gh pr comment 부재"
+  grep -qE '반박|dispute'              "$S/references/review-fix-phase.sh" || fail "review-fix: 반박 어휘 부재"
+  grep -qE 'allowed-tools|--allowed-tools' "$S/references/loop.sh"         || fail "loop.sh: allowed-tools 부재"
+  grep -qE 'review-fix|rebase|cleanup' "$S/SKILL.md"                       || fail "SKILL.md: phase 어휘 부재"
+  grep -qE '상태 전이|Status'          "$S/SKILL.md"                       || fail "SKILL.md: 상태 어휘 부재"
+  grep -qE '자동 머지|auto[- ]?merge'  "$S/SKILL.md"                       || fail "SKILL.md: 자동 머지 어휘 부재"
+  pass "SPEC 검증 명령 통과"
+}
+
+# ----- 인자 부족 시 phase 스크립트 non-zero exit -----
+test_phase_scripts_arg_validation() {
+  local s
+  for s in rebase-phase.sh review-fix-phase.sh cleanup-phase.sh; do
+    if bash "$SKILL_REFS/$s" 2>/dev/null; then
+      fail "$s: 인자 없이 호출됐는데 0 exit (인자 검증 누락)"
+    fi
+  done
+  pass "phase 스크립트 인자 부족 시 non-zero exit"
+}
+
+# ----- cleanup-phase.sh: PR merged 후 worktree·branch 정리 -----
+test_cleanup_phase_removes_worktree_and_branches() {
+  local project="$WORK_DIR/proj"
+  local bare="$WORK_DIR/proj.git"
+  git init -q --bare -b main "$bare"
+  mkdir -p "$project"
+  (
+    cd "$project"
+    git init -q -b main
+    git config user.email "t@e.com"; git config user.name "T"
+    git remote add origin "$bare"
+    git commit --allow-empty -q -m initial
+    git push -q origin main
+    mkdir -p milestones/regular/loops/123
+    # 새 feat 브랜치를 worktree에 직접 생성 (main repo는 main 유지 — 'already used' 회피)
+    git worktree add -q -b feat/123-test milestones/regular/loops/123/.worktree HEAD
+    cd milestones/regular/loops/123/.worktree
+    git commit --allow-empty -q -m "feat: x"
+    git push -q -u origin feat/123-test
+  ) || fail "cleanup test setup 실패"
+  local wt="$project/milestones/regular/loops/123/.worktree"
+  [[ -d "$wt" ]] || fail "셋업: worktree 없음"
+
+  # mock bin (gh stub to avoid network)
+  local mock_bin="$WORK_DIR/mock_bin"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+# gh stub — 본 테스트의 cleanup phase에서 호출되는 'gh project item-edit'를 무음 성공
+exit 0
+GH
+  chmod +x "$mock_bin/gh"
+
+  PATH="$mock_bin:$PATH" bash "$SKILL_REFS/cleanup-phase.sh" "$wt" "feat/123-test" "regular/123" "$project" \
+    || fail "cleanup-phase 실패 exit"
+
+  [[ ! -d "$wt" ]] || fail "cleanup 후 worktree 잔존: $wt"
+  ( cd "$project" && git rev-parse --verify feat/123-test 2>/dev/null ) \
+    && fail "cleanup 후 로컬 feat 브랜치 잔존"
+  ( cd "$bare" && git rev-parse --verify feat/123-test 2>/dev/null ) \
+    && fail "cleanup 후 origin feat 브랜치 잔존"
+  pass "cleanup-phase: worktree + local feat + origin feat 모두 제거"
+}
+
+# ----- review-fix-phase.sh: 종료 신호(merged) 감지 즉시 종료 -----
+test_review_fix_phase_terminates_on_merged() {
+  local project="$WORK_DIR/rf_proj"
+  local bare="$WORK_DIR/rf_proj.git"
+  git init -q --bare -b main "$bare"
+  mkdir -p "$project"
+  (
+    cd "$project"
+    git init -q -b main
+    git config user.email "t@e.com"; git config user.name "T"
+    git remote add origin "$bare"
+    git commit --allow-empty -q -m initial
+    git push -q origin main
+    mkdir -p milestones/regular/loops/123
+    git worktree add -q -b feat/123-rf milestones/regular/loops/123/.worktree HEAD
+    cd milestones/regular/loops/123/.worktree
+    git commit --allow-empty -q -m "feat: y"
+  ) || fail "review-fix test setup 실패"
+  local wt="$project/milestones/regular/loops/123/.worktree"
+
+  # gh mock — PR view 호출에 즉시 MERGED 반환
+  local mock_bin="$WORK_DIR/rf_mock"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+# 단순 mock: --jq 인자 값에 따라 적절한 필드만 반환.
+# review-fix-phase.sh가 호출하는 4가지 --jq 패턴 처리:
+#   .state, .reviewDecision, .author.login,
+#   .comments[] | select(...).body
+case "${1:-}/${2:-}" in
+  pr/view)
+    jq_expr=""
+    for ((i=1; i<=$#; i++)); do
+      if [[ "${!i}" == "--jq" ]]; then
+        j=$((i+1)); jq_expr="${!j}"
+      fi
+    done
+    case "$jq_expr" in
+      .state)              echo "MERGED" ;;
+      .reviewDecision)     echo "" ;;
+      .author.login)       echo "owner" ;;
+      *)                   echo '{"state":"MERGED","reviewDecision":null,"reviews":[],"comments":[],"reviewThreads":[],"number":1,"author":{"login":"owner"}}' ;;
+    esac
+    exit 0
+    ;;
+  pr/list)
+    echo '[{"number":1}]'; exit 0 ;;
+  api/*)
+    echo '[]'; exit 0 ;;
+  project/*)
+    exit 0 ;;
+esac
+exit 0
+GH
+  chmod +x "$mock_bin/gh"
+  cat > "$mock_bin/claude" <<'CL'
+#!/usr/bin/env bash
+exit 0
+CL
+  chmod +x "$mock_bin/claude"
+
+  # 빠른 폴링 (1초)·iter 상한 (5회) — 즉시 MERGED 감지로 1회 polling 후 종료
+  export LOOP_REVIEW_POLL_SECS=1
+  export LOOP_REVIEW_MAX_ITER=5
+  out=$(PATH="$mock_bin:$PATH" bash "$SKILL_REFS/review-fix-phase.sh" "$wt" "feat/123-rf" "regular/123" "$project" "1" 2>&1) \
+    || fail "review-fix-phase 실패 exit. out=$out"
+  echo "$out" | grep -qiE 'merged|종료' \
+    || fail "review-fix-phase: MERGED 종료 신호 출력 부재. out=$out"
+  pass "review-fix-phase: MERGED 즉시 종료"
+}
+
+# ----- rebase-phase.sh: 정상 fast-forward (충돌 없음) 시 0 exit -----
+test_rebase_phase_fast_forward() {
+  local project="$WORK_DIR/rb_proj"
+  local bare="$WORK_DIR/rb_proj.git"
+  git init -q --bare -b main "$bare"
+  mkdir -p "$project"
+  (
+    cd "$project"
+    git init -q -b main
+    git config user.email "t@e.com"; git config user.name "T"
+    git remote add origin "$bare"
+    git commit --allow-empty -q -m initial
+    git push -q origin main
+    # default 브랜치 감지(rebase-phase.sh)의 git symbolic-ref 경로용
+    git remote set-head origin main
+    mkdir -p milestones/regular/loops/123
+    git worktree add -q -b feat/123-rb milestones/regular/loops/123/.worktree HEAD
+    cd milestones/regular/loops/123/.worktree
+    git commit --allow-empty -q -m "feat: z"
+  ) || fail "rebase test setup 실패"
+  local wt="$project/milestones/regular/loops/123/.worktree"
+
+  # gh를 stub해 'gh repo view' 호출이 무음 실패하게 (default branch 감지가
+  # git symbolic-ref fallback으로 떨어지게)
+  local rb_mock="$WORK_DIR/rb_mock"
+  mkdir -p "$rb_mock"
+  cat > "$rb_mock/gh" <<'GH'
+#!/usr/bin/env bash
+exit 1
+GH
+  chmod +x "$rb_mock/gh"
+
+  PATH="$rb_mock:$PATH" bash "$SKILL_REFS/rebase-phase.sh" "$wt" "feat/123-rb" "$project" \
+    || fail "rebase-phase: fast-forward에서 0 exit 기대 (충돌 없음)"
+  pass "rebase-phase: fast-forward 0 exit"
+}
+
+# ----- 실행 -----
+test_spec_verify_command
+test_phase_scripts_arg_validation
+test_cleanup_phase_removes_worktree_and_branches
+test_review_fix_phase_terminates_on_merged
+test_rebase_phase_fast_forward
+
+echo "----------"
+echo "ALL TESTS PASSED"


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가

autopilot:loop의 PR 관련 phase를 확장해 DONE 이후 PR 생애주기 전체를 자동화한다.
SPEC frontmatter `request_review: true` opt-in이 활성화되면 다음 sub-phase들이
순차·일부 background로 구동된다:

1. **pre-PR rebase** — default에서 feat 브랜치 rebase. conflict 시 claude CLI
   자동 해소 시도, 실패 시 ESCALATION abort.
2. **PR 생성** — push, 신규 PR 생성 또는 동일 head의 open PR 갱신.
3. **태스크 상태 전이 (→ 리뷰 관련 상태)** — PR 생성·재사용 성공 시 외부 태스크
   추적 시스템의 *추상 상태*를 "리뷰 관련 상태"로 전이. 구체 값·백킹
   시스템·매핑은 `rules/context.md` 단일 출처에 의존.
4. **review-fix 루프 (background)** — 30초 주기 폴링 (PR-level comments ·
   review threads · review summary). 새 이벤트마다: 매 fix iter 직전 default
   재-rebase, claude CLI 세션으로 fix, 코드 변경 시 commit+push, "리뷰어 틀렸다"
   판명 시 반박 코멘트 1개 게시 (그 외 일체 게시 금지), 새 이벤트·종료 신호를
   stdout 으로 emit.
5. **자동 머지 (조건부)** — 종료 신호가 merged가 *아닌* PR 승인 또는 owner의
   종료 코멘트(`/done`·`합격`·`통과`)로 들어오면 시스템이 `gh pr merge`로
   직접 머지.
6. **cleanup** — 로컬 worktree 제거 + 로컬 feat 삭제 + origin feat 삭제.
7. **태스크 상태 전이 (→ 완료 관련 상태)** — cleanup 0 exit 이후 추상 상태를
   "완료 관련 상태"로 전이. 구체 값·매핑 `rules/context.md` 의존.

PR이 closed (merge 안 됨)로 전이한 경우 review-fix 이후 모든 단계(자동 머지·
cleanup·상태 전이)를 생략한다 — 사용자 판단 대기.

본 phase 그룹의 명령 실행에 필요한 도구 권한은 autopilot 워커의 allowed-tools에
**범위 최소화 원칙**으로 등록된다:

- **GitHub CLI**: 본 phase가 실제 호출하는 PR 관련 서브커맨드만 허용 —
  `gh pr merge`, `gh pr comment`, `gh pr view`, `gh api repos/.../pulls/*` ·
  `repos/.../issues/*/comments` (폴링용). `gh issue *`, `gh repo *` 등
  PR과 무관한 명령은 등록 안 함.
- **GitHub Project**: 본 phase가 사용하는 정확한 명령(`gh project item-edit`)
  만 포인트로 허용.
- **Git**: 본 phase가 호출하는 정확한 서브커맨드만 — `git rebase`,
  `git push --delete`, `git branch -D`, `git worktree remove`. 그 외 일체
  와일드카드 등록 금지.

등록 범위는 autopilot 워커의 실행 컨텍스트에만 한정되며 사용자 대화형
세션의 settings.json은 건드리지 않는다 (메모리 feedback_allowlist_exclude_github
유지).

## Commits
```
eb7ad1d feat(autopilot/loop): SPEC 123 — DONE 이후 PR 생애주기 자동화 (request_review opt-in)
20a34cc chore: autopilot worktree baseline
0f7bf73 feat(spec): 123 — autopilot:loop DONE 이후 PR 리뷰 자동 fix 루프 + Monitor 가설
```

Closes #123
<!-- autopilot:pr-body:end -->