### PR TITLE
docs(autopilot/spec): spec-template.md request_review 주석 현행화 + autopilot 0.2.3

### DIFF
--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop(single-task) + prd/dispatch(multi-task) 4-skill family로 자율 task lifecycle 관리",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/spec/references/spec-template.md
+++ b/plugins/autopilot/skills/spec/references/spec-template.md
@@ -28,11 +28,17 @@ verify: "{{verify_command}}"
 #   3모드 정의·예시는 references/ears-patterns.md "EARS 작성 언어" 절 참조.
 # ears_language: ko
 #
-# request_review (선택): true 지정 시 loop이 task DONE 직후 같은 워크트리에서
-#   PR 생성·재사용 단계를 자동 실행 (push → default 브랜치 자동 감지 → open PR 있으면 갱신,
-#   없으면 새 PR 생성). 제목은 SPEC H1, body는 "무엇을 만들 것인가" + base..HEAD commit log.
-#   숫자 task-id면 body 마지막에 `Closes #<id>` 자동 추가. reviewer·label·assignee는 미설정.
-#   미지정 또는 false면 PR 단계 skip. 자세한 동작은 plugins/autopilot/skills/loop/SKILL.md 참조.
+# request_review (선택): true 지정 시 loop이 task DONE 직후 PR **자동 리뷰·머지 루프**를
+#   활성화한다. PR 생성·재사용 자체는 default ON으로 본 키와 무관하며, 차단하려면 `--no-pr`
+#   플래그를 쓴다. 본 키가 true면 PR 생성·재사용 직후 추가로:
+#     1) pre-PR rebase (default 브랜치 기준, 충돌 시 1회 자동 해소),
+#     2) review-fix 백그라운드 루프 (30s 폴링 — 새 PR 코멘트·리뷰마다 재-rebase → 자동 fix
+#        → commit·push, 필요 시 1개 반박 코멘트),
+#     3) 자동 머지 (reviewDecision `APPROVED` 또는 owner `/done`·`합격`·`통과` 코멘트 →
+#        `gh pr merge --squash`),
+#     4) cleanup (머지 후 worktree 제거 + 로컬·origin feat 브랜치 삭제).
+#   미지정 또는 false면 PR 생성·재사용까지만 실행 후 정지 (자동 fix·머지·cleanup 없음).
+#   요구: `gh` CLI(OAuth 인증) + `yq`. 자세한 동작은 plugins/autopilot/skills/loop/SKILL.md 참조.
 # request_review: true
 ---
 


### PR DESCRIPTION
## Summary

- `plugins/autopilot/skills/spec/references/spec-template.md` L31~36의 `request_review` 주석을 현행 동작에 맞춰 재작성. SPEC 134 머지 후 PR 생성·재사용 phase가 default ON으로 분리됐는데 주석은 옛 동작(키가 PR phase 전체를 게이트)을 그대로 둔 상태였음.
- 새 주석은 `request_review: true`가 켜는 4단계(pre-PR rebase → review-fix 백그라운드 폴링 → 자동 머지 → cleanup)를 명시하고, PR 생성·재사용 자체는 default ON · `--no-pr`로 차단된다는 별개 phase임을 분리해 기술. `gh` CLI(OAuth) + `yq` 요구도 명시.
- 워치 디렉토리(`plugins/`) 변경이므로 `rules/engineering/versioning.md` 룰대로 `plugins/autopilot/.claude-plugin/plugin.json`을 0.2.2 → 0.2.3 patch bump.

사용자 가시 동작 변화 없음(주석 + 버전 문자열만).

## Test plan

- [ ] `plugins/autopilot/skills/spec/references/spec-template.md` 주석이 현재 `plugins/autopilot/skills/loop/SKILL.md` "DONE 이후 PR 리뷰 자동 fix 루프" 절과 1:1로 일치하는지 확인
- [ ] `plugins/autopilot/.claude-plugin/plugin.json` version이 `0.2.3`인지 확인
- [ ] CI/lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)