### PR TITLE
chore(autopilot): bump version 0.2.1 → 0.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "autopilot",
       "source": "./plugins/autopilot",
       "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 자기완결적인 loop 스킬로 자율 task lifecycle 관리",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "category": "automation",
       "tags": ["autonomous", "ralph-loop", "agent-runtime", "self-directed"]
     }

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop(single-task) + prd/dispatch(multi-task) 4-skill family로 자율 task lifecycle 관리",
   "author": {
     "name": "예의상",


### PR DESCRIPTION
## 요약

milestone 2026-05-backing-abstraction의 4 PR(#136·#137·#138·#139) 및 후속 주석 정리(#146)이 main에 머지된 시점의 source 변경분을 반영하는 patch bump.

## 변경

- \`plugins/autopilot/.claude-plugin/plugin.json\` version: 0.2.1 → 0.2.2
- \`.claude-plugin/marketplace.json\` autopilot.version: 0.2.1 → 0.2.2

## 포함된 source 변경 (이전 PR로 main에 이미 머지)

- constitution.md backing-neutral 어휘 재작성 (PR #136)
- SKILL.md 4종(spec·loop·prd·dispatch) backing-neutral 어휘 재작성 (PR #139)
- loop.sh done/blocked 검출·발행 매체 label·status 단일 의존 단일화 (PR #138)
  - \`task_status_is_done\`·\`task_label_present\`·\`LOOP_DONE_LABEL\`·\`ensure_label_exists\` 4 함수 도입
- references 보조 .md 4종 backing-specific 표현 정리 (PR #137)
- \`task_status_is_blocked\` 호출 사이트 stale 주석 정리 (PR #146)

🤖 Generated with [Claude Code](https://claude.com/claude-code)