### PR TITLE
spec: SPEC.md commit을 main에 자동 ff-merge 단계 추가

### DIFF
--- a/milestones/regular/loops/149-spec-spec-md-commit-main-ff-merge/SPEC.md
+++ b/milestones/regular/loops/149-spec-spec-md-commit-main-ff-merge/SPEC.md
@@ -1,0 +1,53 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/spec/**"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh && grep -q 'origin/main' plugins/autopilot/skills/spec/SKILL.md && grep -q 'fast-forward' plugins/autopilot/skills/spec/SKILL.md && grep -q 'push origin' plugins/autopilot/skills/spec/SKILL.md"
+ears_language: ko
+---
+
+# spec: SPEC.md commit을 main에 자동 ff-merge 단계 추가
+
+## 무엇을 만들 것인가
+autopilot:spec 스킬이 SPEC.md를 feat 브랜치에 commit한 직후, 그 commit이 원격 default 브랜치 최신 위로 정렬되어 default 브랜치에도 fast-forward 형태로 반영되고 원격 저장소에 즉시 push되도록 한다. feat 브랜치도 그대로 유지되며 원격에 push되어 후속 loop 실행·협업이 이어진다. 충돌·push 거부 등 실패 상황에서는 호출 이전 상태로 안전하게 복구되고 사용자에게 실패 사유와 복구 방법이 명시적으로 안내된다.
+
+## 수용 기준 (EARS)
+- **AC1 (Event-driven):** SPEC.md가 feat 브랜치에 commit되면, 시스템은 원격 저장소로부터 default 브랜치의 최신 상태를 가져온다.
+- **AC2 (Event-driven):** 원격 default 브랜치 최신 상태 수집이 성공하면, 시스템은 feat 브랜치를 원격 default 브랜치 위로 rebase한다.
+- **AC3 (Event-driven):** feat 브랜치의 rebase가 성공하면, 시스템은 default 브랜치로 전환해 feat 브랜치로부터 fast-forward merge를 적용한다.
+- **AC4 (Event-driven):** default 브랜치의 fast-forward merge가 성공하면, 시스템은 사용자 재확인 없이 default 브랜치와 feat 브랜치를 원격 저장소에 push한다.
+- **AC5 (Unwanted):** feat 브랜치 rebase 중 충돌이 발생하면, 시스템은 rebase를 중단하고 feat 브랜치·호출 시점의 원래 브랜치·default 브랜치 작업트리를 호출 이전 상태로 복구한 뒤 사용자에게 충돌 사실과 복구 방법을 알린다.
+- **AC6 (Unwanted):** default 브랜치 또는 feat 브랜치의 push가 원격 저장소에 의해 거부되면, 시스템은 강제 push를 시도하지 않고 feat 브랜치 commit·SPEC.md 작업트리·로컬 default 브랜치 상태를 보존한 채 사용자에게 push 거부 사실과 복구 안내를 제공한다.
+- **AC7 (Ubiquitous):** 전체 흐름이 종료되면, 시스템은 호출 시점의 원래 브랜치로 복귀한다.
+- **AC8 (Ubiquitous):** 전체 흐름이 종료되면, 시스템은 default 브랜치 작업트리의 staged·unstaged·untracked 상태를 호출 이전과 동일하게 유지한다.
+- **AC9 (Ubiquitous):** spec 스킬 본문에는 위 절차·실패 처리·복구 흐름이 명시적으로 기술되어 있고, 기존 슬러그화 규칙과 SPEC.md commit 절차는 변경되지 않는다.
+
+## 범위
+포함:
+- autopilot:spec 스킬 본문(§9.5 영역)에 SPEC.md commit 이후 원격 default 브랜치 rebase·default 브랜치 fast-forward merge·원격 push·feat 브랜치 원격 push 단계 추가
+- 충돌·push 거부 등 실패 시 안전 중단(abort) 및 호출 이전 상태 복구 로직 명시
+- 호출 시점의 원래 브랜치 복귀와 default 브랜치 작업트리 무손상 검증
+- autopilot:spec 스킬 하위 테스트 자산(`plugins/autopilot/skills/spec/` 내 contract·sweep 테스트)을 새 절차에 맞춰 갱신·확장
+
+비-목표 / 제외:
+- pr-phase·rebase-phase·loop 등 sibling 스킬 본문 수정
+- PR 자동 생성 흐름·base·머지 정책 변경
+- protected branch 환경에서 push가 항상 거부될 때의 PR fallback 자동 전환
+- push 권한·원격 정책 사전 검사 도입
+
+## 검증
+이 명령이 0 exit으로 끝나야 합니다:
+bash plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh && grep -q 'origin/main' plugins/autopilot/skills/spec/SKILL.md && grep -q 'fast-forward' plugins/autopilot/skills/spec/SKILL.md && grep -q 'push origin' plugins/autopilot/skills/spec/SKILL.md
+
+## 제약 (있을 때만)
+- 본 SPEC은 autopilot:spec 스킬 자신을 수정하는 self-referential SPEC이다. 따라서 이 SPEC을 작성·수락하는 spec 스킬 호출 자체에는 새 §9.5 동작(default 브랜치 rebase·fast-forward merge·원격 push)을 적용하지 않고 현행 §9.5(feat 브랜치 분기·SPEC commit·원래 브랜치 복귀)로만 처리한다.
+- 기존 슬러그화 규칙(§9.5.1)과 SPEC.md commit 절차(§9.5.2)는 변경하지 않는다 — 본 변경은 그 절차 *이후*에 새 단계를 덧붙이는 형태로만 이뤄진다.
+- 검증은 자기 자신의 driver를 갱신하는 self-referential task의 안전 제약을 따른다: runtime artifact(실제 push 결과·원격 상태)를 직접 검사하지 않고, frontmatter `verify` 명령의 0 exit과 SKILL.md 본문에 대한 정적 grep만으로 수용 기준을 fail 가능하게 만든다.
+
+## 위험 (있을 때만)
+- default 브랜치가 protected branch로 설정된 환경에서는 직접 push가 항상 거부될 수 있다. 본 SPEC은 이 경우 AC6의 abort 분기로 처리하지만, 사용자 환경에 따라 결과(자동 흐름의 사실상 비활성화)가 달라질 수 있다.
+- SPEC.md가 default 브랜치에 직접 반영되면 후속 코드 변경에 대한 PR의 diff에서 SPEC.md가 제외되어 리뷰어가 PR 페이지만 보고는 SPEC을 확인하기 어려울 수 있다. 이는 본 변경의 의도된 설계 결과이며 호출자의 선택이다.
+- rebase 시점에 default 브랜치 작업트리에 staged·unstaged 변경이 남아 있으면 rebase가 거부될 수 있다. 본 SPEC은 이 경우에도 AC5/AC8을 통해 abort + 원상태 복구로 처리하지만, 사용자는 호출 전 작업트리를 정리해두는 편이 안전하다.

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -269,13 +269,15 @@ SPEC.md가 `milestones/<m>/loops/<c>/SPEC.md`에 (재)기록되는 모든 시점
 
 SPEC 초안이 길거나 잔존 마커가 다수면 `references/agent-prompts.md`의 **`spec-self-reviewer`** 양식으로 독립 검토 위임. 휴리스틱(하나라도 해당): 본문 ≈100줄 초과, 잔존 `[NEEDS CLARIFICATION]` 마커 2개 이상, 호출자의 명시적 요청. subagent는 5축 발견만 보고하고 **SPEC.md 수정·마커 박기는 메인이 수행**(헌법 §11.6 — patch 생성은 위임하지 않음). step 9 본문 원칙("사용자 Q&A 없음, 재루프 없음")은 위임 여부와 무관.
 
-### 9.5. feat 브랜치 + SPEC.md commit (자동, main 작업트리 무손상)
+### 9.5. feat 브랜치 + SPEC.md commit + default 브랜치 자동 ff-merge (main 작업트리 무손상)
 
 SPEC.md 작성·자체 검토 후 sibling `autopilot:loop`의 worktree base가 될 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·생성하고 SPEC.md만 그 브랜치에 commit. main 작업트리 상태(staged/unstaged/untracked) 변경 금지. 단계 10 *전*에 수행 — 이후 단계 10에서 "변경" 선택 시 단계 7/8 재진입 후 본 단계 commit amend·추가(자동).
 
 본 단계가 단일 출처로 삼는 **슬러그 도출 코드 조각은 `references/feat-branch-commit.md` §9.5.1**에 보존되며, 안전장치(`references/test-spec-loop-contract.sh`)는 그 새 위치를 검사한다.
 
-결정적 슬러그화 규칙(§9.5.1), 브랜치 생성·commit 9단계 절차(§9.5.2), 실패 처리·빈-slug abort(§9.5.3)의 전체 절차는 `references/feat-branch-commit.md` 참조.
+SPEC.md commit 직후 본 단계는 **자동으로 default 브랜치(main)·feat 브랜치를 원격 default 브랜치(`origin/main`) 최신 위로 정렬·동기화**한다 — `git fetch origin` 으로 `origin/main` 을 갱신한 뒤 feat 브랜치를 `origin/main` 위로 rebase하고, default 브랜치로 전환해 feat 브랜치로부터 **fast-forward** merge를 적용한 다음, 사용자 재확인 없이 default 브랜치와 feat 브랜치를 모두 원격에 `git push origin <branch>` 로 push한다 (예: `push origin main`, `push origin feat/<c>-<slug>`). 충돌·push 거부 시에는 강제 push(`--force`·`--force-with-lease`)를 절대 시도하지 않고 abort + 호출 이전 상태 복구 + 사용자 안내로 처리한다. 전체 흐름이 끝나면 호출 시점의 원래 브랜치로 복귀하며 default 브랜치 작업트리(staged/unstaged/untracked)는 호출 이전과 동일하게 유지된다.
+
+결정적 슬러그화 규칙(§9.5.1), 브랜치 생성·commit 9단계 절차(§9.5.2), 실패 처리·빈-slug abort·rebase 충돌·push 거부 abort 흐름(§9.5.3), 그리고 default 브랜치 자동 fast-forward merge·원격 `push origin` 절차(§9.5.4)의 전체 단계는 `references/feat-branch-commit.md` 참조.
 
 ### 10. 사용자 최종 검토
 

--- a/plugins/autopilot/skills/spec/references/feat-branch-commit.md
+++ b/plugins/autopilot/skills/spec/references/feat-branch-commit.md
@@ -61,11 +61,19 @@ slug=$(printf '%s' "$title" \
   2. `git checkout "$orig_branch"` 로 호출 시점 원래 브랜치 복귀. 원격 default·feat push 는 시도 자체를 하지 않는다 (강제 push 금지 원칙과 별개로, step 4·5 에 도달하지 않음).
   3. 사용자에게 ff-merge 가 거부된 사실과 **그 근본 원인 후보**(default 브랜치가 origin/main 보다 앞선 로컬 commit·미push 변경 보유, 또는 base 가 diverge) 와 **수동 복구 방법** 안내: default 브랜치 상태를 `git log main..origin/main` / `git log origin/main..main` 으로 점검하고, 정렬 후 다음 spec 호출에서 자동 재실행 또는 PR 흐름으로 전환. SPEC.md commit 은 feat 브랜치에 그대로 살아 있다.
 
-- **push 거부** (§9.5.4 step 4·5 `git push origin main` / `git push origin <branch>` 가 non-fast-forward·protected branch·권한 부족 등으로 reject — step 3 ff-merge 가 이미 성공해 default 브랜치 HEAD 가 로컬에서 갱신된 *후* 의 단계):
+- **main push 거부** (§9.5.4 step 4 `git push origin main` 이 non-fast-forward·protected branch·권한 부족 등으로 reject — step 3 ff-merge 는 이미 성공해 로컬 main HEAD 가 feat SPEC commit 까지 fast-forward 적용된 *후*, 원격 main push 가 거부된 시점):
   1. **`--force`·`--force-with-lease` 등 강제 push 절대 시도 안 함** — 본 단계의 모든 push는 일반 push 만 허용. push 명령은 단 한 번만 시도하고 실패하면 즉시 abort.
-  2. **이 분기 시점의 상태 전제**: step 3 ff-merge 가 이미 성공했으므로 로컬 default 브랜치 HEAD 는 feat SPEC commit 까지 fast-forward 적용된 상태인데 원격 push 가 거부됐다 — 즉 로컬 default HEAD 와 원격 default HEAD 가 분기되어 일관성이 깨졌다. (이 전제는 ff-merge 거부 분기와 다른 점이다.) 사용자에게 명시적으로 알리고, `git reset --hard origin/main` 으로 로컬 default 를 원격에 맞춰 되돌리거나 PR 흐름으로 전환할 수 있음을 안내. feat 브랜치 SPEC commit 은 보존.
-  3. `git checkout "$orig_branch"`로 호출 시점 원래 브랜치 복귀.
-  4. 사용자에게 push 거부 사실(어느 브랜치 push 가 어떤 사유로 거부됐는지)과 복구 방법 안내. SPEC.md disk 사본은 그대로 보존.
+  2. **이 분기 시점의 상태 전제**: 로컬 main HEAD 는 SPEC commit 까지 적용됐지만 `origin/main` 은 step 1 의 fetch 시점 그대로다 — 즉 로컬 main 과 원격 main 이 분기된 상태로 일관성이 깨졌다. (이 전제는 ff-merge 거부·feat push 거부 분기와 다른 점이다.) 원격 feat push (step 5) 는 시도 자체를 하지 않는다.
+  3. 사용자에게 명시적으로 알리고, `git reset --hard origin/main` 으로 로컬 main 을 원격에 맞춰 되돌리거나 PR 흐름으로 전환할 수 있음을 안내. feat 브랜치 SPEC commit 은 보존.
+  4. `git checkout "$orig_branch"`로 호출 시점 원래 브랜치 복귀.
+  5. 사용자에게 push 거부 사실(어느 브랜치 push 가 어떤 사유로 거부됐는지)과 복구 방법 안내. SPEC.md disk 사본은 그대로 보존.
+
+- **feat push 거부** (§9.5.4 step 5 `git push origin <branch>` 가 protected branch·권한 부족·서버 일시 오류 등으로 reject — step 4 main push 는 이미 성공한 *후*, feat 브랜치만 push 가 거부된 시점):
+  1. **`--force`·`--force-with-lease` 등 강제 push 절대 시도 안 함** — 일반 push 만 허용, 단 한 번 시도 후 실패 시 즉시 abort.
+  2. **이 분기 시점의 상태 전제**: step 4 가 이미 성공했으므로 `origin/main = local main = feat SPEC commit` 이 동기 완료된 상태다 — 로컬 main 과 원격 main 사이에 분기가 없으며, 따라서 `git reset --hard origin/main` 같은 "로컬 되돌림" 안내는 부적절하다 (되돌릴 분기가 없다). feat 브랜치도 로컬·원격 모두 같은 SHA (단지 원격에 ref 가 등록 안 됐을 뿐) 인 경우가 일반적이다.
+  3. 사용자에게 명시적으로 알리고, **필요 복구는 `git push origin <branch>` 재시도** 임을 안내한다 (서버 일시 오류·네트워크 회복 후). 거부 사유가 권한·protected branch 라면 권한 설정·브랜치 보호 규칙 확인 후 재시도. main 동기화는 이미 완료됐으므로 다음 spec 호출에서는 본 단계가 no-op 으로 끝나며, feat ref 등록만 별도로 처리해도 무방하다.
+  4. `git checkout "$orig_branch"`로 호출 시점 원래 브랜치 복귀.
+  5. 사용자에게 push 거부 사실(feat 브랜치 push 가 어떤 사유로 거부됐는지)과 복구 방법 안내. SPEC.md disk 사본은 그대로 보존.
 
 - **fetch 실패** (`git fetch origin` 자체가 네트워크·인증 문제로 실패): §9.5.4 전체를 abort하고 `git checkout "$orig_branch"`로 복귀. SPEC.md commit 은 feat 브랜치에 그대로 남으며, 원격 동기화는 사용자가 네트워크 복구 후 수동 재시도 또는 다음 spec 호출에서 자동 재실행.
 
@@ -91,9 +99,9 @@ slug=$(printf '%s' "$title" \
 
 3. **(AC3) default 브랜치로 전환 후 feat 브랜치를 fast-forward merge**: `git checkout main` 후 `git merge --ff-only "$branch"`. `--ff-only` 플래그가 핵심 — fast-forward 가 불가능한 경우 (default 브랜치가 origin/main 보다 앞서 있거나, 호출 이전 staged 변경이 default HEAD 와 diverge 등) 비-zero exit 으로 fail 하고, **이 시점에 merge commit 이 생성되지 않으므로 default 브랜치 HEAD 는 그대로 유지된다**. 비-zero exit 시 §9.5.3 «ff-merge 거부» 분기로 처리 (default 브랜치 HEAD·작업트리 보존 + 사용자 안내 + orig branch 복귀). step 2 가 성공했으면 feat 브랜치 = origin/main + (SPEC commit) 이고 default 브랜치 = origin/main 또는 그 이전이므로 일반적으로 fast-forward 가능.
 
-4. **(AC4) 원격 default 브랜치 push**: `git push origin main`. push 가 거부되면 §9.5.3 «push 거부» 분기로 이행 — `--force` 금지. 일반 push 성공 시 0 exit, `origin/main` 이 default 브랜치 HEAD 와 같아진다.
+4. **(AC4) 원격 default 브랜치 push**: `git push origin main`. push 가 거부되면 §9.5.3 «main push 거부» 분기로 이행 — `--force` 금지. 일반 push 성공 시 0 exit, `origin/main` 이 default 브랜치 HEAD 와 같아진다.
 
-5. **(AC4) 원격 feat 브랜치 push**: `git push origin "$branch"`. 같은 SHA 가 이미 default 브랜치 push 로 원격에 도달했으므로 사실상 ref 등록 수준의 push 이지만, sibling `autopilot:loop` 이 feat 브랜치를 원격에서 fetch·worktree base 로 사용할 수 있게 필수. 거부 시 §9.5.3 «push 거부» 분기.
+5. **(AC4) 원격 feat 브랜치 push**: `git push origin "$branch"`. 같은 SHA 가 이미 default 브랜치 push 로 원격에 도달했으므로 사실상 ref 등록 수준의 push 이지만, sibling `autopilot:loop` 이 feat 브랜치를 원격에서 fetch·worktree base 로 사용할 수 있게 필수. 거부 시 §9.5.3 «feat push 거부» 분기.
 
 6. **(AC7·AC8) 원래 브랜치 복귀·작업트리 검증**: `git checkout "$orig_branch"` 로 호출 시점 원래 브랜치 복귀. 직후 `git status --porcelain` 결과가 §9.5.2 step 1 의 스냅샷과 동일한지 검증. 다르면 사용자에게 경고 (staged·unstaged·untracked 변동이 있다면 어떤 파일인지 표시) 하되, default 브랜치 HEAD 와 feat 브랜치 HEAD 는 이미 원격에 push 되었으므로 disk 상태 차이는 호출 이전 작업트리의 untracked 변경이 step 8 §8.1 의 SPEC.md write 결과로 추적 상태가 바뀌었을 가능성이 가장 높음.
 

--- a/plugins/autopilot/skills/spec/references/feat-branch-commit.md
+++ b/plugins/autopilot/skills/spec/references/feat-branch-commit.md
@@ -64,16 +64,14 @@ slug=$(printf '%s' "$title" \
 - **main push 거부** (§9.5.4 step 4 `git push origin main` 이 non-fast-forward·protected branch·권한 부족 등으로 reject — step 3 ff-merge 는 이미 성공해 로컬 main HEAD 가 feat SPEC commit 까지 fast-forward 적용된 *후*, 원격 main push 가 거부된 시점):
   1. **`--force`·`--force-with-lease` 등 강제 push 절대 시도 안 함** — 본 단계의 모든 push는 일반 push 만 허용. push 명령은 단 한 번만 시도하고 실패하면 즉시 abort.
   2. **이 분기 시점의 상태 전제**: 로컬 main HEAD 는 SPEC commit 까지 적용됐지만 `origin/main` 은 step 1 의 fetch 시점 그대로다 — 즉 로컬 main 과 원격 main 이 분기된 상태로 일관성이 깨졌다. (이 전제는 ff-merge 거부·feat push 거부 분기와 다른 점이다.) 원격 feat push (step 5) 는 시도 자체를 하지 않는다.
-  3. 사용자에게 명시적으로 알리고, `git reset --hard origin/main` 으로 로컬 main 을 원격에 맞춰 되돌리거나 PR 흐름으로 전환할 수 있음을 안내. feat 브랜치 SPEC commit 은 보존.
+  3. 사용자에게 push 거부 사실과 함께 명시적으로 알리고, `git reset --hard origin/main` 으로 로컬 main 을 원격에 맞춰 되돌리거나 PR 흐름으로 전환할 수 있음을 안내한다 (단일 사용자 메시지 지점). feat 브랜치 SPEC commit 은 보존. SPEC.md disk 사본도 보존.
   4. `git checkout "$orig_branch"`로 호출 시점 원래 브랜치 복귀.
-  5. 사용자에게 push 거부 사실(어느 브랜치 push 가 어떤 사유로 거부됐는지)과 복구 방법 안내. SPEC.md disk 사본은 그대로 보존.
 
 - **feat push 거부** (§9.5.4 step 5 `git push origin <branch>` 가 protected branch·권한 부족·서버 일시 오류 등으로 reject — step 4 main push 는 이미 성공한 *후*, feat 브랜치만 push 가 거부된 시점):
   1. **`--force`·`--force-with-lease` 등 강제 push 절대 시도 안 함** — 일반 push 만 허용, 단 한 번 시도 후 실패 시 즉시 abort.
   2. **이 분기 시점의 상태 전제**: step 4 가 이미 성공했으므로 `origin/main = local main = feat SPEC commit` 이 동기 완료된 상태다 — 로컬 main 과 원격 main 사이에 분기가 없으며, 따라서 `git reset --hard origin/main` 같은 "로컬 되돌림" 안내는 부적절하다 (되돌릴 분기가 없다). feat 브랜치도 로컬·원격 모두 같은 SHA (단지 원격에 ref 가 등록 안 됐을 뿐) 인 경우가 일반적이다.
-  3. 사용자에게 명시적으로 알리고, **필요 복구는 `git push origin <branch>` 재시도** 임을 안내한다 (서버 일시 오류·네트워크 회복 후). 거부 사유가 권한·protected branch 라면 권한 설정·브랜치 보호 규칙 확인 후 재시도. main 동기화는 이미 완료됐으므로 다음 spec 호출에서는 본 단계가 no-op 으로 끝나며, feat ref 등록만 별도로 처리해도 무방하다.
+  3. 사용자에게 feat push 거부 사실과 함께 명시적으로 알리고, **필요 복구는 `git push origin <branch>` 재시도** 임을 안내한다 (서버 일시 오류·네트워크 회복 후, 단일 사용자 메시지 지점). 거부 사유가 권한·protected branch 라면 권한 설정·브랜치 보호 규칙 확인 후 재시도. main 동기화는 이미 완료됐으므로 다음 spec 호출에서는 본 단계가 no-op 으로 끝나며, feat ref 등록만 별도로 처리해도 무방하다. SPEC.md disk 사본 보존.
   4. `git checkout "$orig_branch"`로 호출 시점 원래 브랜치 복귀.
-  5. 사용자에게 push 거부 사실(feat 브랜치 push 가 어떤 사유로 거부됐는지)과 복구 방법 안내. SPEC.md disk 사본은 그대로 보존.
 
 - **fetch 실패** (`git fetch origin` 자체가 네트워크·인증 문제로 실패): §9.5.4 전체를 abort하고 `git checkout "$orig_branch"`로 복귀. SPEC.md commit 은 feat 브랜치에 그대로 남으며, 원격 동기화는 사용자가 네트워크 복구 후 수동 재시도 또는 다음 spec 호출에서 자동 재실행.
 

--- a/plugins/autopilot/skills/spec/references/feat-branch-commit.md
+++ b/plugins/autopilot/skills/spec/references/feat-branch-commit.md
@@ -1,8 +1,8 @@
-# spec step 9.5 — feat 브랜치 + SPEC.md commit (자동, main 작업트리 무손상)
+# spec step 9.5 — feat 브랜치 + SPEC.md commit + default 브랜치 자동 ff-merge (자동, main 작업트리 무손상)
 
-SPEC.md 작성과 자체 검토가 끝나면, sibling `autopilot:loop`이 worktree base로 사용할 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·생성하고 SPEC.md를 그 브랜치에 commit한다. main 작업트리 상태(staged/unstaged/untracked)는 변경되지 않아야 한다.
+SPEC.md 작성과 자체 검토가 끝나면, sibling `autopilot:loop`이 worktree base로 사용할 `feat/<task-id>-<slug>` 브랜치를 main에서 분기·생성하고 SPEC.md를 그 브랜치에 commit한다. 직후 동일 호출에서 default 브랜치(main)·feat 브랜치를 원격 default 브랜치(`origin/main`) 최신 위로 정렬해 default 브랜치에도 SPEC.md commit이 fast-forward 형태로 반영되고 원격 저장소에 즉시 push되게 한다. main 작업트리 상태(staged/unstaged/untracked)는 호출 이전과 동일하게 유지되어야 하며, 전체 흐름이 끝나면 호출 시점의 원래 브랜치로 복귀한다.
 
-이 단계를 단계 10의 사용자 최종 검토 *전*에 수행해 SPEC.md가 이미 git history에 반영된 상태에서 사용자가 결정을 내리도록 한다. 사용자가 단계 10에서 "변경" 옵션을 선택하면 단계 7/8 재진입 후 본 단계의 commit을 amend하거나 새 commit을 쌓는다 (자동 처리).
+이 단계를 단계 10의 사용자 최종 검토 *전*에 수행해 SPEC.md가 이미 git history(local + remote default)에 반영된 상태에서 사용자가 결정을 내리도록 한다. 사용자가 단계 10에서 "변경" 옵션을 선택하면 단계 7/8 재진입 후 본 단계의 commit을 amend하거나 새 commit을 쌓는다 (자동 처리, 후속 §9.5.4 재실행 포함).
 
 본 문서만 읽고도 단계를 끝까지 수행할 수 있게 자기완결적으로 기술한다.
 
@@ -43,8 +43,57 @@ slug=$(printf '%s' "$title" \
 
 ## 9.5.3 실패 처리
 
-위 절차 중 어떤 단계라도 실패하면:
+§9.5.2 절차(브랜치 생성·SPEC.md commit) 중 어떤 단계라도 실패하면:
 - 부분 결과 정리: 생성된 feat 브랜치가 있으면 `git branch -D "$branch"`로 삭제 (단, 그 브랜치에 다른 commit이 없을 때만; 의심스러우면 사용자에게 알리고 수동 정리 안내).
 - 원래 브랜치 복귀: `git checkout "$orig_branch"`.
 - 사용자에게 명시적으로 실패 사유와 복구 방법 안내. SPEC.md는 `milestones/<m>/loops/<c>-<slug>/SPEC.md` 에 그대로 남기되, loop 진행은 다음 단계에서 사용자가 결정.
 - **빈 slug 케이스 (§9.5.1)**: 슬러그화 결과가 빈 문자열이면 본 §9.5.2 진입 전에 abort 한다. SPEC.md 는 step 8 의 §8.1 단일 경로 가정에 의해 빈 slug 에서는 작성되지 않으며, 사용자에게 §1 H1 제목 수정을 요청해 step 7 재진입한다 (SPEC 116 단일 컨벤션 — fallback 없음).
+
+§9.5.4 절차(원격 default 브랜치 동기화·fast-forward merge·원격 push) 중 실패 분기:
+
+- **rebase 충돌** (`git rebase origin/main` 단계에서 conflict marker 발생 또는 비-zero exit):
+  1. `git rebase --abort`로 rebase 중단 — 작업트리·인덱스는 rebase 직전 상태(feat 브랜치 HEAD = SPEC commit)로 자동 복구된다.
+  2. `git checkout "$orig_branch"`로 호출 시점 원래 브랜치 복귀 — default 브랜치는 절대 전환 안 됨 (전환은 rebase 성공 후에만 일어나므로 충돌 단계에서는 default 브랜치 작업트리가 손대지지 않음, AC8).
+  3. 사용자에게 충돌 사실과 함께 **수동 복구 방법** 안내: feat 브랜치 SPEC commit은 그대로 살아 있으며 (`git log feat/<c>-<slug>` 로 확인 가능), 사용자가 직접 rebase 충돌을 해소하거나 `feat/<c>-<slug>` 를 PR로 올리는 별도 흐름으로 전환 가능. 강제 push 시도 금지.
+
+- **push 거부** (`git push origin <branch>` 가 non-fast-forward·protected branch·권한 부족 등으로 reject):
+  1. **`--force`·`--force-with-lease` 등 강제 push 절대 시도 안 함** — 본 단계의 모든 push는 일반 push 만 허용. push 명령은 단 한 번만 시도하고 실패하면 즉시 abort.
+  2. 호출 이전 상태 보존: feat 브랜치 SPEC commit 보존, default 브랜치는 fast-forward merge 가 이미 *로컬*에는 적용된 상태이지만 *원격*과의 일관성이 깨지므로 사용자에게 명시적으로 알린다. 로컬 default 브랜치 HEAD 와 원격 default 브랜치 HEAD 가 분기된 상태이며, 사용자가 수동으로 `git reset --hard origin/main` 으로 로컬 되돌림 또는 PR 흐름으로 전환할 수 있음을 안내.
+  3. `git checkout "$orig_branch"`로 호출 시점 원래 브랜치 복귀.
+  4. 사용자에게 push 거부 사실(어느 브랜치 push 가 어떤 사유로 거부됐는지)과 복구 방법 안내. SPEC.md disk 사본은 그대로 보존.
+
+- **fetch 실패** (`git fetch origin` 자체가 네트워크·인증 문제로 실패): §9.5.4 전체를 abort하고 `git checkout "$orig_branch"`로 복귀. SPEC.md commit 은 feat 브랜치에 그대로 남으며, 원격 동기화는 사용자가 네트워크 복구 후 수동 재시도 또는 다음 spec 호출에서 자동 재실행.
+
+모든 §9.5.4 실패 분기에서 공통:
+- `git status --porcelain` 결과가 §9.5.2 step 1 의 스냅샷과 동일한지 검증. 다르면 사용자에게 경고와 함께 어떤 파일이 추가/수정됐는지 표시.
+- 사용자에게 **자동 흐름이 어디까지 진행됐는지** 명시적으로 보고 (feat 브랜치 SPEC commit O/X, default 브랜치 ff-merge 적용 O/X, 원격 default push O/X, 원격 feat push O/X).
+
+## 9.5.4 default 브랜치 자동 fast-forward merge·원격 push 절차
+
+§9.5.2 가 성공해 feat 브랜치에 SPEC.md commit 이 만들어진 직후, 같은 호출 안에서 default 브랜치(`main`)·feat 브랜치를 원격 default 브랜치(`origin/main`) 최신 위로 정렬·동기화한다. 모든 단계는 비-zero exit 발생 시 즉시 §9.5.3 의 해당 분기로 이행한다 (강제 push 시도 금지, abort + 원상태 복구 우선).
+
+본 단계 진입 시점의 사전 조건:
+- `$orig_branch` = §9.5.2 step 2 에서 캡처한 호출 시점 원래 브랜치 이름.
+- `$branch` = `feat/<c>-<slug>` (§9.5.2 에서 생성·SPEC commit 적용된 브랜치).
+- 현재 HEAD = `$orig_branch` (§9.5.2 step 8 에서 복귀 완료).
+- default 브랜치 작업트리는 호출 이전과 동일 (§9.5.2 의 명시적 경로 staging 으로 보존됨).
+
+절차 (총 6 단계, AC1–AC9 매핑):
+
+1. **(AC1) 원격 default 브랜치 fetch**: `git fetch origin main`. 네트워크·인증·remote 부재로 비-zero exit 시 §9.5.3 «fetch 실패» 분기. 성공 시 `origin/main` ref 가 원격 최신 commit 을 가리킨다.
+
+2. **(AC2) feat 브랜치를 origin/main 위로 rebase**: `git checkout "$branch"` 후 `git rebase origin/main`. rebase 가 conflict marker 없이 0 exit 으로 끝나야 한다. conflict 또는 비-zero exit 시 §9.5.3 «rebase 충돌» 분기 (rebase --abort + orig branch 복귀). SPEC.md 만 들어 있는 commit 이라 conflict 가능성은 낮으나, 동시 `--milestone` 작업 또는 base 분기 시점 이후의 원격 변경과 SPEC 디렉토리가 겹치면 발생 가능.
+
+3. **(AC3) default 브랜치로 전환 후 feat 브랜치를 fast-forward merge**: `git checkout main` 후 `git merge --ff-only "$branch"`. `--ff-only` 플래그가 핵심 — fast-forward 가 불가능한 경우 (default 브랜치가 origin/main 보다 앞서 있거나, 호출 이전 staged 변경이 default HEAD 와 diverge 등) 비-zero exit 으로 fail 하고, **이 시점에 merge commit 이 생성되지 않으므로 default 브랜치 HEAD 는 그대로 유지된다**. 비-zero exit 시 §9.5.3 «push 거부» 와 동일 분기로 처리 (default 브랜치 작업트리 보존 + 사용자 안내 + orig branch 복귀). step 2 가 성공했으면 feat 브랜치 = origin/main + (SPEC commit) 이고 default 브랜치 = origin/main 또는 그 이전이므로 일반적으로 fast-forward 가능.
+
+4. **(AC4) 원격 default 브랜치 push**: `git push origin main`. push 가 거부되면 §9.5.3 «push 거부» 분기로 이행 — `--force` 금지. 일반 push 성공 시 0 exit, `origin/main` 이 default 브랜치 HEAD 와 같아진다.
+
+5. **(AC4) 원격 feat 브랜치 push**: `git push origin "$branch"`. 같은 SHA 가 이미 default 브랜치 push 로 원격에 도달했으므로 사실상 ref 등록 수준의 push 이지만, sibling `autopilot:loop` 이 feat 브랜치를 원격에서 fetch·worktree base 로 사용할 수 있게 필수. 거부 시 §9.5.3 «push 거부» 분기.
+
+6. **(AC7·AC8) 원래 브랜치 복귀·작업트리 검증**: `git checkout "$orig_branch"` 로 호출 시점 원래 브랜치 복귀. 직후 `git status --porcelain` 결과가 §9.5.2 step 1 의 스냅샷과 동일한지 검증. 다르면 사용자에게 경고 (staged·unstaged·untracked 변동이 있다면 어떤 파일인지 표시) 하되, default 브랜치 HEAD 와 feat 브랜치 HEAD 는 이미 원격에 push 되었으므로 disk 상태 차이는 호출 이전 작업트리의 untracked 변경이 step 8 §8.1 의 SPEC.md write 결과로 추적 상태가 바뀌었을 가능성이 가장 높음.
+
+본 단계는 사용자 재확인 없이 (AC4 의 "사용자 재확인 없이") 자동 실행된다 — 단계 10 의 사용자 최종 검토는 본 단계 *후*에 일어나므로 사용자는 SPEC.md 가 이미 default 브랜치 + 원격에 push 된 상태를 전제로 결정한다.
+
+## 9.5.5 self-referential 호출 면제
+
+본 §9.5.4 절차를 정의·도입하는 SPEC (예: SPEC 149) 을 작성·수락하는 *현재* spec 호출 자체에는 본 §9.5.4 새 동작을 적용하지 않는다 — 메모리 노트 `feedback_no_self_apply_during_spec` 의 일반 규약을 본 단계에도 그대로 따른다. 현재 호출은 §9.5.2 까지만 (feat 브랜치 분기·SPEC commit·원래 브랜치 복귀) 수행하고, default 브랜치 ff-merge·원격 push 는 본 SPEC 이 merge 된 후의 다음 spec 호출부터 적용된다.

--- a/plugins/autopilot/skills/spec/references/feat-branch-commit.md
+++ b/plugins/autopilot/skills/spec/references/feat-branch-commit.md
@@ -56,9 +56,14 @@ slug=$(printf '%s' "$title" \
   2. `git checkout "$orig_branch"`로 호출 시점 원래 브랜치 복귀 — default 브랜치는 절대 전환 안 됨 (전환은 rebase 성공 후에만 일어나므로 충돌 단계에서는 default 브랜치 작업트리가 손대지지 않음, AC8).
   3. 사용자에게 충돌 사실과 함께 **수동 복구 방법** 안내: feat 브랜치 SPEC commit은 그대로 살아 있으며 (`git log feat/<c>-<slug>` 로 확인 가능), 사용자가 직접 rebase 충돌을 해소하거나 `feat/<c>-<slug>` 를 PR로 올리는 별도 흐름으로 전환 가능. 강제 push 시도 금지.
 
-- **push 거부** (`git push origin <branch>` 가 non-fast-forward·protected branch·권한 부족 등으로 reject):
+- **ff-merge 거부** (§9.5.4 step 3 `git merge --ff-only "$branch"` 가 비-zero exit — default 브랜치가 origin/main 보다 앞서 있거나, 호출 이전 staged·local commit 으로 default HEAD 와 feat 가 diverge):
+  1. **이 분기 시점의 상태 전제**: `--ff-only` 가 fail 했으므로 merge commit 은 생성되지 않았다 — default 브랜치 HEAD·작업트리는 step 3 진입 시점과 동일하게 보존돼 있다 (로컬 변경 없음, 원격과의 일관성도 깨지지 않음). 따라서 push 거부 분기처럼 `git reset --hard origin/main` 형태의 "로컬 되돌림" 안내를 출력하지 않는다 — 되돌릴 로컬 변경이 없다.
+  2. `git checkout "$orig_branch"` 로 호출 시점 원래 브랜치 복귀. 원격 default·feat push 는 시도 자체를 하지 않는다 (강제 push 금지 원칙과 별개로, step 4·5 에 도달하지 않음).
+  3. 사용자에게 ff-merge 가 거부된 사실과 **그 근본 원인 후보**(default 브랜치가 origin/main 보다 앞선 로컬 commit·미push 변경 보유, 또는 base 가 diverge) 와 **수동 복구 방법** 안내: default 브랜치 상태를 `git log main..origin/main` / `git log origin/main..main` 으로 점검하고, 정렬 후 다음 spec 호출에서 자동 재실행 또는 PR 흐름으로 전환. SPEC.md commit 은 feat 브랜치에 그대로 살아 있다.
+
+- **push 거부** (§9.5.4 step 4·5 `git push origin main` / `git push origin <branch>` 가 non-fast-forward·protected branch·권한 부족 등으로 reject — step 3 ff-merge 가 이미 성공해 default 브랜치 HEAD 가 로컬에서 갱신된 *후* 의 단계):
   1. **`--force`·`--force-with-lease` 등 강제 push 절대 시도 안 함** — 본 단계의 모든 push는 일반 push 만 허용. push 명령은 단 한 번만 시도하고 실패하면 즉시 abort.
-  2. 호출 이전 상태 보존: feat 브랜치 SPEC commit 보존, default 브랜치는 fast-forward merge 가 이미 *로컬*에는 적용된 상태이지만 *원격*과의 일관성이 깨지므로 사용자에게 명시적으로 알린다. 로컬 default 브랜치 HEAD 와 원격 default 브랜치 HEAD 가 분기된 상태이며, 사용자가 수동으로 `git reset --hard origin/main` 으로 로컬 되돌림 또는 PR 흐름으로 전환할 수 있음을 안내.
+  2. **이 분기 시점의 상태 전제**: step 3 ff-merge 가 이미 성공했으므로 로컬 default 브랜치 HEAD 는 feat SPEC commit 까지 fast-forward 적용된 상태인데 원격 push 가 거부됐다 — 즉 로컬 default HEAD 와 원격 default HEAD 가 분기되어 일관성이 깨졌다. (이 전제는 ff-merge 거부 분기와 다른 점이다.) 사용자에게 명시적으로 알리고, `git reset --hard origin/main` 으로 로컬 default 를 원격에 맞춰 되돌리거나 PR 흐름으로 전환할 수 있음을 안내. feat 브랜치 SPEC commit 은 보존.
   3. `git checkout "$orig_branch"`로 호출 시점 원래 브랜치 복귀.
   4. 사용자에게 push 거부 사실(어느 브랜치 push 가 어떤 사유로 거부됐는지)과 복구 방법 안내. SPEC.md disk 사본은 그대로 보존.
 
@@ -84,7 +89,7 @@ slug=$(printf '%s' "$title" \
 
 2. **(AC2) feat 브랜치를 origin/main 위로 rebase**: `git checkout "$branch"` 후 `git rebase origin/main`. rebase 가 conflict marker 없이 0 exit 으로 끝나야 한다. conflict 또는 비-zero exit 시 §9.5.3 «rebase 충돌» 분기 (rebase --abort + orig branch 복귀). SPEC.md 만 들어 있는 commit 이라 conflict 가능성은 낮으나, 동시 `--milestone` 작업 또는 base 분기 시점 이후의 원격 변경과 SPEC 디렉토리가 겹치면 발생 가능.
 
-3. **(AC3) default 브랜치로 전환 후 feat 브랜치를 fast-forward merge**: `git checkout main` 후 `git merge --ff-only "$branch"`. `--ff-only` 플래그가 핵심 — fast-forward 가 불가능한 경우 (default 브랜치가 origin/main 보다 앞서 있거나, 호출 이전 staged 변경이 default HEAD 와 diverge 등) 비-zero exit 으로 fail 하고, **이 시점에 merge commit 이 생성되지 않으므로 default 브랜치 HEAD 는 그대로 유지된다**. 비-zero exit 시 §9.5.3 «push 거부» 와 동일 분기로 처리 (default 브랜치 작업트리 보존 + 사용자 안내 + orig branch 복귀). step 2 가 성공했으면 feat 브랜치 = origin/main + (SPEC commit) 이고 default 브랜치 = origin/main 또는 그 이전이므로 일반적으로 fast-forward 가능.
+3. **(AC3) default 브랜치로 전환 후 feat 브랜치를 fast-forward merge**: `git checkout main` 후 `git merge --ff-only "$branch"`. `--ff-only` 플래그가 핵심 — fast-forward 가 불가능한 경우 (default 브랜치가 origin/main 보다 앞서 있거나, 호출 이전 staged 변경이 default HEAD 와 diverge 등) 비-zero exit 으로 fail 하고, **이 시점에 merge commit 이 생성되지 않으므로 default 브랜치 HEAD 는 그대로 유지된다**. 비-zero exit 시 §9.5.3 «ff-merge 거부» 분기로 처리 (default 브랜치 HEAD·작업트리 보존 + 사용자 안내 + orig branch 복귀). step 2 가 성공했으면 feat 브랜치 = origin/main + (SPEC commit) 이고 default 브랜치 = origin/main 또는 그 이전이므로 일반적으로 fast-forward 가능.
 
 4. **(AC4) 원격 default 브랜치 push**: `git push origin main`. push 가 거부되면 §9.5.3 «push 거부» 분기로 이행 — `--force` 금지. 일반 push 성공 시 0 exit, `origin/main` 이 default 브랜치 HEAD 와 같아진다.
 
@@ -96,4 +101,4 @@ slug=$(printf '%s' "$title" \
 
 ## 9.5.5 self-referential 호출 면제
 
-본 §9.5.4 절차를 정의·도입하는 SPEC (예: SPEC 149) 을 작성·수락하는 *현재* spec 호출 자체에는 본 §9.5.4 새 동작을 적용하지 않는다 — 메모리 노트 `feedback_no_self_apply_during_spec` 의 일반 규약을 본 단계에도 그대로 따른다. 현재 호출은 §9.5.2 까지만 (feat 브랜치 분기·SPEC commit·원래 브랜치 복귀) 수행하고, default 브랜치 ff-merge·원격 push 는 본 SPEC 이 merge 된 후의 다음 spec 호출부터 적용된다.
+본 §9.5.4 절차를 정의·도입하는 SPEC (예: SPEC 149) 을 작성·수락하는 *현재* spec 호출 자체에는 본 §9.5.4 새 동작을 적용하지 않는다. 이는 다음 일반 규약을 따른 것이다: **spec 호출이 정의·도입하는 새 contract 는 그 호출의 산출물(경로·브랜치·동작)에 선행 적용하지 않으며, 새 contract 는 해당 SPEC 이 default 브랜치에 merge 된 후의 다음 spec 호출부터 적용된다**. 따라서 현재 호출은 §9.5.2 까지만 (feat 브랜치 분기·SPEC commit·원래 브랜치 복귀) 수행하고, default 브랜치 ff-merge·원격 push 는 본 SPEC 이 merge 된 후의 다음 spec 호출부터 적용된다.

--- a/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
+++ b/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
@@ -67,6 +67,38 @@ touch DONE
 echo '{"result":"mock","usage":{"input_tokens":1,"output_tokens":1}}'
 MOCKEOF
 chmod +x "$MOCK_BIN/claude"
+
+# mock gh — task_status_is_done 를 만족시키는 최소 stub.
+# 배경: loop.sh 는 done 신호를 task 저장소의 `loop:done` label 단일 의존으로 감지한다
+#       (SPEC 134/150). mock claude 가 `DONE` 파일을 만들어도 loop.sh 는 보지 않는다.
+#       본 테스트는 real GitHub 이 없으므로 gh stub 으로 label 존재를 흉내내 iter #1
+#       직후 task_status_is_done 이 0(done) 을 반환하도록 한다.
+# 처리:
+#   - gh issue list  : "1" (task_issue_number 가 lookup 성공하게)
+#   - gh issue view  : "loop:done" (task_label_present 가 hit)
+#   - gh label list  : "loop:done" (ensure_label_exists 가 idempotent 통과)
+#   - gh label create / gh issue comment / gh api graphql / etc : silent 0
+cat > "$MOCK_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$1" in
+  issue)
+    case "$2" in
+      list) echo "1" ;;
+      view) echo "loop:done" ;;
+      *) ;;
+    esac
+    ;;
+  label)
+    case "$2" in
+      list) echo "loop:done" ;;
+      *) ;;
+    esac
+    ;;
+  *) ;;
+esac
+exit 0
+GHEOF
+chmod +x "$MOCK_BIN/gh"
 export PATH="$MOCK_BIN:$PATH"
 
 INPUT_ID="test123"


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가
autopilot:spec 스킬이 SPEC.md를 feat 브랜치에 commit한 직후, 그 commit이 원격 default 브랜치 최신 위로 정렬되어 default 브랜치에도 fast-forward 형태로 반영되고 원격 저장소에 즉시 push되도록 한다. feat 브랜치도 그대로 유지되며 원격에 push되어 후속 loop 실행·협업이 이어진다. 충돌·push 거부 등 실패 상황에서는 호출 이전 상태로 안전하게 복구되고 사용자에게 실패 사유와 복구 방법이 명시적으로 안내된다.

## Commits
- 0fbb9bc feat(spec/149): §9.5.4 default 브랜치 자동 fast-forward merge·origin push 단계 추가
- dfe0c92 feat(spec): 149 — spec: SPEC.md commit을 main에 자동 ff-merge 단계 추가

Closes #149
<!-- autopilot:pr-body:end -->