### PR TITLE
SKILL.md 4개(spec·loop·prd·dispatch) backing-neutral 어휘 재작성

### DIFF
--- a/milestones/2026-05-backing-abstraction/dispatch/DAG.md
+++ b/milestones/2026-05-backing-abstraction/dispatch/DAG.md
@@ -1,0 +1,37 @@
+# DAG — 2026-05-backing-abstraction
+
+`milestones/2026-05-backing-abstraction/prd/PRD.md`의 분해 결과. dispatch가 게이트 ① 승인 후 작성.
+
+생성 시각: 2026-05-16T02:50Z
+
+## 단위 목록
+
+- child-a: constitution.md backing-neutral 어휘 재작성
+  - 영향 파일: plugins/autopilot/skills/loop/references/constitution.md
+  - verify: backing-specific terms grep (comment prefix·issue body·Project Status 등)이 backing-specific section 외부에서 0
+  - 의존성: 없음
+- child-b: SKILL.md 4개(spec·loop·prd·dispatch) backing-neutral 어휘 재작성
+  - 영향 파일: plugins/autopilot/skills/spec/SKILL.md, plugins/autopilot/skills/loop/SKILL.md, plugins/autopilot/skills/prd/SKILL.md, plugins/autopilot/skills/dispatch/SKILL.md
+  - verify: 4개 파일 backing-specific terms grep
+  - 의존성: child-a (헌법 어휘 차용)
+- child-c: loop.sh의 done·blocked 신호 검출·발행 매체 교체 + label name 자동 관리
+  - 영향 파일: plugins/autopilot/skills/loop/references/loop.sh
+  - verify: comment-based detect 코드 부재(last_prefix·prefix comment 검색 코드 없음) + 새 추상 헬퍼 함수 grep + label name 자동 생성·재사용 로직 확인
+  - 의존성: child-a (헌법 어휘 차용)
+- child-d: references 보조 .md(operational-guide·troubleshooting·status-format·agent-prompts) 잔존 표현 정리
+  - 영향 파일: plugins/autopilot/skills/loop/references/operational-guide.md, plugins/autopilot/skills/loop/references/troubleshooting.md, plugins/autopilot/skills/loop/references/status-format.md, plugins/autopilot/skills/loop/references/agent-prompts.md
+  - verify: 4개 파일 backing-specific terms grep
+  - 의존성: child-a (헌법 어휘 차용)
+
+## 의존성·wave 정렬
+
+- wave 1 (정의 선행): [child-a]
+- wave 2 (depends on wave 1, parallel-safe): [child-b, child-c, child-d]
+
+## 메모
+
+phase script들(pr-phase·rebase-phase·review-fix-phase·cleanup-phase)은 task storage 호출이 없고 git/PR/cleanup workflow에 한정되어 본 milestone scope 외로 판단해 child 단위에서 제외. 향후 별도 milestone에서 다룰 수 있다.
+
+격리성 확보: wave 2의 3 child는 각각 다른 파일군(SKILL.md / loop.sh / 보조 .md)을 수정해 동시 실행 시 충돌 없음. wave 1의 child-a 산출물(헌법 본문에 정의된 추상 어휘)은 wave 2의 입력 컨텍스트로만 차용되고 파일 동시 수정은 일어나지 않는다.
+
+self-referential 위험 대응: 각 child SPEC 작성 단계에서 `feedback_no_self_apply_during_spec` 메모리 룰 명시 — 현재 호출은 contract 선행 적용 금지. adapter 유혹 차단: 각 child SPEC의 비-목표에 "adapter 신설 금지" 명시.

--- a/milestones/2026-05-backing-abstraction/loops/133-skill-md-4-spec-loop-prd-dispatch-backing-neutral/SPEC.md
+++ b/milestones/2026-05-backing-abstraction/loops/133-skill-md-4-spec-loop-prd-dispatch-backing-neutral/SPEC.md
@@ -1,0 +1,72 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/spec/SKILL.md", "plugins/autopilot/skills/loop/SKILL.md", "plugins/autopilot/skills/prd/SKILL.md", "plugins/autopilot/skills/dispatch/SKILL.md"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash -c 'set -e; for F in plugins/autopilot/skills/spec/SKILL.md plugins/autopilot/skills/loop/SKILL.md plugins/autopilot/skills/prd/SKILL.md plugins/autopilot/skills/dispatch/SKILL.md; do test -f \"$F\" && ! grep -qE \"gh issue|prefix comment|issue body|\\[done\\]|\\[blocked\\]|Project Status field|GitHub Project\" \"$F\"; done'"
+ears_language: ko
+---
+
+# SKILL.md 4개(spec·loop·prd·dispatch) backing-neutral 어휘 재작성
+
+## 무엇을 만들 것인가
+
+autopilot 스킬 패키지의 4개 SKILL.md(spec·loop·prd·dispatch)에서 task의 backing system을 가리키는 모든 backing-specific 표현을 backing-neutral 추상 어휘로 일관 재작성한다. 추상 어휘는 sibling child(헌법 재작성)이 헌법에 정의한 단위(task 메모리·task 신호·task 상태·task 식별자)를 그대로 차용한다 — 본 child가 새 단위를 신설하지 않는다.
+
+SKILL.md는 사용자가 스킬을 호출하기 전 읽는 인터페이스 문서이므로 추상 어휘가 일관되어야 헌법-스킬-드라이버 세 층의 표현이 정합한다. 본 child의 산출물은 4개 파일에 한정되며 다른 sibling이 다루는 영역(헌법 본문·드라이버 셸·보조 references)은 손대지 않는다.
+
+각 SKILL.md에서 추상화 대상:
+
+- **spec/SKILL.md** — step 2 "task 상태 정합"의 backing 매핑 표 부분이 유일하게 backing-specific 표현을 명시 등장시키는 영역(GitHub Project + Issue 매핑). 그 외 본문은 추상 어휘로 일관 재작성. 매핑 표 자체는 backing-specific section이므로 보존하되 §외부에서 backing-specific 용어 직접 노출 금지.
+- **loop/SKILL.md** — DONE phase·blocked phase·이터간 메모리 운영 안내가 backing-specific 표현을 사용. 추상 어휘로 재작성.
+- **prd/SKILL.md** — 비교적 backing-neutral하지만 milestone-id ↔ issue 매핑 언급이 있다면 추상화.
+- **dispatch/SKILL.md** — child task ↔ issue 매핑·sentinel 신호 검출 안내 등 backing-specific 표현 추상화.
+
+## 수용 기준 (EARS)
+
+1. `plugins/autopilot/skills/{spec,loop,prd,dispatch}/SKILL.md` 4개 파일 모두 존재할 때, 시스템은 각 본문 전체에서 다음 backing-specific 표현 어느 것도 매칭하지 않는다: `gh issue`, `prefix comment`, `issue body`, `[done]`, `[blocked]`, `Project Status field`, `GitHub Project`.
+2. spec/SKILL.md의 step 2 "task 상태 정합" 절차가 추상 어휘로 재작성될 때, 시스템은 task 상태의 4갈래 분기(부재·설계 상태·설계 이전·설계 이후)를 동일한 의미로 보존하되 GitHub Project 구체 매핑을 본문에서 분리한다.
+3. loop/SKILL.md의 DONE phase·blocked 관련 안내가 추상 어휘로 재작성될 때, 시스템은 완료·정지 신호의 의미를 보존하되 매체 표현(comment·label·status field)에 대한 직접 언급을 본문에서 제거한다.
+4. 본 child가 4개 SKILL.md를 재작성하는 동안, 시스템은 sibling child(헌법·loop.sh·기타 references)의 파일을 수정하지 않는다.
+5. 4개 SKILL.md 중 어느 위치에도 backing-specific 표현이 잔존하는 경우, 시스템은 verify 명령으로 그 잔존을 검출하고 0이 아닌 exit으로 실패 신호를 낸다.
+
+## 범위
+
+포함:
+
+- `plugins/autopilot/skills/spec/SKILL.md`의 backing-specific 표현 추상 어휘로 재작성
+- `plugins/autopilot/skills/loop/SKILL.md`의 backing-specific 표현 추상 어휘로 재작성
+- `plugins/autopilot/skills/prd/SKILL.md`의 backing-specific 표현 추상 어휘로 재작성
+- `plugins/autopilot/skills/dispatch/SKILL.md`의 backing-specific 표현 추상 어휘로 재작성
+
+비-목표 / 제외:
+
+- 헌법(`constitution.md`) 재작성 — sibling child-a 담당. 본 child는 헌법이 정의한 추상 어휘를 차용한다.
+- `loop.sh`·기타 phase script 코드 변경 — sibling child-c 담당
+- 보조 references *.md(operational-guide·troubleshooting·status-format·agent-prompts) — sibling child-d 담당
+- `rules/context.md` 변경 — 본 milestone의 명시 비-목표
+- adapter 인터페이스 신설 — 본 milestone의 명시 비-목표
+- SKILL.md의 워크플로 단계 자체 변경 — 본 child는 어휘 재작성만, 단계 추가·삭제 금지
+
+## 검증
+
+이 명령이 0 exit으로 끝나야 합니다:
+
+```bash
+bash -c 'set -e; for F in plugins/autopilot/skills/spec/SKILL.md plugins/autopilot/skills/loop/SKILL.md plugins/autopilot/skills/prd/SKILL.md plugins/autopilot/skills/dispatch/SKILL.md; do test -f "$F" && ! grep -qE "gh issue|prefix comment|issue body|\[done\]|\[blocked\]|Project Status field|GitHub Project" "$F"; done'
+```
+
+## 제약
+
+- `feedback_no_self_apply_during_spec` 메모리 룰: 본 SPEC.md를 작성하는 *현재* spec 호출에는 새 어휘 contract를 선행 적용하지 않는다.
+- `feedback_self_referential_verification` 메모리 룰: 워커는 verify·worktree source(직접 변경한 4개 SKILL.md)만 검사하고 runtime artifact(다른 issue·SPEC·도구 출력)는 검사 대상에서 제외한다.
+- 추상 어휘 단위는 sibling child-a가 헌법에 정의한 것을 그대로 사용한다 — 본 child가 새 단위를 신설하지 않는다.
+- 본 child는 wave 2에 속하며 wave 1의 child-a 산출물(헌법의 어휘 정의)을 입력으로 사용한다. wave 1이 완료되지 않은 상태에서 본 child가 실행되면 추상 어휘가 본문 안에서만 정의되어 헌법과 단절될 위험이 있으므로 dispatch의 wave 순서를 준수한다.
+
+## 위험
+
+- **self-referential 함정**: 본 child가 spec/SKILL.md·loop/SKILL.md를 수정하는 동안, 워커가 그 SKILL.md를 따라 자기 spec/loop 흐름을 진행한다. 중간 상태 SKILL.md가 워커의 다음 동작을 결정할 수 있으므로 verify는 worktree source의 grep으로 한정한다.
+- **adapter 유혹**: SKILL.md에서 추상 어휘를 도입하면서 "이참에 adapter 인터페이스 호출 절차도 SKILL.md에 명시하면 좋겠다"는 유혹. 비-목표에 명시 금지.
+- **매핑 표 위치 모호**: spec/SKILL.md의 step 2 매핑 표를 본문에 그대로 두면 verify가 잡을 수 있다. 매핑 표는 표제 또는 명시 marker로 backing-specific section임을 표시하고 본문에서 분리하거나, `rules/context.md`로 참조 위임. 본 SPEC §"무엇을 만들 것인가"의 4번 결정.

--- a/milestones/2026-05-backing-abstraction/prd/PRD.md
+++ b/milestones/2026-05-backing-abstraction/prd/PRD.md
@@ -1,0 +1,64 @@
+# autopilot 설계·드라이버의 backing-neutral 어휘 + native signal 매체 교체
+
+**Milestone**: 2026-05-backing-abstraction
+
+## 문제
+
+현 autopilot은 task의 backing system(=구체적 task storage·workflow 백엔드. 본 프로젝트의 경우 GitHub Issue + Project)에 강결합되어 있다. 두 측면에서 문제가 나타난다.
+
+첫째, 설계 문서 차원: 헌법(`constitution.md`)·SKILL.md·`references/*.md`의 곳곳에서 "task issue body", "[done] prefix comment", "Project Status field" 같은 backing-specific 표현이 직접 노출된다. 이로 인해 같은 추상 동작(예: "완료 신호 표시")이 매체 이름으로 산재해 기술되고, 향후 다른 backing을 채택할 가능성을 검토하기 전부터 한 backing의 어휘에 갇혀 있다.
+
+둘째, 신호 검출 차원: 워커가 완료 시 발행하는 `[done]` prefix comment를 드라이버(`loop.sh`)가 안정적으로 검출하지 못한다. 0.2.1 헌법은 신호 매체를 comment prefix로 정의했지만 `loop.sh`는 워크트리의 `$WT/DONE` 파일을 체크하는 구 컨벤션 잔존 코드를 사용한다. 그 결과 워커가 매 이터마다 `[done]` comment를 발행하며 수렴해 있어도 드라이버는 이를 모르고 이터 상한(예: 30회)까지 회전하다 자동 `[blocked]` comment로 에스컬레이션된다. 같은 매체에서 발행·검출이 일치하지 않는 한, 이 부정합은 향후 다른 매체로 옮기더라도 반복될 위험이 있다.
+
+두 측면은 한 뿌리에서 나온 증상이다 — 설계와 구현이 backing의 구체 어휘를 같은 자리에서 다루지 않아 매체 변경이 산발적으로 일어나고, 결국 사용자가 매번 부정합을 추적해 고쳐야 한다.
+
+## 목표·비전
+
+스킬 패키지 내 모든 설계 문서(헌법·SKILL.md·`references/*.md`)와 드라이버 코드(`loop.sh`·`pr-phase.sh`·`rebase-phase.sh`·`review-fix-phase.sh`·`cleanup-phase.sh`)가 task backing system을 **backing-neutral 추상 어휘**로 일관 기술한다. 그 추상에서 정의된 동작 — 예: "task에 label 추가", "task의 label 검색", "task status를 X로 전이" — 은 현 GitHub 구현 위에서 그대로 수행된다.
+
+이 milestone은 추상 어휘 layer를 도입하되 **adapter 인터페이스를 신설하거나 다른 backing 구현을 추가하지 않는다**. 단일 GitHub 구현 위에 어휘 layer만 얹어 향후 다른 backing 검토 시 분기 지점을 명확히 한다.
+
+신호 매체 차원에서는 완료 신호를 GitHub label(예: `loop:done`)로, 정지 신호를 GitHub Project Status field 전이(예: `Blocked`)로 단일화한다. 인간 가독·로그를 위한 `[done]`·`[blocked]` prefix comment는 양쪽 모두 함께 발행하되 드라이버 검출 키는 label·status에 단일 의존한다.
+
+## 성공 기준
+
+- 헌법·SKILL.md·`references/*.md`의 텍스트가 backing-neutral 어휘로 일관 기술되어, backing-specific section(예: 헌법의 "GitHub 구현 절" 같은 명시 영역) 외부에서는 "comment prefix", "gh issue body" 같은 구체 표현이 노출되지 않는다.
+- `loop.sh`의 done 신호 검출이 GitHub label 검색(예: `loop:done`)으로 동작하고, blocked 신호 검출이 GitHub Project Status field(예: `Blocked`)로 동작한다. 두 신호 모두 가독·로그용 comment 발행은 유지하되 검출 키는 label·status에 단일 의존한다.
+- 기존 `[done]`·`[blocked]` prefix comment 히스토리는 마이그레이션 없이 보존된다 — 본 milestone 이전에 발행된 comment는 그대로 남고, 본 milestone 이후 발행되는 신호부터만 새 매체로 전환된다.
+- adapter 인터페이스·다른 backing 구현·`rules/context.md` 변경·산출물(SPEC.md·PRD.md·issue body 등) 자동 마이그레이션은 본 milestone에서 일어나지 않는다 (각 child SPEC도 동일).
+- 자율 loop이 이 milestone의 child task를 처리할 때, 워커의 완료 발행과 드라이버의 검출이 일치해 이터 상한 도달 없이 정상 종료한다 — 본 milestone이 해결한 부정합이 child task 실행 자체에서 재현되지 않음을 입증.
+
+## 범위
+
+포함:
+
+- `plugins/autopilot/skills/<skill>/SKILL.md` (spec·loop·prd·dispatch) 4개의 backing-neutral 어휘 재작성
+- `plugins/autopilot/skills/loop/references/constitution.md`의 backing-neutral 어휘 재작성 — 특히 §11(이터간 컨텍스트 운영) 및 §5(정지)·§3.4(완료 판정)
+- `plugins/autopilot/skills/loop/references/{loop,pr-phase,rebase-phase,review-fix-phase,cleanup-phase}.sh`의 backing 호출 식별·추상 헬퍼로 묶기 + done 신호 검출(comment 검색 → label 검색)·blocked 신호 검출(comment 검색 → Project Status field 조회) 교체
+- 새 label name 고정 정의(예: `loop:done`)와 부재 시 자동 생성·재사용 로직
+- `plugins/autopilot/skills/loop/references/{handoff,notes,plan,runlog,escalation}-template.md` 등 보조 문서에서 backing-specific 표현 정리 (없으면 무변경)
+
+비-목표 / 제외:
+
+- adapter/interface 신설 — 추상 어휘 layer는 텍스트 차원과 헬퍼 함수명 차원에서만 적용. 다중 구현을 분기하는 dispatcher는 만들지 않는다
+- 다른 backing 구현(파일 기반·Linear·Jira 등) 추가
+- `rules/context.md` 변경 — 본 프로젝트는 의도적으로 GitHub Project+Issue를 구체화로 채택했으므로 본 milestone의 어휘 추상화 대상에서 명시 제외
+- 스킬 산출물(SPEC.md·PRD.md·issue body·기존 prefix comment 히스토리) 자동 마이그레이션
+- `gh` CLI 의존 자체 제거 — 현 구현이 `gh`를 사용하는 사실 자체는 유지
+
+## 제약
+
+- 기존 `[done]`·`[blocked]` prefix comment 히스토리는 건들지 않음 — 소급 마이그레이션 없음. 본 milestone 이전 issue의 자동 완료 감지는 포기한다.
+- done = label, blocked = Project Status. 양쪽 모두 가독·로그용 comment 발행은 유지하되 드라이버 검출 키는 label·status에 단일 의존한다.
+- label name (예: `loop:done`)은 프로젝트 수준에서 고정하고, 드라이버가 부재 시 자동 생성·재사용한다. 사용자가 별도 입력하지 않아도 작동.
+- Project Status field 명칭(예: `Blocked`)은 의존하되 변경 시 단일 위치에서 갱신 가능하도록 한 모듈에 집중.
+- `feedback_no_self_apply_during_spec` 메모리 룰에 따라, 본 milestone의 어느 child SPEC도 *자신의 호출* 중 새 contract를 자신의 산출물에 선행 적용하지 않는다 — 새 동작은 다음 spec/loop 호출부터 적용된다.
+
+## 위험
+
+- **self-referential**: autopilot 자체를 소재로 child task를 돌리면 spec·loop이 자기 구현을 수정한다. 각 child SPEC에 `feedback_no_self_apply_during_spec`·`feedback_self_referential_verification` 메모리 룰을 명시해, 검증은 verify·worktree source만 보고 runtime artifact 직접 검사를 금지한다. 각 child loop의 자기 구현 호출 함정 차단.
+- **adapter 유혹**: child 작업 중 "adapter 인터페이스를 만드는 게 깔끔해" 유혹으로 범위가 부풀려질 위험. PRD·child SPEC 각각에 "adapter 신설 금지" 비-목표를 명시. 코드 차원의 추상화는 헬퍼 함수명·매개변수 수준에서만 허용하고 다중 구현을 분기하는 dispatcher·인터페이스 객체는 만들지 않는다.
+
+## 분해 힌트
+
+(없음 — dispatch에 맡김)

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Monitor
 
 자율 수행 루프의 통합 운영 인터페이스. 인자로 subcommand와 sub args를 받아 자율 task lifecycle을 관리합니다.
 
-본 스킬은 **자기완결적**입니다 — 워커 헌법(`references/constitution.md`)과 외부 셸 드라이버(`references/loop.sh`)가 이 스킬 패키지에 포함됩니다. target 프로젝트에는 런타임 상태가 모두 `milestones/<m>/loops/<c>/` 단일 nested 트리 안에 생성됩니다 (워크트리 `.worktree/`, lock `.lock`, SPEC). 이터간 메모(계획·교훈·인계·차단·완료)는 GitHub Issue body 계획 섹션과 prefix comment(`[handoff]`·`[notes]`·`[blocked]`·`[done]`)에 누적합니다 — 워크트리에는 메타 파일을 두지 않습니다 (rules/context.md 컨벤션). ad-hoc 단일 task는 `regular` milestone(catch-all)로 자동 정규화됩니다.
+본 스킬은 **자기완결적**입니다 — 워커 헌법(`references/constitution.md`)과 외부 셸 드라이버(`references/loop.sh`)가 이 스킬 패키지에 포함됩니다. target 프로젝트에는 런타임 상태가 모두 `milestones/<m>/loops/<c>/` 단일 nested 트리 안에 생성됩니다 (워크트리 `.worktree/`, lock `.lock`, SPEC). 이터간 메모(계획·교훈·인계·차단·완료)는 **task 메모리**의 계획 섹션과 누적된 **task 신호**(`handoff`·`notes`·`blocked`·`done`)에 모입니다 — 워크트리에는 메타 파일을 두지 않습니다. 추상 어휘는 헌법 §추상 어휘를 단일 출처로 따르고, 본 프로젝트의 백엔드 매핑(메시지 매체·식별자·필드 등)은 `rules/context.md`가 책임집니다. ad-hoc 단일 task는 `regular` milestone(catch-all)로 자동 정규화됩니다.
 
 ## 호출 방법
 
@@ -86,14 +86,14 @@ SPEC frontmatter에 `request_review: true`가 지정된 task만 본 흐름을 �
 | 자동 머지 (auto-merge) | `references/review-fix-phase.sh` 내부 | reviewDecision `APPROVED` 또는 owner의 종료 코멘트(`/done`·`합격`·`통과`)로 `gh pr merge --squash` 수행. PR이 이미 `merged`이면 자동 머지 건너뜀. |
 | cleanup | `references/cleanup-phase.sh` | PR `merged` 후 worktree 제거 + 로컬 feat `branch -D` + origin feat `push --delete`. |
 
-##### 상태 전이 (Status field)
+##### 상태 전이
 
-`rules/context.md`의 추상 상태 어휘에 따라 외부 태스크 추적 시스템(GitHub Project)의 Status 필드를 다음 시점에 전이합니다:
+헌법 §추상 어휘의 **task 상태** 어휘에 따라 다음 시점에 전이합니다:
 
-- PR 생성·재사용 성공 직후 → **Review** (review-fix-phase 진입 시점)
-- cleanup 성공 직후 → **Done**
+- PR 생성·재사용 성공 직후 → task 상태를 `review`로 전이 (review-fix-phase 진입 시점)
+- cleanup 성공 직후 → task 상태를 `done`으로 전이
 
-전이는 `gh project item-edit`로 수행하며, 환경 변수(`LOOP_PROJECT_ID` 등) 부재 시 무음 skip되어 phase 자체는 진행됩니다. 구체 값·매핑은 `rules/context.md` 단일 출처에 의존합니다.
+전이의 구체 명령·환경 변수·라벨 매핑(필요 설정 부재 시 무음 skip 포함)은 `rules/context.md` 단일 출처에 위임됩니다 — phase 자체는 매핑 부재 시에도 진행됩니다.
 
 ##### 종료 조건
 

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec
 description: "기능 추가·동작 수정·지침 작성·새로 만들 등 새 코드 변경을 정의하는 자연어 신호에 대응. autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. 이 레포 표준 워크플로우는 자기완결적 SPEC.md 작성 → feat 브랜치 분기·SPEC commit → autopilot loop 실행 → PR. SPEC.md 작성 후 결정적 슬러그화 규칙(ASCII 영숫자·하이픈만)으로 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·SPEC.md를 commit해 loop·PR 흐름이 단일 feature 브랜치로 통합되게 합니다. 호출 'Skill(skill=\"spec\", args=\"<task-id> [--milestone <m>] [--resume]\")'. milestone 미지정 시 `regular`(catch-all)을 default로 적용."
-allowed-tools: AskUserQuestion, Read, Write, Skill, Agent, Bash(git log:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git show-ref:*), Bash(git for-each-ref:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(echo:*), Bash(head:*), Bash(tr:*), Bash(sed:*), Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh issue create:*), Bash(gh issue edit:*), Bash(gh project item-list:*), Bash(gh project item-edit:*), Bash(gh project item-add:*), Bash(gh api:*)
+allowed-tools: AskUserQuestion, Read, Write, Skill, Agent, Bash(git log:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git show-ref:*), Bash(git for-each-ref:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(echo:*), Bash(head:*), Bash(tr:*), Bash(sed:*), Bash(gh:*)
 ---
 
 # spec
@@ -59,11 +59,11 @@ task-id 형식 검증 실패 또는 자연어 입력 감지 시, 즉시 종료�
 
 ##### 1.2.1 단일 task 규모 수렴 → 프로젝트 태스크 관련 지침
 
-수집된 문제·목표·범위·제약이 단일 task 규모로 정리되면, **프로젝트의 태스크 관련 지침**(예: `CLAUDE.md`·`rules/`의 issue 생성 컨벤션, GitHub project 운영 규칙 등)에 따라 task를 생성해 task-id를 확보한다. 본 스킬은 그 구조를 재정의하지 않고 프로젝트 지침의 issue body 구조(목표·배경·제안·검증 계획·DoD 등)를 그대로 따른다.
+수집된 문제·목표·범위·제약이 단일 task 규모로 정리되면, **프로젝트의 태스크 관련 지침**(예: `CLAUDE.md`·`rules/`의 task 생성 컨벤션·태스크 트래커 운영 규칙 등)에 따라 task를 생성해 task-id를 확보한다. 본 스킬은 그 구조를 재정의하지 않고 프로젝트 지침의 task 본문 구조(목표·배경·제안·검증 계획·DoD 등)를 그대로 따른다.
 
 task-id 확보 후 spec의 **step 2(task 상태 정합)부터 그 task-id로 재개**한다. 라운드에서 합의된 문제·목표·범위·제약은 step 3 이후 단계의 섹션 초안으로 손실 없이 이어진다 (step 7 섹션별 SPEC 제시 시 사전 합의 내용을 초안으로 사용).
 
-task 생성 자체는 외부 도구(`gh` CLI, GitHub project 접근 등 프로젝트 지침이 정한 경로)에 의존한다. 실패 시 사용자에게 명시적으로 알리고 부분 산출물을 남기지 않고 안전하게 종료한다 — `milestones/<m>/loops/<c>/` 디렉터리도 생성하지 않는다.
+task 생성 자체는 프로젝트 지침이 정한 외부 도구(태스크 트래커 CLI·API 등)에 의존한다. 실패 시 사용자에게 명시적으로 알리고 부분 산출물을 남기지 않고 안전하게 종료한다 — `milestones/<m>/loops/<c>/` 디렉터리도 생성하지 않는다.
 
 ##### 1.2.2 마일스톤 규모 수렴 → PRD 라우팅 (AskUserQuestion 승인 필수)
 
@@ -75,30 +75,22 @@ PRD 스킬은 `milestone-id`를 요구하므로, spec은 PRD 스킬을 invoke하
 
 ### 2. task 상태 정합 (일반·--resume 두 모드 공통)
 
-**사전 검사 통과 직후** 실행. task-id로 식별되는 외부 task를 조회하고 4갈래 분기로 상태를 설계 상태(`In Design`)로 정합한다. 본 단계는 일반 모드와 `--resume` 모드 모두에 동일하게 적용된다.
+**사전 검사 통과 직후** 실행. task-id로 식별되는 외부 task를 조회하고 4갈래 분기로 **task 상태**를 설계 상태로 정합한다. 본 단계는 일반 모드와 `--resume` 모드 모두에 동일하게 적용된다.
 
-**백킹 시스템 매핑**: 본 프로젝트는 `rules/context.md`에 따라 **GitHub Project + Issue** 백엔드를 사용한다. 추상 상태 → 구체 매핑:
-
-| 추상 상태 (SPEC) | GitHub Project Status field |
-|---|---|
-| 설계 상태 | `In Design` |
-| 설계 이전 상태 | `Backlog` |
-| 설계 이후 상태 | `In Progress`, `Review`, `Done`, `Blocked`, `Cancelled` 등 그 외 |
-
-task-id ↔ Issue 매핑은 task-id 자체가 issue number(`#42` 또는 `42` 형식)이거나, task-id를 검색 키로 `gh issue list --search`로 단일 매칭을 찾는다. 본 프로젝트 컨벤션 외 다른 프로젝트에서 호출 시 `rules/context.md` 매핑을 재확인.
+**백엔드 매핑 위임**: 본 SKILL.md는 backing-neutral 추상 어휘(task·task-id·task 상태·설계 상태·설계 이전 상태·설계 이후 상태)만 사용한다. 추상 어휘 ↔ 프로젝트 백엔드 구체 매핑(record 식별자, 상태 라벨, 조회·생성·전이 명령)은 `rules/context.md`가 단일 출처로 책임진다. 본 절차 실행 시 그 매핑을 적용해 구체 명령을 합성한다.
 
 **조회 절차**:
-- `gh issue view <task-id>` 또는 `gh issue list --search "<task-id>"`로 task 존재 확인.
-- 존재 시 `gh project item-list <project>`로 해당 issue의 Status field 값 읽기.
+- task-id로 task 존재 확인 (백엔드 매핑이 정한 조회 명령).
+- 존재 시 그 task의 현재 상태 읽기.
 
 **4갈래 분기**:
 
-1. **(a) task 부재** (issue 조회 결과 없음): 새 issue를 `gh issue create`로 생성하고 `gh project item-add`로 Project에 추가 + Status를 `In Design`으로 설정. 새 issue number를 새 task-id로 사용하며 — 이후 워크플로의 `<c>`는 새 task-id로 **교체**한다. `AskUserQuestion`으로 사용자에게 새 task-id를 명시적으로 안내한 후 진행. 새 task-id에 대해 사전 검사(단계 1)의 폴더 존재 검사·형식 검증을 다시 적용한다 (위험: 새 task-id의 `milestones/<m>/loops/<c>/` 폴더가 이미 있을 수 있음).
-2. **(b) 기존 task가 설계 상태(`In Design`)**: 상태를 변경하지 않고 다음 단계로 진행 (resume 케이스).
-3. **(c) 기존 task가 설계 이전 상태(`Backlog`)**: `gh project item-edit`로 Status field를 `In Design`으로 전이한 뒤 다음 단계로 진행.
-4. **(d) 기존 task가 설계 이후 상태(`In Progress`·`Review`·`Done` 등)**: 새 issue를 `gh issue create`로 생성·Project 추가·Status를 `In Design`으로 설정. 새 issue number로 task-id를 **교체**하고 `AskUserQuestion`으로 사용자에게 새 task-id를 명시적으로 안내한 후 진행. (a)와 동일하게 새 task-id에 대해 사전 검사를 재적용.
+1. **(a) task 부재** (조회 결과 없음): 새 task를 생성하고 task 상태를 설계 상태로 설정. 새 task의 식별자를 새 task-id로 사용하며 — 이후 워크플로의 `<c>`는 새 task-id로 **교체**한다. `AskUserQuestion`으로 사용자에게 새 task-id를 명시적으로 안내한 후 진행. 새 task-id에 대해 사전 검사(단계 1)의 폴더 존재 검사·형식 검증을 다시 적용한다 (위험: 새 task-id의 `milestones/<m>/loops/<c>/` 폴더가 이미 있을 수 있음).
+2. **(b) 기존 task가 설계 상태**: 상태를 변경하지 않고 다음 단계로 진행 (resume 케이스).
+3. **(c) 기존 task가 설계 이전 상태**: task 상태를 설계 상태로 전이한 뒤 다음 단계로 진행.
+4. **(d) 기존 task가 설계 이후 상태**: 새 task를 생성·task 상태를 설계 상태로 설정. 새 task의 식별자로 task-id를 **교체**하고 `AskUserQuestion`으로 사용자에게 새 task-id를 명시적으로 안내한 후 진행. (a)와 동일하게 새 task-id에 대해 사전 검사를 재적용.
 
-**(a)·(d) 새 issue 생성 시 title/body 수집**: step 2 시점에는 아직 명확화 라운드(step 5) 전이라 issue 본문에 쓸 문제·목표·범위가 수집되지 않은 상태다. 임의 값으로 채우면 실행 일관성이 깨지므로 다음 절차로 최소 정보를 명시적으로 확보한다:
+**(a)·(d) 새 task 생성 시 title/body 수집**: step 2 시점에는 아직 명확화 라운드(step 5) 전이라 task 본문에 쓸 문제·목표·범위가 수집되지 않은 상태다. 임의 값으로 채우면 실행 일관성이 깨지므로 다음 절차로 최소 정보를 명시적으로 확보한다:
 
 - **Title**: `AskUserQuestion`으로 한 줄 제목을 수집 (1문항, 자유 입력 옵션 포함). 사용자가 "그대로 task-id 사용"을 선택하거나 입력이 비어 있으면 원래 task-id 문자열을 fallback 제목으로 사용한다.
 - **Body**: 최소 본문은 다음 두 줄로 고정 — 임의 확장 금지:
@@ -107,17 +99,17 @@ task-id ↔ Issue 매핑은 task-id 자체가 issue number(`#42` 또는 `42` 형
   SPEC: milestones/<m>/loops/<new-task-id>/SPEC.md
   ```
   본문 템플릿의 플레이스홀더 처리는 **두 단계로 나뉜다**:
-  - **`<m>` (milestone)**: step 1에서 이미 결정된 값(`--milestone <m>` 또는 default `regular`). `gh issue create` 호출 *전에* 실제 milestone 문자열로 치환한다.
-  - **`<new-task-id>` (issue number)**: `gh issue create` 호출 시점엔 아직 발급되지 않은 값. `<m>`만 치환한 임시 body(`<new-task-id>`는 리터럴로 남김)로 `gh issue create`를 호출하고, 반환된 issue number(`N`)로 즉시 `gh issue edit N --body <substituted-body>`를 호출해 리터럴을 실제 번호로 치환한다.
-  edit 실패 시 abort 규칙은 다른 `gh` 호출과 동일하다.
+  - **`<m>` (milestone)**: step 1에서 이미 결정된 값(`--milestone <m>` 또는 default `regular`). task 생성 호출 *전에* 실제 milestone 문자열로 치환한다.
+  - **`<new-task-id>` (백엔드 record 식별자)**: task 생성 호출 시점엔 아직 발급되지 않은 값. `<m>`만 치환한 임시 body(`<new-task-id>`는 리터럴로 남김)로 task를 생성하고, 반환된 식별자(`N`)로 즉시 body update 호출을 보내 리터럴을 실제 식별자로 치환한다.
+  update 실패 시 abort 규칙은 다른 백엔드 호출과 동일하다.
 
-  명확화 라운드(step 5) 완료 시점에 본 issue 본문을 update할지 여부는 본 SPEC 범위 밖이며, 필요하면 사용자가 수동으로 보강한다.
+  명확화 라운드(step 5) 완료 시점에 본 task 본문을 update할지 여부는 본 SPEC 범위 밖이며, 필요하면 사용자가 수동으로 보강한다.
 
-본 절차로 입력이 결정된 뒤에만 `gh issue create --title <title> --body <body>`를 호출한다. 사용자가 title 수집 단계에서 명시적 취소를 선택하면 (a)·(d) 분기는 abort로 처리한다 — `milestones/` 디렉터리도 생성하지 않는다.
+본 절차로 입력이 결정된 뒤에만 task 생성 호출(title·body 함께)을 발행한다. 사용자가 title 수집 단계에서 명시적 취소를 선택하면 (a)·(d) 분기는 abort로 처리한다 — `milestones/` 디렉터리도 생성하지 않는다.
 
-**호출 실패 시 abort**: task 조회·생성·편집·상태 전이 호출(`gh issue view`·`gh issue create`·`gh issue edit`·`gh project item-list`·`gh project item-edit`·`gh project item-add`) 중 어느 하나라도 0이 아닌 exit으로 실패하면 명확한 에러 메시지와 함께 abort. 자동 roll-back은 수행하지 않으며 부분 실패 상태로 다음 단계로 진행하지 않는다.
+**호출 실패 시 abort**: task 조회·생성·편집·상태 전이 호출 중 어느 하나라도 0이 아닌 exit으로 실패하면 명확한 에러 메시지와 함께 abort. 자동 roll-back은 수행하지 않으며 부분 실패 상태로 다음 단계로 진행하지 않는다.
 
-**범위 외 (비-목표)**: loop `start` 시점의 `In Design → In Progress` 전이, SPEC 승인 후 자동 후속 전이는 본 단계의 책임이 아니다 (다른 스킬·이벤트가 담당).
+**범위 외 (비-목표)**: loop `start` 시점의 설계 상태 → 진행 상태 전이, SPEC 승인 후 자동 후속 전이는 본 단계의 책임이 아니다 (다른 스킬·이벤트가 담당).
 
 ### 3. 컨텍스트 탐색
 


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가

autopilot 스킬 패키지의 4개 SKILL.md(spec·loop·prd·dispatch)에서 task의 backing system을 가리키는 모든 backing-specific 표현을 backing-neutral 추상 어휘로 일관 재작성한다. 추상 어휘는 sibling child(헌법 재작성)이 헌법에 정의한 단위(task 메모리·task 신호·task 상태·task 식별자)를 그대로 차용한다 — 본 child가 새 단위를 신설하지 않는다.

SKILL.md는 사용자가 스킬을 호출하기 전 읽는 인터페이스 문서이므로 추상 어휘가 일관되어야 헌법-스킬-드라이버 세 층의 표현이 정합한다. 본 child의 산출물은 4개 파일에 한정되며 다른 sibling이 다루는 영역(헌법 본문·드라이버 셸·보조 references)은 손대지 않는다.

각 SKILL.md에서 추상화 대상:

- **spec/SKILL.md** — step 2 "task 상태 정합"의 backing 매핑 표 부분이 유일하게 backing-specific 표현을 명시 등장시키는 영역(GitHub Project + Issue 매핑). 그 외 본문은 추상 어휘로 일관 재작성. 매핑 표 자체는 backing-specific section이므로 보존하되 §외부에서 backing-specific 용어 직접 노출 금지.
- **loop/SKILL.md** — DONE phase·blocked phase·이터간 메모리 운영 안내가 backing-specific 표현을 사용. 추상 어휘로 재작성.
- **prd/SKILL.md** — 비교적 backing-neutral하지만 milestone-id ↔ issue 매핑 언급이 있다면 추상화.
- **dispatch/SKILL.md** — child task ↔ issue 매핑·sentinel 신호 검출 안내 등 backing-specific 표현 추상화.

## Commits
- 92a3d94 refactor(autopilot/skills): SKILL.md 4종 backing-neutral 어휘 재작성
- 2857c46 feat(spec): 133 — SKILL.md 4개 backing-neutral 어휘 재작성
- 0a47eda docs(dispatch): 2026-05-backing-abstraction — DAG.md (게이트 ① 승인 후)
- af58abe docs(prd): 2026-05-backing-abstraction — autopilot 설계·드라이버 backing-neutral 어휘 + native signal 매체 교체

Closes #133
<!-- autopilot:pr-body:end -->