### PR TITLE
spec·loop 스킬 SKILL.md frontmatter에 권한 허용 패턴 명시

### DIFF
--- a/milestones/regular/loops/113-spec-loop-skill-md-frontmatter/SPEC.md
+++ b/milestones/regular/loops/113-spec-loop-skill-md-frontmatter/SPEC.md
@@ -1,0 +1,52 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/spec/**", "plugins/autopilot/skills/loop/**", "tests/autopilot/**"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash tests/autopilot/test-skill-allow-tools.sh"
+request_review: true
+---
+
+# spec·loop 스킬 SKILL.md frontmatter에 권한 허용 패턴 명시
+
+## 무엇을 만들 것인가
+`autopilot:spec`·`autopilot:loop` 두 스킬을 호출할 때 권한 prompt가 거의 발생하지 않도록, 각 스킬의 `SKILL.md` frontmatter에 사용 권한 패턴을 명시한다. 패턴 집합은 issue #113 본문이 enumerate한 직전 세션 실측 결과를 기준으로 한다. 외부 시스템 상태를 변경할 수 있는 `gh` CLI는 `gh pr` 계열만 허용하고 그 외에는 포함하지 않는다. `Bash(*)` 같은 catch-all 광역 권한은 금지한다.
+
+## 수용 기준 (EARS)
+- **AC1**: 시스템은 `plugins/autopilot/skills/spec/SKILL.md` frontmatter에 권한 허용 패턴 배열을 포함한다.
+- **AC2**: 시스템은 `plugins/autopilot/skills/loop/SKILL.md` frontmatter에 권한 허용 패턴 배열을 포함한다.
+- **AC3**: 위 두 SKILL.md의 frontmatter는 YAML로 parse 성공한다.
+- **AC4**: 위 두 frontmatter의 허용 패턴 배열은 catch-all 패턴(`Bash(*)`·`*` 단독)을 포함하지 않는다.
+- **AC5**: 위 두 frontmatter의 허용 패턴 배열은 `gh pr` prefix를 제외한 모든 `gh ` prefix 패턴을 포함하지 않는다.
+- **AC6**: 위 두 frontmatter의 허용 패턴 배열은 각 배열 내에서 중복 항목을 포함하지 않는다.
+- **AC7**: `spec/SKILL.md`의 허용 패턴 배열은 issue #113 본문 `autopilot:spec` 섹션과 `공통·보조` 섹션이 enumerate한 패턴(gh 패턴 제외)을 모두 포함한다.
+- **AC8**: `loop/SKILL.md`의 허용 패턴 배열은 issue #113 본문 `autopilot:loop` 섹션과 `공통·보조` 섹션이 enumerate한 패턴(gh 패턴 제외)을 모두 포함한다.
+
+## 범위
+포함:
+- `plugins/autopilot/skills/spec/SKILL.md` frontmatter에 허용 패턴 배열 추가
+- `plugins/autopilot/skills/loop/SKILL.md` frontmatter에 허용 패턴 배열 추가
+- 정적 검사 verify script 추가 (위 AC1~AC8 자동 검증)
+
+비-목표 / 제외:
+- `dispatch`·`prd` 등 다른 autopilot 스킬 (후속 issue로 분리)
+- `~/.claude/settings.json`·`.claude/settings.json`·`.claude/settings.local.json` 변경
+- `fewer-permission-prompts` 스킬 도입·비교 (별도 경로, 본 SPEC 범위 밖)
+- 권한 prompt 발생 빈도 동적 측정
+
+## 검증
+이 명령이 0 exit으로 끝나야 합니다:
+```
+bash tests/autopilot/test-skill-allow-tools.sh
+```
+
+## 제약 (있을 때만)
+- 본 repo는 plugin source repo이며, 실제 권한 prompt 감소 효과는 사용자 환경의 plugin cache가 새 `SKILL.md`를 동기화한 뒤에만 관측된다.
+- `SKILL.md` frontmatter에 사용할 정확한 key 이름(`allow-tools` 혹은 `allowed-tools`)은 Claude Code의 frontmatter 처리 명세에 따르며, loop 워커가 구현 단계에서 1회 확인해 두 SKILL.md에 일관 적용한다.
+- AC7·AC8의 "issue #113 본문 enumerate 패턴"은 SPEC 작성 시점의 issue body 내용을 정답으로 한다. verify script는 그 정답 집합을 frozen reference로 보유해 외부 API 호출 없이 비교한다.
+
+## 위험 (있을 때만)
+- `SKILL.md` frontmatter의 허용-패턴 키가 실제로 Claude Code skill loader에서 권한 자동 허용에 사용되지 않을 가능성 — 이 경우 본 SPEC의 효과(prompt 빈도 감소)는 실현되지 않는다. loop 구현 초기에 1회 동작 확인 후 진행한다.
+- enumerate된 패턴 일부가 실제 호출과 좁게 불일치할 수 있음(경로·인자 변동). 보수적으로 유지하되 누락 발견 시 후속 PR로 추가한다.

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -1,7 +1,24 @@
 ---
 name: loop
 description: 자율 수행 루프(랄프 루프) 운영 인터페이스. start/status/stop/list/cleanup/logs 서브커맨드로 자율 task의 lifecycle을 관리합니다. SPEC 작성은 별도 'autopilot:spec' 스킬을 사용. 본 스킬은 자기완결적이며 헌법·드라이버를 모두 references/에 포함합니다.
-allowed-tools: Monitor
+allowed-tools:
+  - Monitor
+  # SPEC 113 — issue #113 본문 `autopilot:loop` 섹션 (직전 세션 실측)
+  - Bash(bash * loop.sh start *)
+  - Bash(bash * loop.sh status *)
+  - Bash(bash * loop.sh stop *)
+  - Bash(bash * loop.sh list)
+  - Bash(bash * loop.sh cleanup *)
+  - Bash(bash * loop.sh logs *)
+  - Bash(tail -F /private/tmp/* | grep -E --line-buffered *)
+  # SPEC 113 — issue #113 본문 `공통·보조` 섹션
+  - Bash(git -C * stash list)
+  - Bash(git -C * stash pop *)
+  - Bash(git -C * stash show *)
+  - Bash(rm */ESCALATION.md)
+  - Bash(rm */DONE)
+  - Bash(ps -p *)
+  - Bash(cat */*.lock)
 ---
 
 # loop

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -1,7 +1,65 @@
 ---
 name: spec
 description: "기능 추가·동작 수정·지침 작성·새로 만들 등 새 코드 변경을 정의하는 자연어 신호에 대응. autopilot loop이 입력으로 받는 SPEC.md를 대화형으로 생성. 한 질문씩 명확화·섹션별 승인·EARS 포맷·[NEEDS CLARIFICATION] 마커로 자율 loop이 도중 질문 없이 완수 가능한 자기완결적 SPEC을 만듭니다. 이 레포 표준 워크플로우는 자기완결적 SPEC.md 작성 → feat 브랜치 분기·SPEC commit → autopilot loop 실행 → PR. SPEC.md 작성 후 결정적 슬러그화 규칙(ASCII 영숫자·하이픈만)으로 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·SPEC.md를 commit해 loop·PR 흐름이 단일 feature 브랜치로 통합되게 합니다. 호출 'Skill(skill=\"spec\", args=\"<task-id> [--milestone <m>] [--resume]\")'. milestone 미지정 시 `regular`(catch-all)을 default로 적용."
-allowed-tools: AskUserQuestion, Read, Write, Skill, Agent, Bash(git log:*), Bash(git status:*), Bash(git rev-parse:*), Bash(git checkout:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git show-ref:*), Bash(git for-each-ref:*), Bash(ls:*), Bash(cat:*), Bash(find:*), Bash(mkdir:*), Bash(grep:*), Bash(echo:*), Bash(head:*), Bash(tr:*), Bash(sed:*), Bash(gh:*)
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Write
+  - Skill
+  - Agent
+  # 기존 단축 prefix 패턴 (보존)
+  - Bash(git log:*)
+  - Bash(git status:*)
+  - Bash(git rev-parse:*)
+  - Bash(git checkout:*)
+  - Bash(git branch:*)
+  - Bash(git add:*)
+  - Bash(git commit:*)
+  - Bash(git show-ref:*)
+  - Bash(git for-each-ref:*)
+  - Bash(ls:*)
+  - Bash(cat:*)
+  - Bash(find:*)
+  - Bash(mkdir:*)
+  - Bash(grep:*)
+  - Bash(echo:*)
+  - Bash(head:*)
+  - Bash(tr:*)
+  - Bash(sed:*)
+  # SPEC 113 — issue #113 본문 `autopilot:spec` 섹션 (직전 세션 실측)
+  - Bash(git -C * rev-parse *)
+  - Bash(git -C * status --porcelain)
+  - Bash(git -C * log *)
+  - Bash(git -C * branch *)
+  - Bash(git -C * show-ref *)
+  - Bash(git -C * for-each-ref *)
+  - Bash(git -C * ls-files *)
+  - Bash(git -C * diff *)
+  - Bash(git -C * checkout *)
+  - Bash(git -C * checkout -b *)
+  - Bash(git -C * add *)
+  - Bash(git -C * commit *)
+  - Bash(git update-ref *)
+  - Bash(git branch *)
+  - Bash(git -C * hash-object -w *)
+  - Bash(GIT_INDEX_FILE=* git -C * read-tree *)
+  - Bash(GIT_INDEX_FILE=* git -C * update-index --add --cacheinfo *)
+  - Bash(GIT_INDEX_FILE=* git -C * write-tree)
+  - Bash(git -C * commit-tree * -p *)
+  - Bash(mkdir -p milestones/**)
+  - Bash(awk *)
+  - Bash(sed *)
+  - Bash(tr *)
+  - Bash(grep -rE * plugins/autopilot/**)
+  - Bash(grep -rln * plugins/autopilot/**)
+  # SPEC 113 — issue #113 본문 `공통·보조` 섹션
+  - Bash(git -C * stash list)
+  - Bash(git -C * stash pop *)
+  - Bash(git -C * stash show *)
+  - Bash(rm */ESCALATION.md)
+  - Bash(rm */DONE)
+  - Bash(ps -p *)
+  - Bash(cat */*.lock)
 ---
 
 # spec

--- a/tests/autopilot/test-skill-allow-tools.sh
+++ b/tests/autopilot/test-skill-allow-tools.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# SPEC 113: autopilot:spec / autopilot:loop SKILL.md frontmatter 권한 허용
+# 패턴 정적 검증.
+#
+# AC1·AC2 — 두 SKILL.md frontmatter에 권한 허용 패턴 배열이 존재.
+# AC3    — 두 SKILL.md frontmatter는 YAML로 parse 성공.
+# AC4    — 배열은 catch-all 패턴(`Bash(*)`·`*` 단독)을 포함하지 않는다.
+# AC5    — 배열은 `gh pr` prefix를 제외한 모든 `gh ` prefix 패턴을 포함하지 않는다.
+# AC6    — 배열 내 중복 항목 없음.
+# AC7    — spec/SKILL.md 배열에 issue #113 본문 `autopilot:spec` + `공통·보조` 패턴 모두 포함.
+# AC8    — loop/SKILL.md 배열에 issue #113 본문 `autopilot:loop` + `공통·보조` 패턴 모두 포함.
+#
+# 비교 기준 집합(AC7·AC8)은 SPEC 작성 시점의 issue body를 frozen reference로
+# 본 스크립트에 박는다. 외부 API 호출은 수행하지 않는다.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SPEC_SKILL_MD="$REPO_ROOT/plugins/autopilot/skills/spec/SKILL.md"
+LOOP_SKILL_MD="$REPO_ROOT/plugins/autopilot/skills/loop/SKILL.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "OK: $*"; }
+
+command -v yq >/dev/null 2>&1 || fail "yq (mikefarah) 필요 — target 프로젝트 의존성"
+
+[[ -f "$SPEC_SKILL_MD" ]] || fail "$SPEC_SKILL_MD 부재"
+[[ -f "$LOOP_SKILL_MD" ]] || fail "$LOOP_SKILL_MD 부재"
+
+# ---------------------------------------------------------------------------
+# frontmatter 추출 (첫 --- ~ 두 번째 --- 사이)
+extract_frontmatter() {
+  awk '
+    BEGIN { in_fm = 0; count = 0 }
+    /^---$/ {
+      count++
+      if (count == 1) { in_fm = 1; next }
+      if (count == 2) { exit }
+    }
+    in_fm { print }
+  ' "$1"
+}
+
+SPEC_FM="$(extract_frontmatter "$SPEC_SKILL_MD")"
+LOOP_FM="$(extract_frontmatter "$LOOP_SKILL_MD")"
+
+[[ -n "$SPEC_FM" ]] || fail "spec SKILL.md frontmatter 추출 실패"
+[[ -n "$LOOP_FM" ]] || fail "loop SKILL.md frontmatter 추출 실패"
+
+# ---------------------------------------------------------------------------
+echo "=== AC3: YAML parse ==="
+echo "$SPEC_FM" | yq eval . - >/dev/null 2>&1 \
+  || fail "AC3: spec SKILL.md frontmatter YAML parse 실패"
+echo "$LOOP_FM" | yq eval . - >/dev/null 2>&1 \
+  || fail "AC3: loop SKILL.md frontmatter YAML parse 실패"
+ok "AC3: spec·loop SKILL.md frontmatter YAML parse 통과"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== AC1·AC2: allowed-tools 배열 존재 ==="
+spec_kind="$(printf '%s\n' "$SPEC_FM" | yq eval '.allowed-tools | tag' -)"
+loop_kind="$(printf '%s\n' "$LOOP_FM" | yq eval '.allowed-tools | tag' -)"
+[[ "$spec_kind" == "!!seq" ]] \
+  || fail "AC1: spec SKILL.md allowed-tools 가 YAML 배열(seq) 아님 (실측: $spec_kind)"
+[[ "$loop_kind" == "!!seq" ]] \
+  || fail "AC2: loop SKILL.md allowed-tools 가 YAML 배열(seq) 아님 (실측: $loop_kind)"
+ok "AC1·AC2: 두 SKILL.md allowed-tools 가 YAML 배열"
+
+# 배열 항목 수집 — newline-separated
+spec_items="$(printf '%s\n' "$SPEC_FM" | yq eval '.allowed-tools[]' -)"
+loop_items="$(printf '%s\n' "$LOOP_FM" | yq eval '.allowed-tools[]' -)"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== AC4: catch-all 패턴 부재 ==="
+check_no_catchall() {
+  local name="$1" items="$2" line
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    case "$line" in
+      'Bash(*)'|'*')
+        fail "AC4: $name 에 catch-all 패턴 발견: $line"
+        ;;
+    esac
+  done <<< "$items"
+}
+check_no_catchall "spec" "$spec_items"
+check_no_catchall "loop" "$loop_items"
+ok "AC4: catch-all (Bash(*)·*) 부재"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== AC5: gh pr 외 gh 패턴 부재 ==="
+# Bash(...) 안의 내부를 추출해 검사. 두 형태 모두 점검:
+#   1) Bash(gh ...) - 공백으로 분리된 첫 단어
+#   2) Bash(gh:...) - 콜론으로 분리된 prefix
+check_gh_only_pr() {
+  local name="$1" items="$2" line inner
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    # Bash(...) prefix 인 항목만 검사
+    case "$line" in
+      'Bash('*')')
+        # 안쪽 내용 추출
+        inner="${line#Bash(}"
+        inner="${inner%)}"
+        # gh 패턴 검사
+        case "$inner" in
+          gh\ pr*|'gh pr'*)
+            : # 허용
+            ;;
+          gh\ *|gh:*)
+            fail "AC5: $name 에 gh pr 외 gh 패턴 발견: $line"
+            ;;
+        esac
+        ;;
+    esac
+  done <<< "$items"
+}
+check_gh_only_pr "spec" "$spec_items"
+check_gh_only_pr "loop" "$loop_items"
+ok "AC5: gh pr 외 gh 패턴 부재"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== AC6: 중복 항목 부재 ==="
+check_no_dup() {
+  local name="$1" items="$2" dup
+  dup="$(printf '%s\n' "$items" | grep -v '^$' | sort | uniq -d || true)"
+  if [[ -n "$dup" ]]; then
+    fail "AC6: $name 에 중복 항목 존재: $dup"
+  fi
+}
+check_no_dup "spec" "$spec_items"
+check_no_dup "loop" "$loop_items"
+ok "AC6: 중복 항목 부재"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== AC7·AC8: issue #113 본문 enumerate 패턴 포함 ==="
+
+# issue #113 본문의 `autopilot:spec` 섹션 패턴 (gh 패턴 제외)
+SPEC_REQ=(
+  'Bash(git -C * rev-parse *)'
+  'Bash(git -C * status --porcelain)'
+  'Bash(git -C * log *)'
+  'Bash(git -C * branch *)'
+  'Bash(git -C * show-ref *)'
+  'Bash(git -C * for-each-ref *)'
+  'Bash(git -C * ls-files *)'
+  'Bash(git -C * diff *)'
+  'Bash(git -C * checkout *)'
+  'Bash(git -C * checkout -b *)'
+  'Bash(git -C * add *)'
+  'Bash(git -C * commit *)'
+  'Bash(git update-ref *)'
+  'Bash(git branch *)'
+  'Bash(git -C * hash-object -w *)'
+  'Bash(GIT_INDEX_FILE=* git -C * read-tree *)'
+  'Bash(GIT_INDEX_FILE=* git -C * update-index --add --cacheinfo *)'
+  'Bash(GIT_INDEX_FILE=* git -C * write-tree)'
+  'Bash(git -C * commit-tree * -p *)'
+  'Bash(mkdir -p milestones/**)'
+  'Bash(awk *)'
+  'Bash(sed *)'
+  'Bash(tr *)'
+  'Bash(grep -rE * plugins/autopilot/**)'
+  'Bash(grep -rln * plugins/autopilot/**)'
+)
+
+# issue #113 본문의 `autopilot:loop` 섹션 패턴 (gh 패턴 제외)
+LOOP_REQ=(
+  'Bash(bash * loop.sh start *)'
+  'Bash(bash * loop.sh status *)'
+  'Bash(bash * loop.sh stop *)'
+  'Bash(bash * loop.sh list)'
+  'Bash(bash * loop.sh cleanup *)'
+  'Bash(bash * loop.sh logs *)'
+  'Bash(tail -F /private/tmp/* | grep -E --line-buffered *)'
+)
+
+# issue #113 본문의 `공통·보조` 섹션 패턴 (gh 패턴 제외)
+COMMON_REQ=(
+  'Bash(git -C * stash list)'
+  'Bash(git -C * stash pop *)'
+  'Bash(git -C * stash show *)'
+  'Bash(rm */ESCALATION.md)'
+  'Bash(rm */DONE)'
+  'Bash(ps -p *)'
+  'Bash(cat */*.lock)'
+)
+
+check_contains_all() {
+  local name="$1" items="$2"
+  shift 2
+  local missing=0 req
+  for req in "$@"; do
+    if ! grep -qxF -- "$req" <<< "$items"; then
+      echo "  MISSING ($name): $req" >&2
+      missing=1
+    fi
+  done
+  if (( missing != 0 )); then
+    fail "$name 에 누락 패턴 존재 (위 MISSING 항목 참조)"
+  fi
+}
+
+check_contains_all "spec/SKILL.md" "$spec_items" "${SPEC_REQ[@]}" "${COMMON_REQ[@]}"
+ok "AC7: spec SKILL.md 에 issue spec 섹션 + 공통·보조 섹션 패턴 모두 포함"
+
+check_contains_all "loop/SKILL.md" "$loop_items" "${LOOP_REQ[@]}" "${COMMON_REQ[@]}"
+ok "AC8: loop SKILL.md 에 issue loop 섹션 + 공통·보조 섹션 패턴 모두 포함"
+
+echo ""
+echo "ALL CHECKS PASSED"


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가
`autopilot:spec`·`autopilot:loop` 두 스킬을 호출할 때 권한 prompt가 거의 발생하지 않도록, 각 스킬의 `SKILL.md` frontmatter에 사용 권한 패턴을 명시한다. 패턴 집합은 issue #113 본문이 enumerate한 직전 세션 실측 결과를 기준으로 한다. 외부 시스템 상태를 변경할 수 있는 `gh` CLI는 `gh pr` 계열만 허용하고 그 외에는 포함하지 않는다. `Bash(*)` 같은 catch-all 광역 권한은 금지한다.

## Commits
- 6e210e1 feat(autopilot/spec·loop): SKILL.md frontmatter allowed-tools 권한 허용 패턴 명시 (SPEC 113)
- b5bd5a9 feat(spec): 113 — spec·loop 스킬 SKILL.md frontmatter에 권한 허용 패턴 명시

Closes #113
<!-- autopilot:pr-body:end -->