### PR TITLE
chore(autopilot): bump version 0.2.3 → 0.3.0

### DIFF
--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop(single-task) + prd/dispatch(multi-task) 4-skill family로 자율 task lifecycle 관리",
   "author": {
     "name": "예의상",


### PR DESCRIPTION
## Summary

`autopilot` 플러그인 버전 0.2.3 → 0.3.0 (minor) bump.

SPEC 150 머지(#154 → `b8c6f11`)로 main에 반영된 변경:
- 헌법(`constitution.md`)에 워커 done·blocked 신호 매체 부착 동작 명시 추가
- `loop.sh`의 `$WT/DONE` 호환 OR 결합·status view·cleanup 가드 모두 제거
- 검출 키를 `task_status_is_done` 단일 의존으로 통일

## Why minor (0.x 시리즈)

- `$WT/DONE` fallback 제거는 0.2.0 잔존 호환 layer 삭제(breaking)
- 헌법 본문에 워커 행동 지침 추가는 의미 있는 동작 변경
- 0.x 시리즈에서 minor는 의미 있는 동작 변경·breaking 신호로 사용