### PR TITLE
docs(autopilot/loop): SPEC 134 머지 후 stale 주석 2건 정리

### DIFF
--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -867,8 +867,8 @@ iterate() {
   if task_status_is_done "$TASK_ID" || [[ -f "$WT/DONE" ]]; then
     return 100   # 메인 루프에서 정상 종료 처리
   fi
-  # 워커가 진행 불가 보고 시 task issue에 [blocked] prefix comment + Status=Blocked 전이 (헌법 §5.2, SPEC AC5).
-  # 드라이버는 Project Status 또는 최신 comment prefix로 차단 신호를 감지한다 (SPEC AC4).
+  # 워커가 진행 불가 보고 시 task issue에 [blocked] prefix comment + Status=Blocked 전이 (헌법 §5.2).
+  # 드라이버는 Project Status=Blocked 단일 의존으로 차단 신호를 감지한다 (SPEC 134 §제약).
   if task_status_is_blocked "$TASK_ID"; then
     return 101   # 메인 루프에서 [blocked] 처리
   fi
@@ -1316,7 +1316,7 @@ cmd_status() {
     if [[ -f "$lock_file" ]]; then
       state="running"
     elif [[ -d "$wt" ]]; then
-      # 차단 신호는 task issue의 Project Status=Blocked 또는 최신 [blocked] prefix comment.
+      # 차단 신호는 task issue의 Project Status=Blocked 단일 의존 (SPEC 134 §제약).
       # gh 부재·미설정 시 task_status_is_blocked가 1을 반환해 자연스럽게 idle로 떨어진다.
       if task_status_is_blocked "$tid"; then
         state="blocked"


### PR DESCRIPTION
## 요약

PR #138(SPEC 134)이 `task_status_is_blocked`를 Project Status field 단일 의존으로 재작성했지만, 두 위치의 인접 주석이 이전 OR 결합 표현을 그대로 남겨 함수 본체와 의미가 어긋난 상태였습니다. 본 PR은 그 stale 주석을 정리합니다(함수 본체·로직 무변경).

## 변경 (총 3건의 주석 갱신)

- `plugins/autopilot/skills/loop/references/loop.sh:870`
  - 이전: "워커가 진행 불가 보고 시 task issue에 [blocked] prefix comment + Status=Blocked 전이 (헌법 §5.2, SPEC AC5)."
  - 신규: "워커가 진행 불가 보고 시 task issue에 [blocked] prefix comment + Status=Blocked 전이 (헌법 §5.2)."
  - `SPEC AC5` 인용 제거 — 본 PR scope가 SPEC 134 §제약(단일 의존)이라 인접 주석에서 구 SPEC 인용도 정리.
- `plugins/autopilot/skills/loop/references/loop.sh:871`
  - 이전: "드라이버는 Project Status 또는 최신 comment prefix로 차단 신호를 감지한다 (SPEC AC4)."
  - 신규: "드라이버는 Project Status=Blocked 단일 의존으로 차단 신호를 감지한다 (SPEC 134 §제약)."
- `plugins/autopilot/skills/loop/references/loop.sh:1319`
  - 이전: "차단 신호는 task issue의 Project Status=Blocked 또는 최신 [blocked] prefix comment."
  - 신규: "차단 신호는 task issue의 Project Status=Blocked 단일 의존 (SPEC 134 §제약)."

## 검증

- `bash -n` OK
- SPEC 134 verify PASS (4 함수 정의 grep — `task_status_is_done`·`task_label_present`·`LOOP_DONE_LABEL`·`ensure_label_exists`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)