### PR TITLE
loop.sh의 done·blocked 신호 검출·발행 매체 교체 + label name 자동 관리

### DIFF
--- a/milestones/2026-05-backing-abstraction/dispatch/DAG.md
+++ b/milestones/2026-05-backing-abstraction/dispatch/DAG.md
@@ -1,0 +1,37 @@
+# DAG — 2026-05-backing-abstraction
+
+`milestones/2026-05-backing-abstraction/prd/PRD.md`의 분해 결과. dispatch가 게이트 ① 승인 후 작성.
+
+생성 시각: 2026-05-16T02:50Z
+
+## 단위 목록
+
+- child-a: constitution.md backing-neutral 어휘 재작성
+  - 영향 파일: plugins/autopilot/skills/loop/references/constitution.md
+  - verify: backing-specific terms grep (comment prefix·issue body·Project Status 등)이 backing-specific section 외부에서 0
+  - 의존성: 없음
+- child-b: SKILL.md 4개(spec·loop·prd·dispatch) backing-neutral 어휘 재작성
+  - 영향 파일: plugins/autopilot/skills/spec/SKILL.md, plugins/autopilot/skills/loop/SKILL.md, plugins/autopilot/skills/prd/SKILL.md, plugins/autopilot/skills/dispatch/SKILL.md
+  - verify: 4개 파일 backing-specific terms grep
+  - 의존성: child-a (헌법 어휘 차용)
+- child-c: loop.sh의 done·blocked 신호 검출·발행 매체 교체 + label name 자동 관리
+  - 영향 파일: plugins/autopilot/skills/loop/references/loop.sh
+  - verify: comment-based detect 코드 부재(last_prefix·prefix comment 검색 코드 없음) + 새 추상 헬퍼 함수 grep + label name 자동 생성·재사용 로직 확인
+  - 의존성: child-a (헌법 어휘 차용)
+- child-d: references 보조 .md(operational-guide·troubleshooting·status-format·agent-prompts) 잔존 표현 정리
+  - 영향 파일: plugins/autopilot/skills/loop/references/operational-guide.md, plugins/autopilot/skills/loop/references/troubleshooting.md, plugins/autopilot/skills/loop/references/status-format.md, plugins/autopilot/skills/loop/references/agent-prompts.md
+  - verify: 4개 파일 backing-specific terms grep
+  - 의존성: child-a (헌법 어휘 차용)
+
+## 의존성·wave 정렬
+
+- wave 1 (정의 선행): [child-a]
+- wave 2 (depends on wave 1, parallel-safe): [child-b, child-c, child-d]
+
+## 메모
+
+phase script들(pr-phase·rebase-phase·review-fix-phase·cleanup-phase)은 task storage 호출이 없고 git/PR/cleanup workflow에 한정되어 본 milestone scope 외로 판단해 child 단위에서 제외. 향후 별도 milestone에서 다룰 수 있다.
+
+격리성 확보: wave 2의 3 child는 각각 다른 파일군(SKILL.md / loop.sh / 보조 .md)을 수정해 동시 실행 시 충돌 없음. wave 1의 child-a 산출물(헌법 본문에 정의된 추상 어휘)은 wave 2의 입력 컨텍스트로만 차용되고 파일 동시 수정은 일어나지 않는다.
+
+self-referential 위험 대응: 각 child SPEC 작성 단계에서 `feedback_no_self_apply_during_spec` 메모리 룰 명시 — 현재 호출은 contract 선행 적용 금지. adapter 유혹 차단: 각 child SPEC의 비-목표에 "adapter 신설 금지" 명시.

--- a/milestones/2026-05-backing-abstraction/loops/134-loop-sh-done-blocked-label-name/SPEC.md
+++ b/milestones/2026-05-backing-abstraction/loops/134-loop-sh-done-blocked-label-name/SPEC.md
@@ -1,0 +1,76 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/loop/references/loop.sh"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash -c 'set -e; F=plugins/autopilot/skills/loop/references/loop.sh; test -f \"$F\" && bash -n \"$F\" && grep -qE \"task_status_is_done\\(\\)\" \"$F\" && grep -qE \"task_label_present\\(\\)|task_has_label\\(\\)\" \"$F\" && grep -qE \"^[[:space:]]*LOOP_DONE_LABEL=\" \"$F\" && grep -qE \"ensure_label_exists\\(\\)|task_ensure_label_exists\\(\\)\" \"$F\"'"
+ears_language: ko
+---
+
+# loop.sh의 done·blocked 신호 검출·발행 매체 교체 + label name 자동 관리
+
+## 무엇을 만들 것인가
+
+autopilot 드라이버 `loop.sh`에서 done 신호와 blocked 신호의 *검출*과 *발행* 매체를 추상 어휘의 단일 의존(검출 키)으로 단일화한다. 완료 신호의 검출 키는 task 식별자에 부속된 label(예: `loop:done`)이고, 정지 신호의 검출 키는 task 상태 field 값(예: `Blocked`)이다. 양쪽 모두 인간 가독·로그를 위한 신호 발행은 함께 유지하되, 드라이버의 판정 분기는 label·status에만 의존한다.
+
+본 child는 다음을 추가하거나 교체한다:
+
+- **task_status_is_done() 함수의 정식 재구성** — milestone 진행 동안 적용된 hotfix(comment prefix 마지막 매치 기반)는 임시 조치이며, 본 child가 정식으로 label 검출로 교체한다. comment 기반 검색은 더 이상 단일 검출 키가 아니다.
+- **task_label_present() 헬퍼 함수** — task 식별자가 주어졌을 때 그 task에 특정 label이 붙어 있는지를 boolean으로 반환하는 추상 헬퍼.
+- **LOOP_DONE_LABEL 상수** — 완료 label의 이름(예: `loop:done`). 프로젝트 수준에서 고정되며 드라이버가 부재 시 자동 생성·재사용한다.
+- **ensure_label_exists() 헬퍼 함수** — task storage에 해당 label이 존재하는지 확인하고, 없으면 만든다. 사용자가 별도 입력하지 않아도 드라이버가 self-bootstrap한다.
+- **신호 발행 부분의 이중 발행** — 워커가 완료 시 `[done]` 신호 발행(가독·로그)과 `loop:done` label 추가(검출 키) 두 동작을 모두 수행하도록 헌법·SKILL.md가 지시하는데, 드라이버는 검출 시점에 label만 본다. 본 child가 그 검출 경로를 단일화한다.
+- **blocked 검출** — task_status_is_blocked()는 이미 status field와 comment OR 결합. 본 child가 단일 의존(status field만)으로 단순화한다. 단, project status 자동 전이가 미구현인 환경(`AUTOPILOT_PROJECT_ITEM_ID` 미설정)을 위한 graceful degradation은 헬퍼 호출의 best-effort로 유지하되 판정 키는 label·status 단일 의존을 깨지 않는다.
+- **comment 기반 검출 코드 제거** — 0.2.0 호환 잔존 `$WT/DONE` 파일 체크와 hotfix의 comment prefix 검색은 본 child의 새 단일 검출 경로(label·status)가 동작하기 시작하면 제거한다. 호환을 위한 OR 결합은 milestone 종료 후 사용자가 결정할 수 있도록 frontmatter 또는 환경 변수로 분리.
+
+## 수용 기준 (EARS)
+
+1. `plugins/autopilot/skills/loop/references/loop.sh`가 존재할 때, 시스템은 bash 문법 검사(`bash -n`)에서 0 exit으로 통과한다.
+2. `loop.sh`에 `task_status_is_done()` 함수가 정의되어 있을 때, 시스템은 그 함수가 task 식별자를 인자로 받아 task에 `LOOP_DONE_LABEL` 값과 일치하는 label이 붙어 있을 때만 0(done)을 반환하도록 구현한다.
+3. `loop.sh`에 `task_label_present()` 헬퍼 함수가 정의될 때, 시스템은 그 함수가 task 식별자와 label 이름을 받아 label 존재 여부를 0/1로 반환한다.
+4. `loop.sh`에 `LOOP_DONE_LABEL=` 상수가 정의될 때, 시스템은 그 값이 단일 위치에서 결정되어 프로젝트 수준에서 고정된다(다른 모듈에 분산 정의 금지).
+5. `loop.sh`에 `ensure_label_exists()` 헬퍼 함수가 정의될 때, 시스템은 task storage에 해당 label이 없으면 자동 생성하고, 있으면 그대로 재사용한다.
+6. 본 child가 `loop.sh`를 재작성하는 동안, 시스템은 sibling child(헌법·SKILL.md·기타 references)의 파일을 수정하지 않는다.
+
+## 범위
+
+포함:
+
+- `plugins/autopilot/skills/loop/references/loop.sh`의 done·blocked 신호 검출 경로를 label·status 단일 의존으로 재구성
+- 새 헬퍼 함수 추가: `task_status_is_done`(정식), `task_label_present`, `ensure_label_exists`
+- 새 상수 `LOOP_DONE_LABEL` 정의 및 label 자동 생성·재사용 로직
+- comment 기반 검출 코드(hotfix·0.2.0 호환 잔존) 제거 또는 단일 검출 키 외부로 분리
+
+비-목표 / 제외:
+
+- 헌법 본문 변경 — sibling child-a 담당
+- SKILL.md 어휘 변경 — sibling child-b 담당
+- 보조 references *.md 정리 — sibling child-d 담당
+- phase script(`pr-phase.sh`·`rebase-phase.sh`·`review-fix-phase.sh`·`cleanup-phase.sh`) 변경 — task storage 호출이 없어 본 milestone scope 외
+- `rules/context.md` 변경 — 본 milestone의 명시 비-목표
+- adapter 인터페이스 신설 — 본 milestone의 명시 비-목표. 헬퍼 함수명·매개변수 수준의 추상화는 허용하되 다중 구현을 분기하는 dispatcher·인터페이스 객체는 만들지 않는다.
+- 기존 [done]·[blocked] prefix comment 히스토리 마이그레이션
+
+## 검증
+
+이 명령이 0 exit으로 끝나야 합니다:
+
+```bash
+bash -c 'set -e; F=plugins/autopilot/skills/loop/references/loop.sh; test -f "$F" && bash -n "$F" && grep -qE "task_status_is_done\(\)" "$F" && grep -qE "task_label_present\(\)|task_has_label\(\)" "$F" && grep -qE "^[[:space:]]*LOOP_DONE_LABEL=" "$F" && grep -qE "ensure_label_exists\(\)|task_ensure_label_exists\(\)" "$F"'
+```
+
+## 제약
+
+- `feedback_no_self_apply_during_spec` 메모리 룰: 본 SPEC.md를 작성하는 *현재* spec 호출에는 새 검출 contract를 선행 적용하지 않는다.
+- `feedback_self_referential_verification` 메모리 룰: 워커는 verify·worktree source(직접 변경한 `loop.sh`)만 검사하고 runtime artifact(자기 task의 issue label·다른 task의 검출 동작)는 검사 대상에서 제외한다. 본 child는 자기 task의 완료 검출이 *자기 자신을 통해* 작동하는 self-referential 함정에 가장 취약한 child다.
+- 본 child는 wave 2에 속하며 wave 1의 child-a 산출물(헌법의 어휘 정의)을 입력으로 사용한다.
+- `LOOP_DONE_LABEL`의 기본값(예: `loop:done`)은 단일 위치에서 결정되며 프로젝트 수준에서 고정. 사용자가 환경 변수로 override할 수 있도록 fallback 패턴을 따른다(예: `: "${LOOP_DONE_LABEL:=loop:done}"`).
+
+## 위험
+
+- **self-referential 함정 (최대 위험)**: 본 child가 `loop.sh`의 done 검출 로직을 수정하는 동안, 워커 자신의 task 완료가 자기 변경한 검출 로직으로 판정된다. 워커가 verify 통과 후 완료 신호(label·comment) 발행을 정확히 따라야 자기 task의 완료가 인식된다. milestone 진행 동안 적용된 hotfix(comment prefix 마지막 매치)는 본 child가 정식 label 검출로 교체하기 *전*까지는 유효해야 하므로, 본 child의 워커는 자기 변경의 부분적 적용(예: 새 헬퍼는 추가했지만 호출 사이트는 아직 안 옮긴 상태)이 자기 검출을 깨뜨리지 않도록 변경을 단일 commit으로 묶거나 호환 OR 결합을 유지한 채로 종료해야 한다.
+- **adapter 유혹**: "이참에 label 검출 헬퍼를 task storage adapter 인터페이스로 추상화하자"는 유혹. 비-목표에 명시 금지. 헬퍼 함수명은 추상이지만 본문 구현은 단일 GitHub 호출(`gh issue view --json labels`)을 그대로 사용한다.
+- **label 자동 생성 권한 부족**: task storage에 label 생성 권한이 없는 환경에서 `ensure_label_exists`가 실패할 수 있다. 그 경우 best-effort로 stderr 경고 + 검출 1(false) 반환. 본 SPEC §검증은 함수 정의의 grep만 보므로 runtime 실패는 본 verify 범위 밖.
+- **하위 호환**: 기존 워커가 발행한 `[done]` prefix comment만 있고 label이 없는 task는 본 child 적용 후 영원히 done 판정 안 됨. PRD §제약 "소급 마이그레이션 없음"에 따라 의도된 동작. 본 milestone 이전 issue는 수동 처리.

--- a/milestones/2026-05-backing-abstraction/prd/PRD.md
+++ b/milestones/2026-05-backing-abstraction/prd/PRD.md
@@ -1,0 +1,64 @@
+# autopilot 설계·드라이버의 backing-neutral 어휘 + native signal 매체 교체
+
+**Milestone**: 2026-05-backing-abstraction
+
+## 문제
+
+현 autopilot은 task의 backing system(=구체적 task storage·workflow 백엔드. 본 프로젝트의 경우 GitHub Issue + Project)에 강결합되어 있다. 두 측면에서 문제가 나타난다.
+
+첫째, 설계 문서 차원: 헌법(`constitution.md`)·SKILL.md·`references/*.md`의 곳곳에서 "task issue body", "[done] prefix comment", "Project Status field" 같은 backing-specific 표현이 직접 노출된다. 이로 인해 같은 추상 동작(예: "완료 신호 표시")이 매체 이름으로 산재해 기술되고, 향후 다른 backing을 채택할 가능성을 검토하기 전부터 한 backing의 어휘에 갇혀 있다.
+
+둘째, 신호 검출 차원: 워커가 완료 시 발행하는 `[done]` prefix comment를 드라이버(`loop.sh`)가 안정적으로 검출하지 못한다. 0.2.1 헌법은 신호 매체를 comment prefix로 정의했지만 `loop.sh`는 워크트리의 `$WT/DONE` 파일을 체크하는 구 컨벤션 잔존 코드를 사용한다. 그 결과 워커가 매 이터마다 `[done]` comment를 발행하며 수렴해 있어도 드라이버는 이를 모르고 이터 상한(예: 30회)까지 회전하다 자동 `[blocked]` comment로 에스컬레이션된다. 같은 매체에서 발행·검출이 일치하지 않는 한, 이 부정합은 향후 다른 매체로 옮기더라도 반복될 위험이 있다.
+
+두 측면은 한 뿌리에서 나온 증상이다 — 설계와 구현이 backing의 구체 어휘를 같은 자리에서 다루지 않아 매체 변경이 산발적으로 일어나고, 결국 사용자가 매번 부정합을 추적해 고쳐야 한다.
+
+## 목표·비전
+
+스킬 패키지 내 모든 설계 문서(헌법·SKILL.md·`references/*.md`)와 드라이버 코드(`loop.sh`·`pr-phase.sh`·`rebase-phase.sh`·`review-fix-phase.sh`·`cleanup-phase.sh`)가 task backing system을 **backing-neutral 추상 어휘**로 일관 기술한다. 그 추상에서 정의된 동작 — 예: "task에 label 추가", "task의 label 검색", "task status를 X로 전이" — 은 현 GitHub 구현 위에서 그대로 수행된다.
+
+이 milestone은 추상 어휘 layer를 도입하되 **adapter 인터페이스를 신설하거나 다른 backing 구현을 추가하지 않는다**. 단일 GitHub 구현 위에 어휘 layer만 얹어 향후 다른 backing 검토 시 분기 지점을 명확히 한다.
+
+신호 매체 차원에서는 완료 신호를 GitHub label(예: `loop:done`)로, 정지 신호를 GitHub Project Status field 전이(예: `Blocked`)로 단일화한다. 인간 가독·로그를 위한 `[done]`·`[blocked]` prefix comment는 양쪽 모두 함께 발행하되 드라이버 검출 키는 label·status에 단일 의존한다.
+
+## 성공 기준
+
+- 헌법·SKILL.md·`references/*.md`의 텍스트가 backing-neutral 어휘로 일관 기술되어, backing-specific section(예: 헌법의 "GitHub 구현 절" 같은 명시 영역) 외부에서는 "comment prefix", "gh issue body" 같은 구체 표현이 노출되지 않는다.
+- `loop.sh`의 done 신호 검출이 GitHub label 검색(예: `loop:done`)으로 동작하고, blocked 신호 검출이 GitHub Project Status field(예: `Blocked`)로 동작한다. 두 신호 모두 가독·로그용 comment 발행은 유지하되 검출 키는 label·status에 단일 의존한다.
+- 기존 `[done]`·`[blocked]` prefix comment 히스토리는 마이그레이션 없이 보존된다 — 본 milestone 이전에 발행된 comment는 그대로 남고, 본 milestone 이후 발행되는 신호부터만 새 매체로 전환된다.
+- adapter 인터페이스·다른 backing 구현·`rules/context.md` 변경·산출물(SPEC.md·PRD.md·issue body 등) 자동 마이그레이션은 본 milestone에서 일어나지 않는다 (각 child SPEC도 동일).
+- 자율 loop이 이 milestone의 child task를 처리할 때, 워커의 완료 발행과 드라이버의 검출이 일치해 이터 상한 도달 없이 정상 종료한다 — 본 milestone이 해결한 부정합이 child task 실행 자체에서 재현되지 않음을 입증.
+
+## 범위
+
+포함:
+
+- `plugins/autopilot/skills/<skill>/SKILL.md` (spec·loop·prd·dispatch) 4개의 backing-neutral 어휘 재작성
+- `plugins/autopilot/skills/loop/references/constitution.md`의 backing-neutral 어휘 재작성 — 특히 §11(이터간 컨텍스트 운영) 및 §5(정지)·§3.4(완료 판정)
+- `plugins/autopilot/skills/loop/references/{loop,pr-phase,rebase-phase,review-fix-phase,cleanup-phase}.sh`의 backing 호출 식별·추상 헬퍼로 묶기 + done 신호 검출(comment 검색 → label 검색)·blocked 신호 검출(comment 검색 → Project Status field 조회) 교체
+- 새 label name 고정 정의(예: `loop:done`)와 부재 시 자동 생성·재사용 로직
+- `plugins/autopilot/skills/loop/references/{handoff,notes,plan,runlog,escalation}-template.md` 등 보조 문서에서 backing-specific 표현 정리 (없으면 무변경)
+
+비-목표 / 제외:
+
+- adapter/interface 신설 — 추상 어휘 layer는 텍스트 차원과 헬퍼 함수명 차원에서만 적용. 다중 구현을 분기하는 dispatcher는 만들지 않는다
+- 다른 backing 구현(파일 기반·Linear·Jira 등) 추가
+- `rules/context.md` 변경 — 본 프로젝트는 의도적으로 GitHub Project+Issue를 구체화로 채택했으므로 본 milestone의 어휘 추상화 대상에서 명시 제외
+- 스킬 산출물(SPEC.md·PRD.md·issue body·기존 prefix comment 히스토리) 자동 마이그레이션
+- `gh` CLI 의존 자체 제거 — 현 구현이 `gh`를 사용하는 사실 자체는 유지
+
+## 제약
+
+- 기존 `[done]`·`[blocked]` prefix comment 히스토리는 건들지 않음 — 소급 마이그레이션 없음. 본 milestone 이전 issue의 자동 완료 감지는 포기한다.
+- done = label, blocked = Project Status. 양쪽 모두 가독·로그용 comment 발행은 유지하되 드라이버 검출 키는 label·status에 단일 의존한다.
+- label name (예: `loop:done`)은 프로젝트 수준에서 고정하고, 드라이버가 부재 시 자동 생성·재사용한다. 사용자가 별도 입력하지 않아도 작동.
+- Project Status field 명칭(예: `Blocked`)은 의존하되 변경 시 단일 위치에서 갱신 가능하도록 한 모듈에 집중.
+- `feedback_no_self_apply_during_spec` 메모리 룰에 따라, 본 milestone의 어느 child SPEC도 *자신의 호출* 중 새 contract를 자신의 산출물에 선행 적용하지 않는다 — 새 동작은 다음 spec/loop 호출부터 적용된다.
+
+## 위험
+
+- **self-referential**: autopilot 자체를 소재로 child task를 돌리면 spec·loop이 자기 구현을 수정한다. 각 child SPEC에 `feedback_no_self_apply_during_spec`·`feedback_self_referential_verification` 메모리 룰을 명시해, 검증은 verify·worktree source만 보고 runtime artifact 직접 검사를 금지한다. 각 child loop의 자기 구현 호출 함정 차단.
+- **adapter 유혹**: child 작업 중 "adapter 인터페이스를 만드는 게 깔끔해" 유혹으로 범위가 부풀려질 위험. PRD·child SPEC 각각에 "adapter 신설 금지" 비-목표를 명시. 코드 차원의 추상화는 헬퍼 함수명·매개변수 수준에서만 허용하고 다중 구현을 분기하는 dispatcher·인터페이스 객체는 만들지 않는다.
+
+## 분해 힌트
+
+(없음 — dispatch에 맡김)

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -195,8 +195,11 @@ task_status_is_done() {
 # 로그 채널이며 판정에 사용되지 않는다 — 워커가 [blocked] prefix comment 발행과
 # 함께 Status=Blocked 전이 두 동작을 모두 수행해야 0(blocked)을 반환한다.
 # graceful degradation: AUTOPILOT_PROJECT_ITEM_ID 미설정·gh 부재·GraphQL 실패는
-# best-effort로 stderr WARN + 1(판정 불가) 반환 — 검출 키를 comment로 이중화하지
-# 않는다 (SPEC 134 §제약 "판정 키는 label·status 단일 의존을 깨지 않는다").
+# 1(판정 불가)로 조용히 폴백한다 (검출 키를 comment로 이중화하지 않는다 — SPEC 134
+# §제약 "판정 키는 label·status 단일 의존을 깨지 않는다"). 침묵 폴백 이유: 본 함수는
+# `list` 서브커맨드의 task별 순회와 `--watch` 모드의 60초 polling 루프에서 호출되어
+# WARN을 매번 출력하면 로그 플러딩 — 미설정 환경에서 idle 판정으로 자연 폴백하는 게
+# 설계 의도다. 디버깅 시 `gh api graphql` 직접 호출로 원인 분리.
 # 반환: 0=blocked, 1=blocked 아님(판정 불가 포함).
 task_status_is_blocked() {
   # task-id 매개변수는 시그니처 유지 위해 받지만 Status는 ITEM_ID 기반이라 직접

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -190,56 +190,31 @@ task_status_is_done() {
   task_label_present "$task_id" "$LOOP_DONE_LABEL"
 }
 
-# task issue의 차단 신호 검사 (헌법 §5·§12, SPEC AC4·8).
-# Status·comment 두 신호의 OR 결합 — 어느 한쪽이라도 차단을 가리키면 blocked.
-#   1. AUTOPILOT_PROJECT_ITEM_ID가 설정돼 있고 GraphQL Status가 정확히 "Blocked"이면
-#      그 자리에서 0(blocked) 반환. early-exit short-circuit.
-#   2. 그 외 모든 경로(Status가 In Progress 등 / GraphQL 실패 / ITEM_ID 미설정)는
-#      comment fallback으로 fallthrough — 가장 최근에 매치된 prefix가 `[blocked]`이면
-#      0, `[unblocked]`/`[resume]`이면 1.
-# 자동 Status 전이가 미구현이므로 워커가 `[blocked]` comment를 발행해도 Status는
-# In Progress로 남는다. 따라서 차단 발효는 comment 신호가 단일 진실원이며, Status는
-# 사람의 명시적 Blocked 전이가 있을 때만 부가 신호로 기능한다. Unblock 절차도
-# `[unblocked]`/`[resume]` prefix comment 발행이 정식 — Status UI 변경만으로는
-# fallback이 여전히 `[blocked]`를 감지해 차단이 유지됨에 주의.
+# task issue의 차단 신호 검사 (헌법 §5·§12, SPEC 134 §제약).
+# 정식 검출 키: Project Status field 값(`Blocked`) 단일 의존. comment 본문은 가독·
+# 로그 채널이며 판정에 사용되지 않는다 — 워커가 [blocked] prefix comment 발행과
+# 함께 Status=Blocked 전이 두 동작을 모두 수행해야 0(blocked)을 반환한다.
+# graceful degradation: AUTOPILOT_PROJECT_ITEM_ID 미설정·gh 부재·GraphQL 실패는
+# best-effort로 stderr WARN + 1(판정 불가) 반환 — 검출 키를 comment로 이중화하지
+# 않는다 (SPEC 134 §제약 "판정 키는 label·status 단일 의존을 깨지 않는다").
 # 반환: 0=blocked, 1=blocked 아님(판정 불가 포함).
 task_status_is_blocked() {
-  local task_id="${1:-$TASK_ID}"
-  local issue
-  issue=$(task_issue_number "$task_id" 2>/dev/null) || return 1
+  # task-id 매개변수는 시그니처 유지 위해 받지만 Status는 ITEM_ID 기반이라 직접
+  # 사용하지 않는다 (label·issue 매핑 없음).
+  : "${1:-${TASK_ID:-}}"
   if ! command -v gh >/dev/null 2>&1; then
     return 1
   fi
-
-  # 1차: Project Status가 명시적으로 Blocked이면 즉시 blocked 판정.
-  # non-Blocked·응답 비어있음·GraphQL 실패 → comment fallback으로 fallthrough.
-  # 이유: Status 자동 전이가 미구현이므로 워커가 [blocked] comment를 발행해도
-  # Status는 In Progress 그대로 남는다. 두 신호를 OR로 결합해야 ITEM_ID 설정
-  # 환경에서도 [blocked] comment 기반 차단이 작동한다 (SPEC AC5).
-  if [[ -n "${AUTOPILOT_PROJECT_ITEM_ID:-}" ]]; then
-    local status
-    status=$(gh api graphql -f query='
-      query($id:ID!){ node(id:$id){ ... on ProjectV2Item {
-        fieldValueByName(name:"Status"){ ... on ProjectV2ItemFieldSingleSelectValue { name } } } } }' \
-      -f id="$AUTOPILOT_PROJECT_ITEM_ID" \
-      --jq '.data.node.fieldValueByName.name // empty' 2>/dev/null || true)
-    if [[ "$status" == "Blocked" ]]; then
-      return 0
-    fi
+  if [[ -z "${AUTOPILOT_PROJECT_ITEM_ID:-}" ]]; then
+    return 1
   fi
-
-  # 2차: comment-only fallback. [blocked] 이후 [unblocked]/[resume] 유무로 판정.
-  # capture는 매치 실패 시 jq 에러를 던지므로 `?`로 흡수해 stream에서 제거하고,
-  # 매치된 prefix 값만 모은 배열의 마지막 요소를 선택. 비-prefix comment가 마지막에
-  # 추가돼도 그 요소는 배열에 들어가지 않으므로 false-unblock 발생 안 함.
-  local last_prefix
-  last_prefix=$(gh issue view "$issue" --json comments \
-    --jq '[.comments[]
-            | (.body | split("\n")[0])
-            | (capture("^\\[(?<p>blocked|unblocked|resume)\\]") | .p)?
-            | select(. != null)]
-          | last // empty' 2>/dev/null || true)
-  [[ "$last_prefix" == "blocked" ]] && return 0
+  local status
+  status=$(gh api graphql -f query='
+    query($id:ID!){ node(id:$id){ ... on ProjectV2Item {
+      fieldValueByName(name:"Status"){ ... on ProjectV2ItemFieldSingleSelectValue { name } } } } }' \
+    -f id="$AUTOPILOT_PROJECT_ITEM_ID" \
+    --jq '.data.node.fieldValueByName.name // empty' 2>/dev/null || true)
+  [[ "$status" == "Blocked" ]] && return 0
   return 1
 }
 

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -56,6 +56,15 @@ Bash(ls:*),\
 Read,Edit,Write,Glob,Grep"
 export AUTOPILOT_REBASE_ALLOWED_TOOLS
 
+# ----- task storage 검출 키 (SPEC 134 AC4) -----
+#
+# 완료 신호의 검출 키는 task 식별자에 부속된 label 이름이다 (헌법 §12, SKILL.md).
+# 워커가 완료 시 `[done]` prefix comment(가독·로그)와 본 label 추가(검출 키)를 모두
+# 수행해야 드라이버가 done으로 판정한다. comment 본문은 더 이상 단일 검출 키가 아니다.
+# 환경 변수 override 허용 — 단, label 이름은 프로젝트 수준에서 단일 위치에 고정되어
+# task storage adapter 다중 분기를 만들지 않는다 (SPEC 134 §비-목표).
+LOOP_DONE_LABEL="${LOOP_DONE_LABEL:-loop:done}"
+
 # ----- 헬퍼 -----
 
 die() {
@@ -115,6 +124,70 @@ task_issue_number() {
     return 0
   fi
   return 1
+}
+
+# task issue에 특정 label이 붙어 있는지 boolean 검사 (SPEC 134 AC3).
+# 인자: $1=task-id (생략 시 $TASK_ID), $2=label 이름 (필수).
+# 반환: 0=label 존재, 1=label 부재 또는 판정 불가 (issue 매핑 실패·gh 부재 포함).
+# 구현은 단일 GitHub 호출(`gh issue view --json labels`)로 한정 — adapter 인터페이스
+# 신설 없음 (SPEC 134 §비-목표).
+task_label_present() {
+  local task_id="${1:-$TASK_ID}"
+  local label="${2:-}"
+  [[ -z "$label" ]] && return 1
+  local issue
+  issue=$(task_issue_number "$task_id" 2>/dev/null) || return 1
+  if ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+  # gh CLI의 `--jq`는 단일 expression 인자만 받아 jq의 `--arg`를 통과시키지 않으므로
+  # name 목록만 추출해 셸에서 정확 일치 비교 (grep -F -x).
+  local names
+  names=$(gh issue view "$issue" --json labels \
+    --jq '.labels[].name' 2>/dev/null || true)
+  [[ -z "$names" ]] && return 1
+  printf '%s\n' "$names" | grep -qxF "$label" && return 0
+  return 1
+}
+
+# task storage에 label이 존재하는지 확인하고, 없으면 자동 생성 (SPEC 134 AC5).
+# 인자: $1=label 이름 (필수).
+# 권한 부족·gh 부재 시 best-effort로 stderr WARN + 비-0 반환 (비차단 진행).
+# SPEC 134 §위험 "label 자동 생성 권한 부족" — runtime 실패는 verify 범위 밖.
+ensure_label_exists() {
+  local label="${1:-}"
+  [[ -z "$label" ]] && return 1
+  if ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+  # 존재 여부 확인 — `gh label list --search`는 prefix·substring을 함께 반환할 수
+  # 있으므로 name 목록만 추출 후 셸에서 정확 일치 비교 (gh `--jq`는 jq `--arg`를
+  # 통과시키지 않아 셸 비교가 안전).
+  local names
+  names=$(gh label list --search "$label" --json name \
+    --jq '.[].name' 2>/dev/null || true)
+  if [[ -n "$names" ]] && printf '%s\n' "$names" | grep -qxF "$label"; then
+    return 0
+  fi
+  # 미존재 — 생성 시도. race 또는 권한 부족 시 WARN.
+  if ! gh label create "$label" \
+        --description "autopilot loop 완료 신호 (드라이버 검출 키)" \
+        >/dev/null 2>&1; then
+    echo "[$(now_iso)] WARN: label '$label' 자동 생성 실패 — 권한 부족·race·gh 응답 비정상. 수동 생성 필요." >&2
+    return 1
+  fi
+  echo "[$(now_iso)] label '$label' 자동 생성 완료." >&2
+  return 0
+}
+
+# task issue의 완료 신호 검사 (헌법 §12, SPEC 134 AC2).
+# 정식 검출 키: task issue에 LOOP_DONE_LABEL 값과 일치하는 label이 붙어 있는지.
+# comment 본문은 가독·로그 채널이며 판정에 사용되지 않는다 — 워커가 [done] prefix
+# comment 발행과 함께 label 추가 두 동작을 모두 수행해야 0(done)을 반환한다.
+# 반환: 0=done, 1=done 아님(판정 불가 포함).
+task_status_is_done() {
+  local task_id="${1:-$TASK_ID}"
+  task_label_present "$task_id" "$LOOP_DONE_LABEL"
 }
 
 # task issue의 차단 신호 검사 (헌법 §5·§12, SPEC AC4·8).
@@ -809,8 +882,11 @@ iterate() {
     CLAUDE_FAIL_STREAK=0
   fi
 
-  # 종료 신호 검사 (먼저)
-  if [[ -f "$WT/DONE" ]]; then
+  # 종료 신호 검사 (먼저) — 헌법 §12, SPEC 134 AC2.
+  # 정식 검출 키: task issue에 LOOP_DONE_LABEL이 붙어 있는지 (task_status_is_done).
+  # 호환 OR 결합: 0.2.0 잔존 $WT/DONE 파일 신호도 수용 — milestone 종료 후
+  # 사용자 결정으로 제거 예정 (SPEC 134 §제약 "호환 OR 결합 유지").
+  if task_status_is_done "$TASK_ID" || [[ -f "$WT/DONE" ]]; then
     return 100   # 메인 루프에서 정상 종료 처리
   fi
   # 워커가 진행 불가 보고 시 task issue에 [blocked] prefix comment + Status=Blocked 전이 (헌법 §5.2, SPEC AC5).
@@ -969,6 +1045,12 @@ cmd_start() {
 
   # 5. 락 획득
   acquire_lock
+
+  # 5.5. 완료 신호 label self-bootstrap (SPEC 134 AC5).
+  # task storage에 LOOP_DONE_LABEL이 없으면 자동 생성. 권한 부족·gh 부재 시
+  # WARN 후 비차단 — 워커가 label 추가에 실패해도 $WT/DONE 호환 OR 결합으로
+  # 완료 감지가 깨지지 않는다.
+  ensure_label_exists "$LOOP_DONE_LABEL" || true
 
   # 6. 워크트리 생성 (없는 경우)
   if [[ ! -d "$WT" ]]; then


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가

autopilot 드라이버 `loop.sh`에서 done 신호와 blocked 신호의 *검출*과 *발행* 매체를 추상 어휘의 단일 의존(검출 키)으로 단일화한다. 완료 신호의 검출 키는 task 식별자에 부속된 label(예: `loop:done`)이고, 정지 신호의 검출 키는 task 상태 field 값(예: `Blocked`)이다. 양쪽 모두 인간 가독·로그를 위한 신호 발행은 함께 유지하되, 드라이버의 판정 분기는 label·status에만 의존한다.

본 child는 다음을 추가하거나 교체한다:

- **task_status_is_done() 함수의 정식 재구성** — milestone 진행 동안 적용된 hotfix(comment prefix 마지막 매치 기반)는 임시 조치이며, 본 child가 정식으로 label 검출로 교체한다. comment 기반 검색은 더 이상 단일 검출 키가 아니다.
- **task_label_present() 헬퍼 함수** — task 식별자가 주어졌을 때 그 task에 특정 label이 붙어 있는지를 boolean으로 반환하는 추상 헬퍼.
- **LOOP_DONE_LABEL 상수** — 완료 label의 이름(예: `loop:done`). 프로젝트 수준에서 고정되며 드라이버가 부재 시 자동 생성·재사용한다.
- **ensure_label_exists() 헬퍼 함수** — task storage에 해당 label이 존재하는지 확인하고, 없으면 만든다. 사용자가 별도 입력하지 않아도 드라이버가 self-bootstrap한다.
- **신호 발행 부분의 이중 발행** — 워커가 완료 시 `[done]` 신호 발행(가독·로그)과 `loop:done` label 추가(검출 키) 두 동작을 모두 수행하도록 헌법·SKILL.md가 지시하는데, 드라이버는 검출 시점에 label만 본다. 본 child가 그 검출 경로를 단일화한다.
- **blocked 검출** — task_status_is_blocked()는 이미 status field와 comment OR 결합. 본 child가 단일 의존(status field만)으로 단순화한다. 단, project status 자동 전이가 미구현인 환경(`AUTOPILOT_PROJECT_ITEM_ID` 미설정)을 위한 graceful degradation은 헬퍼 호출의 best-effort로 유지하되 판정 키는 label·status 단일 의존을 깨지 않는다.
- **comment 기반 검출 코드 제거** — 0.2.0 호환 잔존 `$WT/DONE` 파일 체크와 hotfix의 comment prefix 검색은 본 child의 새 단일 검출 경로(label·status)가 동작하기 시작하면 제거한다. 호환을 위한 OR 결합은 milestone 종료 후 사용자가 결정할 수 있도록 frontmatter 또는 환경 변수로 분리.

## Commits
- d7bd141 feat(autopilot/loop): done/blocked 검출·발행 매체를 label·status 단일 의존으로 단일화 (SPEC 134)
- 544bf54 feat(spec): 134 — loop.sh done·blocked signal media to label·status + label auto-management
- 0a47eda docs(dispatch): 2026-05-backing-abstraction — DAG.md (게이트 ① 승인 후)
- af58abe docs(prd): 2026-05-backing-abstraction — autopilot 설계·드라이버 backing-neutral 어휘 + native signal 매체 교체

Closes #134
<!-- autopilot:pr-body:end -->