### PR TITLE
spec·loop 스킬 SKILL.md frontmatter에 권한 허용 패턴 명시

### DIFF
--- a/milestones/regular/loops/113-spec-loop-skill-md-frontmatter/SPEC.md
+++ b/milestones/regular/loops/113-spec-loop-skill-md-frontmatter/SPEC.md
@@ -1,0 +1,51 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/spec/**", "plugins/autopilot/skills/loop/**", "tests/autopilot/**"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash tests/autopilot/test-skill-allow-tools.sh"
+---
+
+# spec·loop 스킬 SKILL.md frontmatter에 권한 허용 패턴 명시
+
+## 무엇을 만들 것인가
+`autopilot:spec`·`autopilot:loop` 두 스킬을 호출할 때 권한 prompt가 거의 발생하지 않도록, 각 스킬의 `SKILL.md` frontmatter에 사용 권한 패턴을 명시한다. 패턴 집합은 issue #113 본문이 enumerate한 직전 세션 실측 결과를 기준으로 한다. 외부 시스템 상태를 변경할 수 있는 `gh` CLI는 `gh pr` 계열만 허용하고 그 외에는 포함하지 않는다. `Bash(*)` 같은 catch-all 광역 권한은 금지한다.
+
+## 수용 기준 (EARS)
+- **AC1**: 시스템은 `plugins/autopilot/skills/spec/SKILL.md` frontmatter에 권한 허용 패턴 배열을 포함한다.
+- **AC2**: 시스템은 `plugins/autopilot/skills/loop/SKILL.md` frontmatter에 권한 허용 패턴 배열을 포함한다.
+- **AC3**: 위 두 SKILL.md의 frontmatter는 YAML로 parse 성공한다.
+- **AC4**: 위 두 frontmatter의 허용 패턴 배열은 catch-all 패턴(`Bash(*)`·`*` 단독)을 포함하지 않는다.
+- **AC5**: 위 두 frontmatter의 허용 패턴 배열은 `gh pr` prefix를 제외한 모든 `gh ` prefix 패턴을 포함하지 않는다.
+- **AC6**: 위 두 frontmatter의 허용 패턴 배열은 각 배열 내에서 중복 항목을 포함하지 않는다.
+- **AC7**: `spec/SKILL.md`의 허용 패턴 배열은 issue #113 본문 `autopilot:spec` 섹션과 `공통·보조` 섹션이 enumerate한 패턴(gh 패턴 제외)을 모두 포함한다.
+- **AC8**: `loop/SKILL.md`의 허용 패턴 배열은 issue #113 본문 `autopilot:loop` 섹션과 `공통·보조` 섹션이 enumerate한 패턴(gh 패턴 제외)을 모두 포함한다.
+
+## 범위
+포함:
+- `plugins/autopilot/skills/spec/SKILL.md` frontmatter에 허용 패턴 배열 추가
+- `plugins/autopilot/skills/loop/SKILL.md` frontmatter에 허용 패턴 배열 추가
+- 정적 검사 verify script 추가 (위 AC1~AC8 자동 검증)
+
+비-목표 / 제외:
+- `dispatch`·`prd` 등 다른 autopilot 스킬 (후속 issue로 분리)
+- `~/.claude/settings.json`·`.claude/settings.json`·`.claude/settings.local.json` 변경
+- `fewer-permission-prompts` 스킬 도입·비교 (별도 경로, 본 SPEC 범위 밖)
+- 권한 prompt 발생 빈도 동적 측정
+
+## 검증
+이 명령이 0 exit으로 끝나야 합니다:
+```
+bash tests/autopilot/test-skill-allow-tools.sh
+```
+
+## 제약 (있을 때만)
+- 본 repo는 plugin source repo이며, 실제 권한 prompt 감소 효과는 사용자 환경의 plugin cache가 새 `SKILL.md`를 동기화한 뒤에만 관측된다.
+- `SKILL.md` frontmatter에 사용할 정확한 key 이름(`allow-tools` 혹은 `allowed-tools`)은 Claude Code의 frontmatter 처리 명세에 따르며, loop 워커가 구현 단계에서 1회 확인해 두 SKILL.md에 일관 적용한다.
+- AC7·AC8의 "issue #113 본문 enumerate 패턴"은 SPEC 작성 시점의 issue body 내용을 정답으로 한다. verify script는 그 정답 집합을 frozen reference로 보유해 외부 API 호출 없이 비교한다.
+
+## 위험 (있을 때만)
+- `SKILL.md` frontmatter의 허용-패턴 키가 실제로 Claude Code skill loader에서 권한 자동 허용에 사용되지 않을 가능성 — 이 경우 본 SPEC의 효과(prompt 빈도 감소)는 실현되지 않는다. loop 구현 초기에 1회 동작 확인 후 진행한다.
+- enumerate된 패턴 일부가 실제 호출과 좁게 불일치할 수 있음(경로·인자 변동). 보수적으로 유지하되 누락 발견 시 후속 PR로 추가한다.

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -1,7 +1,22 @@
 ---
 name: loop
 description: 자율 수행 루프(랄프 루프) 운영 인터페이스. start/status/stop/list/cleanup/logs 서브커맨드로 자율 task의 lifecycle을 관리합니다. SPEC 작성은 별도 'autopilot:spec' 스킬을 사용. 본 스킬은 자기완결적이며 헌법·드라이버를 모두 references/에 포함합니다.
-allowed-tools: Monitor
+allowed-tools:
+  - Monitor
+  - 'Bash(bash * loop.sh start *)'
+  - 'Bash(bash * loop.sh status *)'
+  - 'Bash(bash * loop.sh stop *)'
+  - 'Bash(bash * loop.sh list)'
+  - 'Bash(bash * loop.sh cleanup *)'
+  - 'Bash(bash * loop.sh logs *)'
+  - 'Bash(tail -F /private/tmp/* | grep -E --line-buffered *)'
+  - 'Bash(git -C * stash list)'
+  - 'Bash(git -C * stash pop *)'
+  - 'Bash(git -C * stash show *)'
+  - 'Bash(rm */ESCALATION.md)'
+  - 'Bash(rm */DONE)'
+  - 'Bash(ps -p *)'
+  - 'Bash(cat */*.lock)'
 ---
 
 # loop

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -1,7 +1,44 @@
 ---
 name: spec
 description: "기능 추가·동작 수정·지침 작성·새로 만들 등 새 코드 변경을 정의하는 자연어 신호에 대응. autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. 이 레포 표준 워크플로우는 자기완결적 SPEC.md 작성 → feat 브랜치 분기·SPEC commit → autopilot loop 실행 → PR. SPEC.md 작성 후 결정적 슬러그화 규칙(ASCII 영숫자·하이픈만)으로 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·SPEC.md를 commit해 loop·PR 흐름이 단일 feature 브랜치로 통합되게 합니다. 호출 'Skill(skill=\"spec\", args=\"<task-id> [--milestone <m>] [--resume]\")'. milestone 미지정 시 `regular`(catch-all)을 default로 적용."
-allowed-tools: AskUserQuestion, Read, Write, Skill, Agent, Bash(git log:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git show-ref:*), Bash(git for-each-ref:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(echo:*), Bash(head:*), Bash(tr:*), Bash(sed:*), Bash(gh:*)
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+  - Skill
+  - Agent
+  - 'Bash(git -C * rev-parse *)'
+  - 'Bash(git -C * status --porcelain)'
+  - 'Bash(git -C * log *)'
+  - 'Bash(git -C * branch *)'
+  - 'Bash(git -C * show-ref *)'
+  - 'Bash(git -C * for-each-ref *)'
+  - 'Bash(git -C * ls-files *)'
+  - 'Bash(git -C * diff *)'
+  - 'Bash(git -C * checkout *)'
+  - 'Bash(git -C * checkout -b *)'
+  - 'Bash(git -C * add *)'
+  - 'Bash(git -C * commit *)'
+  - 'Bash(git update-ref *)'
+  - 'Bash(git branch *)'
+  - 'Bash(git -C * hash-object -w *)'
+  - 'Bash(GIT_INDEX_FILE=* git -C * read-tree *)'
+  - 'Bash(GIT_INDEX_FILE=* git -C * update-index --add --cacheinfo *)'
+  - 'Bash(GIT_INDEX_FILE=* git -C * write-tree)'
+  - 'Bash(git -C * commit-tree * -p *)'
+  - 'Bash(mkdir -p milestones/**)'
+  - 'Bash(awk *)'
+  - 'Bash(sed *)'
+  - 'Bash(tr *)'
+  - 'Bash(grep -rE * plugins/autopilot/**)'
+  - 'Bash(grep -rln * plugins/autopilot/**)'
+  - 'Bash(git -C * stash list)'
+  - 'Bash(git -C * stash pop *)'
+  - 'Bash(git -C * stash show *)'
+  - 'Bash(rm */ESCALATION.md)'
+  - 'Bash(rm */DONE)'
+  - 'Bash(ps -p *)'
+  - 'Bash(cat */*.lock)'
 ---
 
 # spec

--- a/tests/autopilot/test-skill-allow-tools.sh
+++ b/tests/autopilot/test-skill-allow-tools.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# autopilot:spec·autopilot:loop SKILL.md frontmatter 권한 허용 패턴 정적 검증
+#
+# SPEC `milestones/regular/loops/113-spec-loop-skill-md-frontmatter/SPEC.md` AC1~AC8.
+# enumerate 패턴 frozen reference는 issue #113 본문(SPEC 작성 시점) 그대로 임베드.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SPEC_MD="$REPO_ROOT/plugins/autopilot/skills/spec/SKILL.md"
+LOOP_MD="$REPO_ROOT/plugins/autopilot/skills/loop/SKILL.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "OK: $*"; }
+
+# 의존 도구
+command -v yq      >/dev/null || { echo "SKIP: yq 미설치"; exit 0; }
+command -v python3 >/dev/null || { echo "SKIP: python3 미설치"; exit 0; }
+
+[[ -f "$SPEC_MD" ]] || fail "spec/SKILL.md 부재: $SPEC_MD"
+[[ -f "$LOOP_MD" ]] || fail "loop/SKILL.md 부재: $LOOP_MD"
+
+# ---------------------------------------------------------------------------
+# frontmatter 추출 (첫 `---` 다음 ~ 두 번째 `---` 직전)
+extract_frontmatter() {
+  awk 'BEGIN{c=0} /^---$/{c++; if(c>=2) exit; next} c==1{print}' "$1"
+}
+
+# allowed-tools를 line별 항목으로 반환. 입력이 배열이 아니면 비어 있을 수 있다.
+list_tools() {
+  extract_frontmatter "$1" | yq -o=json '.allowed-tools' 2>/dev/null | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+if not isinstance(data, list):
+    sys.exit(0)
+for item in data:
+    print(item)
+'
+}
+
+# allowed-tools가 YAML 배열인지 확인
+is_array() {
+  extract_frontmatter "$1" | yq -o=json '.allowed-tools' 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+sys.exit(0 if isinstance(data, list) else 1)
+'
+}
+
+# ---------------------------------------------------------------------------
+echo "=== TEST: AC3 (YAML parse 성공) + AC1·AC2 (frontmatter 배열 포함) ==="
+is_array "$SPEC_MD" || fail "AC1·AC3: spec/SKILL.md frontmatter의 allowed-tools가 YAML 배열로 parse되지 않음"
+ok "AC1·AC3: spec/SKILL.md allowed-tools가 YAML 배열로 parse됨"
+
+is_array "$LOOP_MD" || fail "AC2·AC3: loop/SKILL.md frontmatter의 allowed-tools가 YAML 배열로 parse되지 않음"
+ok "AC2·AC3: loop/SKILL.md allowed-tools가 YAML 배열로 parse됨"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TEST: AC4 (catch-all 패턴 없음) ==="
+check_no_catchall() {
+  local md="$1" label="$2"
+  local tools; tools=$(list_tools "$md")
+  if grep -qFx 'Bash(*)' <<< "$tools"; then
+    fail "$label: 'Bash(*)' catch-all 패턴 포함"
+  fi
+  if grep -qFx '*' <<< "$tools"; then
+    fail "$label: '*' 단독 catch-all 패턴 포함"
+  fi
+  ok "$label: catch-all 패턴 없음"
+}
+check_no_catchall "$SPEC_MD" "spec/SKILL.md"
+check_no_catchall "$LOOP_MD" "loop/SKILL.md"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TEST: AC5 (gh pr 외 모든 gh prefix 패턴 없음) ==="
+check_no_gh_except_pr() {
+  local md="$1" label="$2"
+  local tools; tools=$(list_tools "$md")
+  while IFS= read -r tool; do
+    [[ -z "$tool" ]] && continue
+    # Bash(gh ...) 또는 Bash(gh:...) 형식 검출
+    if [[ "$tool" =~ Bash\(gh[\ :] ]]; then
+      # gh pr 인지 확인 (Bash(gh pr ...) 또는 Bash(gh pr))
+      if ! [[ "$tool" =~ Bash\(gh\ pr(\ |\)) ]]; then
+        fail "$label: gh pr 외 gh 패턴 포함 — $tool"
+      fi
+    fi
+  done <<< "$tools"
+  ok "$label: gh pr 외 gh 패턴 없음"
+}
+check_no_gh_except_pr "$SPEC_MD" "spec/SKILL.md"
+check_no_gh_except_pr "$LOOP_MD" "loop/SKILL.md"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TEST: AC6 (배열 내 중복 없음) ==="
+check_no_dupes() {
+  local md="$1" label="$2"
+  local tools; tools=$(list_tools "$md")
+  local dup; dup=$(echo "$tools" | sort | uniq -d)
+  if [[ -n "$dup" ]]; then
+    fail "$label: 중복 항목 — $dup"
+  fi
+  ok "$label: 중복 없음"
+}
+check_no_dupes "$SPEC_MD" "spec/SKILL.md"
+check_no_dupes "$LOOP_MD" "loop/SKILL.md"
+
+# ---------------------------------------------------------------------------
+# AC7·AC8: issue #113 본문 enumerate 패턴 (frozen reference)
+
+# autopilot:spec 섹션
+SPEC_SECTION=(
+  'Bash(git -C * rev-parse *)'
+  'Bash(git -C * status --porcelain)'
+  'Bash(git -C * log *)'
+  'Bash(git -C * branch *)'
+  'Bash(git -C * show-ref *)'
+  'Bash(git -C * for-each-ref *)'
+  'Bash(git -C * ls-files *)'
+  'Bash(git -C * diff *)'
+  'Bash(git -C * checkout *)'
+  'Bash(git -C * checkout -b *)'
+  'Bash(git -C * add *)'
+  'Bash(git -C * commit *)'
+  'Bash(git update-ref *)'
+  'Bash(git branch *)'
+  'Bash(git -C * hash-object -w *)'
+  'Bash(GIT_INDEX_FILE=* git -C * read-tree *)'
+  'Bash(GIT_INDEX_FILE=* git -C * update-index --add --cacheinfo *)'
+  'Bash(GIT_INDEX_FILE=* git -C * write-tree)'
+  'Bash(git -C * commit-tree * -p *)'
+  'Bash(mkdir -p milestones/**)'
+  'Bash(awk *)'
+  'Bash(sed *)'
+  'Bash(tr *)'
+  'Bash(grep -rE * plugins/autopilot/**)'
+  'Bash(grep -rln * plugins/autopilot/**)'
+)
+
+# autopilot:loop 섹션
+LOOP_SECTION=(
+  'Bash(bash * loop.sh start *)'
+  'Bash(bash * loop.sh status *)'
+  'Bash(bash * loop.sh stop *)'
+  'Bash(bash * loop.sh list)'
+  'Bash(bash * loop.sh cleanup *)'
+  'Bash(bash * loop.sh logs *)'
+  'Bash(tail -F /private/tmp/* | grep -E --line-buffered *)'
+)
+
+# 공통·보조 섹션 (spec·loop 모두 필요)
+COMMON_SECTION=(
+  'Bash(git -C * stash list)'
+  'Bash(git -C * stash pop *)'
+  'Bash(git -C * stash show *)'
+  'Bash(rm */ESCALATION.md)'
+  'Bash(rm */DONE)'
+  'Bash(ps -p *)'
+  'Bash(cat */*.lock)'
+)
+
+check_required_patterns() {
+  local md="$1" label="$2"
+  shift 2
+  local required=("$@")
+  local tools; tools=$(list_tools "$md")
+  local missing=()
+  for pattern in "${required[@]}"; do
+    if ! grep -qFx "$pattern" <<< "$tools"; then
+      missing+=("$pattern")
+    fi
+  done
+  if (( ${#missing[@]} > 0 )); then
+    printf 'FAIL: %s 누락 패턴:\n' "$label" >&2
+    printf '  - %s\n' "${missing[@]}" >&2
+    exit 1
+  fi
+  ok "$label: 필수 패턴 ${#required[@]}개 모두 포함"
+}
+
+echo ""
+echo "=== TEST: AC7 (spec/SKILL.md = spec 섹션 + 공통·보조) ==="
+check_required_patterns "$SPEC_MD" "spec/SKILL.md" \
+  "${SPEC_SECTION[@]}" "${COMMON_SECTION[@]}"
+
+echo ""
+echo "=== TEST: AC8 (loop/SKILL.md = loop 섹션 + 공통·보조) ==="
+check_required_patterns "$LOOP_MD" "loop/SKILL.md" \
+  "${LOOP_SECTION[@]}" "${COMMON_SECTION[@]}"
+
+echo ""
+echo "PASS"


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가
`autopilot:spec`·`autopilot:loop` 두 스킬을 호출할 때 권한 prompt가 거의 발생하지 않도록, 각 스킬의 `SKILL.md` frontmatter에 사용 권한 패턴을 명시한다. 패턴 집합은 issue #113 본문이 enumerate한 직전 세션 실측 결과를 기준으로 한다. 외부 시스템 상태를 변경할 수 있는 `gh` CLI는 `gh pr` 계열만 허용하고 그 외에는 포함하지 않는다. `Bash(*)` 같은 catch-all 광역 권한은 금지한다.

## Commits
- e98b89c feat(spec/113): spec·loop SKILL.md frontmatter allow-tools 배열 명시 + 정적 verify
- eb16ea0 feat(spec): 113 — spec·loop 스킬 SKILL.md frontmatter에 권한 허용 패턴 명시

Closes #113
<!-- autopilot:pr-body:end -->