### PR TITLE
references 보조 .md(operational-guide·troubleshooting·status-format·agent-prompts) 잔존 표현 정리

### DIFF
--- a/milestones/2026-05-backing-abstraction/dispatch/DAG.md
+++ b/milestones/2026-05-backing-abstraction/dispatch/DAG.md
@@ -1,0 +1,37 @@
+# DAG — 2026-05-backing-abstraction
+
+`milestones/2026-05-backing-abstraction/prd/PRD.md`의 분해 결과. dispatch가 게이트 ① 승인 후 작성.
+
+생성 시각: 2026-05-16T02:50Z
+
+## 단위 목록
+
+- child-a: constitution.md backing-neutral 어휘 재작성
+  - 영향 파일: plugins/autopilot/skills/loop/references/constitution.md
+  - verify: backing-specific terms grep (comment prefix·issue body·Project Status 등)이 backing-specific section 외부에서 0
+  - 의존성: 없음
+- child-b: SKILL.md 4개(spec·loop·prd·dispatch) backing-neutral 어휘 재작성
+  - 영향 파일: plugins/autopilot/skills/spec/SKILL.md, plugins/autopilot/skills/loop/SKILL.md, plugins/autopilot/skills/prd/SKILL.md, plugins/autopilot/skills/dispatch/SKILL.md
+  - verify: 4개 파일 backing-specific terms grep
+  - 의존성: child-a (헌법 어휘 차용)
+- child-c: loop.sh의 done·blocked 신호 검출·발행 매체 교체 + label name 자동 관리
+  - 영향 파일: plugins/autopilot/skills/loop/references/loop.sh
+  - verify: comment-based detect 코드 부재(last_prefix·prefix comment 검색 코드 없음) + 새 추상 헬퍼 함수 grep + label name 자동 생성·재사용 로직 확인
+  - 의존성: child-a (헌법 어휘 차용)
+- child-d: references 보조 .md(operational-guide·troubleshooting·status-format·agent-prompts) 잔존 표현 정리
+  - 영향 파일: plugins/autopilot/skills/loop/references/operational-guide.md, plugins/autopilot/skills/loop/references/troubleshooting.md, plugins/autopilot/skills/loop/references/status-format.md, plugins/autopilot/skills/loop/references/agent-prompts.md
+  - verify: 4개 파일 backing-specific terms grep
+  - 의존성: child-a (헌법 어휘 차용)
+
+## 의존성·wave 정렬
+
+- wave 1 (정의 선행): [child-a]
+- wave 2 (depends on wave 1, parallel-safe): [child-b, child-c, child-d]
+
+## 메모
+
+phase script들(pr-phase·rebase-phase·review-fix-phase·cleanup-phase)은 task storage 호출이 없고 git/PR/cleanup workflow에 한정되어 본 milestone scope 외로 판단해 child 단위에서 제외. 향후 별도 milestone에서 다룰 수 있다.
+
+격리성 확보: wave 2의 3 child는 각각 다른 파일군(SKILL.md / loop.sh / 보조 .md)을 수정해 동시 실행 시 충돌 없음. wave 1의 child-a 산출물(헌법 본문에 정의된 추상 어휘)은 wave 2의 입력 컨텍스트로만 차용되고 파일 동시 수정은 일어나지 않는다.
+
+self-referential 위험 대응: 각 child SPEC 작성 단계에서 `feedback_no_self_apply_during_spec` 메모리 룰 명시 — 현재 호출은 contract 선행 적용 금지. adapter 유혹 차단: 각 child SPEC의 비-목표에 "adapter 신설 금지" 명시.

--- a/milestones/2026-05-backing-abstraction/loops/135-references-md-operational-guide-troubleshooting-status-format-agent-prompts/SPEC.md
+++ b/milestones/2026-05-backing-abstraction/loops/135-references-md-operational-guide-troubleshooting-status-format-agent-prompts/SPEC.md
@@ -1,0 +1,71 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/loop/references/operational-guide.md", "plugins/autopilot/skills/loop/references/troubleshooting.md", "plugins/autopilot/skills/loop/references/status-format.md", "plugins/autopilot/skills/loop/references/agent-prompts.md"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash -c 'set -e; for F in plugins/autopilot/skills/loop/references/operational-guide.md plugins/autopilot/skills/loop/references/troubleshooting.md plugins/autopilot/skills/loop/references/status-format.md plugins/autopilot/skills/loop/references/agent-prompts.md; do test -f \"$F\" && ! grep -qE \"gh issue|prefix comment|issue body|\\[done\\]|\\[blocked\\]|Project Status field|GitHub Project\" \"$F\"; done'"
+ears_language: ko
+---
+
+# references 보조 .md(operational-guide·troubleshooting·status-format·agent-prompts) 잔존 표현 정리
+
+## 무엇을 만들 것인가
+
+autopilot loop 스킬의 보조 references 4개(`operational-guide.md`·`troubleshooting.md`·`status-format.md`·`agent-prompts.md`)에서 backing-specific 표현 잔존을 추상 어휘로 정리한다. 추상 어휘는 sibling child(헌법 재작성)이 정의한 단위(task 메모리·task 신호·task 상태·task 식별자)를 차용한다 — 본 child가 새 단위를 신설하지 않는다.
+
+각 파일의 역할상 backing-specific 표현이 등장하는 위치:
+
+- **operational-guide.md** — 사용자가 워크플로를 운영할 때 참조하는 가이드. status·blocked 운영·신호 발행 안내가 backing-specific 표현을 사용할 수 있음.
+- **troubleshooting.md** — ESCALATION 카테고리별 처리. 워커의 신호와 차단 절차 안내에 backing 매체 표현이 등장할 수 있음.
+- **status-format.md** — status 출력 형식. status field 매핑 표현이 backing-specific일 수 있음.
+- **agent-prompts.md** — 이터 내 Agent dispatch 브리프 양식. backing 의존성이 낮을 가능성이 높으나 점검.
+
+본 child의 산출물은 4개 파일에 한정된다. 다른 sibling이 다루는 영역(헌법 본문·SKILL.md·드라이버 셸)은 손대지 않는다.
+
+## 수용 기준 (EARS)
+
+1. `plugins/autopilot/skills/loop/references/{operational-guide,troubleshooting,status-format,agent-prompts}.md` 4개 파일 모두 존재할 때, 시스템은 각 본문 전체에서 다음 backing-specific 표현 어느 것도 매칭하지 않는다: `gh issue`, `prefix comment`, `issue body`, `[done]`, `[blocked]`, `Project Status field`, `GitHub Project`.
+2. 본 child가 4개 보조 references를 정리하는 동안, 시스템은 sibling child(헌법·SKILL.md·loop.sh)의 파일을 수정하지 않는다.
+3. 4개 보조 references 중 어느 위치에도 backing-specific 표현이 잔존하는 경우, 시스템은 verify 명령으로 그 잔존을 검출하고 0이 아닌 exit으로 실패 신호를 낸다.
+4. 보조 references의 워크플로·카테고리·운영 절차 의미는 변경 없이 어휘만 추상화된다 — 절차 추가·삭제 금지.
+
+## 범위
+
+포함:
+
+- `plugins/autopilot/skills/loop/references/operational-guide.md`의 backing-specific 표현 추상 어휘로 정리
+- `plugins/autopilot/skills/loop/references/troubleshooting.md`의 backing-specific 표현 추상 어휘로 정리
+- `plugins/autopilot/skills/loop/references/status-format.md`의 backing-specific 표현 추상 어휘로 정리
+- `plugins/autopilot/skills/loop/references/agent-prompts.md`의 backing-specific 표현 추상 어휘로 정리
+
+비-목표 / 제외:
+
+- 헌법(`constitution.md`) 재작성 — sibling child-a 담당
+- SKILL.md(spec·loop·prd·dispatch) 어휘 변경 — sibling child-b 담당
+- `loop.sh`·기타 phase script 코드 변경 — sibling child-c 담당
+- `rules/context.md` 변경 — 본 milestone의 명시 비-목표
+- adapter 인터페이스 신설 — 본 milestone의 명시 비-목표
+- 보조 references의 운영 절차·ESCALATION 카테고리·status 출력 형식 자체 변경 — 본 child는 어휘 정리만
+
+## 검증
+
+이 명령이 0 exit으로 끝나야 합니다:
+
+```bash
+bash -c 'set -e; for F in plugins/autopilot/skills/loop/references/operational-guide.md plugins/autopilot/skills/loop/references/troubleshooting.md plugins/autopilot/skills/loop/references/status-format.md plugins/autopilot/skills/loop/references/agent-prompts.md; do test -f "$F" && ! grep -qE "gh issue|prefix comment|issue body|\[done\]|\[blocked\]|Project Status field|GitHub Project" "$F"; done'
+```
+
+## 제약
+
+- `feedback_no_self_apply_during_spec` 메모리 룰: 본 SPEC.md 작성하는 *현재* spec 호출에는 새 어휘 contract를 선행 적용하지 않는다.
+- `feedback_self_referential_verification` 메모리 룰: 워커는 verify·worktree source(직접 변경한 4개 보조 references)만 검사한다.
+- 추상 어휘 단위는 sibling child-a가 헌법에 정의한 것을 그대로 사용한다 — 본 child가 새 단위를 신설하지 않는다.
+- 본 child는 wave 2에 속하며 wave 1의 child-a 산출물(헌법의 어휘 정의)을 입력으로 사용한다.
+
+## 위험
+
+- **self-referential 함정**: 본 child가 `troubleshooting.md`의 ESCALATION 카테고리별 처리 안내를 수정하면, 워커가 ESCALATION 발생 시 그 안내를 따라 동작한다. 중간 상태 안내가 워커의 다음 동작을 결정할 수 있으므로 verify는 worktree source의 grep으로 한정한다.
+- **adapter 유혹**: 보조 references에서 backing 추상화를 다루면서 "이참에 backing adapter 매핑 표를 여기에 두자"는 유혹. 비-목표에 명시 금지. 매핑은 sibling child의 SKILL.md·`rules/context.md`에 위임.
+- **빈 파일 가능성**: 일부 보조 references는 이미 backing-specific 표현이 0건일 수 있다. 그 경우 본 child의 verify는 즉시 통과하고 변경 commit 없이 완료될 수 있다 — 정상 동작. 워커는 verify 통과만 보고 완료 판정.

--- a/milestones/2026-05-backing-abstraction/prd/PRD.md
+++ b/milestones/2026-05-backing-abstraction/prd/PRD.md
@@ -1,0 +1,64 @@
+# autopilot 설계·드라이버의 backing-neutral 어휘 + native signal 매체 교체
+
+**Milestone**: 2026-05-backing-abstraction
+
+## 문제
+
+현 autopilot은 task의 backing system(=구체적 task storage·workflow 백엔드. 본 프로젝트의 경우 GitHub Issue + Project)에 강결합되어 있다. 두 측면에서 문제가 나타난다.
+
+첫째, 설계 문서 차원: 헌법(`constitution.md`)·SKILL.md·`references/*.md`의 곳곳에서 "task issue body", "[done] prefix comment", "Project Status field" 같은 backing-specific 표현이 직접 노출된다. 이로 인해 같은 추상 동작(예: "완료 신호 표시")이 매체 이름으로 산재해 기술되고, 향후 다른 backing을 채택할 가능성을 검토하기 전부터 한 backing의 어휘에 갇혀 있다.
+
+둘째, 신호 검출 차원: 워커가 완료 시 발행하는 `[done]` prefix comment를 드라이버(`loop.sh`)가 안정적으로 검출하지 못한다. 0.2.1 헌법은 신호 매체를 comment prefix로 정의했지만 `loop.sh`는 워크트리의 `$WT/DONE` 파일을 체크하는 구 컨벤션 잔존 코드를 사용한다. 그 결과 워커가 매 이터마다 `[done]` comment를 발행하며 수렴해 있어도 드라이버는 이를 모르고 이터 상한(예: 30회)까지 회전하다 자동 `[blocked]` comment로 에스컬레이션된다. 같은 매체에서 발행·검출이 일치하지 않는 한, 이 부정합은 향후 다른 매체로 옮기더라도 반복될 위험이 있다.
+
+두 측면은 한 뿌리에서 나온 증상이다 — 설계와 구현이 backing의 구체 어휘를 같은 자리에서 다루지 않아 매체 변경이 산발적으로 일어나고, 결국 사용자가 매번 부정합을 추적해 고쳐야 한다.
+
+## 목표·비전
+
+스킬 패키지 내 모든 설계 문서(헌법·SKILL.md·`references/*.md`)와 드라이버 코드(`loop.sh`·`pr-phase.sh`·`rebase-phase.sh`·`review-fix-phase.sh`·`cleanup-phase.sh`)가 task backing system을 **backing-neutral 추상 어휘**로 일관 기술한다. 그 추상에서 정의된 동작 — 예: "task에 label 추가", "task의 label 검색", "task status를 X로 전이" — 은 현 GitHub 구현 위에서 그대로 수행된다.
+
+이 milestone은 추상 어휘 layer를 도입하되 **adapter 인터페이스를 신설하거나 다른 backing 구현을 추가하지 않는다**. 단일 GitHub 구현 위에 어휘 layer만 얹어 향후 다른 backing 검토 시 분기 지점을 명확히 한다.
+
+신호 매체 차원에서는 완료 신호를 GitHub label(예: `loop:done`)로, 정지 신호를 GitHub Project Status field 전이(예: `Blocked`)로 단일화한다. 인간 가독·로그를 위한 `[done]`·`[blocked]` prefix comment는 양쪽 모두 함께 발행하되 드라이버 검출 키는 label·status에 단일 의존한다.
+
+## 성공 기준
+
+- 헌법·SKILL.md·`references/*.md`의 텍스트가 backing-neutral 어휘로 일관 기술되어, backing-specific section(예: 헌법의 "GitHub 구현 절" 같은 명시 영역) 외부에서는 "comment prefix", "gh issue body" 같은 구체 표현이 노출되지 않는다.
+- `loop.sh`의 done 신호 검출이 GitHub label 검색(예: `loop:done`)으로 동작하고, blocked 신호 검출이 GitHub Project Status field(예: `Blocked`)로 동작한다. 두 신호 모두 가독·로그용 comment 발행은 유지하되 검출 키는 label·status에 단일 의존한다.
+- 기존 `[done]`·`[blocked]` prefix comment 히스토리는 마이그레이션 없이 보존된다 — 본 milestone 이전에 발행된 comment는 그대로 남고, 본 milestone 이후 발행되는 신호부터만 새 매체로 전환된다.
+- adapter 인터페이스·다른 backing 구현·`rules/context.md` 변경·산출물(SPEC.md·PRD.md·issue body 등) 자동 마이그레이션은 본 milestone에서 일어나지 않는다 (각 child SPEC도 동일).
+- 자율 loop이 이 milestone의 child task를 처리할 때, 워커의 완료 발행과 드라이버의 검출이 일치해 이터 상한 도달 없이 정상 종료한다 — 본 milestone이 해결한 부정합이 child task 실행 자체에서 재현되지 않음을 입증.
+
+## 범위
+
+포함:
+
+- `plugins/autopilot/skills/<skill>/SKILL.md` (spec·loop·prd·dispatch) 4개의 backing-neutral 어휘 재작성
+- `plugins/autopilot/skills/loop/references/constitution.md`의 backing-neutral 어휘 재작성 — 특히 §11(이터간 컨텍스트 운영) 및 §5(정지)·§3.4(완료 판정)
+- `plugins/autopilot/skills/loop/references/{loop,pr-phase,rebase-phase,review-fix-phase,cleanup-phase}.sh`의 backing 호출 식별·추상 헬퍼로 묶기 + done 신호 검출(comment 검색 → label 검색)·blocked 신호 검출(comment 검색 → Project Status field 조회) 교체
+- 새 label name 고정 정의(예: `loop:done`)와 부재 시 자동 생성·재사용 로직
+- `plugins/autopilot/skills/loop/references/{handoff,notes,plan,runlog,escalation}-template.md` 등 보조 문서에서 backing-specific 표현 정리 (없으면 무변경)
+
+비-목표 / 제외:
+
+- adapter/interface 신설 — 추상 어휘 layer는 텍스트 차원과 헬퍼 함수명 차원에서만 적용. 다중 구현을 분기하는 dispatcher는 만들지 않는다
+- 다른 backing 구현(파일 기반·Linear·Jira 등) 추가
+- `rules/context.md` 변경 — 본 프로젝트는 의도적으로 GitHub Project+Issue를 구체화로 채택했으므로 본 milestone의 어휘 추상화 대상에서 명시 제외
+- 스킬 산출물(SPEC.md·PRD.md·issue body·기존 prefix comment 히스토리) 자동 마이그레이션
+- `gh` CLI 의존 자체 제거 — 현 구현이 `gh`를 사용하는 사실 자체는 유지
+
+## 제약
+
+- 기존 `[done]`·`[blocked]` prefix comment 히스토리는 건들지 않음 — 소급 마이그레이션 없음. 본 milestone 이전 issue의 자동 완료 감지는 포기한다.
+- done = label, blocked = Project Status. 양쪽 모두 가독·로그용 comment 발행은 유지하되 드라이버 검출 키는 label·status에 단일 의존한다.
+- label name (예: `loop:done`)은 프로젝트 수준에서 고정하고, 드라이버가 부재 시 자동 생성·재사용한다. 사용자가 별도 입력하지 않아도 작동.
+- Project Status field 명칭(예: `Blocked`)은 의존하되 변경 시 단일 위치에서 갱신 가능하도록 한 모듈에 집중.
+- `feedback_no_self_apply_during_spec` 메모리 룰에 따라, 본 milestone의 어느 child SPEC도 *자신의 호출* 중 새 contract를 자신의 산출물에 선행 적용하지 않는다 — 새 동작은 다음 spec/loop 호출부터 적용된다.
+
+## 위험
+
+- **self-referential**: autopilot 자체를 소재로 child task를 돌리면 spec·loop이 자기 구현을 수정한다. 각 child SPEC에 `feedback_no_self_apply_during_spec`·`feedback_self_referential_verification` 메모리 룰을 명시해, 검증은 verify·worktree source만 보고 runtime artifact 직접 검사를 금지한다. 각 child loop의 자기 구현 호출 함정 차단.
+- **adapter 유혹**: child 작업 중 "adapter 인터페이스를 만드는 게 깔끔해" 유혹으로 범위가 부풀려질 위험. PRD·child SPEC 각각에 "adapter 신설 금지" 비-목표를 명시. 코드 차원의 추상화는 헬퍼 함수명·매개변수 수준에서만 허용하고 다중 구현을 분기하는 dispatcher·인터페이스 객체는 만들지 않는다.
+
+## 분해 힌트
+
+(없음 — dispatch에 맡김)

--- a/plugins/autopilot/skills/loop/references/agent-prompts.md
+++ b/plugins/autopilot/skills/loop/references/agent-prompts.md
@@ -87,7 +87,7 @@ Agent({
 
 **메인 이터의 후속 처리:**
 - ✅ → §3.5 Self-Review 4축 단계로 진행
-- ❌ → task issue에 `[notes]` prefix comment로 발견 사항 추가, fix 후 다시 spec-compliance-reviewer 호출 (재호출 횟수 누적은 fix:symptom streak 검사 대상)
+- ❌ → task 메모리에 `[notes]` 신호로 발견 사항 추가, fix 후 다시 spec-compliance-reviewer 호출 (재호출 횟수 누적은 fix:symptom streak 검사 대상)
 
 ---
 
@@ -183,7 +183,7 @@ Agent({
 **메인 이터의 후속 처리:**
 - 예 → §3.5 Self-Review 4축 통과로 인정
 - 수정 후 진행 → Critical/Important 항목을 fix·재검토. fix 누적은 §4.2 조기 정지 조건 (3+ fix) 대상
-- 아니오 → DONE_WITH_CONCERNS 신호로 task issue에 `[handoff]` prefix comment의 `## 의심점` 섹션에 기록 후 종료
+- 아니오 → DONE_WITH_CONCERNS 신호로 task 메모리에 `[handoff]` 신호의 `## 의심점` 섹션에 기록 후 종료
 
 ---
 

--- a/plugins/autopilot/skills/loop/references/operational-guide.md
+++ b/plugins/autopilot/skills/loop/references/operational-guide.md
@@ -32,7 +32,7 @@ milestones/<m>/loops/<c>/
     ├── .iterations/<n>.log    # 매 이터 stdout 캡처 (gitignored, worktree-local)
     └── milestones/<m>/loops/<c>/
         └── SPEC.md            # feat 브랜치 commit으로 자연 노출
-# 이터간 상태(계획·교훈·인계·차단·완료)는 워크트리에 두지 않고 task issue body·prefix comments로 위임 (헌법 §11)
+# 이터간 상태(계획·교훈·인계·차단·완료)는 워크트리에 두지 않고 task 메모리·task 신호로 위임 (헌법 §11)
 ```
 
 단일 task는 `<m>=regular`로 정규화 — `regular/<task-id>`. `.gitignore` 무시 패턴은 `milestones/**/loops/**/.worktree/`와 `milestones/**/loops/**/.lock`.
@@ -61,7 +61,7 @@ LOOP_SH="$HOME/.claude/plugins/autopilot/skills/loop/references/loop.sh"
 Skill(skill: "spec", args: "auth-refactor")   # 대화형 SPEC.md 생성
 bash "$LOOP_SH" start auth-refactor           # 루프 시작
 bash "$LOOP_SH" logs auth-refactor --tail  # 별도 터미널에서 모니터링
-# 정지: Ctrl+C, DONE 파일 생성, 또는 `[done]`/`[blocked]` prefix comment 작성 시 자동 종료
+# 정지: Ctrl+C, DONE 파일 생성, 또는 완료·차단 신호 발행 시 자동 종료
 ```
 
 ## 외부 SPEC 파일 전달 (--spec 플래그)
@@ -108,25 +108,20 @@ bash "$LOOP_SH" logs auth-refactor [--tail | --iter N]
 
 ## DONE_WITH_CONCERNS 처리
 
-이터가 verify는 통과했으나 self-review에서 의심점을 발견하면 `[done]` comment 대신 `[handoff]` prefix comment 본문에 `## 의심점` 섹션을 포함시켜 작성하고 정상 종료합니다. 사용자 개입은 보통 불필요 — 다음 이터가 의심점을 읽고 검증·해소한 후 깨끗한 `[done]` prefix comment를 작성합니다.
+이터가 verify는 통과했으나 self-review에서 의심점을 발견하면 완료 신호 대신 `[handoff]` 신호 본문에 `## 의심점` 섹션을 포함시켜 작성하고 정상 종료합니다. 사용자 개입은 보통 불필요 — 다음 이터가 의심점을 읽고 검증·해소한 후 깨끗한 완료 신호를 발행합니다.
 
 ## ESCALATION 처리
 
 카테고리별 처리 흐름: `references/troubleshooting.md` 참조.
 
-```bash
-ISSUE=<task-issue-number>                                 # task-id가 숫자면 issue number와 동일
-gh issue view "$ISSUE" --comments | tail -n 60            # 최근 `[blocked]` comment 본문 확인
-cd milestones/<m>/loops/<c>/.worktree
-$EDITOR "milestones/<m>/loops/<c>/SPEC.md"                # 필요 시 SPEC 보정
-gh issue comment "$ISSUE" --body "[notes] 후속 조치 메모"   # 결정 사항 누적
-gh issue comment "$ISSUE" --body "[unblocked] 후속 조치 완료"  # Blocked 해제
-#   ([resume] prefix도 동등. task_status_is_blocked가 가장 최근 매치된 prefix
-#    comment를 단일 진실원으로 보므로, Projects UI에서 Status만 바꾸는 것으로는
-#    fallback이 [blocked]를 계속 감지해 차단이 유지됨.)
-cd <project-root> && bash "$LOOP_SH" start <task-id>      # 재시작
-# --watch 모드면 [unblocked]/[resume] comment로 차단 신호가 해제되는 순간 자동 재개 (polling)
-```
+1. task 메모리에서 task 식별자로 조회해 최근 차단 신호 본문 확인
+2. 워크트리(`milestones/<m>/loops/<c>/.worktree`)로 이동, 필요 시 SPEC 보정 (`milestones/<m>/loops/<c>/SPEC.md`)
+3. task 메모리에 `[notes] 후속 조치 메모` 누적
+4. `[unblocked] 후속 조치 완료` 신호 발행해 차단 해제 (`[resume]` 신호도 동등)
+5. `<project-root>`에서 `bash "$LOOP_SH" start <task-id>` 로 재시작
+   - `--watch` 모드면 `[unblocked]`/`[resume]` 신호로 차단 신호가 해제되는 순간 자동 재개 (polling)
+
+차단 해제는 신호 발행이 정식 절차 — `task_status_is_blocked`가 가장 최근 매치된 신호를 단일 진실원으로 보므로, task 상태 UI에서 상태만 변경해도 fallback이 차단 신호를 계속 감지해 차단이 유지됩니다.
 
 ## 동시 실행
 
@@ -146,14 +141,14 @@ MAX_CONCURRENT=5 bash "$LOOP_SH" start new-task &   # 캡 상향
 | `MAX_CONCURRENT` | — | 3 | 동시 실행 task 수 |
 | `MAX_ITERATIONS` | `--max-iterations N` | 30 | 이터 상한 |
 | `WALL_CLOCK_MINUTES` | `--wall-clock-minutes N` | 120 | 시계 캡(분) |
-| — | `--watch` | off | 차단 신호(Status=`Blocked` 또는 `[blocked]` prefix comment) 감지 시 정지 대신 polling 재개 대기. `task_status_is_blocked`의 OR 결합과 일치. |
+| — | `--watch` | off | 차단 신호(task 상태가 `Blocked`이거나 차단 신호가 발행됨) 감지 시 정지 대신 polling 재개 대기. `task_status_is_blocked`의 OR 결합과 일치. |
 | `WATCH_TIMEOUT_HOURS` | — | 24 | --watch 모드에서 polling 최대 시간(시간 단위). 초과 시 exit 1 |
 
 워크트리 위치는 v0.2부터 메인 레포 내부 `milestones/<m>/loops/<c>/.worktree/`로 고정 — 외부 sibling 경로를 지정하는 환경 변수는 더 이상 제공하지 않습니다.
 
 ## 객관 게이트
 
-드라이버가 매 이터 후 다음을 검사합니다. 위반 시 자동 halt + 자동 `[blocked]` prefix comment 작성·Project Status=`Blocked` 전이:
+드라이버가 매 이터 후 다음을 검사합니다. 위반 시 자동 halt + 자동 차단 신호 발행·task 상태=`Blocked` 전이:
 
 | 가드 | 기준 |
 |---|---|

--- a/plugins/autopilot/skills/loop/references/operational-guide.md
+++ b/plugins/autopilot/skills/loop/references/operational-guide.md
@@ -112,7 +112,7 @@ bash "$LOOP_SH" logs auth-refactor [--tail | --iter N]
 
 ## ESCALATION 처리
 
-카테고리별 처리 흐름: `references/troubleshooting.md` 참조.
+카테고리별 처리 흐름: `references/troubleshooting.md` 참조. 아래 단계의 추상 동작(task 메모리 조회·신호 발행 등)을 현 backing에서 실행하는 구체 명령 매핑은 헌법 §11 (이터간 컨텍스트 운영) 참조.
 
 1. task 메모리에서 task 식별자로 조회해 최근 차단 신호 본문 확인
 2. 워크트리(`milestones/<m>/loops/<c>/.worktree`)로 이동, 필요 시 SPEC 보정 (`milestones/<m>/loops/<c>/SPEC.md`)

--- a/plugins/autopilot/skills/loop/references/troubleshooting.md
+++ b/plugins/autopilot/skills/loop/references/troubleshooting.md
@@ -1,15 +1,15 @@
 # ESCALATION 카테고리별 처리 가이드
 
-정지된 task의 `[blocked]` prefix comment 본문 `**카테고리**` 필드 별 사람의 처리 권장 흐름. comment 본문은 `gh issue view <task-issue> --comments`로 읽고, Blocked 해제는 task issue에 `[unblocked]` 또는 `[resume]` prefix comment를 발행합니다 — `gh issue comment <task-issue> --body '[unblocked] 해제 사유'`. (`task_status_is_blocked`가 가장 최근 매치된 prefix comment를 단일 진실원으로 보므로, GitHub Projects UI에서 Status를 변경하는 것만으로는 차단이 유지됩니다 — `[unblocked]`/`[resume]` comment 발행이 정식 절차.)
+정지된 task의 차단 신호 본문 `**카테고리**` 필드 별 사람의 처리 권장 흐름. 신호 본문은 task 메모리에서 task 식별자로 조회해 읽고, 차단 해제는 task에 `[unblocked]` 또는 `[resume]` 신호를 발행합니다 — `[unblocked] 해제 사유` 신호. (`task_status_is_blocked`가 가장 최근 매치된 신호를 단일 진실원으로 보므로, task 상태 UI에서 상태를 변경하는 것만으로는 차단이 유지됩니다 — `[unblocked]`/`[resume]` 신호 발행이 정식 절차.)
 
 ## config-gap (환경 설정·도구 부재)
 
 증상: 도구 미설치, 자격증명 부재, 환경 변수 누락 등.
 
 처리:
-1. `[blocked]` comment 본문 읽고 missing item 식별 (`gh issue view <task-issue> --comments`)
+1. 차단 신호 본문 읽고 missing item 식별 (task 메모리에서 task 식별자로 조회)
 2. target 프로젝트 환경 조정 (도구 설치, env var 설정 등)
-3. `gh issue comment <task-issue> --body '[unblocked] <해제 사유>'` 발행해 Blocked 해제 (`[resume]` prefix도 동등)
+3. `[unblocked] <해제 사유>` 신호 발행해 차단 해제 (`[resume]` 신호도 동등)
 4. `start <task-id>` 또는 watch 모드면 자동 재개
 
 ## spec-gap (SPEC.md 결함)
@@ -17,9 +17,9 @@
 증상: 모호한 수용 기준, 검증 명령 부적합, scope 정의 미흡 등.
 
 처리:
-1. `[blocked]` comment 본문의 "필요한 결정" 섹션 검토
+1. 차단 신호 본문의 "필요한 결정" 섹션 검토
 2. 워크트리의 SPEC.md 직접 수정. 워크트리 루트는 `milestones/<m>/loops/<c>/.worktree`이고 그 안 SPEC 위치는 `milestones/<m>/loops/<c>/SPEC.md`. (SPEC 작성은 spec 스킬 사용: Skill(skill: "spec", args: "<task-id>"))
-3. `gh issue comment <task-issue> --body '[unblocked] SPEC 보정 완료'` 발행해 Blocked 해제 후 재시작
+3. `[unblocked] SPEC 보정 완료` 신호 발행해 차단 해제 후 재시작
 
 ## architecture-gap (코드 구조 변경 필요)
 
@@ -43,7 +43,7 @@
 
 증상: 위 4종에 안 맞는 케이스.
 
-처리: `[blocked]` comment 본문 내용 검토 후 사람의 판단.
+처리: 차단 신호 본문 내용 검토 후 사람의 판단.
 
 ## halt 발생 시 stash 확인
 


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가

autopilot loop 스킬의 보조 references 4개(`operational-guide.md`·`troubleshooting.md`·`status-format.md`·`agent-prompts.md`)에서 backing-specific 표현 잔존을 추상 어휘로 정리한다. 추상 어휘는 sibling child(헌법 재작성)이 정의한 단위(task 메모리·task 신호·task 상태·task 식별자)를 차용한다 — 본 child가 새 단위를 신설하지 않는다.

각 파일의 역할상 backing-specific 표현이 등장하는 위치:

- **operational-guide.md** — 사용자가 워크플로를 운영할 때 참조하는 가이드. status·blocked 운영·신호 발행 안내가 backing-specific 표현을 사용할 수 있음.
- **troubleshooting.md** — ESCALATION 카테고리별 처리. 워커의 신호와 차단 절차 안내에 backing 매체 표현이 등장할 수 있음.
- **status-format.md** — status 출력 형식. status field 매핑 표현이 backing-specific일 수 있음.
- **agent-prompts.md** — 이터 내 Agent dispatch 브리프 양식. backing 의존성이 낮을 가능성이 높으나 점검.

본 child의 산출물은 4개 파일에 한정된다. 다른 sibling이 다루는 영역(헌법 본문·SKILL.md·드라이버 셸)은 손대지 않는다.

## Commits
- 19d8b6b refactor(autopilot/loop): 135 — references 보조 .md backing-specific 표현 추상화
- 07741a4 feat(spec): 135 — references 보조 .md 4개 잔존 표현 정리
- 0a47eda docs(dispatch): 2026-05-backing-abstraction — DAG.md (게이트 ① 승인 후)
- af58abe docs(prd): 2026-05-backing-abstraction — autopilot 설계·드라이버 backing-neutral 어휘 + native signal 매체 교체

Closes #135
<!-- autopilot:pr-body:end -->