### PR TITLE
review-fix-phase: reviewThreads 의존 제거 + silent-fail 감지

### DIFF
--- a/milestones/regular/loops/155-review-fix-phase-reviewthreads-silent-fail/SPEC.md
+++ b/milestones/regular/loops/155-review-fix-phase-reviewthreads-silent-fail/SPEC.md
@@ -1,0 +1,72 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/loop/references/review-fix-phase.sh"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash -c 'set -e; F=plugins/autopilot/skills/loop/references/review-fix-phase.sh; test -f \"$F\" && bash -n \"$F\" && ! grep -qE \"reviewThreads\" \"$F\" && grep -qE \"stuck|consecutive[-_]idle|silent[-_]fail\" \"$F\"'"
+ears_language: ko
+---
+
+# review-fix-phase: reviewThreads 의존 제거 + silent-fail 감지
+
+## 무엇을 만들 것인가
+
+`autopilot:loop`의 review-fix-phase는 PR 리뷰 이벤트 세 소스(PR-level conversation comments, review summaries, review thread inline comments)를 폴링으로 수집해 새 이벤트마다 fix 이터를 dispatch한다. 현재 구현은 단일 `gh pr view --json reviews,reviewThreads,comments` 호출로 세 소스를 동시에 fetch하지만, `reviewThreads` JSON 필드는 일부 gh CLI 버전(현재 사용자 환경 포함)에서 지원되지 않아 호출 전체가 비-zero exit으로 실패한다. 실패 시 코드는 `|| echo '{}'` 패턴으로 빈 JSON으로 대체하므로 `collect_new_events`는 모든 이벤트 ID를 0개로 판정하고, 폴링 루프는 silent로 계속 돌면서 fix를 영원히 시작하지 않는다.
+
+본 task는 두 가지를 함께 변경한다:
+
+1. **reviewThreads JSON 필드 의존 제거** — review thread inline comments 수집을 `gh pr view --json reviewThreads`가 아닌 다른 gh CLI 호환 매체로 우회한다. PR-level comments와 review summaries 수집은 호환성 영향이 없으므로 그대로 유지하되, 세 소스를 *각각 독립 호출*로 분리해 한 소스의 fetch 실패가 다른 소스 수집을 차단하지 않게 한다.
+
+2. **silent-fail 감지·escalation** — review-fix-phase 폴링이 의도하지 않게 silent로 도는 패턴(예: gh CLI 호출 실패가 fallback으로 묻혀 새 이벤트 0건으로 잘못 판정되거나, PR check가 완료됐는데도 리뷰 코멘트·완료 코멘트 모두 부재 상태로 연속 폴링이 idle)을 명시적으로 감지해 `ESCALATION` 토큰을 stdout으로 emit한다. 한 번이 아닌 *연속 N회* 임계로 false positive를 줄인다.
+
+두 변경은 같은 의도다 — review-fix-phase가 silent로 머물지 않고 fix 흐름을 시작하거나 명시적으로 실패를 보고하도록 만든다.
+
+## 수용 기준 (EARS)
+
+1. `plugins/autopilot/skills/loop/references/review-fix-phase.sh`가 존재할 때, 시스템은 본 파일 내 `reviewThreads` JSON 필드 참조를 모두 제거하고, `gh pr view --json reviewThreads` 호출 의존을 본문에서 모두 없앤다.
+2. review-fix-phase가 폴링하는 동안 연속 N회(N은 본 task 내부에서 결정, 최소 3 이상) 새 이벤트가 0건이면, 시스템은 stuck 진단을 수행해 silent-fail 패턴(세 이벤트 fetch 호출 중 어느 하나라도 비-zero exit으로 실패한 경우 또는 PR check 완료 + 리뷰 코멘트 부재 + owner cmd 부재) 감지 시 `ESCALATION` 토큰을 stdout으로 emit한다.
+
+## 범위
+
+포함:
+
+- `review-fix-phase.sh`의 `collect_new_events` 재구성 — `reviewThreads` JSON 필드 의존 제거, 세 소스(PR-level comments·review summaries·review thread inline comments)를 *각각 독립 호출*로 분리
+- `review-fix-phase.sh` 폴링 루프에 silent-fail 감지·`ESCALATION` emit 로직 추가
+
+비-목표 / 제외:
+
+- 다른 phase script(`pr-phase.sh`·`rebase-phase.sh`·`cleanup-phase.sh`) 변경
+- 워커 헌법(`constitution.md`) 변경
+- `loop.sh`의 검출 로직 (SPEC 134·150 그대로)
+- gh CLI 버전 자동 감지·강제 upgrade
+- review thread 수집의 GraphQL 호출 신설 (`gh api graphql`) — REST endpoint로 충분
+- DISPUTE 코멘트 게시 정책 변경
+- silent-fail 외 escalation 채널(notification·webhook 등) 추가
+
+## 검증
+
+이 명령이 0 exit으로 끝나야 합니다:
+
+```bash
+bash -c 'set -e; F=plugins/autopilot/skills/loop/references/review-fix-phase.sh; test -f "$F" && bash -n "$F" && ! grep -qE "reviewThreads" "$F" && grep -qE "stuck|consecutive[-_]idle|silent[-_]fail" "$F"'
+```
+
+## 제약
+
+- 세 이벤트 소스 수집을 *각각 독립 호출*로 분리해 한 소스 fetch 실패가 다른 소스를 차단하지 않게 한다 — verify 명령으로 직접 검증되지 않으므로 본 제약으로 보강.
+- review thread inline comments 수집은 `gh pr view --json reviewThreads` 대신 gh CLI 호환 endpoint(예: `gh api repos/{owner}/{repo}/pulls/{n}/comments`)로 우회한다. `gh api graphql` 호출은 비-목표.
+- silent-fail 감지의 연속 임계 N은 본 task 내부에서 결정하되 3 이상으로 설정해 false positive를 줄인다.
+- 기존 SEEN_FILE의 ID prefix 컨벤션(`comment:`·`review:`·`thread:`)은 세 소스 호출 분리 후에도 유지해 dedup이 손상되지 않게 한다.
+- 본 task가 `review-fix-phase.sh`를 수정하는 동안 sibling 파일(다른 phase script·헌법 등)을 수정하지 않는다 — `scope.include`가 `review-fix-phase.sh` 단일 파일이므로 다른 파일 변경은 워크플로 게이트에서 차단된다.
+- `feedback_no_self_apply_during_spec` 룰: 본 SPEC을 작성하는 *현재* spec 호출은 review-fix-phase.sh를 변경하지 않는다 — 변경은 loop 실행 시점.
+- `feedback_self_referential_verification` 룰: 워커는 verify·worktree source(직접 변경한 review-fix-phase.sh)만 검사하고, runtime artifact(자기 task의 PR 코멘트·자기 review-fix 실행 결과)는 검증 대상에서 제외.
+
+## 위험
+
+- **stuck 감지 false positive**: PR이 자연 idle(아무도 리뷰 안 함, owner도 cmd 안 보냄)인 경우도 stuck으로 분류되어 ESCALATION emit 가능. silent-fail 감지 조건을 명확히 분리해야 함 — fetch 호출 실패와 PR 자연 idle은 구분해 처리.
+- **gh CLI REST endpoint 의존**: `gh api repos/.../pulls/{n}/comments`도 gh CLI 버전·토큰 권한에 따라 실패 가능. 본 SPEC은 REST 호출 실패도 silent-fail 감지의 한 패턴으로 다루며 자기 복구는 안 함.
+- **dedup 의미 변화 위험**: 세 소스 호출 분리 후에도 SEEN_FILE의 ID prefix(`comment:`·`review:`·`thread:`)가 유지되지 않으면 같은 이벤트가 다른 prefix로 dedup 미스되어 재진입.
+- **다른 silent-fail 패턴**: 본 SPEC은 `collect_new_events`·폴링 루프 silent-fail만 다룬다. owner cmd 검사 등 다른 위치의 silent-fail은 별도 SPEC 필요.
+- **self-referential 함정 (낮음)**: 본 task의 워커가 review-fix-phase.sh를 변경하면서 같은 review-fix-phase로 자기 PR 리뷰를 처리하지는 않는다 — review-fix-phase는 `request_review: true` opt-in이며 본 SPEC frontmatter에서 별도 결정. PR 리뷰 자동 fix를 본 SPEC에서 사용할지 여부와 무관하게 verify는 정적 grep으로 fail 가능하므로 self-referential 위험은 SPEC 150보다 현저히 낮다.

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -123,39 +123,69 @@ try_auto_merge() {
   return 0
 }
 
-# ----- 새 이벤트 수집 (PR comments + review threads + review summary) -----
+# ----- 새 이벤트 수집 (3 소스 *독립 호출*) -----
 # 3 소스의 모든 항목 ID 화이트리스트 후 SEEN_FILE에 없는 것만 new로 분류.
-# - PR-level comments: gh api repos/{owner}/{repo}/issues/{n}/comments
-# - Review summaries: gh pr view --json reviews
-# - Review threads (inline): gh pr view --json reviewThreads → 각 comment ID
+# 한 소스 fetch 실패가 다른 소스를 차단하지 않도록 *각각 독립 호출*. 단일
+# `gh pr view --json reviews,...,comments` 묶음 호출은 일부 gh CLI 버전이
+# 특정 필드(예: 과거의 inline review-thread 필드)를 지원하지 않을 때 호출
+# 전체가 비-zero exit으로 실패하고 fallback이 빈 JSON으로 묻혀 silent-fail의
+# 원인이 되었음.
+# - PR-level issue comments         : gh api repos/{owner}/{repo}/issues/{n}/comments
+# - Review summaries                : gh api repos/{owner}/{repo}/pulls/{n}/reviews
+# - Review thread inline comments   : gh api repos/{owner}/{repo}/pulls/{n}/comments
+# (REST endpoint로 통일해 gh CLI 버전 의존성을 최소화.)
+#
+# 호출 실패는 caller(폴링 루프)의 silent-fail / stuck 감지에 사용되므로
+# FETCH_FAIL_FILE에 0|1 한 줄로 기록한다 — `$()` 캡처로 stdout이 변수에 묶이는
+# 본 함수의 구조상 함수의 반환값을 이용해 fetch 실패를 전달할 수 없기 때문.
+FETCH_FAIL_FILE="$WT/.iterations/review-fix-last-fetch-fail"
 collect_new_events() {
   # 후보 ID만 emit (mark_seen은 caller가 성공 후에 별도 호출). 본 함수는 `$()`로
   # 호출돼 stdout이 변수로 캡처되므로 여기서 mark_seen하면 caller가 fix 실패해도
   # 이미 영구히 seen 처리됨 — rebase·claude·commit 중 실패 시 재시도 불가능.
   # jq 사전 검사는 진입부에서 완료됨.
-  local pr_json
-  pr_json=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviews,reviewThreads,comments 2>/dev/null || echo '{}')
+  local fetch_fail=0
+  local raw
 
-  # PR-level comments (issue comments)
-  while IFS= read -r raw_id; do
-    [[ -z "$raw_id" ]] && continue
-    local id="comment:$raw_id"
-    is_seen "$id" || echo "$id"
-  done < <( printf '%s' "$pr_json" | jq -r '.comments[]?.id // empty' )
+  # (1) PR-level issue comments
+  if raw=$( cd "$WT" && gh api "repos/{owner}/{repo}/issues/$PR_NUMBER/comments" 2>/dev/null ); then
+    while IFS= read -r raw_id; do
+      [[ -z "$raw_id" ]] && continue
+      local id="comment:$raw_id"
+      is_seen "$id" || echo "$id"
+    done < <( printf '%s' "$raw" | jq -r '.[]?.id // empty' 2>/dev/null )
+  else
+    fetch_fail=1
+  fi
 
-  # Review summary entries
-  while IFS= read -r raw_id; do
-    [[ -z "$raw_id" ]] && continue
-    local id="review:$raw_id"
-    is_seen "$id" || echo "$id"
-  done < <( printf '%s' "$pr_json" | jq -r '.reviews[]?.id // empty' )
+  # (2) Review summary entries
+  if raw=$( cd "$WT" && gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/reviews" 2>/dev/null ); then
+    while IFS= read -r raw_id; do
+      [[ -z "$raw_id" ]] && continue
+      local id="review:$raw_id"
+      is_seen "$id" || echo "$id"
+    done < <( printf '%s' "$raw" | jq -r '.[]?.id // empty' 2>/dev/null )
+  else
+    fetch_fail=1
+  fi
 
-  # Review threads inline comments
-  while IFS= read -r raw_id; do
-    [[ -z "$raw_id" ]] && continue
-    local id="thread:$raw_id"
-    is_seen "$id" || echo "$id"
-  done < <( printf '%s' "$pr_json" | jq -r '.reviewThreads[]?.comments[]?.id // empty' )
+  # (3) Review thread inline comments — REST endpoint (gh CLI 버전 비의존)
+  if raw=$( cd "$WT" && gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" 2>/dev/null ); then
+    while IFS= read -r raw_id; do
+      [[ -z "$raw_id" ]] && continue
+      local id="thread:$raw_id"
+      is_seen "$id" || echo "$id"
+    done < <( printf '%s' "$raw" | jq -r '.[]?.id // empty' 2>/dev/null )
+  else
+    fetch_fail=1
+  fi
+
+  # 이번 호출의 fetch 실패 여부 기록 — 폴링 루프가 silent-fail / stuck 감지에 사용
+  if (( fetch_fail )); then
+    echo 1 > "$FETCH_FAIL_FILE" 2>/dev/null || true
+  else
+    echo 0 > "$FETCH_FAIL_FILE" 2>/dev/null || true
+  fi
 }
 
 # fix iter 성공 후 한 묶음으로 seen 마킹 — 실패 분기에서는 호출되지 않으므로 다음
@@ -166,6 +196,22 @@ mark_events_seen() {
     mark_seen "$id"
   done
 }
+
+# ----- silent-fail / consecutive-idle 감지 (stuck) -----
+# 폴링이 연속 N회(>=3) 동안 새 이벤트 0건이면 silent-fail 패턴을 검사:
+#   (i)  최근 collect_new_events 호출에서 한 소스라도 fetch 실패 — gh CLI 호환성·
+#        토큰 권한·네트워크 문제로 이벤트를 못 가져왔는데 fallback이 묻혀 0건으로
+#        보이는 경우 (stuck).
+#   (ii) PR check 완료(pending 0) + 리뷰 0 + 코멘트 0 — 리뷰 흐름이 시작도 안 됐고
+#        owner 의사 표시도 없음 (stuck).
+# 위 두 조건 중 하나라도 해당하면 ESCALATION 토큰 emit 후 종료. 어디도 해당 안 되면
+# 자연 idle(리뷰어 응답 대기 등)로 간주하고 카운터만 리셋해 다음 임계까지 계속
+# 폴링한다 — false positive 방지. 임계 N은 envvar로 조정 가능하되 floor 3.
+CONSECUTIVE_IDLE=0
+CONSECUTIVE_IDLE_THRESHOLD="${LOOP_REVIEW_IDLE_THRESHOLD:-3}"
+if (( CONSECUTIVE_IDLE_THRESHOLD < 3 )); then
+  CONSECUTIVE_IDLE_THRESHOLD=3
+fi
 
 # ----- 메인 폴링 루프 -----
 iter=0
@@ -233,9 +279,32 @@ while (( iter < MAX_ITER )); do
   # (d) 신규 이벤트 수집·dispatch
   new_events="$( collect_new_events )"
   if [[ -z "$new_events" ]]; then
+    CONSECUTIVE_IDLE=$((CONSECUTIVE_IDLE + 1))
+    if (( CONSECUTIVE_IDLE >= CONSECUTIVE_IDLE_THRESHOLD )); then
+      # silent-fail / stuck 패턴 검사 — false positive 방지를 위해 두 패턴으로 분리.
+      last_fetch_fail=$( cat "$FETCH_FAIL_FILE" 2>/dev/null || echo 0 )
+      if [[ "$last_fetch_fail" == "1" ]]; then
+        emit_escalation "silent-fail 감지 (stuck): ${CONSECUTIVE_IDLE}회 연속 idle 중 이벤트 fetch 호출 실패 — 사용자 개입 필요 (PR #$PR_NUMBER)"
+        exit 1
+      fi
+      # PR check 완료 + 활동 부재 — 셋 다 명시적으로 "0"일 때만 trigger (값이 비어
+      # 있으면 자체 fetch 실패이므로 위 분기에서 처리; 안전을 위해 false 처리).
+      pending_checks=$( cd "$WT" && gh pr view "$PR_NUMBER" --json statusCheckRollup \
+                          --jq '[.statusCheckRollup[]? | select((.status // "COMPLETED") != "COMPLETED")] | length' 2>/dev/null || echo "" )
+      total_reviews=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviews --jq '.reviews | length' 2>/dev/null || echo "" )
+      total_comments=$( cd "$WT" && gh pr view "$PR_NUMBER" --json comments --jq '.comments | length' 2>/dev/null || echo "" )
+      if [[ "$pending_checks" == "0" && "$total_reviews" == "0" && "$total_comments" == "0" ]]; then
+        emit_escalation "silent-fail 감지 (stuck): ${CONSECUTIVE_IDLE}회 연속 idle + PR check 완료 + 리뷰·코멘트·owner cmd 모두 부재 — 사용자 개입 필요 (PR #$PR_NUMBER)"
+        exit 1
+      fi
+      # 자연 idle (리뷰어 응답 대기 등) — 카운터만 리셋, 폴링 계속
+      CONSECUTIVE_IDLE=0
+    fi
     sleep "$POLL_SECS"
     continue
   fi
+  # 진전 (새 이벤트 감지) — idle 카운터 리셋
+  CONSECUTIVE_IDLE=0
 
   # 새 이벤트 요약 emit (AC6)
   echo "[review-fix-phase] 새 이벤트 감지:"
@@ -251,7 +320,14 @@ while (( iter < MAX_ITER )); do
   fi
 
   # (ii) claude CLI fix 세션 (AC8) — 새 이벤트 본문을 stdin으로 전달
-  fix_prompt_body=$( cd "$WT" && gh pr view "$PR_NUMBER" --json comments,reviews,reviewThreads 2>/dev/null || echo "")
+  # PR header(comments + reviews)와 review thread inline 코멘트를 분리 fetch —
+  # 단일 `--json` 묶음 호출에 thread 필드를 포함시키면 gh CLI 버전에 따라
+  # silent-fail 가능. 호출 실패 시 fallback은 의도적으로 "{}" / "[]"로 유지
+  # (collect_new_events의 FETCH_FAIL_FILE이 silent-fail 감지를 책임지므로,
+  # 본 위치에서 또 한번 escalation을 emit하면 중복·잡음).
+  fix_prompt_header=$( cd "$WT" && gh pr view "$PR_NUMBER" --json comments,reviews 2>/dev/null || echo "{}" )
+  fix_prompt_threads=$( cd "$WT" && gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" 2>/dev/null || echo "[]" )
+  fix_prompt_body=$(printf 'PR comments + reviews:\n%s\n\nReview thread inline comments:\n%s\n' "$fix_prompt_header" "$fix_prompt_threads")
   claude_prompt=$(cat <<EOF
 You are a fix worker for PR #$PR_NUMBER on branch '$BRANCH'.
 New review events:

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -293,8 +293,12 @@ while (( iter < MAX_ITER )); do
                           --jq '[.statusCheckRollup[]? | select((.status // "COMPLETED") != "COMPLETED")] | length' 2>/dev/null || echo "" )
       total_reviews=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviews --jq '.reviews | length' 2>/dev/null || echo "" )
       total_comments=$( cd "$WT" && gh pr view "$PR_NUMBER" --json comments --jq '.comments | length' 2>/dev/null || echo "" )
-      if [[ "$pending_checks" == "0" && "$total_reviews" == "0" && "$total_comments" == "0" ]]; then
-        emit_escalation "silent-fail 감지 (stuck): ${CONSECUTIVE_IDLE}회 연속 idle + PR check 완료 + 리뷰·코멘트·owner cmd 모두 부재 — 사용자 개입 필요 (PR #$PR_NUMBER)"
+      # inline review thread comments는 `/pulls/{n}/comments` REST endpoint에 별도로 산다 —
+      # `gh pr view --json comments`는 `/issues/{n}/comments`(PR-level conversation)만 반영하므로
+      # claude-review가 inline만 게시한 케이스에서 false-positive ESCALATION을 막으려면 추가 체크.
+      total_inline=$( cd "$WT" && gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" --jq 'length' 2>/dev/null || echo "" )
+      if [[ "$pending_checks" == "0" && "$total_reviews" == "0" && "$total_comments" == "0" && "$total_inline" == "0" ]]; then
+        emit_escalation "silent-fail 감지 (stuck): ${CONSECUTIVE_IDLE}회 연속 idle + PR check 완료 + 리뷰·코멘트·inline·owner cmd 모두 부재 — 사용자 개입 필요 (PR #$PR_NUMBER)"
         exit 1
       fi
       # 자연 idle (리뷰어 응답 대기 등) — 카운터만 리셋, 폴링 계속
@@ -333,7 +337,7 @@ You are a fix worker for PR #$PR_NUMBER on branch '$BRANCH'.
 New review events:
 $new_events
 
-Full PR comment/review JSON (for reference):
+Full PR comment/review context (for reference):
 $fix_prompt_body
 
 Goal:


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가

`autopilot:loop`의 review-fix-phase는 PR 리뷰 이벤트 세 소스(PR-level conversation comments, review summaries, review thread inline comments)를 폴링으로 수집해 새 이벤트마다 fix 이터를 dispatch한다. 현재 구현은 단일 `gh pr view --json reviews,reviewThreads,comments` 호출로 세 소스를 동시에 fetch하지만, `reviewThreads` JSON 필드는 일부 gh CLI 버전(현재 사용자 환경 포함)에서 지원되지 않아 호출 전체가 비-zero exit으로 실패한다. 실패 시 코드는 `|| echo '{}'` 패턴으로 빈 JSON으로 대체하므로 `collect_new_events`는 모든 이벤트 ID를 0개로 판정하고, 폴링 루프는 silent로 계속 돌면서 fix를 영원히 시작하지 않는다.

본 task는 두 가지를 함께 변경한다:

1. **reviewThreads JSON 필드 의존 제거** — review thread inline comments 수집을 `gh pr view --json reviewThreads`가 아닌 다른 gh CLI 호환 매체로 우회한다. PR-level comments와 review summaries 수집은 호환성 영향이 없으므로 그대로 유지하되, 세 소스를 *각각 독립 호출*로 분리해 한 소스의 fetch 실패가 다른 소스 수집을 차단하지 않게 한다.

2. **silent-fail 감지·escalation** — review-fix-phase 폴링이 의도하지 않게 silent로 도는 패턴(예: gh CLI 호출 실패가 fallback으로 묻혀 새 이벤트 0건으로 잘못 판정되거나, PR check가 완료됐는데도 리뷰 코멘트·완료 코멘트 모두 부재 상태로 연속 폴링이 idle)을 명시적으로 감지해 `ESCALATION` 토큰을 stdout으로 emit한다. 한 번이 아닌 *연속 N회* 임계로 false positive를 줄인다.

두 변경은 같은 의도다 — review-fix-phase가 silent로 머물지 않고 fix 흐름을 시작하거나 명시적으로 실패를 보고하도록 만든다.

## Commits
- c1d2103 fix:root review-fix-phase: reviewThreads 의존 제거 + silent-fail/stuck 감지
- 9a3cabe feat(spec): 155 — review-fix-phase: reviewThreads 의존 제거 + silent-fail 감지

Closes #155
<!-- autopilot:pr-body:end -->