### PR TITLE
unify dispatch spec delegation contract

### DIFF
--- a/milestones/regular/loops/141-unify-dispatch-spec-delegation-contract/SPEC.md
+++ b/milestones/regular/loops/141-unify-dispatch-spec-delegation-contract/SPEC.md
@@ -1,0 +1,104 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/spec/**", "plugins/autopilot/skills/dispatch/**"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash -c 'set -e; spec=plugins/autopilot/skills/spec/SKILL.md; dispatch=plugins/autopilot/skills/dispatch/SKILL.md; grep -qE -- \"--milestone <m>\" \"$spec\"; grep -qE \"슬래시.*거부|args.*슬래시\" \"$spec\"; grep -qE \"기본 milestone|default milestone\" \"$spec\"; grep -qE \"dispatch.*위임|위임.*dispatch\" \"$spec\"; grep -qE \"자율 루프.*자동|자동.*루프\" \"$spec\"; grep -qE \"세 옵션|3옵션\" \"$spec\"; grep -qE -- \"--milestone <m> <자연어\" \"$dispatch\"; ! grep -qE \"args.*\\\"<m>/<c>\\\"\" \"$dispatch\"; grep -qE \"스냅샷.*차이|디렉토리.*스냅샷\" \"$dispatch\"'"
+# ears_language: ko (default)
+---
+
+# unify dispatch spec delegation contract
+
+## 무엇을 만들 것인가
+
+`autopilot:dispatch` 가 `autopilot:spec` 을 위임 호출할 때의 contract 를 단일화한다. dispatch 는 child task 식별자를 알 필요가 없으며 spec 이 task 생성·명세 작성·설계 브랜치 준비·후속 자율 루프 시작까지 단일 호출에서 완수한다.
+
+spec 은 milestone 을 별도 인자로만 받는다 — args 본문에는 task 식별자 또는 자연어 task 설명만 들어가고, milestone 은 항상 명시적인 플래그로 명시한다. 플래그가 없으면 프로젝트 기본 milestone (`regular`) 으로 적용된다. args 본문 안 슬래시는 거부된다 — 한 정보는 한 위치.
+
+dispatch 의 위임 호출은 task 식별자 대신 처리할 task 의 자연어 설명·milestone 만 넘긴다. milestone 은 명시 플래그로, 자연어 설명은 그 뒤 본문으로 전달된다. 이를 받은 spec 은 호출자가 dispatch 임을 인식해 최종 사용자 확인 단계를 생략하고 자율 루프를 바로 시작한다. 사용자가 spec 을 직접 호출한 경우에는 기존의 최종 확인 단계·세 옵션 (loop start · SPEC 만 확정 · 변경) 이 그대로 유지된다.
+
+dispatch 는 위임 전후 설계 산출물 저장소의 스냅샷 차이로 child 의 명세 경로를 식별하며 task 식별자 자체는 참조하지 않는다.
+
+## 수용 기준 (EARS)
+
+AC1 (Event-driven): 사용자가 spec 을 단일 식별자만으로 호출할 때, 시스템은 milestone 을 프로젝트 기본 milestone 으로 적용한다.
+
+AC2 (Event-driven): 사용자가 spec 을 `--milestone <m>` 인자와 함께 호출할 때, 시스템은 `<m>` 을 milestone 으로 적용한다.
+
+AC3 (Unwanted): 사용자가 spec 을 슬래시 포함 args (플래그 부분 제외 본문) 로 호출하면, 시스템은 이를 거부한다.
+
+AC4 (Event-driven): spec args 의 플래그 제외 남은 값이 task 식별자 패턴이면 시스템은 그 값을 기존 task 식별자로 해석한다.
+
+AC5 (Event-driven): spec args 의 플래그 제외 남은 값이 task 식별자 패턴이 아닌 자연어이면 시스템은 그 값을 task 생성 입력으로 처리한다.
+
+AC6 (Event-driven): dispatch 가 spec 을 위임 호출할 때, 시스템은 단일 args 문자열로 `--milestone <m> <자연어 task 설명>` 형식만 전달한다.
+
+AC7 (State-driven): dispatch 가 위임 호출한 경우, spec 은 task 생성·명세 작성·설계 브랜치 준비·자율 루프 시작까지 단일 호출에서 완수한다.
+
+AC8 (Optional): 사용자가 spec 을 직접 호출한 경우, 시스템은 최종 확인 단계의 세 옵션 (loop start · SPEC 만 확정 · 변경) 을 제시한다.
+
+AC9 (Ubiquitous): dispatch 는 child task 식별자를 보유하지 않고 명세 경로 스냅샷 차이로 child 명세 경로만 식별한다.
+
+AC10 (Ubiquitous, 메타): 본 SPEC 호출 흐름은 이전 컨벤션으로 완료되며 새 contract 는 본 SPEC 다음 호출부터 적용된다 (self-referential 보호).
+
+## 범위
+
+포함:
+- spec 스킬 명세 명확화 (`--milestone` 플래그 · 슬래시 args 거부 · 단일 본문 값 해석 · dispatch 위임 모드 분기 · 자율 루프 자동 시작 · 사용자 직접 호출 세 옵션 유지)
+- dispatch 스킬 명세 명확화 (spec 위임 구체 형식 · child 식별자 미보유 · 명세 경로 스냅샷 차이 기반 child 식별)
+
+비-목표 / 제외:
+- 자율 루프 스킬·구동 스크립트 수정
+- PRD 스킬 명세 수정
+- 기존 설계 산출물 저장소 하위 마이그레이션
+- dispatch 의 wave 처리·게이트·sentinel watch 로직 자체
+- spec slug 컨벤션·feat 브랜치 명명 규칙 변경
+- 다른 플러그인의 인자 컨벤션
+- 본 SPEC 호출 흐름 자체 (AC10)
+
+## 검증
+
+이 명령이 0 exit 으로 끝나야 합니다:
+
+```
+bash -c 'set -e
+spec=plugins/autopilot/skills/spec/SKILL.md
+dispatch=plugins/autopilot/skills/dispatch/SKILL.md
+
+# spec: --milestone 플래그 명시
+grep -qE -- "--milestone <m>" "$spec"
+# spec: 슬래시 args 본문 거부 명시
+grep -qE "슬래시.*거부|args.*슬래시" "$spec"
+# spec: default milestone 적용 명시 (regular 라는 단어 자체는 흔하므로 "기본 milestone" 결합으로 좁힘)
+grep -qE "기본 milestone|default milestone" "$spec"
+# spec: dispatch 위임 모드 분기 명시
+grep -qE "dispatch.*위임|위임.*dispatch" "$spec"
+# spec: 자율 루프 자동 시작 명시
+grep -qE "자율 루프.*자동|자동.*루프" "$spec"
+# spec: step 10 세 옵션 유지 (사용자 직접 호출 — "세 옵션"·"3옵션" 표현으로 좁힘)
+grep -qE "세 옵션|3옵션" "$spec"
+
+# dispatch: 새 위임 형식
+grep -qE -- "--milestone <m> <자연어" "$dispatch"
+# dispatch: 기존 <m>/<c> 형식 제거
+! grep -qE "args.*\"<m>/<c>\"" "$dispatch"
+# dispatch: 스냅샷 차이 기반 child 식별
+grep -qE "스냅샷.*차이|디렉토리.*스냅샷" "$dispatch"'
+```
+
+## 제약
+
+- 변경 대상은 spec 스킬·dispatch 스킬 명세 문서 둘 뿐. 자율 루프 구동 스크립트·다른 플러그인·기존 산출물은 변경하지 않는다.
+- EARS 작성 언어: ko (프로젝트 기본).
+- 검증은 정적 grep 기반 (실행 가능 코드가 아닌 문서 변경).
+- 본 SPEC 호출 흐름은 self-referential 이므로 이전 컨벤션으로 완료되어야 한다 (AC10). 워커는 본 SPEC 가 정의하는 새 contract 를 본 SPEC 의 호출 경로·브랜치 결정에 미리 적용하지 않는다.
+- 사용자가 합의한 항목 안에 해당하지 않는 컨벤션 변경은 권한 초과.
+
+## 위험
+
+- self-referential 위험: 본 SPEC 가 spec 스킬 자체를 재정의. 본 호출 경로·브랜치는 이전 컨벤션으로 이미 결정되어 있으므로 워커는 변경이 적용되지 않는 명세 파일만 수정해야 한다 (memory `feedback_no_self_apply_during_spec`).
+- 기존 호출자: 이전 컨벤션 (슬래시 자동 해석·예전 위임 형식 등) 을 쓰던 진입점이 있으면 깨진다. 워커는 수정 전 grep 으로 호출처를 확인하고 영향 범위를 NOTES.md 에 기록해야 한다.
+- dispatch 위임 모드의 자동 loop start 실패 처리·롤백은 본 SPEC 범위 밖. 본 SPEC 는 contract 만 정의하며, 운영 실패 처리는 별도 task 로 다루는 것을 권장.
+- task 식별자 vs 자연어 구분 휴리스틱 모호성. 워커는 현 spec step 1 의 기존 자연어 감지 휴리스틱 (물음표·따옴표·문장 부호 다중·길이 ≥ 40자 등) 을 그대로 우선 적용하고, 모호한 경계 사례는 NOTES.md 에 기록 후 사용자 결정을 따른다.

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -25,7 +25,7 @@ description: "milestone 단위 PRD를 child SPEC들로 자동 분해해 DAG(wave
    → 분해 (단위 후보 추출 + 3 조건 검사 + 하드 캡 검사)
    → 게이트 ① 분해 plan 승인 (사용자 AskUserQuestion)
    → DAG.md 작성 (milestones/<m>/dispatch/DAG.md)
-   → 게이트 ② spec 위임 (각 child 분해 plan 항목에 대해 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") — task-id 는 spec 이 task 생성 단계에서 결정)
+   → 게이트 ② spec 위임 (각 child에 대해 Skill(skill: "spec", args: "<m>/<c>"))
    → 게이트 ③ 최종 확인 (SPEC 경로·verify 명령·의존성 표 + 사용자 승인)
    → wave 단위 병렬 실행 (각 child에 Bash(loop start <m>/<c>, run_in_background: true) 호출, sentinel은 Bash(dispatch.sh watch_wave ...))
    → sentinel watch (DONE/ESCALATION.md)
@@ -67,11 +67,9 @@ wave 2 (depends on wave 1): [child-c]
 
 ### 게이트 ② spec 위임
 
-승인된 DAG의 각 child 분해 plan 항목에 대해 `Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>")` 호출 — milestone 은 명시 플래그로, child 식별자 (task-id) 는 dispatch 가 보유하지 않고 spec 이 task 생성 단계에서 결정한다. PRD 본문·분해 plan 항목은 자연어 인자 안에 포함해 전달.
+승인된 DAG의 각 child에 대해 `Skill(skill: "spec", args: "<m>/<c>")` 호출. 입력 컨텍스트로 PRD 본문 + 분해 plan 항목 전달 (자연어 안내).
 
-**child 명세 경로 식별 (스냅샷 차이)** — dispatch 는 각 위임 호출 직전에 `milestones/<m>/loops/` 디렉토리 스냅샷을 찍고, 호출 직후 스냅샷 차이로 새로 생성된 `milestones/<m>/loops/<c>-<slug>/SPEC.md` 경로만 식별한다. `<c>` 자체는 dispatch 가 참조하지 않으며, 이후 단계(게이트 ③ 표·실행)는 식별한 명세 경로로 작동.
-
-spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검토의 세 옵션 질문을 생략하고 후속 자율 루프 자동 시작까지 단일 호출에서 완수(상세는 `plugins/autopilot/skills/spec/SKILL.md` §호출 방법 — dispatch 위임 모드).
+spec 스킬은 자체적으로 9-step 대화 진행. 사용자가 SPEC 작성에 직접 참여.
 
 ### 게이트 ③ 최종 확인
 
@@ -191,7 +189,7 @@ for wave in waves:
 ## 규칙
 
 - 본 스킬은 target 프로젝트의 `milestones/<m>/dispatch/` 디렉터리만 직접 작성한다 (DAG.md·DISPATCH_LOG.md).
-- spec 위임은 항상 `Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>")` 형식 — milestone 플래그 + 자연어 본문, task-id 는 spec 이 task 생성 단계에서 결정. child 식별은 호출 전후 `milestones/<m>/loops/` 디렉토리 스냅샷 차이로.
-- loop 실행은 항상 `<m>/<c>` 2-컴포넌트 task-id로 (child 식별 후).
+- spec 위임은 항상 `Skill(skill: "spec", args: "<m>/<c>")` 형식 — 2-컴포넌트 task-id.
+- loop 실행은 항상 `<m>/<c>` 2-컴포넌트 task-id로.
 - `regular` milestone-id는 ad-hoc 단일 task catch-all이므로 PRD가 없고 `dispatch start regular`는 거부.
 - 모든 결정·승인은 `AskUserQuestion`으로 (CLAUDE.md 규칙).

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -25,7 +25,7 @@ description: "milestone 단위 PRD를 child SPEC들로 자동 분해해 DAG(wave
    → 분해 (단위 후보 추출 + 3 조건 검사 + 하드 캡 검사)
    → 게이트 ① 분해 plan 승인 (사용자 AskUserQuestion)
    → DAG.md 작성 (milestones/<m>/dispatch/DAG.md)
-   → 게이트 ② spec 위임 (각 child에 대해 Skill(skill: "spec", args: "<m>/<c>"))
+   → 게이트 ② spec 위임 (각 child 분해 plan 항목에 대해 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") — task-id 는 spec 이 task 생성 단계에서 결정)
    → 게이트 ③ 최종 확인 (SPEC 경로·verify 명령·의존성 표 + 사용자 승인)
    → wave 단위 병렬 실행 (각 child에 Bash(loop start <m>/<c>, run_in_background: true) 호출, sentinel은 Bash(dispatch.sh watch_wave ...))
    → sentinel watch (DONE/ESCALATION.md)
@@ -67,9 +67,11 @@ wave 2 (depends on wave 1): [child-c]
 
 ### 게이트 ② spec 위임
 
-승인된 DAG의 각 child에 대해 `Skill(skill: "spec", args: "<m>/<c>")` 호출. 입력 컨텍스트로 PRD 본문 + 분해 plan 항목 전달 (자연어 안내).
+승인된 DAG의 각 child 분해 plan 항목에 대해 `Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>")` 호출 — milestone 은 명시 플래그로, child 식별자 (task-id) 는 dispatch 가 보유하지 않고 spec 이 task 생성 단계에서 결정한다. PRD 본문·분해 plan 항목은 자연어 인자 안에 포함해 전달.
 
-spec 스킬은 자체적으로 9-step 대화 진행. 사용자가 SPEC 작성에 직접 참여.
+**child 명세 경로 식별 (스냅샷 차이)** — dispatch 는 각 위임 호출 직전에 `milestones/<m>/loops/` 디렉토리 스냅샷을 찍고, 호출 직후 스냅샷 차이로 새로 생성된 `milestones/<m>/loops/<c>-<slug>/SPEC.md` 경로만 식별한다. `<c>` 자체는 dispatch 가 참조하지 않으며, 이후 단계(게이트 ③ 표·실행)는 식별한 명세 경로로 작동.
+
+spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검토의 세 옵션 질문을 생략하고 후속 자율 루프 자동 시작까지 단일 호출에서 완수(상세는 `plugins/autopilot/skills/spec/SKILL.md` §호출 방법 — dispatch 위임 모드).
 
 ### 게이트 ③ 최종 확인
 
@@ -189,7 +191,7 @@ for wave in waves:
 ## 규칙
 
 - 본 스킬은 target 프로젝트의 `milestones/<m>/dispatch/` 디렉터리만 직접 작성한다 (DAG.md·DISPATCH_LOG.md).
-- spec 위임은 항상 `Skill(skill: "spec", args: "<m>/<c>")` 형식 — 2-컴포넌트 task-id.
-- loop 실행은 항상 `<m>/<c>` 2-컴포넌트 task-id로.
+- spec 위임은 항상 `Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>")` 형식 — milestone 플래그 + 자연어 본문, task-id 는 spec 이 task 생성 단계에서 결정. child 식별은 호출 전후 `milestones/<m>/loops/` 디렉토리 스냅샷 차이로.
+- loop 실행은 항상 `<m>/<c>` 2-컴포넌트 task-id로 (child 식별 후).
 - `regular` milestone-id는 ad-hoc 단일 task catch-all이므로 PRD가 없고 `dispatch start regular`는 거부.
 - 모든 결정·승인은 `AskUserQuestion`으로 (CLAUDE.md 규칙).

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -71,7 +71,7 @@ wave 2 (depends on wave 1): [child-c]
 
 **child 명세 경로 식별 (스냅샷 차이)** — dispatch 는 각 위임 호출 직전에 `milestones/<m>/loops/` 디렉토리 스냅샷을 찍고, 호출 직후 스냅샷 차이로 새로 생성된 `milestones/<m>/loops/<c>-<slug>/SPEC.md` 경로만 식별한다. `<c>` 자체는 dispatch 가 참조하지 않으며, 이후 단계(게이트 ③ 표·실행)는 식별한 명세 경로로 작동.
 
-spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검토의 세 옵션 질문을 생략하고 후속 자율 루프 자동 시작까지 단일 호출에서 완수(상세는 `plugins/autopilot/skills/spec/SKILL.md` §호출 방법 — dispatch 위임 모드).
+spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검토의 세 옵션 질문을 생략하고 후속 자율 루프 자동 시작까지 단일 호출에서 완수(상세는 `plugins/autopilot/skills/spec/SKILL.md` §호출 방법 — dispatch 위임 모드). **즉 위임 호출 시점에 child 의 loop 가 이미 자동 시작되며, 이후 wave 실행 섹션은 sentinel watch 전용 — `loop start` 중복 호출 금지**. wave 순서 보장은 start-time 게이팅이 아닌 wave 별 watch_wave + fail-fast 스코프로 강제되므로, wave 2+ child 도 spec 위임 시점에 함께 시작된다(wave 1 결과를 입력으로 요구하는 wave 2 child 는 그 child loop 자체의 의존성 검사로 대응).
 
 ### 게이트 ③ 최종 확인
 
@@ -90,8 +90,7 @@ spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검�
 
 ```
 for wave in waves:
-  for child in wave:
-    Bash(loop start <m>/<c>, run_in_background: true)  # 비동기 시작 — watch_wave가 sentinel 폴링. run_in_background 없이는 동기 블로킹이라 wave 병렬 안 됨
+  # child loop 는 게이트 ② 의 spec 위임 시점에 이미 자동 시작됨 (spec dispatch-위임 모드의 auto-loop-start). dispatch 는 별도 `loop start` 호출 없이 sentinel watch 만 수행 — 중복 시작 방지.
 
   while wave 진행 중:
     # references/dispatch.sh watch_wave <m> child1 child2 ...

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -27,7 +27,7 @@ description: "milestone 단위 PRD를 child SPEC들로 자동 분해해 DAG(wave
    → DAG.md 작성 (milestones/<m>/dispatch/DAG.md)
    → 게이트 ② spec 위임 (각 child 분해 plan 항목에 대해 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") — task-id 는 spec 이 task 생성 단계에서 결정)
    → 게이트 ③ 최종 확인 (SPEC 경로·verify 명령·의존성 표 + 사용자 승인)
-   → wave 단위 병렬 실행 (각 child에 Bash(loop start <m>/<c>, run_in_background: true) 호출, sentinel은 Bash(dispatch.sh watch_wave ...))
+   → wave 단위 병렬 실행 (child loop 는 게이트 ② 시점에 spec 위임으로 이미 자동 시작됨, sentinel은 Bash(dispatch.sh watch_wave ...))
    → sentinel watch (DONE/ESCALATION.md)
    → fail-fast (ESCALATION 시 같은 wave 다른 child들 loop stop)
    → wave 모두 통과 후 최종 보고

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -30,8 +30,7 @@ description: "milestone 단위 PRD를 child SPEC들로 자동 분해해 DAG(wave
      · 게이트 ③ spec 위임 (per-wave): 그 wave 의 각 child 분해 plan 항목에 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") — task-id 는 spec 이 task 생성 단계에서 결정. spec 의 dispatch-위임 모드 auto-loop-start 로 그 wave 의 child loop 가 자동 시작
      · sentinel watch (Bash(dispatch.sh watch_wave ...)) — 이 wave 의 DONE/ESCALATION 감시
      · 성공 시 다음 wave 의 게이트 ③ per-wave 로 진행. wave 끝까지 반복
-   → sentinel watch (DONE/ESCALATION.md)
-   → fail-fast (ESCALATION 시 같은 wave 다른 child들 loop stop)
+       (sentinel watch · fail-fast 는 per-wave 단계에 포함 — 마일스톤 레벨 별도 sentinel 없음)
    → wave 모두 통과 후 최종 보고
 ```
 

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch
-description: "milestone 단위 PRD를 child SPEC들로 자동 분해해 DAG(wave) 단위로 loop을 병렬 실행하는 오케스트레이션 인터페이스. start/status/stop/list/cleanup/logs/resume 서브커맨드로 milestone lifecycle ops도 책임. PRD 입력 검증·게이트 3종(분해 plan·spec 위임·최종 확인)·sentinel watch + fail-fast 포함."
+description: "milestone 단위 PRD를 child SPEC들로 자동 분해해 DAG(wave) 단위로 loop을 병렬 실행하는 오케스트레이션 인터페이스. start/status/stop/list/cleanup/logs/resume 서브커맨드로 milestone lifecycle ops도 책임. PRD 입력 검증·게이트 3종(분해 plan·최종 확인·spec 위임)·sentinel watch + fail-fast 포함."
 ---
 
 # dispatch
@@ -25,11 +25,11 @@ description: "milestone 단위 PRD를 child SPEC들로 자동 분해해 DAG(wave
    → 분해 (단위 후보 추출 + 3 조건 검사 + 하드 캡 검사)
    → 게이트 ① 분해 plan 승인 (사용자 AskUserQuestion)
    → DAG.md 작성 (milestones/<m>/dispatch/DAG.md)
-   → 게이트 ③ 최종 확인 (DAG 레벨 wave·child·예상 verify·의존성 표 + 사용자 승인. SPEC 자체는 각 wave 진입 시 비로소 작성)
+   → 게이트 ② 최종 확인 (DAG 레벨 wave·child·예상 verify·의존성 표 + 사용자 승인. SPEC 자체는 각 wave 진입 시 비로소 작성)
    → wave 단위 순차 실행 (wave 안 child 간은 병렬):
-     · 게이트 ② spec 위임 (per-wave): 그 wave 의 각 child 분해 plan 항목에 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") — task-id 는 spec 이 task 생성 단계에서 결정. spec 의 dispatch-위임 모드 auto-loop-start 로 그 wave 의 child loop 가 자동 시작
+     · 게이트 ③ spec 위임 (per-wave): 그 wave 의 각 child 분해 plan 항목에 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") — task-id 는 spec 이 task 생성 단계에서 결정. spec 의 dispatch-위임 모드 auto-loop-start 로 그 wave 의 child loop 가 자동 시작
      · sentinel watch (Bash(dispatch.sh watch_wave ...)) — 이 wave 의 DONE/ESCALATION 감시
-     · 성공 시 다음 wave 의 게이트 ② per-wave 로 진행. wave 끝까지 반복
+     · 성공 시 다음 wave 의 게이트 ③ per-wave 로 진행. wave 끝까지 반복
    → sentinel watch (DONE/ESCALATION.md)
    → fail-fast (ESCALATION 시 같은 wave 다른 child들 loop stop)
    → wave 모두 통과 후 최종 보고
@@ -67,15 +67,7 @@ wave 2 (depends on wave 1): [child-c]
 
 승인 시 `references/dag-template.md` 치환해 `milestones/<m>/dispatch/DAG.md` 기록 (`mkdir -p milestones/<m>/dispatch/` 후).
 
-### 게이트 ② spec 위임 (wave 단위 순차)
-
-dispatch 는 spec 위임을 **wave 단위로 순차** 실행한다 — wave 1 부터 시작해 직전 wave 의 `watch_wave` 가 성공 (exit 100) 으로 종료한 직후 다음 wave 로 진행. 한 wave 안에서는 그 wave 의 child 분해 plan 항목들에 대해 `Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>")` 를 호출한다 (한 wave 안 child 위임은 병렬·순서 무관) — milestone 은 명시 플래그로, child 식별자 (task-id) 는 dispatch 가 보유하지 않고 spec 이 task 생성 단계에서 결정한다. PRD 본문·분해 plan 항목은 자연어 인자 안에 포함해 전달.
-
-**child 명세 경로 식별 (스냅샷 차이)** — dispatch 는 각 위임 호출 직전에 `milestones/<m>/loops/` 디렉토리 스냅샷을 찍고, 호출 직후 스냅샷 차이로 새로 생성된 `milestones/<m>/loops/<c>-<slug>/SPEC.md` 경로만 식별한다. `<c>` 자체는 dispatch 가 참조하지 않으며, 이후 단계(`watch_wave` 인자·DISPATCH_LOG)는 식별한 명세 경로로 작동.
-
-spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검토의 세 옵션 질문을 생략하고 후속 자율 루프 자동 시작까지 단일 호출에서 완수(상세는 `plugins/autopilot/skills/spec/SKILL.md` §호출 방법 — dispatch 위임 모드). **즉 한 wave 의 spec 위임 호출 시점에 그 wave 의 child loop 가 자동 시작되며, 이후 같은 wave 의 실행 섹션은 sentinel watch 전용 — `loop start` 중복 호출 금지**. wave 순서 보장은 start-time 게이팅이 아닌 **spec 위임 자체를 wave 단위로 순차화** 함으로써 강제된다 — wave 2+ child loop 는 의존 wave 의 `watch_wave` 가 성공으로 종료한 *후* 비로소 spec 위임을 통해 시작되므로, `loop/SKILL.md` 에 별도 inter-wave runtime 의존성 검사 메커니즘이 없어도 dependency 순서가 깨지지 않는다.
-
-### 게이트 ③ 최종 확인 (DAG 레벨)
+### 게이트 ② 최종 확인 (DAG 레벨)
 
 모든 wave 의 plan 표를 재제시. SPEC 자체는 wave 별 spec 위임 시점에 비로소 작성되므로, 본 표는 분해 plan 단계에서 추출한 child 한 줄 요약·예상 verify 명령·DAG 의존성을 보여준다 (실제 SPEC 경로는 wave 별 위임 직후 DISPATCH_LOG 에 기록):
 ```
@@ -86,13 +78,21 @@ spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검�
 | 2    | child-c | <한 줄>             | pytest tests/c        | child-a   |
 ```
 
-`AskUserQuestion` 옵션: `(a) 실행 시작`, `(b) 취소`. 승인 시 wave 1 의 게이트 ② per-wave spec 위임 → `watch_wave` 순차 실행 시작.
+`AskUserQuestion` 옵션: `(a) 실행 시작`, `(b) 취소`. 승인 시 wave 1 의 게이트 ③ per-wave spec 위임 → `watch_wave` 순차 실행 시작.
+
+### 게이트 ③ spec 위임 (wave 단위 순차)
+
+dispatch 는 spec 위임을 **wave 단위로 순차** 실행한다 — wave 1 부터 시작해 직전 wave 의 `watch_wave` 가 성공 (exit 100) 으로 종료한 직후 다음 wave 로 진행. 한 wave 안에서는 그 wave 의 child 분해 plan 항목들에 대해 `Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>")` 를 호출한다 (한 wave 안 child 위임은 병렬·순서 무관) — milestone 은 명시 플래그로, child 식별자 (task-id) 는 dispatch 가 보유하지 않고 spec 이 task 생성 단계에서 결정한다. PRD 본문·분해 plan 항목은 자연어 인자 안에 포함해 전달.
+
+**child 명세 경로 식별 (스냅샷 차이)** — dispatch 는 각 위임 호출 직전에 `milestones/<m>/loops/` 디렉토리 스냅샷을 찍고, 호출 직후 스냅샷 차이로 새로 생성된 `milestones/<m>/loops/<c>-<slug>/SPEC.md` 경로만 식별한다. `<c>` 자체는 dispatch 가 참조하지 않으며, 이후 단계(`watch_wave` 인자·DISPATCH_LOG)는 식별한 명세 경로로 작동.
+
+spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검토의 세 옵션 질문을 생략하고 후속 자율 루프 자동 시작까지 단일 호출에서 완수(상세는 `plugins/autopilot/skills/spec/SKILL.md` §호출 방법 — dispatch 위임 모드). **즉 한 wave 의 spec 위임 호출 시점에 그 wave 의 child loop 가 자동 시작되며, 이후 같은 wave 의 실행 섹션은 sentinel watch 전용 — `loop start` 중복 호출 금지**. wave 순서 보장은 start-time 게이팅이 아닌 **spec 위임 자체를 wave 단위로 순차화** 함으로써 강제된다 — wave 2+ child loop 는 의존 wave 의 `watch_wave` 가 성공으로 종료한 *후* 비로소 spec 위임을 통해 시작되므로, `loop/SKILL.md` 에 별도 inter-wave runtime 의존성 검사 메커니즘이 없어도 dependency 순서가 깨지지 않는다.
 
 ## 실행 (wave 단위 순차, wave 안 child 병렬)
 
 ```
 for wave in waves:
-  # 1) per-wave 게이트 ② spec 위임: 그 wave 의 각 child 에 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") 호출.
+  # 1) per-wave 게이트 ③ spec 위임: 그 wave 의 각 child 에 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") 호출.
   #    spec 의 dispatch-위임 모드 auto-loop-start 로 그 wave 의 child loop 가 자동 시작된다.
   #    이전 wave 들의 loop 는 그 wave 의 watch_wave 가 이미 DONE 으로 종료한 상태 — 의존 산출물 준비 완료.
   #    dispatch 는 별도 `loop start` 호출 없이 sentinel watch 만 수행 (중복 시작 방지).
@@ -110,7 +110,7 @@ for wave in waves:
       다음 wave 차단 + 종료 (재계획은 사용자)
 
     모두 DONE (watch_wave exit 100):
-      DISPATCH_LOG.md 기록 → 다음 wave 의 per-wave 게이트 ② spec 위임으로 진입
+      DISPATCH_LOG.md 기록 → 다음 wave 의 per-wave 게이트 ③ spec 위임으로 진입
 
     타임아웃 (watch_wave exit 102):
       watch_wave가 진행 중 child들에 kill -TERM (orphan 방지, 자동)

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -25,9 +25,11 @@ description: "milestone 단위 PRD를 child SPEC들로 자동 분해해 DAG(wave
    → 분해 (단위 후보 추출 + 3 조건 검사 + 하드 캡 검사)
    → 게이트 ① 분해 plan 승인 (사용자 AskUserQuestion)
    → DAG.md 작성 (milestones/<m>/dispatch/DAG.md)
-   → 게이트 ② spec 위임 (각 child 분해 plan 항목에 대해 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") — task-id 는 spec 이 task 생성 단계에서 결정)
-   → 게이트 ③ 최종 확인 (SPEC 경로·verify 명령·의존성 표 + 사용자 승인)
-   → wave 단위 병렬 실행 (child loop 는 게이트 ② 시점에 spec 위임으로 이미 자동 시작됨, sentinel은 Bash(dispatch.sh watch_wave ...))
+   → 게이트 ③ 최종 확인 (DAG 레벨 wave·child·예상 verify·의존성 표 + 사용자 승인. SPEC 자체는 각 wave 진입 시 비로소 작성)
+   → wave 단위 순차 실행 (wave 안 child 간은 병렬):
+     · 게이트 ② spec 위임 (per-wave): 그 wave 의 각 child 분해 plan 항목에 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") — task-id 는 spec 이 task 생성 단계에서 결정. spec 의 dispatch-위임 모드 auto-loop-start 로 그 wave 의 child loop 가 자동 시작
+     · sentinel watch (Bash(dispatch.sh watch_wave ...)) — 이 wave 의 DONE/ESCALATION 감시
+     · 성공 시 다음 wave 의 게이트 ② per-wave 로 진행. wave 끝까지 반복
    → sentinel watch (DONE/ESCALATION.md)
    → fail-fast (ESCALATION 시 같은 wave 다른 child들 loop stop)
    → wave 모두 통과 후 최종 보고
@@ -65,32 +67,35 @@ wave 2 (depends on wave 1): [child-c]
 
 승인 시 `references/dag-template.md` 치환해 `milestones/<m>/dispatch/DAG.md` 기록 (`mkdir -p milestones/<m>/dispatch/` 후).
 
-### 게이트 ② spec 위임
+### 게이트 ② spec 위임 (wave 단위 순차)
 
-승인된 DAG의 각 child 분해 plan 항목에 대해 `Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>")` 호출 — milestone 은 명시 플래그로, child 식별자 (task-id) 는 dispatch 가 보유하지 않고 spec 이 task 생성 단계에서 결정한다. PRD 본문·분해 plan 항목은 자연어 인자 안에 포함해 전달.
+dispatch 는 spec 위임을 **wave 단위로 순차** 실행한다 — wave 1 부터 시작해 직전 wave 의 `watch_wave` 가 성공 (exit 100) 으로 종료한 직후 다음 wave 로 진행. 한 wave 안에서는 그 wave 의 child 분해 plan 항목들에 대해 `Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>")` 를 호출한다 (한 wave 안 child 위임은 병렬·순서 무관) — milestone 은 명시 플래그로, child 식별자 (task-id) 는 dispatch 가 보유하지 않고 spec 이 task 생성 단계에서 결정한다. PRD 본문·분해 plan 항목은 자연어 인자 안에 포함해 전달.
 
-**child 명세 경로 식별 (스냅샷 차이)** — dispatch 는 각 위임 호출 직전에 `milestones/<m>/loops/` 디렉토리 스냅샷을 찍고, 호출 직후 스냅샷 차이로 새로 생성된 `milestones/<m>/loops/<c>-<slug>/SPEC.md` 경로만 식별한다. `<c>` 자체는 dispatch 가 참조하지 않으며, 이후 단계(게이트 ③ 표·실행)는 식별한 명세 경로로 작동.
+**child 명세 경로 식별 (스냅샷 차이)** — dispatch 는 각 위임 호출 직전에 `milestones/<m>/loops/` 디렉토리 스냅샷을 찍고, 호출 직후 스냅샷 차이로 새로 생성된 `milestones/<m>/loops/<c>-<slug>/SPEC.md` 경로만 식별한다. `<c>` 자체는 dispatch 가 참조하지 않으며, 이후 단계(`watch_wave` 인자·DISPATCH_LOG)는 식별한 명세 경로로 작동.
 
-spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검토의 세 옵션 질문을 생략하고 후속 자율 루프 자동 시작까지 단일 호출에서 완수(상세는 `plugins/autopilot/skills/spec/SKILL.md` §호출 방법 — dispatch 위임 모드). **즉 위임 호출 시점에 child 의 loop 가 이미 자동 시작되며, 이후 wave 실행 섹션은 sentinel watch 전용 — `loop start` 중복 호출 금지**. wave 순서 보장은 start-time 게이팅이 아닌 wave 별 watch_wave + fail-fast 스코프로 강제되므로, wave 2+ child 도 spec 위임 시점에 함께 시작된다(wave 1 결과를 입력으로 요구하는 wave 2 child 는 그 child loop 자체의 의존성 검사로 대응).
+spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검토의 세 옵션 질문을 생략하고 후속 자율 루프 자동 시작까지 단일 호출에서 완수(상세는 `plugins/autopilot/skills/spec/SKILL.md` §호출 방법 — dispatch 위임 모드). **즉 한 wave 의 spec 위임 호출 시점에 그 wave 의 child loop 가 자동 시작되며, 이후 같은 wave 의 실행 섹션은 sentinel watch 전용 — `loop start` 중복 호출 금지**. wave 순서 보장은 start-time 게이팅이 아닌 **spec 위임 자체를 wave 단위로 순차화** 함으로써 강제된다 — wave 2+ child loop 는 의존 wave 의 `watch_wave` 가 성공으로 종료한 *후* 비로소 spec 위임을 통해 시작되므로, `loop/SKILL.md` 에 별도 inter-wave runtime 의존성 검사 메커니즘이 없어도 dependency 순서가 깨지지 않는다.
 
-### 게이트 ③ 최종 확인
+### 게이트 ③ 최종 확인 (DAG 레벨)
 
-모든 SPEC 작성 후 표 재제시:
+모든 wave 의 plan 표를 재제시. SPEC 자체는 wave 별 spec 위임 시점에 비로소 작성되므로, 본 표는 분해 plan 단계에서 추출한 child 한 줄 요약·예상 verify 명령·DAG 의존성을 보여준다 (실제 SPEC 경로는 wave 별 위임 직후 DISPATCH_LOG 에 기록):
 ```
-| child   | SPEC 경로                                | verify 명령           | 의존성    |
-|---------|------------------------------------------|-----------------------|-----------|
-| child-a | milestones/<m>/loops/child-a/SPEC.md     | pytest tests/a        | 없음      |
-| child-b | milestones/<m>/loops/child-b/SPEC.md     | pytest tests/b        | 없음      |
-| child-c | milestones/<m>/loops/child-c/SPEC.md     | pytest tests/c        | child-a   |
+| wave | child   | 한 줄 요약          | 예상 verify 명령      | 의존성    |
+|------|---------|---------------------|-----------------------|-----------|
+| 1    | child-a | <한 줄>             | pytest tests/a        | 없음      |
+| 1    | child-b | <한 줄>             | pytest tests/b        | 없음      |
+| 2    | child-c | <한 줄>             | pytest tests/c        | child-a   |
 ```
 
-`AskUserQuestion` 옵션: `(a) 실행 시작`, `(b) 취소`. 승인 시 wave 1부터 실행.
+`AskUserQuestion` 옵션: `(a) 실행 시작`, `(b) 취소`. 승인 시 wave 1 의 게이트 ② per-wave spec 위임 → `watch_wave` 순차 실행 시작.
 
-## 실행 (wave 단위 병렬)
+## 실행 (wave 단위 순차, wave 안 child 병렬)
 
 ```
 for wave in waves:
-  # child loop 는 게이트 ② 의 spec 위임 시점에 이미 자동 시작됨 (spec dispatch-위임 모드의 auto-loop-start). dispatch 는 별도 `loop start` 호출 없이 sentinel watch 만 수행 — 중복 시작 방지.
+  # 1) per-wave 게이트 ② spec 위임: 그 wave 의 각 child 에 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") 호출.
+  #    spec 의 dispatch-위임 모드 auto-loop-start 로 그 wave 의 child loop 가 자동 시작된다.
+  #    이전 wave 들의 loop 는 그 wave 의 watch_wave 가 이미 DONE 으로 종료한 상태 — 의존 산출물 준비 완료.
+  #    dispatch 는 별도 `loop start` 호출 없이 sentinel watch 만 수행 (중복 시작 방지).
 
   while wave 진행 중:
     # references/dispatch.sh watch_wave <m> child1 child2 ...
@@ -105,7 +110,7 @@ for wave in waves:
       다음 wave 차단 + 종료 (재계획은 사용자)
 
     모두 DONE (watch_wave exit 100):
-      DISPATCH_LOG.md 기록 → 다음 wave
+      DISPATCH_LOG.md 기록 → 다음 wave 의 per-wave 게이트 ② spec 위임으로 진입
 
     타임아웃 (watch_wave exit 102):
       watch_wave가 진행 중 child들에 kill -TERM (orphan 방지, 자동)

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -17,21 +17,15 @@ milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `a
 
 또는 사용자가 자연어로 의도 전달 시 모델이 자동 호출.
 
-### dispatch 위임 모드
-
-`autopilot:dispatch` 가 본 스킬을 위임 호출할 때는 단일 args 형식 `--milestone <m> <자연어 task 설명>` 으로 전달한다 — task 식별자는 dispatch 가 보유하지 않으며 본 스킬이 step 2 task 생성 단계에서 결정한다. dispatch 의 위임 호출로 인식한 경우, step 10 최종 검토의 세 옵션 사용자 질문을 생략하고 후속 **자율 루프를 자동** 시작한다(`Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계). 사용자가 본 스킬을 직접 호출한 경우에는 step 10 의 세 옵션 (loop start · SPEC 만 확정 · 변경) 이 그대로 유지된다.
-
-위임 호출 인식 휴리스틱: args 본문이 task-id 패턴이 아닌 자연어이고 호출 컨텍스트(상위 Skill 호출 체인)에 `autopilot:dispatch` 가 존재. 모호 시 사용자 직접 호출로 간주(safe-default).
-
 ## 10단계 워크플로
 
 호출 시 다음 10단계를 TodoWrite로 등록·실행. 각 단계는 사용자 결정·승인을 `AskUserQuestion`으로 받습니다.
 
 ### 1. 사전 검사
 
-- args 본문(플래그 제외) 형식 검증 (loop.sh의 `validate_task_id` 동일 규칙): 비어 있거나 `..` 포함, `.` 단독 컴포넌트(`.`·`./foo`·`foo/.`·`a/./b`), `__` 포함, 공백 포함 시 실패. **args 본문에 슬래시(`/`) 포함 시 거부** — milestone 은 항상 `--milestone <m>` 플래그로만 전달하고, args 본문에는 task 식별자 또는 자연어 task 설명 한 값만 들어간다(한 정보는 한 위치). 과거 컨벤션이던 `<m>/<c>` 본문 형식은 폐기. spec·loop 이 같은 (milestone, task-id) 쌍을 받아야 `--resume` 라운드트립이 성립.
-- milestone 인자 파싱: `--milestone <m>` 명시 시 `<m>` 사용, 미지정 시 **기본 milestone (`regular`)** 적용 — sibling `autopilot:loop` 이 단일 컴포넌트 task-id 를 `regular/<task-id>` 로 정규화하는 컨벤션과 일치. milestone 에도 동일 형식 검증 적용 (단일 컴포넌트 — `/` 미허용).
-- 자연어 입력 감지: args 본문이 task-id 패턴이 아닌 자연어 문장(물음표·따옴표·문장 부호 다중, 길이 ≥ 40자 등 휴리스틱)이면 task 생성 입력으로 분류 — 사용자 직접 호출 시 아래 **검증 실패 라우팅**, dispatch 위임 호출(§호출 방법 — dispatch 위임 모드)에서는 자연어 본문이 정상 입력이므로 task 생성 단계로 바로 진입.
+- task-id 형식 검증 (loop.sh의 `validate_task_id` 동일 규칙): 비어 있거나 `..` 포함, `.` 단독 컴포넌트(`.`·`./foo`·`foo/.`·`a/./b`), `__` 포함, 공백 포함 시 실패. 슬래시(`/`)는 `--milestone <m>` 명시 시에만 허용 — nested task-id(`sub-area/child` 등)가 정상 사용 사례. `--milestone` 미지정 + 슬래시 포함은 실패(loop.sh의 `normalize_task_id`가 첫 컴포넌트를 milestone으로 해석해 spec default `regular`와 어긋남 → `--resume` 라운드트립 깨짐). spec·loop이 같은 (milestone, task-id) 쌍을 받아야 `--resume` 라운드트립이 성립.
+- milestone 인자 파싱: `--milestone <m>` 명시 시 `<m>` 사용, 미지정 시 default `regular`. milestone에도 동일 형식 검증 적용 (단일 컴포넌트 — `/` 미허용).
+- 자연어 입력 감지: 인자가 task-id 패턴이 아닌 자연어 문장(물음표·따옴표·문장 부호 다중, 길이 ≥ 40자 등 휴리스틱)이면 검증 실패로 분류 — 즉시 abort 대신 아래 **검증 실패 라우팅**.
 - 어떤 형태의 검증 실패든 직접 abort/die 하지 않고 라우팅으로 분기. 통과 시 일반/--resume 모드 분기로 진행.
 - **일반 모드**: `milestones/<m>/loops/<c>/` 존재 시 abort + `AskUserQuestion` 3옵션 (다른 task-id / `--resume` / 백업 후 새로). 이하 `<c>`는 task-id 지칭.
 - **--resume 모드**: `milestones/<m>/loops/<c>/SPEC.md` 부재 시 abort. 잔존 `[NEEDS CLARIFICATION` 마커 0개 시 "해결할 마커 없음" 안내 후 종료
@@ -223,14 +217,11 @@ SPEC.md 작성·자체 검토 후 sibling `autopilot:loop`의 worktree base가 �
 
 ### 10. 사용자 최종 검토
 
-**호출 모드 분기**:
+SPEC.md 경로(§8.1 slug-bearing)·요약 안내 후 `AskUserQuestion`으로 **명시적 결정 입력**(자유 텍스트 종결구 금지 — CLAUDE.md 규칙). 옵션 3개(상호배타):
 
-- **dispatch 위임 모드** (§호출 방법 — dispatch 위임 모드): 본 단계의 세 옵션 사용자 질문을 생략하고 `Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계 — task 생성 → SPEC 작성 → 설계 브랜치 준비 → 자율 루프 자동 시작까지 단일 호출에서 완수.
-- **사용자 직접 호출 모드** (default): SPEC.md 경로(§8.1 slug-bearing)·요약 안내 후 `AskUserQuestion`으로 **명시적 결정 입력**(자유 텍스트 종결구 금지 — CLAUDE.md 규칙). 옵션 3개(상호배타):
-
-  - **지금 loop start 호출** (Recommended) — `Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계. 모니터 추가 질문 없이 loop 기본 동작(자동 Monitor 가설 포함, `plugins/autopilot/skills/loop/SKILL.md`) 적용. default `regular`이면 `start <c>` 단축형 동등.
-  - **SPEC만 확정** — 경로 안내·종료. 사용자가 별도 시점에 `Skill(skill: "loop", args: "start <m>/<c>")` 직접 호출.
-  - **변경** — 변경 섹션을 묻고 단계 7/8 재진입.
+- **지금 loop start 호출** (Recommended) — `Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계. 모니터 추가 질문 없이 loop 기본 동작(자동 Monitor 가설 포함, `plugins/autopilot/skills/loop/SKILL.md`) 적용. default `regular`이면 `start <c>` 단축형 동등.
+- **SPEC만 확정** — 경로 안내·종료. 사용자가 별도 시점에 `Skill(skill: "loop", args: "start <m>/<c>")` 직접 호출.
+- **변경** — 변경 섹션을 묻고 단계 7/8 재진입.
 
 ## --resume 모드 요약
 

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -17,15 +17,21 @@ milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `a
 
 또는 사용자가 자연어로 의도 전달 시 모델이 자동 호출.
 
+### dispatch 위임 모드
+
+`autopilot:dispatch` 가 본 스킬을 위임 호출할 때는 단일 args 형식 `--milestone <m> <자연어 task 설명>` 으로 전달한다 — task 식별자는 dispatch 가 보유하지 않으며 본 스킬이 step 2 task 생성 단계에서 결정한다. dispatch 의 위임 호출로 인식한 경우, step 10 최종 검토의 세 옵션 사용자 질문을 생략하고 후속 **자율 루프를 자동** 시작한다(`Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계). 사용자가 본 스킬을 직접 호출한 경우에는 step 10 의 세 옵션 (loop start · SPEC 만 확정 · 변경) 이 그대로 유지된다.
+
+위임 호출 인식 휴리스틱: args 본문이 task-id 패턴이 아닌 자연어이고 호출 컨텍스트(상위 Skill 호출 체인)에 `autopilot:dispatch` 가 존재. 모호 시 사용자 직접 호출로 간주(safe-default).
+
 ## 10단계 워크플로
 
 호출 시 다음 10단계를 TodoWrite로 등록·실행. 각 단계는 사용자 결정·승인을 `AskUserQuestion`으로 받습니다.
 
 ### 1. 사전 검사
 
-- task-id 형식 검증 (loop.sh의 `validate_task_id` 동일 규칙): 비어 있거나 `..` 포함, `.` 단독 컴포넌트(`.`·`./foo`·`foo/.`·`a/./b`), `__` 포함, 공백 포함 시 실패. 슬래시(`/`)는 `--milestone <m>` 명시 시에만 허용 — nested task-id(`sub-area/child` 등)가 정상 사용 사례. `--milestone` 미지정 + 슬래시 포함은 실패(loop.sh의 `normalize_task_id`가 첫 컴포넌트를 milestone으로 해석해 spec default `regular`와 어긋남 → `--resume` 라운드트립 깨짐). spec·loop이 같은 (milestone, task-id) 쌍을 받아야 `--resume` 라운드트립이 성립.
-- milestone 인자 파싱: `--milestone <m>` 명시 시 `<m>` 사용, 미지정 시 default `regular`. milestone에도 동일 형식 검증 적용 (단일 컴포넌트 — `/` 미허용).
-- 자연어 입력 감지: 인자가 task-id 패턴이 아닌 자연어 문장(물음표·따옴표·문장 부호 다중, 길이 ≥ 40자 등 휴리스틱)이면 검증 실패로 분류 — 즉시 abort 대신 아래 **검증 실패 라우팅**.
+- args 본문(플래그 제외) 형식 검증 (loop.sh의 `validate_task_id` 동일 규칙): 비어 있거나 `..` 포함, `.` 단독 컴포넌트(`.`·`./foo`·`foo/.`·`a/./b`), `__` 포함, 공백 포함 시 실패. **args 본문에 슬래시(`/`) 포함 시 거부** — milestone 은 항상 `--milestone <m>` 플래그로만 전달하고, args 본문에는 task 식별자 또는 자연어 task 설명 한 값만 들어간다(한 정보는 한 위치). 과거 컨벤션이던 `<m>/<c>` 본문 형식은 폐기. spec·loop 이 같은 (milestone, task-id) 쌍을 받아야 `--resume` 라운드트립이 성립.
+- milestone 인자 파싱: `--milestone <m>` 명시 시 `<m>` 사용, 미지정 시 **기본 milestone (`regular`)** 적용 — sibling `autopilot:loop` 이 단일 컴포넌트 task-id 를 `regular/<task-id>` 로 정규화하는 컨벤션과 일치. milestone 에도 동일 형식 검증 적용 (단일 컴포넌트 — `/` 미허용).
+- 자연어 입력 감지: args 본문이 task-id 패턴이 아닌 자연어 문장(물음표·따옴표·문장 부호 다중, 길이 ≥ 40자 등 휴리스틱)이면 task 생성 입력으로 분류 — 사용자 직접 호출 시 아래 **검증 실패 라우팅**, dispatch 위임 호출(§호출 방법 — dispatch 위임 모드)에서는 자연어 본문이 정상 입력이므로 task 생성 단계로 바로 진입.
 - 어떤 형태의 검증 실패든 직접 abort/die 하지 않고 라우팅으로 분기. 통과 시 일반/--resume 모드 분기로 진행.
 - **일반 모드**: `milestones/<m>/loops/<c>/` 존재 시 abort + `AskUserQuestion` 3옵션 (다른 task-id / `--resume` / 백업 후 새로). 이하 `<c>`는 task-id 지칭.
 - **--resume 모드**: `milestones/<m>/loops/<c>/SPEC.md` 부재 시 abort. 잔존 `[NEEDS CLARIFICATION` 마커 0개 시 "해결할 마커 없음" 안내 후 종료
@@ -217,11 +223,14 @@ SPEC.md 작성·자체 검토 후 sibling `autopilot:loop`의 worktree base가 �
 
 ### 10. 사용자 최종 검토
 
-SPEC.md 경로(§8.1 slug-bearing)·요약 안내 후 `AskUserQuestion`으로 **명시적 결정 입력**(자유 텍스트 종결구 금지 — CLAUDE.md 규칙). 옵션 3개(상호배타):
+**호출 모드 분기**:
 
-- **지금 loop start 호출** (Recommended) — `Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계. 모니터 추가 질문 없이 loop 기본 동작(자동 Monitor 가설 포함, `plugins/autopilot/skills/loop/SKILL.md`) 적용. default `regular`이면 `start <c>` 단축형 동등.
-- **SPEC만 확정** — 경로 안내·종료. 사용자가 별도 시점에 `Skill(skill: "loop", args: "start <m>/<c>")` 직접 호출.
-- **변경** — 변경 섹션을 묻고 단계 7/8 재진입.
+- **dispatch 위임 모드** (§호출 방법 — dispatch 위임 모드): 본 단계의 세 옵션 사용자 질문을 생략하고 `Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계 — task 생성 → SPEC 작성 → 설계 브랜치 준비 → 자율 루프 자동 시작까지 단일 호출에서 완수.
+- **사용자 직접 호출 모드** (default): SPEC.md 경로(§8.1 slug-bearing)·요약 안내 후 `AskUserQuestion`으로 **명시적 결정 입력**(자유 텍스트 종결구 금지 — CLAUDE.md 규칙). 옵션 3개(상호배타):
+
+  - **지금 loop start 호출** (Recommended) — `Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계. 모니터 추가 질문 없이 loop 기본 동작(자동 Monitor 가설 포함, `plugins/autopilot/skills/loop/SKILL.md`) 적용. default `regular`이면 `start <c>` 단축형 동등.
+  - **SPEC만 확정** — 경로 안내·종료. 사용자가 별도 시점에 `Skill(skill: "loop", args: "start <m>/<c>")` 직접 호출.
+  - **변경** — 변경 섹션을 묻고 단계 7/8 재진입.
 
 ## --resume 모드 요약
 

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -21,7 +21,7 @@ milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `a
 
 `autopilot:dispatch` 가 본 스킬을 위임 호출할 때는 단일 args 형식 `--milestone <m> <자연어 task 설명>` 으로 전달한다 — task 식별자는 dispatch 가 보유하지 않으며 본 스킬이 step 2 task 생성 단계에서 결정한다. dispatch 의 위임 호출로 인식한 경우, step 10 최종 검토의 세 옵션 사용자 질문을 생략하고 후속 **자율 루프를 자동** 시작한다(`Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계). 사용자가 본 스킬을 직접 호출한 경우에는 step 10 의 세 옵션 (loop start · SPEC 만 확정 · 변경) 이 그대로 유지된다.
 
-위임 호출 인식 휴리스틱: args 본문이 task-id 패턴이 아닌 자연어이고 호출 컨텍스트(상위 Skill 호출 체인)에 `autopilot:dispatch` 가 존재. 모호 시 사용자 직접 호출로 간주(safe-default).
+위임 호출 인식 휴리스틱: args 본문이 task-id 패턴이 아닌 자연어이고, **현재 Skill 호출의 직접 부모(immediate caller)가 `autopilot:dispatch`** 인 경우 — 같은 대화 히스토리 안에서 과거 턴에 dispatch 가 사용됐다 해도 현재 호출의 직접 부모가 아니면 위임 모드가 아니다. 모호 시 사용자 직접 호출로 간주(safe-default 가 직접 부모 판별 불가 케이스를 커버).
 
 ## 10단계 워크플로
 
@@ -29,7 +29,7 @@ milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `a
 
 ### 1. 사전 검사
 
-- args 본문(플래그 제외) 형식 검증 (loop.sh의 `validate_task_id` 동일 규칙): 비어 있거나 `..` 포함, `.` 단독 컴포넌트(`.`·`./foo`·`foo/.`·`a/./b`), `__` 포함, 공백 포함 시 실패. **args 본문에 슬래시(`/`) 포함 시 거부** — milestone 은 항상 `--milestone <m>` 플래그로만 전달하고, args 본문에는 task 식별자 또는 자연어 task 설명 한 값만 들어간다(한 정보는 한 위치). 과거 컨벤션이던 `<m>/<c>` 본문 형식은 폐기. spec·loop 이 같은 (milestone, task-id) 쌍을 받아야 `--resume` 라운드트립이 성립.
+- args 본문(플래그 제외) 형식 검증 (loop.sh 의 `validate_task_id` 와 **동일한 기본 규칙 + 슬래시 추가 제약**): 비어 있거나 `..` 포함, `.` 단독 컴포넌트(`.`·`./foo`·`foo/.`·`a/./b`), `__` 포함, 공백 포함 시 실패. **args 본문에 슬래시(`/`) 포함 시 거부** — `validate_task_id` 자체는 nested task-id 표기를 위해 슬래시를 허용하지만, spec 본문은 슬래시를 거부하는 추가 제약을 둔다. milestone 은 항상 `--milestone <m>` 플래그로만 전달하고, args 본문에는 task 식별자 또는 자연어 task 설명 한 값만 들어간다(한 정보는 한 위치). 과거 컨벤션이던 `<m>/<c>` 본문 형식은 폐기. spec·loop 이 같은 (milestone, task-id) 쌍을 받아야 `--resume` 라운드트립이 성립.
 - milestone 인자 파싱: `--milestone <m>` 명시 시 `<m>` 사용, 미지정 시 **기본 milestone (`regular`)** 적용 — sibling `autopilot:loop` 이 단일 컴포넌트 task-id 를 `regular/<task-id>` 로 정규화하는 컨벤션과 일치. milestone 에도 동일 형식 검증 적용 (단일 컴포넌트 — `/` 미허용).
 - 자연어 입력 감지: args 본문이 task-id 패턴이 아닌 자연어 문장(물음표·따옴표·문장 부호 다중, 길이 ≥ 40자 등 휴리스틱)이면 task 생성 입력으로 분류 — 사용자 직접 호출 시 아래 **검증 실패 라우팅**, dispatch 위임 호출(§호출 방법 — dispatch 위임 모드)에서는 자연어 본문이 정상 입력이므로 task 생성 단계로 바로 진입.
 - 어떤 형태의 검증 실패든 직접 abort/die 하지 않고 라우팅으로 분기. 통과 시 일반/--resume 모드 분기로 진행.


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가

`autopilot:dispatch` 가 `autopilot:spec` 을 위임 호출할 때의 contract 를 단일화한다. dispatch 는 child task 식별자를 알 필요가 없으며 spec 이 task 생성·명세 작성·설계 브랜치 준비·후속 자율 루프 시작까지 단일 호출에서 완수한다.

spec 은 milestone 을 별도 인자로만 받는다 — args 본문에는 task 식별자 또는 자연어 task 설명만 들어가고, milestone 은 항상 명시적인 플래그로 명시한다. 플래그가 없으면 프로젝트 기본 milestone (`regular`) 으로 적용된다. args 본문 안 슬래시는 거부된다 — 한 정보는 한 위치.

dispatch 의 위임 호출은 task 식별자 대신 처리할 task 의 자연어 설명·milestone 만 넘긴다. milestone 은 명시 플래그로, 자연어 설명은 그 뒤 본문으로 전달된다. 이를 받은 spec 은 호출자가 dispatch 임을 인식해 최종 사용자 확인 단계를 생략하고 자율 루프를 바로 시작한다. 사용자가 spec 을 직접 호출한 경우에는 기존의 최종 확인 단계·세 옵션 (loop start · SPEC 만 확정 · 변경) 이 그대로 유지된다.

dispatch 는 위임 전후 설계 산출물 저장소의 스냅샷 차이로 child 의 명세 경로를 식별하며 task 식별자 자체는 참조하지 않는다.

## Commits
- d6f8080 feat(spec,dispatch): 141 — unify dispatch ↔ spec delegation contract
- 434ded4 Revert "feat(spec,dispatch): 141 — unify dispatch ↔ spec delegation contract"
- bccb1cc feat(spec,dispatch): 141 — unify dispatch ↔ spec delegation contract
- ff8889d feat(spec): 141 — unify dispatch spec delegation contract

Closes #141
<!-- autopilot:pr-body:end -->