### PR TITLE
feat(autopilot): SPEC 116 — spec↔loop feat 브랜치·worktree slug-bearing 단일 컨벤션

### DIFF
--- a/milestones/regular/loops/116/SPEC.md
+++ b/milestones/regular/loops/116/SPEC.md
@@ -1,0 +1,76 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/spec/**", "plugins/autopilot/skills/loop/**"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh"
+ears_language: ko
+---
+
+# spec↔loop feat 브랜치·worktree 경로 단일 규약 통일
+
+## 무엇을 만들 것인가
+
+`autopilot:spec` 스킬이 만드는 feat 브랜치와 `autopilot:loop` 스킬이 검색·진입하는 feat 브랜치가 같은 명명 규약을 따른다. 사용자가 default milestone(`regular`)과 단일 컴포넌트 task-id를 줘도 spec→loop 라운드트립이 수동 rename·재진입 없이 성립한다.
+
+SPEC.md 디렉토리와 loop의 worktree 디렉토리가 `milestones/<m>/loops/<input-id>-<slug>/` 단일 컨벤션으로 정합한다. SPEC.md는 그 디렉토리의 `SPEC.md`로, worktree는 그 안의 `.worktree` 서브디렉토리로 생성된다. PR phase가 SPEC.md 경로를 도출할 때도 같은 단일 컨벤션을 따른다.
+
+slug 도출은 결정적(SPEC §1 H1 제목에서 ASCII 소문자·하이픈 슬러그화)이고, spec과 loop 양쪽이 같은 규칙으로 같은 slug에 도달한다. loop은 발견된 feat 브랜치 이름에서 slug를 추출해 디렉토리 위치를 결정한다.
+
+사전 EnterWorktree 등 외부 메커니즘이 만든 별도 브랜치·디렉토리가 있을 경우, spec이 만든 feat 브랜치 + `<input-id>-<slug>` 디렉토리가 단일 정답 위치로 유지된다. 외부 worktree 동기화·migration은 비-목표.
+
+## 수용 기준 (EARS)
+
+- (Ubiquitous) SPEC 작성·자체 검토가 끝나면, spec은 `feat/<input-id>-<slug>` 브랜치를 main에서 분기·생성하고 SPEC.md를 `milestones/<m>/loops/<input-id>-<slug>/SPEC.md` 경로에 commit해야 한다.
+- (Event-driven) 사용자가 spec 직후 `Skill(loop, args: "start <input-id>")`를 호출할 때, loop은 `feat/<input-id>-<slug>` 브랜치를 수동 rename·수동 개입 없이 발견해야 한다.
+- (Ubiquitous) loop이 worktree를 생성할 때, 그 경로는 `milestones/<m>/loops/<input-id>-<slug>/.worktree`여야 한다. slug는 발견된 feat 브랜치 이름에서 추출된다.
+- (Ubiquitous) PR phase는 SPEC.md를 `milestones/<m>/loops/<input-id>-<slug>/SPEC.md` 단일 경로에서 읽어야 한다. 다른 경로 fallback은 없다.
+- (Ubiquitous) spec과 loop은 동일한 SPEC §1 H1 제목으로부터 동일한 slug 문자열에 도달해야 한다. slug 규칙은 ASCII 소문자화 후 `[a-z0-9-]` 외 모든 문자를 `-`로 치환·연속 `-` 단일화·양끝 `-` 제거.
+- (Unwanted-behavior) 동일 input-id에 두 개 이상의 feat 브랜치가 매칭되면 loop은 어떤 브랜치도 자동 선택하지 않고 명시적 모호성 에러로 비-zero exit 종료해야 한다.
+
+## 범위
+
+포함:
+- `plugins/autopilot/skills/spec/SKILL.md` — step 8 SPEC.md 디렉토리 경로(`<c>` 슬롯 slug-bearing), step 9.5.2 브랜치 명령, slug 도출 결과를 디렉토리 경로에도 적용
+- `plugins/autopilot/skills/loop/references/loop.sh` — `find_feat_branch` 검색 패턴을 input-id 원형까지 확장, `compute_paths`의 `<c>` 슬롯을 feat 브랜치 이름에서 추출한 slug-bearing 값으로 처리
+- `plugins/autopilot/skills/loop/references/pr-phase.sh` — `SPEC_FILE` 경로 도출이 slug-bearing 디렉토리를 가리키도록 정합
+- 라운드트립 verify 스크립트(`plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh`) 신설
+
+비-목표 / 제외:
+- 기존 슬러그 없는 `milestones/<m>/loops/<input-id>/` 디렉토리(loops/65·69·71·72·75·78·79·104 등) 자동 마이그레이션
+- 기존 `feat/regular/<input-id>-*` legacy 브랜치 자동 rename·삭제 (수동 정리)
+- `EnterWorktree` 동작 자체 변경 (사전 외부 worktree 동기화는 비-목표)
+- `autopilot:dispatch`·`autopilot:prd` 스킬 인터페이스 변경
+- 다중 컴포넌트 task-id(`a/b/c` 형태)에서의 slug 위치 정의 — 본 SPEC는 단일 컴포넌트 task-id에 집중
+
+## 검증
+
+이 명령이 0 exit으로 끝나야 합니다:
+
+```
+bash plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
+```
+
+스크립트가 수행하는 검사:
+
+1. slug 도출 결정성: SPEC §1 H1 "Foo Bar" → slug `foo-bar`. spec·loop 양쪽 도출 경로가 동일 결과.
+2. find_feat_branch 라운드트립: 임시 git 픽스처에 `feat/<input-id>-<slug>` 브랜치 생성 후 `find_feat_branch <input-id>`가 단일 매칭 반환.
+3. worktree 경로 도출: feat 브랜치 이름에서 slug 추출 → `milestones/<m>/loops/<input-id>-<slug>/.worktree` 경로 정합.
+4. SPEC.md 경로 정합: spec이 작성하는 경로 = loop·pr-phase가 읽는 경로(`milestones/<m>/loops/<input-id>-<slug>/SPEC.md`).
+5. 다중 매칭 die: 같은 input-id에 2+ feat 브랜치 존재 시 loop의 find_feat_branch가 비-zero exit + stderr 모호성 메시지.
+
+모든 검사가 통과하면 exit 0, 실패 시 비-zero + 어느 검사가 깨졌는지 stderr 출력.
+
+## 제약
+
+- 본 작업은 self-referential 변경(spec 스킬이 spec 스킬과 sibling loop 스킬을 수정)이다. verify는 워크트리 source만 검사하며 runtime artifact(`~/.claude/plugins/cache/...` 등)는 참조하지 않는다.
+- 기존 슬러그 없는 `milestones/<m>/loops/<input-id>/` 디렉토리는 본 SPEC 후 새 contract에서 인식되지 않는다. 본 SPEC는 그것들을 삭제·이동하지 않는다.
+- spec→loop 라운드트립은 default milestone(`regular`) + 단일 컴포넌트 task-id 케이스를 우선 보장한다. 다중 컴포넌트는 별도 SPEC.
+
+## 위험
+
+- self-referential 자기 호출: 본 SPEC를 만든 spec 호출(116번)은 *현재* 코드 기준으로 step 9.5.2를 수행하므로, 본 호출이 만드는 브랜치·SPEC.md 경로는 슬러그 없는 `<c>` 형식일 수 있다. 새 contract는 본 SPEC 머지 이후의 spec 호출부터 적용된다. 본 SPEC 호출의 산출물(브랜치·디렉토리)은 검증 시점에 새 컨벤션으로 수동 정렬이 필요할 수 있다.
+- 다중 매칭 die: 사용자 환경에 기존 `feat/regular/<input-id>-*` legacy 브랜치가 잔존하면 새 패턴과 동시 매칭되어 loop이 die. 수동 정리 필요(비-목표 항목으로 명시).
+- multi-component task-id: dispatch가 `regular/sub-area/116` 같은 다중 컴포넌트 task-id를 만들 경우 slug 위치·worktree 경로 정의가 비자명. 본 SPEC 범위 외 — 발생 시 별도 SPEC.

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -186,39 +186,77 @@ compute_paths() {
   task_id="$(normalize_task_id "$raw_task_id")"
   PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
     || die "git 저장소 안에서 실행해야 합니다."
-  # BRANCH는 cmd_start의 feat 브랜치 감지에서만 설정 — 단일 contract.
-  # v0.2 cutover: 워크트리·lock·메타 파일이 모두 milestones/<m>/loops/<c>/ 단일
-  # 트리 안에 있다. 외부 sibling·.loops/locks/는 사용하지 않음.
   local milestone="${task_id%%/*}"
   local child="${task_id#*/}"
-  LOOPS_DIR="$PROJECT_ROOT/milestones/$milestone/loops/$child"
-  # LOOPS_DIR_REL: worktree 안의 SPEC.md canonical 경로 prefix (신규 contract).
-  # 신규 contract에선 SPEC.md가 feat 브랜치에 commit되어 worktree에서
-  # <wt>/$LOOPS_DIR_REL/SPEC.md 경로로 자연 노출된다.
-  LOOPS_DIR_REL="milestones/$milestone/loops/$child"
+
+  # SPEC 116 단일 컨벤션: feat 브랜치 이름의 slug 가 디렉토리 이름의 suffix.
+  # find_feat_branch 가 input-id (child) 만으로 `feat/<child>-<slug>` 또는 `feat/<child>` 를 찾는다.
+  # 매칭 없음(rc=1)은 legacy/uninitialized 상태로 간주해 slug-less fallback.
+  # 매칭 2+ (rc=2)는 모호성으로 즉시 die.
+  local feat_branch=""
+  local ffb_rc=0
+  set +e
+  feat_branch=$(find_feat_branch "$child")
+  ffb_rc=$?
+  set -e
+  case $ffb_rc in
+    0) ;;                     # 단일 매칭
+    1) feat_branch="" ;;      # 매칭 없음 — slug-less fallback
+    2) die "여러 feat 브랜치가 input-id '$child' 와 매칭됩니다 (위 stderr 참조)." ;;
+    *) die "find_feat_branch 비정상 종료 (rc=$ffb_rc)" ;;
+  esac
+
+  # feat 브랜치 이름에서 slug 추출 — `feat/<child>-<slug>` 패턴의 suffix.
+  local slug=""
+  if [[ -n "$feat_branch" ]]; then
+    local prefix="feat/$child"
+    if [[ "$feat_branch" == "${prefix}-"* ]]; then
+      slug="${feat_branch#${prefix}-}"
+    fi
+    # feat_branch == "$prefix" (slug-less 브랜치) → slug 비어있음 유지
+  fi
+
+  local loop_dir_name="$child"
+  if [[ -n "$slug" ]]; then
+    loop_dir_name="$child-$slug"
+  fi
+
+  # v0.2 cutover: 워크트리·lock·메타 파일이 모두 milestones/<m>/loops/<c>[-<slug>]/ 단일 트리.
+  LOOPS_DIR="$PROJECT_ROOT/milestones/$milestone/loops/$loop_dir_name"
+  # LOOPS_DIR_REL: worktree 안의 SPEC.md canonical 경로 prefix.
+  # SPEC.md 는 feat 브랜치에 동일 slug-bearing 경로로 commit 되어 worktree 에서
+  # <wt>/$LOOPS_DIR_REL/SPEC.md 로 자연 노출된다.
+  LOOPS_DIR_REL="milestones/$milestone/loops/$loop_dir_name"
   WT="$LOOPS_DIR/.worktree"
   LOCK_FILE="$LOOPS_DIR/.lock"
-  # 정규화된 task-id를 caller에게 노출 (cmd_start에서 TASK_ID로 사용)
+  # 정규화된 task-id 와 발견된 feat 브랜치를 caller 에게 노출.
   TASK_ID_NORMALIZED="$task_id"
+  FEAT_BRANCH="$feat_branch"
 }
 
-# 신규 contract 감지: feat/<task-id> 또는 feat/<task-id>-<slug> 브랜치 검색.
-# 0개 매칭이면 빈 출력 + return 1 (legacy 분기로 fallback).
-# 정확히 1개 매칭이면 브랜치 이름 출력 + return 0.
-# 2개 이상이면 die (모호성).
+# feat 브랜치 검색: input-id (정규화된 task-id 의 child 컴포넌트) 만으로 `feat/<id>` 또는
+# `feat/<id>-<slug>` 패턴을 찾는다. SPEC 116 단일 컨벤션 — milestone prefix 는 사용하지 않는다.
+#
+# 반환:
+#   0 + stdout 에 단일 브랜치 이름     — 매칭 정확히 1개
+#   1 + stdout 빈 출력                — 매칭 없음 (legacy/uninitialized)
+#   2 + stderr 모호성 안내            — 매칭 2개 이상 (caller 가 die 결정)
 find_feat_branch() {
-  local task_id="$1"
+  local input_id="$1"
   local matches count
   matches=$(git -C "$PROJECT_ROOT" for-each-ref \
     --format='%(refname:short)' \
-    "refs/heads/feat/$task_id" \
-    "refs/heads/feat/$task_id-*" 2>/dev/null)
+    "refs/heads/feat/$input_id" \
+    "refs/heads/feat/$input_id-*" 2>/dev/null)
   if [[ -z "$matches" ]]; then
     return 1
   fi
   count=$(printf '%s\n' "$matches" | grep -c .)
   if [[ $count -ge 2 ]]; then
-    die "여러 feat 브랜치가 task-id '$task_id'와 매칭됨 (모호):\n$matches\n수동으로 하나 남기고 다른 것 정리 후 재시도."
+    echo "ERROR: 여러 feat 브랜치가 input-id '$input_id' 와 매칭됨 (모호):" >&2
+    printf '%s\n' "$matches" >&2
+    echo "수동으로 하나 남기고 다른 것 정리 후 재시도." >&2
+    return 2
   fi
   printf '%s\n' "$matches"
   return 0
@@ -763,13 +801,13 @@ cmd_start() {
     echo "외부 SPEC 파일 복사: $spec_path → $LOOPS_DIR/SPEC.md"
   fi
 
-  # 1.5. 단일 contract: feat/<task-id>[-<slug>] 브랜치를 main repo에서 찾고 worktree base로 사용.
+  # 1.5. 단일 contract: feat/<input-id>[-<slug>] 브랜치를 compute_paths 에서 이미 검색·캐시 (FEAT_BRANCH).
   # 없으면 즉시 abort — legacy task-branch fallback 분기는 제거됨 (v0.3 cutover).
-  local feat_branch=""
-  if ! feat_branch=$(find_feat_branch "$task_id") || [[ -z "$feat_branch" ]]; then
-    die "feat 브랜치 부재 — 'feat/${task_id}' 또는 'feat/${task_id}-<slug>' 브랜치가 main repo에 없음.\n먼저 실행하세요: Skill(skill: \"spec\", args: \"$task_id\")"
+  if [[ -z "${FEAT_BRANCH:-}" ]]; then
+    local _child="${task_id#*/}"
+    die "feat 브랜치 부재 — 'feat/${_child}' 또는 'feat/${_child}-<slug>' 브랜치가 main repo에 없음.\n먼저 실행하세요: Skill(skill: \"spec\", args: \"$_child\")"
   fi
-  BRANCH="$feat_branch"
+  BRANCH="$FEAT_BRANCH"
 
   # 2. SPEC.md 존재·내용 검증 — feat 브랜치 commit에서 읽음.
   local spec_content=""
@@ -976,14 +1014,34 @@ cmd_start() {
 cmd_status() {
   local filter_task_id="${1:-}"
 
-  # filter 지정 시 task-id 검증 + 정규화 (단일 컴포넌트 → regular/)
+  PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
+    || die "git 저장소 안에서 실행해야 합니다."
+
+  # filter 지정 시 task-id 검증 + 정규화 (단일 컴포넌트 → regular/) + SPEC 116
+  # slug-bearing 디렉토리 매핑 (feat 브랜치 발견 시).
   if [[ -n "$filter_task_id" ]]; then
     validate_task_id "$filter_task_id"
     filter_task_id="$(normalize_task_id "$filter_task_id")"
+    local _fchild="${filter_task_id#*/}"
+    local _fmile="${filter_task_id%%/*}"
+    local _ffeat=""
+    local _frc=0
+    set +e
+    _ffeat=$(find_feat_branch "$_fchild")
+    _frc=$?
+    set -e
+    case $_frc in
+      0|1) ;;  # 단일 매칭 또는 매칭 없음 — 다음 단계로
+      2) die "filter input-id '$_fchild' 가 모호 (위 stderr 참조)" ;;
+      *) die "find_feat_branch 비정상 종료 (rc=$_frc)" ;;
+    esac
+    if [[ -n "$_ffeat" ]]; then
+      local _fprefix="feat/$_fchild"
+      if [[ "$_ffeat" == "${_fprefix}-"* ]]; then
+        filter_task_id="${_fmile}/${_fchild}-${_ffeat#${_fprefix}-}"
+      fi
+    fi
   fi
-
-  PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
-    || die "git 저장소 안에서 실행해야 합니다."
 
   # task-id 목록 수집: milestones/<m>/loops/<c>/SPEC.md 단일 트리
   # (M1 cutover: legacy .loops/<id>/SPEC.md 스캔 제거)

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -209,11 +209,7 @@ compute_paths() {
   # feat 브랜치 이름에서 slug 추출 — `feat/<child>-<slug>` 패턴의 suffix.
   local slug=""
   if [[ -n "$feat_branch" ]]; then
-    local prefix="feat/$child"
-    if [[ "$feat_branch" == "${prefix}-"* ]]; then
-      slug="${feat_branch#${prefix}-}"
-    fi
-    # feat_branch == "$prefix" (slug-less 브랜치) → slug 비어있음 유지
+    slug=$(slug_from_feat_branch "$child" "$feat_branch")
   fi
 
   local loop_dir_name="$child"
@@ -260,6 +256,18 @@ find_feat_branch() {
   fi
   printf '%s\n' "$matches"
   return 0
+}
+
+# feat 브랜치 이름에서 slug 추출. SPEC 116 단일 컨벤션 — `feat/<child>-<slug>` 패턴의 suffix.
+# 인자: $1 = child(input-id), $2 = branch 이름.
+# stdout: slug, 또는 빈 문자열(slug-less 브랜치·형식 불일치 시).
+slug_from_feat_branch() {
+  local child="$1"
+  local branch="$2"
+  local prefix="feat/$child"
+  if [[ "$branch" == "${prefix}-"* ]]; then
+    printf '%s\n' "${branch#${prefix}-}"
+  fi
 }
 
 # ----- 동시성 락 -----
@@ -1036,9 +1044,10 @@ cmd_status() {
       *) die "find_feat_branch 비정상 종료 (rc=$_frc)" ;;
     esac
     if [[ -n "$_ffeat" ]]; then
-      local _fprefix="feat/$_fchild"
-      if [[ "$_ffeat" == "${_fprefix}-"* ]]; then
-        filter_task_id="${_fmile}/${_fchild}-${_ffeat#${_fprefix}-}"
+      local _fslug
+      _fslug=$(slug_from_feat_branch "$_fchild" "$_ffeat")
+      if [[ -n "$_fslug" ]]; then
+        filter_task_id="${_fmile}/${_fchild}-${_fslug}"
       fi
     fi
   fi

--- a/plugins/autopilot/skills/loop/references/pr-phase.sh
+++ b/plugins/autopilot/skills/loop/references/pr-phase.sh
@@ -63,9 +63,9 @@ fi
 
 # ----- SPEC 제목·본문 추출 (M3) -----
 # TASK_ID 는 정규화된 '<milestone>/<child>' 형태. SPEC 116 단일 컨벤션:
-# SPEC.md 는 워크트리 안의 `milestones/<m>/loops/<child>-<slug>/SPEC.md` (slug 비-empty 시)
-# 또는 fallback `milestones/<m>/loops/<child>/SPEC.md` 단일 경로에서 읽는다.
+# SPEC.md 는 워크트리 안의 `milestones/<m>/loops/<child>-<slug>/SPEC.md` 단일 경로에서 읽는다.
 # slug 는 $BRANCH (`feat/<child>-<slug>`) 이름에서 추출 — spec 스킬·loop 드라이버와 동일 키.
+# SPEC 116 EARS AC4: "다른 경로 fallback은 없다" — slug-less 경로는 의도적으로 미지원.
 SPEC_MILESTONE="${TASK_ID%%/*}"
 SPEC_CHILD="${TASK_ID#*/}"
 SPEC_SLUG_FROM_BRANCH=""
@@ -73,11 +73,11 @@ SPEC_BRANCH_PREFIX="feat/${SPEC_CHILD}"
 if [[ "$BRANCH" == "${SPEC_BRANCH_PREFIX}-"* ]]; then
   SPEC_SLUG_FROM_BRANCH="${BRANCH#${SPEC_BRANCH_PREFIX}-}"
 fi
-if [[ -n "$SPEC_SLUG_FROM_BRANCH" ]]; then
-  SPEC_FILE="$WT/milestones/${SPEC_MILESTONE}/loops/${SPEC_CHILD}-${SPEC_SLUG_FROM_BRANCH}/SPEC.md"
-else
-  SPEC_FILE="$WT/milestones/${SPEC_MILESTONE}/loops/${SPEC_CHILD}/SPEC.md"
+if [[ -z "$SPEC_SLUG_FROM_BRANCH" ]]; then
+  echo "ERROR: slug 추출 실패 — BRANCH='$BRANCH'가 'feat/${SPEC_CHILD}-<slug>' 형식 아님. SPEC 116 단일 컨벤션 위반." >&2
+  exit 1
 fi
+SPEC_FILE="$WT/milestones/${SPEC_MILESTONE}/loops/${SPEC_CHILD}-${SPEC_SLUG_FROM_BRANCH}/SPEC.md"
 [[ -f "$SPEC_FILE" ]] || { echo "ERROR: SPEC.md 없음: $SPEC_FILE" >&2; exit 1; }
 
 # 첫 H1 (frontmatter 이후의 단일 # 라인)

--- a/plugins/autopilot/skills/loop/references/pr-phase.sh
+++ b/plugins/autopilot/skills/loop/references/pr-phase.sh
@@ -62,9 +62,22 @@ if [[ -z "$DEFAULT_BRANCH" ]]; then
 fi
 
 # ----- SPEC 제목·본문 추출 (M3) -----
-# TASK_ID는 정규화된 '<milestone>/<child>' 형태. 단일 contract: SPEC은 워크트리 안의
-# milestones/<m>/loops/<c>/SPEC.md 단일 경로에서 읽음.
-SPEC_FILE="$WT/milestones/${TASK_ID%%/*}/loops/${TASK_ID#*/}/SPEC.md"
+# TASK_ID 는 정규화된 '<milestone>/<child>' 형태. SPEC 116 단일 컨벤션:
+# SPEC.md 는 워크트리 안의 `milestones/<m>/loops/<child>-<slug>/SPEC.md` (slug 비-empty 시)
+# 또는 fallback `milestones/<m>/loops/<child>/SPEC.md` 단일 경로에서 읽는다.
+# slug 는 $BRANCH (`feat/<child>-<slug>`) 이름에서 추출 — spec 스킬·loop 드라이버와 동일 키.
+SPEC_MILESTONE="${TASK_ID%%/*}"
+SPEC_CHILD="${TASK_ID#*/}"
+SPEC_SLUG_FROM_BRANCH=""
+SPEC_BRANCH_PREFIX="feat/${SPEC_CHILD}"
+if [[ "$BRANCH" == "${SPEC_BRANCH_PREFIX}-"* ]]; then
+  SPEC_SLUG_FROM_BRANCH="${BRANCH#${SPEC_BRANCH_PREFIX}-}"
+fi
+if [[ -n "$SPEC_SLUG_FROM_BRANCH" ]]; then
+  SPEC_FILE="$WT/milestones/${SPEC_MILESTONE}/loops/${SPEC_CHILD}-${SPEC_SLUG_FROM_BRANCH}/SPEC.md"
+else
+  SPEC_FILE="$WT/milestones/${SPEC_MILESTONE}/loops/${SPEC_CHILD}/SPEC.md"
+fi
 [[ -f "$SPEC_FILE" ]] || { echo "ERROR: SPEC.md 없음: $SPEC_FILE" >&2; exit 1; }
 
 # 첫 H1 (frontmatter 이후의 단일 # 라인)

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -215,8 +215,9 @@ subagent의 보고는 사실 수집·인용에 그치며, **결정·합성은 �
 
 SPEC.md 가 들어갈 디렉토리는 step 9.5.1 의 결정적 슬러그화 규칙을 step 7 에서 합의된 §1 H1 제목에 적용해 `<slug>` 를 먼저 산출한 뒤 다음 단일 컨벤션을 따른다:
 
-- `<slug>` 가 비-empty: `milestones/<m>/loops/<c>-<slug>/SPEC.md`
-- `<slug>` 가 빈 문자열로 환원: `milestones/<m>/loops/<c>/SPEC.md` (fallback)
+- `milestones/<m>/loops/<c>-<slug>/SPEC.md`
+
+`<slug>` 가 빈 문자열로 환원되면 fallback 경로를 만들지 않는다 — SPEC 116 EARS AC4 (단일 컨벤션, 다른 경로 fallback 없음) 위반이 되고, sibling pr-phase 도 같은 이유로 슬러그 없는 브랜치를 받으면 abort 한다. 빈 slug 발생 시 §9.5.1 의 실패 처리로 분기해 사용자에게 §1 H1 제목 수정 (step 7 재진입) 을 요청한다.
 
 여기서 `<c>` 는 본 스킬의 input task-id (단계 1 검증을 통과한 값). 본 디렉토리 이름이 곧 sibling `autopilot:loop` 이 발견하는 feat 브랜치 `feat/<c>-<slug>` 의 `<slug>` 와 동일해 spec→loop 라운드트립이 단일 컨벤션으로 정합한다.
 
@@ -253,7 +254,7 @@ SPEC §1 제목(첫 H1, `# ` 다음 텍스트)에서 `<slug>`를 도출:
 3. 연속된 `-`를 단일 `-`로 압축
 4. 시작·끝의 `-` 제거
 
-결과가 빈 문자열이면 `<slug>` 없이 `feat/<task-id>` 단독으로 fallback. 같은 SPEC 제목은 항상 같은 slug를 만든다.
+결과가 빈 문자열이면 fallback 브랜치(`feat/<c>` 단독)·fallback 디렉토리(`milestones/<m>/loops/<c>/`)를 만들지 않는다 — SPEC 116 EARS AC4 단일 컨벤션 위반이며 sibling pr-phase 도 동일 이유로 abort. 빈 slug 발생 시 §9.5.3 실패 처리로 분기해 사용자에게 §1 H1 제목 수정(step 7 재진입)을 요청한다. 같은 SPEC 제목은 항상 같은 slug 를 만든다.
 
 구현 예 (bash):
 
@@ -267,16 +268,14 @@ slug=$(printf '%s' "$title" \
 
 #### 9.5.2 브랜치 생성·commit 절차
 
-본 단계의 모든 경로 참조는 §8.1 에서 결정된 slug-bearing 디렉토리 — `milestones/<m>/loops/<c>-<slug>/SPEC.md` (slug 비-empty 시) 또는 `milestones/<m>/loops/<c>/SPEC.md` (slug fallback) — 와 정합하게 동일 `<slug>` 를 사용한다. 브랜치 이름의 `<slug>` 와 디렉토리 이름의 `<slug>` 는 반드시 같다.
+본 단계의 모든 경로 참조는 §8.1 에서 결정된 slug-bearing 디렉토리 — `milestones/<m>/loops/<c>-<slug>/SPEC.md` — 와 정합하게 동일 `<slug>` 를 사용한다. 브랜치 이름의 `<slug>` 와 디렉토리 이름의 `<slug>` 는 반드시 같다. `<slug>` 가 빈 문자열이면 §9.5.1 의 빈-slug 실패 처리로 사전 분기되므로 본 단계는 항상 non-empty `<slug>` 를 가정한다 (SPEC 116 단일 컨벤션, EARS AC4 — fallback 없음).
 
 1. `git status --porcelain`으로 main 작업트리 상태 스냅샷 캡처. unstaged·untracked가 있으면 그 사실을 인지 (다음 단계의 git 동작이 영향 안 주도록 명시적 경로 사용).
 2. 현재 브랜치 이름 보존: `orig_branch=$(git rev-parse --abbrev-ref HEAD)`.
-3. 브랜치 이름 결정 (§8.1 과 동일 `<slug>`):
-   - `branch="feat/<c>-<slug>"` (slug 비-empty 시)
-   - `branch="feat/<c>"` (slug fallback)
+3. 브랜치 이름 결정 (§8.1 과 동일 `<slug>`): `branch="feat/<c>-<slug>"`. (빈 slug 케이스는 §9.5.1 에서 이미 abort 되어 본 단계 진입 자체가 없다.)
 4. `git show-ref --verify --quiet "refs/heads/$branch"`로 충돌 확인. 이미 존재하면 사용자에게 알리고 `AskUserQuestion`으로 (덮어쓰기 / 새 이름 / 종료) 선택.
 5. `git checkout -b "$branch" main`으로 main에서 명시적으로 분기. base를 명시하지 않으면 호출 시점 HEAD에서 분기되어 비-main 브랜치에서 호출 시 엉뚱한 base로 feat 브랜치가 만들어진다. main 작업트리의 다른 변경은 그대로 따라옴 (이를 의도). SPEC.md만 add·commit하므로 다른 파일은 새 commit에 들어가지 않는다.
-6. SPEC.md 경로를 §8.1 의 slug-bearing 경로(`milestones/<m>/loops/<c>-<slug>/SPEC.md` 또는 fallback `milestones/<m>/loops/<c>/SPEC.md`)로 두고 `git add <spec_path>` 로 명시적으로 SPEC.md만 staging (`git add .` 절대 금지).
+6. SPEC.md 경로를 §8.1 의 slug-bearing 경로(`milestones/<m>/loops/<c>-<slug>/SPEC.md`)로 두고 `git add <spec_path>` 로 명시적으로 SPEC.md만 staging (`git add .` 절대 금지).
 7. `git commit -m "feat(spec): <c> — <title>" -- "<spec_path>"`로 SPEC만 commit. `-- <pathspec>` 형식이 다른 staged 파일을 commit에서 격리.
 8. `git checkout "$orig_branch"`로 원래 브랜치 복귀.
 9. 복귀 후 `git status --porcelain` 결과가 step 1과 동일한지 검증. 다르면 사용자에게 경고.
@@ -286,11 +285,12 @@ slug=$(printf '%s' "$title" \
 위 절차 중 어떤 단계라도 실패하면:
 - 부분 결과 정리: 생성된 feat 브랜치가 있으면 `git branch -D "$branch"`로 삭제 (단, 그 브랜치에 다른 commit이 없을 때만; 의심스러우면 사용자에게 알리고 수동 정리 안내).
 - 원래 브랜치 복귀: `git checkout "$orig_branch"`.
-- 사용자에게 명시적으로 실패 사유와 복구 방법 안내. SPEC.md는 `milestones/<m>/loops/<c>/SPEC.md`에 그대로 남기되, loop 진행은 다음 단계에서 사용자가 결정.
+- 사용자에게 명시적으로 실패 사유와 복구 방법 안내. SPEC.md는 `milestones/<m>/loops/<c>-<slug>/SPEC.md` 에 그대로 남기되, loop 진행은 다음 단계에서 사용자가 결정.
+- **빈 slug 케이스 (§9.5.1)**: 슬러그화 결과가 빈 문자열이면 본 §9.5.2 진입 전에 abort 한다. SPEC.md 는 step 8 의 §8.1 단일 경로 가정에 의해 빈 slug 에서는 작성되지 않으며, 사용자에게 §1 H1 제목 수정을 요청해 step 7 재진입한다 (SPEC 116 단일 컨벤션 — fallback 없음).
 
 ### 10. 사용자 최종 검토
 
-SPEC.md 경로(§8.1 에서 결정된 slug-bearing 경로 — `milestones/<m>/loops/<c>-<slug>/SPEC.md` 또는 fallback `milestones/<m>/loops/<c>/SPEC.md`)와 요약을 먼저 안내한 뒤, `AskUserQuestion`으로 **명시적 결정 입력**을 받는다 (자유 텍스트 안내·자유 텍스트 끝 질문 종결구 금지 — CLAUDE.md 규칙). 옵션은 다음 3개:
+SPEC.md 경로(§8.1 에서 결정된 slug-bearing 경로 — `milestones/<m>/loops/<c>-<slug>/SPEC.md`)와 요약을 먼저 안내한 뒤, `AskUserQuestion`으로 **명시적 결정 입력**을 받는다 (자유 텍스트 안내·자유 텍스트 끝 질문 종결구 금지 — CLAUDE.md 규칙). 옵션은 다음 3개:
 
 - **지금 loop start 호출** (Recommended) — 동일 task-id로 sibling 스킬을 자동 연계 호출: `Skill(skill: "loop", args: "start <m>/<c>")`. 사용자가 이 옵션을 선택하면 모델은 즉시 본 Skill 호출을 발행하며, 추가 모니터 결정 질문은 묻지 않고 loop 기본 동작(자동 Monitor 가설 포함, `plugins/autopilot/skills/loop/SKILL.md` 참조)을 그대로 적용한다. milestone이 default `regular`인 경우 `start <c>` 단축형도 동등 (loop.sh가 자동 정규화).
 - **SPEC만 확정** — 경로만 안내하고 종료. 사용자가 이후 별도 시점에 `Skill(skill: "loop", args: "start <m>/<c>")`를 직접 호출.

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -211,7 +211,16 @@ subagent의 보고는 사실 수집·인용에 그치며, **결정·합성은 �
 
 미해결 항목은 `[NEEDS CLARIFICATION: <구체 질문>]` 마커로 박은 채 작성.
 
-`mkdir -p milestones/<m>/loops/<c>` 후 `milestones/<m>/loops/<c>/SPEC.md`에 기록.
+#### 8.1 SPEC.md 저장 경로 (slug-bearing 단일 컨벤션)
+
+SPEC.md 가 들어갈 디렉토리는 step 9.5.1 의 결정적 슬러그화 규칙을 step 7 에서 합의된 §1 H1 제목에 적용해 `<slug>` 를 먼저 산출한 뒤 다음 단일 컨벤션을 따른다:
+
+- `<slug>` 가 비-empty: `milestones/<m>/loops/<c>-<slug>/SPEC.md`
+- `<slug>` 가 빈 문자열로 환원: `milestones/<m>/loops/<c>/SPEC.md` (fallback)
+
+여기서 `<c>` 는 본 스킬의 input task-id (단계 1 검증을 통과한 값). 본 디렉토리 이름이 곧 sibling `autopilot:loop` 이 발견하는 feat 브랜치 `feat/<c>-<slug>` 의 `<slug>` 와 동일해 spec→loop 라운드트립이 단일 컨벤션으로 정합한다.
+
+`mkdir -p <위 경로의 디렉토리>` 후 그 안의 `SPEC.md` 로 기록.
 
 ### 9. 자체 검토
 
@@ -258,15 +267,17 @@ slug=$(printf '%s' "$title" \
 
 #### 9.5.2 브랜치 생성·commit 절차
 
+본 단계의 모든 경로 참조는 §8.1 에서 결정된 slug-bearing 디렉토리 — `milestones/<m>/loops/<c>-<slug>/SPEC.md` (slug 비-empty 시) 또는 `milestones/<m>/loops/<c>/SPEC.md` (slug fallback) — 와 정합하게 동일 `<slug>` 를 사용한다. 브랜치 이름의 `<slug>` 와 디렉토리 이름의 `<slug>` 는 반드시 같다.
+
 1. `git status --porcelain`으로 main 작업트리 상태 스냅샷 캡처. unstaged·untracked가 있으면 그 사실을 인지 (다음 단계의 git 동작이 영향 안 주도록 명시적 경로 사용).
 2. 현재 브랜치 이름 보존: `orig_branch=$(git rev-parse --abbrev-ref HEAD)`.
-3. 브랜치 이름 결정:
-   - `branch="feat/<task-id>-<slug>"` (slug 비-empty 시)
-   - `branch="feat/<task-id>"` (slug fallback)
+3. 브랜치 이름 결정 (§8.1 과 동일 `<slug>`):
+   - `branch="feat/<c>-<slug>"` (slug 비-empty 시)
+   - `branch="feat/<c>"` (slug fallback)
 4. `git show-ref --verify --quiet "refs/heads/$branch"`로 충돌 확인. 이미 존재하면 사용자에게 알리고 `AskUserQuestion`으로 (덮어쓰기 / 새 이름 / 종료) 선택.
 5. `git checkout -b "$branch" main`으로 main에서 명시적으로 분기. base를 명시하지 않으면 호출 시점 HEAD에서 분기되어 비-main 브랜치에서 호출 시 엉뚱한 base로 feat 브랜치가 만들어진다. main 작업트리의 다른 변경은 그대로 따라옴 (이를 의도). SPEC.md만 add·commit하므로 다른 파일은 새 commit에 들어가지 않는다.
-6. `git add "milestones/<m>/loops/<c>/SPEC.md"`로 명시적으로 SPEC.md만 staging (`git add .` 절대 금지).
-7. `git commit -m "feat(spec): <task-id> — <title>" -- "milestones/<m>/loops/<c>/SPEC.md"`로 SPEC만 commit. `-- <pathspec>` 형식이 다른 staged 파일을 commit에서 격리.
+6. SPEC.md 경로를 §8.1 의 slug-bearing 경로(`milestones/<m>/loops/<c>-<slug>/SPEC.md` 또는 fallback `milestones/<m>/loops/<c>/SPEC.md`)로 두고 `git add <spec_path>` 로 명시적으로 SPEC.md만 staging (`git add .` 절대 금지).
+7. `git commit -m "feat(spec): <c> — <title>" -- "<spec_path>"`로 SPEC만 commit. `-- <pathspec>` 형식이 다른 staged 파일을 commit에서 격리.
 8. `git checkout "$orig_branch"`로 원래 브랜치 복귀.
 9. 복귀 후 `git status --porcelain` 결과가 step 1과 동일한지 검증. 다르면 사용자에게 경고.
 
@@ -279,7 +290,7 @@ slug=$(printf '%s' "$title" \
 
 ### 10. 사용자 최종 검토
 
-SPEC.md 경로(`milestones/<m>/loops/<c>/SPEC.md`)와 요약을 먼저 안내한 뒤, `AskUserQuestion`으로 **명시적 결정 입력**을 받는다 (자유 텍스트 안내·자유 텍스트 끝 질문 종결구 금지 — CLAUDE.md 규칙). 옵션은 다음 3개:
+SPEC.md 경로(§8.1 에서 결정된 slug-bearing 경로 — `milestones/<m>/loops/<c>-<slug>/SPEC.md` 또는 fallback `milestones/<m>/loops/<c>/SPEC.md`)와 요약을 먼저 안내한 뒤, `AskUserQuestion`으로 **명시적 결정 입력**을 받는다 (자유 텍스트 안내·자유 텍스트 끝 질문 종결구 금지 — CLAUDE.md 규칙). 옵션은 다음 3개:
 
 - **지금 loop start 호출** (Recommended) — 동일 task-id로 sibling 스킬을 자동 연계 호출: `Skill(skill: "loop", args: "start <m>/<c>")`. 사용자가 이 옵션을 선택하면 모델은 즉시 본 Skill 호출을 발행하며, 추가 모니터 결정 질문은 묻지 않고 loop 기본 동작(자동 Monitor 가설 포함, `plugins/autopilot/skills/loop/SKILL.md` 참조)을 그대로 적용한다. milestone이 default `regular`인 경우 `start <c>` 단축형도 동등 (loop.sh가 자동 정규화).
 - **SPEC만 확정** — 경로만 안내하고 종료. 사용자가 이후 별도 시점에 `Skill(skill: "loop", args: "start <m>/<c>")`를 직접 호출.

--- a/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
+++ b/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
@@ -89,6 +89,24 @@ grep -qF "sed -e 's/--*/-/g'" "$SPEC_SKILL_MD" \
 grep -qF "milestones/<m>/loops/<c>-<slug>" "$SPEC_SKILL_MD" \
   || { echo "FAIL T1e: SKILL.md missing slug-bearing directory reference (milestones/<m>/loops/<c>-<slug>)" >&2; exit 1; }
 
+# T1f: slug-less fallback 경로·브랜치가 SKILL.md 에 살아 있으면 SPEC 116 EARS AC4 위반.
+# 구 문구(회귀하면 fail):
+#   - "milestones/<m>/loops/<c>/SPEC.md` (fallback)" / "(slug fallback)"
+#   - "branch=\"feat/<c>\"" / "feat/<task-id>` 단독으로 fallback"
+T1F_BAN=(
+  'loops/<c>/SPEC.md` (fallback)'
+  'loops/<c>/SPEC.md` (slug fallback)'
+  'branch="feat/<c>"'
+  '`feat/<task-id>` 단독으로 fallback'
+)
+for pat in "${T1F_BAN[@]}"; do
+  if grep -qF "$pat" "$SPEC_SKILL_MD"; then
+    echo "FAIL T1f: SKILL.md 에 slug-less fallback 문구 회귀 — '$pat' 발견 (EARS AC4 위반)" >&2
+    grep -nF "$pat" "$SPEC_SKILL_MD" >&2 || true
+    exit 1
+  fi
+done
+
 echo "OK T1: slug 도출 결정성 + SKILL.md drift guard"
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
+++ b/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
@@ -157,6 +157,7 @@ WT_SPEC="$EXPECTED_WT/${DIR_REL}/SPEC.md"
   || { echo "FAIL T4a: worktree 안 SPEC.md 부재: $WT_SPEC" >&2; exit 1; }
 
 # pr-phase.sh 의 SPEC_FILE 도출 — feat 브랜치 이름의 slug를 사용해야 한다.
+# SPEC 116 EARS AC4: "다른 경로 fallback은 없다" — slug-less 경로는 미지원, 단일 컨벤션.
 # 동일 도출 로직을 본 테스트에서 재현해 결과가 slug-bearing 경로와 일치하는지 확인.
 PR_TASK_ID="regular/${INPUT_ID}"
 PR_BRANCH="feat/${INPUT_ID}-${SLUG}"
@@ -167,11 +168,11 @@ PR_PREFIX="feat/${PR_CHILD}"
 if [[ "$PR_BRANCH" == "${PR_PREFIX}-"* ]]; then
   PR_SLUG_FROM_BRANCH="${PR_BRANCH#${PR_PREFIX}-}"
 fi
-if [[ -n "$PR_SLUG_FROM_BRANCH" ]]; then
-  PR_DERIVED_SPEC="$EXPECTED_WT/milestones/${PR_MILESTONE}/loops/${PR_CHILD}-${PR_SLUG_FROM_BRANCH}/SPEC.md"
-else
-  PR_DERIVED_SPEC="$EXPECTED_WT/milestones/${PR_MILESTONE}/loops/${PR_CHILD}/SPEC.md"
+if [[ -z "$PR_SLUG_FROM_BRANCH" ]]; then
+  echo "FAIL T4b-pre: 테스트 fixture 의 PR_BRANCH 가 feat/${PR_CHILD}-<slug> 형식 아님 — fixture 결함" >&2
+  exit 1
 fi
+PR_DERIVED_SPEC="$EXPECTED_WT/milestones/${PR_MILESTONE}/loops/${PR_CHILD}-${PR_SLUG_FROM_BRANCH}/SPEC.md"
 [[ "$PR_DERIVED_SPEC" == "$WT_SPEC" ]] \
   || { echo "FAIL T4b: pr-phase 도출 경로 ≠ 실제 경로:" >&2
        echo "  derived: $PR_DERIVED_SPEC" >&2
@@ -186,7 +187,16 @@ if ! grep -qE '\$\{?BRANCH#' "$PR_PHASE_SH"; then
   exit 1
 fi
 
-echo "OK T4: SPEC.md 경로 정합 (slug-bearing 단일 컨벤션)"
+# T4d: pr-phase.sh 에 slug-less fallback 경로가 없는지 검사 — SPEC 116 EARS AC4 "다른 경로 fallback은 없다".
+# 구 fallback 패턴: `${SPEC_CHILD}/SPEC.md` (slug-bearing 분기의 else 측에서 SPEC_CHILD 만 사용).
+# 신 컨벤션: slug 추출 실패 시 즉시 abort, 다른 경로 시도 금지.
+if grep -nE 'SPEC_FILE=.*loops/\$\{?SPEC_CHILD\}?/SPEC\.md' "$PR_PHASE_SH" >/dev/null; then
+  echo "FAIL T4d: pr-phase.sh 에 slug-less fallback 경로(\${SPEC_CHILD}/SPEC.md) 존재 — EARS AC4 위반:" >&2
+  grep -nE 'SPEC_FILE=' "$PR_PHASE_SH" >&2 || true
+  exit 1
+fi
+
+echo "OK T4: SPEC.md 경로 정합 (slug-bearing 단일 컨벤션, fallback 없음)"
 
 # ──────────────────────────────────────────────────────────────────────────────
 # T5. 모호성 die — 동일 input-id 매칭 브랜치가 2+ 일 때

--- a/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
+++ b/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# test-spec-loop-contract.sh — SPEC 116 verify
+#
+# spec↔loop feat 브랜치·worktree 경로 단일 규약 contract verifier.
+#
+# 검사 항목 (SPEC 116 수용 기준 매핑):
+#   T1. slug 도출 결정성 — canonical 알고리즘이 "Foo Bar" → "foo-bar".
+#       + spec SKILL.md 가 canonical 알고리즘을 문서화하고 있는지 (drift guard).
+#       + spec SKILL.md 가 slug-bearing SPEC.md 경로를 참조하는지.
+#   T2. find_feat_branch — `feat/<input-id>-<slug>` 브랜치를 input-id 만으로 발견.
+#   T3. worktree 경로 — `milestones/<m>/loops/<input-id>-<slug>/.worktree`.
+#   T4. SPEC.md 경로 정합 — spec 작성 경로 = loop 읽기 경로 = pr-phase 읽기 경로.
+#   T5. 모호성 die — 동일 input-id 매칭 브랜치 2+ 일 때 비-zero exit + 안내.
+#
+# 셋업: 임시 git fixture · mock claude (DONE 즉시 생성) · yq 필요.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LOOP_SH="$REPO_ROOT/plugins/autopilot/skills/loop/references/loop.sh"
+PR_PHASE_SH="$REPO_ROOT/plugins/autopilot/skills/loop/references/pr-phase.sh"
+SPEC_SKILL_MD="$REPO_ROOT/plugins/autopilot/skills/spec/SKILL.md"
+
+[[ -f "$LOOP_SH" ]]      || { echo "FAIL setup: loop.sh missing: $LOOP_SH" >&2; exit 1; }
+[[ -f "$PR_PHASE_SH" ]]  || { echo "FAIL setup: pr-phase.sh missing: $PR_PHASE_SH" >&2; exit 1; }
+[[ -f "$SPEC_SKILL_MD" ]]|| { echo "FAIL setup: SKILL.md missing: $SPEC_SKILL_MD" >&2; exit 1; }
+
+# yq 의존 — 없으면 cmd_start가 scope.include 파싱 단계에서 die.
+command -v yq >/dev/null 2>&1 \
+  || { echo "SKIP: yq 미설치 — verify 실행 불가" >&2; exit 0; }
+
+# Canonical slug 알고리즘 (SKILL.md §9.5.1 단일 출처). 이 함수가 변하면
+# SKILL.md 문서·loop 코드 추출 로직과 함께 변경해야 한다.
+canonical_slug() {
+  local title="$1"
+  printf '%s' "$title" \
+    | LC_ALL=C tr '[:upper:]' '[:lower:]' \
+    | LC_ALL=C tr -c 'a-z0-9-' '-' \
+    | sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//'
+}
+
+WORK_DIR=$(mktemp -d)
+# shellcheck disable=SC2064
+trap "rm -rf $WORK_DIR" EXIT
+
+PROJECT="$WORK_DIR/proj"
+mkdir -p "$PROJECT"
+cd "$PROJECT"
+git init -q
+git config user.email t@t
+git config user.name t
+git commit --allow-empty -m init -q
+MAIN_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+# baseline empty commit (suppressor 오탐 방지)
+git commit --allow-empty -q -m "chore: baseline"
+
+# mock claude — stdin 소비 + DONE 생성 + JSON 응답
+MOCK_BIN="$WORK_DIR/mock-bin"
+mkdir -p "$MOCK_BIN"
+cat > "$MOCK_BIN/claude" <<'MOCKEOF'
+#!/usr/bin/env bash
+cat > /dev/null
+touch DONE
+echo '{"result":"mock","usage":{"input_tokens":1,"output_tokens":1}}'
+MOCKEOF
+chmod +x "$MOCK_BIN/claude"
+export PATH="$MOCK_BIN:$PATH"
+
+INPUT_ID="test123"
+TITLE="Foo Bar"
+SLUG=$(canonical_slug "$TITLE")
+DIR_REL="milestones/regular/loops/${INPUT_ID}-${SLUG}"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# T1. slug 도출 결정성 + SKILL.md drift guard
+# ──────────────────────────────────────────────────────────────────────────────
+[[ "$SLUG" == "foo-bar" ]] \
+  || { echo "FAIL T1a: canonical_slug 'Foo Bar' = '$SLUG', want 'foo-bar'" >&2; exit 1; }
+
+# SKILL.md 단일 출처 검사 — canonical bash 알고리즘 라인이 그대로 박혀 있어야 한다.
+grep -qF "LC_ALL=C tr '[:upper:]' '[:lower:]'" "$SPEC_SKILL_MD" \
+  || { echo "FAIL T1b: SKILL.md missing canonical lowercase step" >&2; exit 1; }
+grep -qF "LC_ALL=C tr -c 'a-z0-9-' '-'" "$SPEC_SKILL_MD" \
+  || { echo "FAIL T1c: SKILL.md missing canonical char-replacement step" >&2; exit 1; }
+grep -qF "sed -e 's/--*/-/g'" "$SPEC_SKILL_MD" \
+  || { echo "FAIL T1d: SKILL.md missing canonical collapse step" >&2; exit 1; }
+
+# SKILL.md 가 slug-bearing SPEC.md 경로 컨벤션을 참조해야 한다 (단일 컨벤션 선언).
+grep -qF "milestones/<m>/loops/<c>-<slug>" "$SPEC_SKILL_MD" \
+  || { echo "FAIL T1e: SKILL.md missing slug-bearing directory reference (milestones/<m>/loops/<c>-<slug>)" >&2; exit 1; }
+
+echo "OK T1: slug 도출 결정성 + SKILL.md drift guard"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fixture: slug-bearing 디렉토리·feat 브랜치 셋업 (spec 스킬의 신규 contract 결과를 모사)
+# ──────────────────────────────────────────────────────────────────────────────
+mkdir -p "$PROJECT/$DIR_REL"
+cat > "$PROJECT/$DIR_REL/SPEC.md" <<SPECEOF
+---
+scope:
+  include: ["src/**"]
+verify: "true"
+---
+
+# $TITLE
+
+## 무엇을 만들 것인가
+Test fixture.
+SPECEOF
+
+git checkout -q -b "feat/${INPUT_ID}-${SLUG}"
+git add -f "$DIR_REL/SPEC.md"
+git commit -q -m "feat(spec): ${INPUT_ID} — ${TITLE}"
+git checkout -q "$MAIN_BRANCH"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# T2. find_feat_branch — input-id 단일 인자로 발견
+# ──────────────────────────────────────────────────────────────────────────────
+set +e
+T2_OUT=$(bash "$LOOP_SH" start "$INPUT_ID" --no-pr --max-iterations 1 2>&1)
+T2_RC=$?
+set -e
+
+if [[ $T2_RC -ne 0 ]]; then
+  echo "FAIL T2: loop.sh start '$INPUT_ID' rc=$T2_RC" >&2
+  echo "----- output:" >&2
+  echo "$T2_OUT" >&2
+  echo "----- branches:" >&2
+  git branch -a >&2
+  exit 1
+fi
+echo "$T2_OUT" | grep -q "feat 브랜치 부재" \
+  && { echo "FAIL T2: find_feat_branch did not match feat/${INPUT_ID}-${SLUG} by input-id alone" >&2
+       echo "$T2_OUT" >&2; exit 1; }
+
+echo "OK T2: find_feat_branch — input-id roundtrip"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# T3. worktree 경로 — slug-bearing
+# ──────────────────────────────────────────────────────────────────────────────
+EXPECTED_WT="$PROJECT/${DIR_REL}/.worktree"
+if [[ ! -d "$EXPECTED_WT" ]]; then
+  echo "FAIL T3: 기대 worktree 경로 부재: $EXPECTED_WT" >&2
+  echo "  실제 worktree 디렉토리:" >&2
+  find "$PROJECT/milestones" -name '.worktree' -type d 2>/dev/null >&2 || true
+  exit 1
+fi
+echo "OK T3: worktree 경로 — $EXPECTED_WT"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# T4. SPEC.md 경로 정합 (spec 작성 = loop 읽기 = pr-phase 읽기)
+# ──────────────────────────────────────────────────────────────────────────────
+# spec 작성 경로 = $DIR_REL/SPEC.md (위 fixture)
+# loop 읽기 경로 = worktree 안의 $DIR_REL/SPEC.md
+WT_SPEC="$EXPECTED_WT/${DIR_REL}/SPEC.md"
+[[ -f "$WT_SPEC" ]] \
+  || { echo "FAIL T4a: worktree 안 SPEC.md 부재: $WT_SPEC" >&2; exit 1; }
+
+# pr-phase.sh 의 SPEC_FILE 도출 — feat 브랜치 이름의 slug를 사용해야 한다.
+# 동일 도출 로직을 본 테스트에서 재현해 결과가 slug-bearing 경로와 일치하는지 확인.
+PR_TASK_ID="regular/${INPUT_ID}"
+PR_BRANCH="feat/${INPUT_ID}-${SLUG}"
+PR_CHILD="${PR_TASK_ID#*/}"
+PR_MILESTONE="${PR_TASK_ID%%/*}"
+PR_SLUG_FROM_BRANCH=""
+PR_PREFIX="feat/${PR_CHILD}"
+if [[ "$PR_BRANCH" == "${PR_PREFIX}-"* ]]; then
+  PR_SLUG_FROM_BRANCH="${PR_BRANCH#${PR_PREFIX}-}"
+fi
+if [[ -n "$PR_SLUG_FROM_BRANCH" ]]; then
+  PR_DERIVED_SPEC="$EXPECTED_WT/milestones/${PR_MILESTONE}/loops/${PR_CHILD}-${PR_SLUG_FROM_BRANCH}/SPEC.md"
+else
+  PR_DERIVED_SPEC="$EXPECTED_WT/milestones/${PR_MILESTONE}/loops/${PR_CHILD}/SPEC.md"
+fi
+[[ "$PR_DERIVED_SPEC" == "$WT_SPEC" ]] \
+  || { echo "FAIL T4b: pr-phase 도출 경로 ≠ 실제 경로:" >&2
+       echo "  derived: $PR_DERIVED_SPEC" >&2
+       echo "  actual:  $WT_SPEC" >&2; exit 1; }
+
+# pr-phase.sh 의 실제 코드가 $BRANCH 로부터 slug 를 추출해 SPEC_FILE 을 만드는지 확인 (drift guard).
+# 구 코드: SPEC_FILE="$WT/milestones/${TASK_ID%%/*}/loops/${TASK_ID#*/}/SPEC.md"  ← slug 미고려
+# 신 코드: $BRANCH 기반 slug 추출 (`${BRANCH#feat/<child>-}` 패턴) 후 경로 조립.
+if ! grep -qE '\$\{?BRANCH#' "$PR_PHASE_SH"; then
+  echo "FAIL T4c: pr-phase.sh SPEC_FILE 도출이 \$BRANCH 의 slug 를 사용하지 않음 (\${BRANCH#...} 패턴 부재):" >&2
+  grep -nE 'SPEC_FILE=' "$PR_PHASE_SH" >&2 || true
+  exit 1
+fi
+
+echo "OK T4: SPEC.md 경로 정합 (slug-bearing 단일 컨벤션)"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# T5. 모호성 die — 동일 input-id 매칭 브랜치가 2+ 일 때
+# ──────────────────────────────────────────────────────────────────────────────
+# 추가 feat 브랜치 생성: feat/${INPUT_ID}-another-slug
+git checkout -q -b "feat/${INPUT_ID}-another-slug"
+git checkout -q "$MAIN_BRANCH"
+
+set +e
+T5_OUT=$(bash "$LOOP_SH" status "$INPUT_ID" 2>&1)
+T5_RC=$?
+set -e
+
+[[ $T5_RC -ne 0 ]] \
+  || { echo "FAIL T5a: 모호 케이스에서 비-zero exit 미발생 (rc=$T5_RC)" >&2
+       echo "$T5_OUT" >&2; exit 1; }
+echo "$T5_OUT" | grep -qE '여러 feat 브랜치|모호|ambig' \
+  || { echo "FAIL T5b: stderr 모호성 안내 부재" >&2
+       echo "$T5_OUT" >&2; exit 1; }
+
+echo "OK T5: 모호성 die"
+
+echo ""
+echo "ALL TESTS PASSED (T1–T5)"


### PR DESCRIPTION
## 요약

- `autopilot:spec` 스킬이 만드는 feat 브랜치와 `autopilot:loop`이 검색·진입하는 feat 브랜치가 같은 명명 규약을 따르도록 단일 contract 통일.
- SPEC.md 디렉토리·loop worktree·pr-phase SPEC 경로가 `milestones/<m>/loops/<input-id>-<slug>/` slug-bearing 단일 컨벤션으로 정합.
- `find_feat_branch`가 input-id 원형 패턴도 검색해 default milestone(`regular`) + 단일 컴포넌트 task-id에서 spec→loop 라운드트립이 수동 rename 없이 성립.

## 변경

- `plugins/autopilot/skills/spec/SKILL.md` — step 8 SPEC.md 디렉토리·step 9.5.2 브랜치 명령 slug-bearing 정합.
- `plugins/autopilot/skills/loop/references/loop.sh` — `find_feat_branch` 입력 원형 검색 패턴 추가, `compute_paths`가 feat 브랜치 이름에서 slug 추출.
- `plugins/autopilot/skills/loop/references/pr-phase.sh` — `SPEC_FILE` 경로가 slug-bearing 디렉토리 가리키도록 정합.
- `plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh` 신설 — T1(slug 결정성)·T2(roundtrip)·T3(worktree 경로)·T4(SPEC.md 단일 경로)·T5(모호성 die) 5개 검사.

## Test plan

- [x] `bash plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh` exit 0 (T1–T5 ALL PASSED)
- [x] 라이브 라운드트립: spec 116 + loop start 116 — 워크트리 `milestones/regular/loops/116/.worktree`에서 자율 이터 #1 DONE 정상 종료

Closes #116