### PR TITLE
Push sync policy: rebase locally, merge on remote

### DIFF
--- a/milestones/regular/loops/169-push-sync-policy-rebase-locally-merge-on-remote/SPEC.md
+++ b/milestones/regular/loops/169-push-sync-policy-rebase-locally-merge-on-remote/SPEC.md
@@ -1,0 +1,74 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/loop/**"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh"
+---
+
+# Push sync policy: rebase locally, merge on remote
+
+## 무엇을 만들 것인가
+
+loop의 자율 push 흐름이 base 동기화 단계에서 *동기화 시점에 자기 브랜치가 원격에 이미 존재하는지*를 검사해 두 경로로 분기한다. 원격 트래킹 브랜치가 없으면 rebase로 base 위에 자기 commit들을 재배치(history 재작성)하고, 이미 존재하면 merge로 base 변경분만 흡수해 자기 commit의 SHA를 보존한다. 어떤 경로에서도 force push는 도입하지 않으며, 분기 자체는 단일 sync helper에 위치해 PR 생성 직전·review-fix iter의 모든 push 직전 호출 지점에서 동일하게 재사용된다. 동기화 중 충돌이 발생하면 기존 sync 모듈의 1회 자동 해소 절차를 그대로 사용하고, 실패 시 보수적 좌절로 복구한다.
+
+## 수용 기준 (EARS)
+
+- **AC1** (Event-driven): loop이 push 직전 base 동기화를 수행할 때, 시스템은 동기화 시점의 원격 트래킹 브랜치 존재 여부를 판정해 rebase 경로 또는 merge 경로로 분기한다.
+- **AC2** (Optional): 원격 트래킹 브랜치가 부재인 경우, 시스템은 자기 브랜치를 base 위로 rebase로 재배치한다.
+- **AC3** (Optional): 원격 트래킹 브랜치가 이미 존재하는 경우, 시스템은 base 변경분을 자기 브랜치에 merge로 흡수해 자기 commit의 SHA를 보존한다.
+- **AC4** (Ubiquitous): 시스템은 push 경로에서 force push(`--force`·`--force-with-lease` 포함)를 사용하지 않는다.
+- **AC5** (Event-driven): 동기화 중 충돌이 발생할 때, 시스템은 기존 sync 모듈의 자동 해소 절차를 1회 시도한다.
+- **AC6** (Unwanted): 자동 해소 1회 시도 후에도 충돌이 남아 있으면, 시스템은 원래 워크트리 상태로 복구하고 비-zero exit으로 종료한다.
+- **AC7** (Ubiquitous): PR 생성 직전·review-fix iter의 모든 push 직전 동기화는 동일한 sync helper를 통해 수행된다 (각 phase 안의 직접 `git rebase`·`git merge` 라인 부재).
+
+## 범위
+
+포함:
+
+- `plugins/autopilot/skills/loop/references/rebase-phase.sh` — 분기 도입 (helper 본체)
+- `plugins/autopilot/skills/loop/references/pr-phase.sh` — inline rebase 블록 제거 후 helper 호출로 통일
+- `plugins/autopilot/skills/loop/references/review-fix-phase.sh` — 이미 helper 호출 중이므로 검증만 (코드 변경 없을 수 있음)
+- `plugins/autopilot/skills/loop/SKILL.md` — 정책 설명 갱신
+- `plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh` — merge 경로 케이스 추가
+
+비-목표 / 제외:
+
+- helper 파일명 변경 (rename — 환경 변수·문서 파급 회피)
+- force push · force-with-lease 도입
+- `cleanup-phase.sh`의 `git push --delete` (push sync 경로 아님)
+- 일반 워크플로(CLAUDE.md·git hooks)의 push 정책
+- 다른 워커가 같은 브랜치에 push한 외부 mutation 흡수 (별도 issue 가능성)
+
+## 검증
+
+이 명령이 0 exit으로 끝나야 합니다:
+
+```bash
+bash plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
+```
+
+SPEC 구현 중 추가될 케이스:
+
+- 원격 트래킹 부재 fixture → rebase 경로 수행 확인 (AC2)
+- 원격 트래킹 존재 fixture → merge commit 생성·자기 commit SHA 보존 확인 (AC3)
+- force 관련 플래그 grep → push 경로에 부재 확인 (AC4)
+- 충돌 fixture + 해소 실패 → 워크트리 복구 + 비-zero exit (AC6)
+- pr-phase·review-fix-phase grep → 직접 `git rebase`·`git merge` 라인 부재 (AC7)
+
+## 제약
+
+- 기존 sync 모듈의 자동 해소 절차는 `AUTOPILOT_REBASE_ALLOWED_TOOLS` 환경 변수에 의존 (이름은 REBASE로 남으나 rename은 범위 제외).
+- merge 충돌 자동 해소 로직은 `MERGE_HEAD` 존재 상태를 처리해야 하며 rebase 시의 `REBASE_HEAD` 상태와 분별되어 동작한다.
+- 분기 검사 `git ls-remote --heads origin <branch>`는 원격 접근 권한에 의존 (기존 push와 동일 권한이므로 새로운 제약 아님).
+- `git symbolic-ref --quiet refs/remotes/origin/HEAD` 의존 (기존 fallback `gh repo view` 그대로 유지).
+- bash 4 이상 (loop.sh 기존 가정과 동일).
+
+## 위험
+
+- merge 경로에서 `Merge origin/<base> into ...` commit이 PR `## Commits` 섹션에 노출됨 (사용자 합의 — 상위 설정이 squash-merge면 최종 history에는 미포함).
+- review-fix iter는 매 회 동기화를 수행하므로, base 변화 없는 경우에도 merge 경로에서 불필요 commit이 생성되지 않도록 (`--ff-only` 사전 시도 등) 주의 필요.
+- 다른 워커가 같은 PR 브랜치에 commit을 추가한 경우(외부 mutation)는 현 SPEC 범위 밖 — 현재 동작대로는 `git push origin <branch>`가 non-FF로 거부될 수 있으므로 별도 처리 필요 (이슈 별도 제기 권장).
+- helper 이름이 `rebase-phase.sh` 그대로 유지되어 의미·이름 불일치 — 향후 독자가 혼란에 빠질 수 있음 (rename 없이 내부 주석·SKILL.md로 의도 명시).

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -77,7 +77,10 @@ task가 `DONE`에 도달한 직후 같은 워크트리에서 PR 생성(또는 �
 
 활성화 시 동작:
 - default 브랜치 자동 감지 (`gh repo view` → `git symbolic-ref refs/remotes/origin/HEAD`)
-- push 직전에 `origin/<base>`로부터 `git fetch` + `git rebase` 수행 (SPEC 103 AC3) — base 최신 변경분을 흡수, fast-forward 가능하면 no-op. 첫 rebase가 충돌로 실패하면 `-X theirs`(feat 브랜치 우선) 전략으로 정확히 1회 자동 해결 시도(SPEC 103 AC4). 재시도도 실패하면 `git rebase --abort`로 워크트리 복구 + 명시적 사용자 알림 + non-zero exit (보수적 좌절 — 사용자 수동 해결 필요)
+- push 직전에 `origin/<base>`로부터 `git fetch` + 단일 sync helper(`references/rebase-phase.sh`)로 base 동기화 (SPEC 169) — helper가 `git ls-remote --heads origin <branch>`로 원격 트래킹 브랜치 존재 여부를 판정해 두 경로로 분기한다:
+  - **부재 → rebase 경로**: `git rebase origin/<base>`로 history 재배치 (첫 PR 진입 전 깨끗한 linear history)
+  - **존재 → merge 경로**: `git merge --ff-only` → 실패 시 non-ff `git merge --no-edit`로 base 변경분만 흡수 (자기 commit SHA 보존, force push 회피)
+- 어떤 경로에서도 force push(`--force`·`--force-with-lease` 포함)는 도입되지 않는다 (SPEC 169 AC4). 충돌 시 claude CLI 세션 1회로 자동 해소 시도(SPEC 169 AC5), 실패 시 해당 모드의 `--abort`로 워크트리 복구 + non-zero exit (보수적 좌절, SPEC 169 AC6)
 - 현재 브랜치를 `origin`으로 push
 - 동일 head 브랜치에 open PR이 없으면 **새 PR 생성**, 있으면 **기존 PR을 in-place로 갱신** (제목·body 동기화)
 - PR 제목 = SPEC 문서의 H1, body = SPEC "무엇을 만들 것인가" 본문 + base..HEAD commit log
@@ -99,8 +102,8 @@ SPEC frontmatter에 `request_review: true`가 지정된 task만 본 흐름을 �
 
 | 단계 | 스크립트 | 역할 |
 |---|---|---|
-| pre-PR rebase | `references/rebase-phase.sh` | default 브랜치로부터 워크트리 feat 브랜치 rebase. 충돌 시 claude CLI 1회 자동 해소, 실패 시 ESCALATION abort. |
-| review-fix 루프 (background) | `references/review-fix-phase.sh` | 30초 주기 폴링 (PR comments · review threads · summary). 새 이벤트마다 재-rebase → claude CLI fix → commit+push → (필요 시) 1개 반박 코멘트. |
+| pre-PR sync | `references/rebase-phase.sh` | default 브랜치로부터 워크트리 feat 브랜치 동기화 (SPEC 169). 원격 트래킹 부재면 rebase, 존재면 merge 경로. 충돌 시 claude CLI 1회 자동 해소, 실패 시 해당 모드의 `--abort`로 복구 + ESCALATION abort. |
+| review-fix 루프 (background) | `references/review-fix-phase.sh` | 30초 주기 폴링 (PR comments · review threads · summary). 새 이벤트마다 base 재동기화(sync helper — merge 경로) → claude CLI fix → commit+push → (필요 시) 1개 반박 코멘트. |
 | 자동 머지 (auto-merge) | `references/review-fix-phase.sh` 내부 | reviewDecision `APPROVED` 또는 owner의 종료 코멘트(`/done`·`합격`·`통과`)로 `gh pr merge --squash` 수행. PR이 이미 `merged`이면 자동 머지 건너뜀. |
 | cleanup | `references/cleanup-phase.sh` | PR `merged` 후 worktree 제거 + 로컬 feat `branch -D` + origin feat `push --delete`. |
 

--- a/plugins/autopilot/skills/loop/references/pr-phase.sh
+++ b/plugins/autopilot/skills/loop/references/pr-phase.sh
@@ -26,10 +26,6 @@ set -euo pipefail
 WT="${1:-}"
 BRANCH="${2:-}"
 TASK_ID="${3:-}"
-# PROJECT_ROOT: 본 phase에서는 미사용 — 후속 phase(리뷰 모니터·자동 fix·완료 감지·정리)에서
-# 메인 repo를 대상으로 cherry-pick·merge·worktree remove 등 워크트리 밖 작업을 수행할 때 필요.
-# caller(loop.sh)는 이미 전달하고 있어 시그니처는 유지하되, 호출자 실수(누락) 방지를 위해 검증은
-# 유지. 본 스크립트 내 사용 위치가 추가될 때 본 주석 제거.
 PROJECT_ROOT="${4:-}"
 
 [[ -n "$WT" && -n "$BRANCH" && -n "$TASK_ID" && -n "$PROJECT_ROOT" ]] \

--- a/plugins/autopilot/skills/loop/references/pr-phase.sh
+++ b/plugins/autopilot/skills/loop/references/pr-phase.sh
@@ -113,36 +113,23 @@ collect_commit_log() {
   ( cd "$WT" && git log --pretty=format:'- %h %s' "$base..HEAD" 2>/dev/null || true )
 }
 
-# COMMIT_LOG·PR_BODY 조립은 rebase 이후로 미룬다 — 충돌 자동 해결(-X theirs)이 SHA를 재작성하면
-# PR body '## Commits' 섹션이 구 SHA를 표시하기 때문. SPEC_TITLE·WHAT_SECTION은 rebase 영향을
-# 받지 않으므로 위에서 미리 추출해 둔다.
+# COMMIT_LOG·PR_BODY 조립은 sync helper 이후로 미룬다 — rebase 경로에서 충돌 자동 해소가
+# SHA를 재작성하면 PR body '## Commits' 섹션이 구 SHA를 표시하기 때문. SPEC_TITLE·WHAT_SECTION은
+# sync 영향을 받지 않으므로 위에서 미리 추출해 둔다.
 
-# ----- base branch rebase (SPEC 103 M2/AC3·M3/AC4) -----
-# PR 생성 직전에 origin/<base>로부터 fetch + rebase를 수행해 base 최신 변경분을 흡수한다.
-# fast-forward(또는 동일 history)면 no-op으로 통과한다. 첫 평범한 rebase가 실패하면(충돌
-# 가능성 — 본 단계 외 환경 오류도 포함될 수 있음) `-X theirs` 전략으로 정확히 1회만 재시도한다
-# (M3/AC4 휴리스틱: feat 브랜치의 변경을 base 위에 우선 적용). 재시도도 실패하면 워크트리를
-# `git rebase --abort`로 복구하고 명시적 사용자 알림 + non-zero exit (보수적 좌절).
-# 1회 제한은 분기를 한 갈래만 두어 코드로 강제한다 — counter 변수 불필요.
-echo "[pr-phase] origin/$DEFAULT_BRANCH fetch"
-if ! ( cd "$WT" && git fetch origin "$DEFAULT_BRANCH" 2>&1 ); then
-  echo "ERROR: git fetch origin $DEFAULT_BRANCH 실패" >&2
+# ----- base 동기화 (SPEC 169) -----
+# 단일 sync helper(rebase-phase.sh)를 통해 fetch + 동기화를 수행한다. helper가 원격 트래킹
+# 브랜치 존재 여부를 검사해 rebase / merge 경로로 분기하므로 본 phase는 직접 `git rebase`·
+# `git merge`를 호출하지 않는다 (SPEC 169 AC7). force push도 helper·본 phase 모두에서 부재
+# (AC4). 충돌 자동 해소(1회) 및 실패 시 워크트리 abort 복구는 helper 책임.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+echo "[pr-phase] base 동기화 → $SCRIPT_DIR/rebase-phase.sh (SPEC 169 sync helper)"
+if ! bash "$SCRIPT_DIR/rebase-phase.sh" "$WT" "$BRANCH" "$PROJECT_ROOT"; then
+  echo "ERROR: base 동기화 실패 — PR 단계 abort (helper의 ESCALATION 로그 참조)" >&2
   exit 1
 fi
 
-echo "[pr-phase] origin/$DEFAULT_BRANCH rebase"
-if ! ( cd "$WT" && git rebase "origin/$DEFAULT_BRANCH" 2>&1 ); then
-  echo "[pr-phase] rebase 실패 감지 — 충돌 1회 자동 해결 시도 (-X theirs)"
-  ( cd "$WT" && git rebase --abort 2>/dev/null || true )
-  if ! ( cd "$WT" && git rebase -X theirs "origin/$DEFAULT_BRANCH" 2>&1 ); then
-    ( cd "$WT" && git rebase --abort 2>/dev/null || true )
-    echo "ERROR: rebase 충돌 자동 해결 실패 (1회 시도 후 좌절). 워크트리는 'git rebase --abort'로 복구됨 — 사용자 수동 해결 후 재시도하세요." >&2
-    exit 1
-  fi
-  echo "[pr-phase] rebase 충돌 자동 해결 성공 (-X theirs)"
-fi
-
-# ----- COMMIT_LOG·PR_BODY 조립 (rebase 이후 — SHA 재작성 흡수) -----
+# ----- COMMIT_LOG·PR_BODY 조립 (sync 이후 — rebase 경로의 SHA 재작성 흡수) -----
 COMMIT_LOG="$(collect_commit_log)"
 
 # Body 본문 (fence 안 내용)

--- a/plugins/autopilot/skills/loop/references/rebase-phase.sh
+++ b/plugins/autopilot/skills/loop/references/rebase-phase.sh
@@ -1,22 +1,30 @@
 #!/usr/bin/env bash
-# rebase-phase.sh — SPEC 123 M1
+# rebase-phase.sh — SPEC 123 M1 + SPEC 169 push sync policy
 #
-# PR 생성·재사용 직전, 그리고 review-fix 루프의 각 fix iter 직전에 호출되어
-# 워크트리의 feat 브랜치를 default 브랜치로 rebase한다.
+# PR 생성·재사용 직전, 그리고 review-fix 루프의 각 fix iter 직전에 호출되는 단일 sync helper.
+# 워크트리의 feat 브랜치를 default 브랜치로 동기화한다.
+#
+# 동기화 모드 (SPEC 169):
+#   - 원격 트래킹 브랜치 부재 → rebase 경로 (history 재배치, 깨끗한 linear history)
+#   - 원격 트래킹 브랜치 존재 → merge 경로 (자기 commit SHA 보존, force push 회피)
+# 두 경로 어디서도 force push(`--force`·`--force-with-lease` 포함)를 도입하지 않는다.
 #
 # 사용:
 #   bash rebase-phase.sh <worktree> <branch> <project-root>
 #
-# 동작:
+# 동작 요약:
 #   1. default 브랜치 감지 (gh repo view → git symbolic-ref → 실패 abort)
 #   2. origin/<default> fetch
-#   3. git rebase origin/<default>
-#   4. 성공 시 0 exit (fast-forward·동일 history 포함).
-#   5. 실패(충돌) 시 claude CLI 세션 1회로 자동 해소 시도 (SPEC 123 AC2).
-#      - claude CLI 미설치·실패 시 보수적 좌절 (rebase --abort + non-zero exit).
-#   6. 자동 해소 후 `git rebase --continue` 시도, 그래도 실패하면 abort.
-#   7. 어떤 단계든 비-zero exit 시 stdout 첫 줄에 "ESCALATION" prefix를 출력해
-#      caller(loop.sh·review-fix-phase.sh)가 종료 신호로 감지하게 한다 (SPEC 123 AC19).
+#   3. `git ls-remote --heads origin <branch>`로 원격 브랜치 존재 여부 판정 → SYNC_MODE
+#   4. rebase 경로: `git rebase origin/<default>`
+#      merge  경로: `git merge --ff-only origin/<default>` → 실패 시 non-ff `git merge --no-edit`
+#   5. 충돌 시 claude CLI 세션 1회로 자동 해소 시도 (SPEC 123 AC2 / SPEC 169 AC5).
+#      - claude 미설치·세션 실패·해소 후 잔존 → 해당 모드의 abort 명령으로 워크트리 복구 + 비-zero exit.
+#   6. 어떤 단계든 비-zero exit 시 stdout 첫 줄에 "ESCALATION" prefix를 출력해
+#      caller(loop.sh·pr-phase.sh·review-fix-phase.sh)가 종료 신호로 감지하게 한다.
+#
+# 파일명은 SPEC 169 이후에도 `rebase-phase.sh` 그대로 유지(rename은 환경변수·문서 파급 회피로 SPEC 범위 외).
+# 의미는 "sync helper" — 본 스크립트 자체는 두 모드를 모두 책임진다.
 
 set -euo pipefail
 
@@ -60,68 +68,131 @@ if ! ( cd "$WT" && git fetch origin "$DEFAULT_BRANCH" 2>&1 ); then
   exit 1
 fi
 
-echo "[rebase-phase] rebase onto origin/$DEFAULT_BRANCH"
-if ( cd "$WT" && git rebase "origin/$DEFAULT_BRANCH" 2>&1 ); then
-  echo "[rebase-phase] rebase 성공 (충돌 없음)"
-  exit 0
+# ----- 동기화 모드 판정 (SPEC 169 AC1) -----
+# `git ls-remote --heads --exit-code origin <branch>`는 원격에 해당 ref가 있으면 0,
+# 없으면 2를 반환. 원격에 자기 브랜치가 이미 존재하면 history 재작성이 force push를
+# 강제하므로 merge로 base 변경분만 흡수한다. 부재 시(첫 PR 진입 전)는 깨끗한 linear
+# history를 위해 rebase로 재배치한다.
+SYNC_MODE="rebase"
+if ( cd "$WT" && git ls-remote --heads --exit-code origin "$BRANCH" >/dev/null 2>&1 ); then
+  SYNC_MODE="merge"
 fi
+echo "[rebase-phase] sync mode: $SYNC_MODE (origin/$BRANCH $( [[ $SYNC_MODE == merge ]] && echo present || echo absent ))"
 
-# ----- 충돌 — claude CLI 1회 자동 해소 시도 -----
-echo "[rebase-phase] rebase 충돌 감지 — claude CLI 자동 해소 시도 (1회)"
-
-if ! command -v claude >/dev/null 2>&1; then
-  ( cd "$WT" && git rebase --abort 2>/dev/null || true )
-  emit_escalation "claude CLI 미설치 — 충돌 자동 해소 불가"
-  exit 1
-fi
-
-# claude 세션에 conflict marker가 있는 파일 목록 + diff를 stdin으로 넘긴다.
 # allowed-tools는 caller(loop.sh)에서 export한 환경 변수 또는 본 스크립트 기본값.
+# 환경 변수 이름은 SPEC 169 이후에도 `AUTOPILOT_REBASE_ALLOWED_TOOLS` 유지 — rename은
+# SPEC 169 범위 외(파급 회피).
 ALLOWED_TOOLS_REBASE="${AUTOPILOT_REBASE_ALLOWED_TOOLS:-Bash(git add:*),Bash(git status:*),Bash(git diff:*),Bash(cat:*),Bash(ls:*),Read,Edit,Write}"
 
-# claude 세션이 충돌을 해소할 수 있도록 작업 디렉토리·헌법(워크트리 CLAUDE.md)을 제공.
-# --dangerously-skip-permissions는 사용하지 않고 allowed-tools로 명시 범위 제한.
-conflict_files=$( cd "$WT" && git diff --name-only --diff-filter=U 2>/dev/null || true )
-
-claude_prompt=$(cat <<EOF
-You are inside a git rebase conflict on branch '$BRANCH' onto 'origin/$DEFAULT_BRANCH'.
+# ----- 공통 충돌 해소 helper (claude CLI 1회) -----
+# 두 경로(rebase·merge)가 동일한 해소 전략을 공유한다 — claude 세션에 conflict marker
+# 파일을 알리고 in-place로 해소하게 한 뒤 `git add`까지 위임, 본 스크립트가 continue.
+# 반환:
+#   0 = 세션 완료 + unresolved 잔존 없음 (caller가 mode별 --continue 수행)
+#   1 = claude 미설치 또는 세션 비-zero exit
+#   2 = 세션 후에도 unresolved 잔존
+resolve_conflicts_via_claude() {
+  local mode_label="$1"   # "rebase" 또는 "merge" — 로그·프롬프트 어휘만 분기
+  if ! command -v claude >/dev/null 2>&1; then
+    return 1
+  fi
+  # claude 세션에 conflict marker가 있는 파일 목록 + diff를 stdin으로 넘긴다.
+  local conflict_files
+  conflict_files=$( cd "$WT" && git diff --name-only --diff-filter=U 2>/dev/null || true )
+  # claude 세션이 충돌을 해소할 수 있도록 작업 디렉토리·헌법(워크트리 CLAUDE.md)을 제공.
+  # --dangerously-skip-permissions는 사용하지 않고 allowed-tools로 명시 범위 제한.
+  local claude_prompt
+  claude_prompt=$(cat <<EOF
+You are inside a git $mode_label conflict on branch '$BRANCH' onto 'origin/$DEFAULT_BRANCH'.
 Conflicted files:
 $conflict_files
 
 Goal: resolve each conflict in-place, preferring the intent of branch '$BRANCH' (feat
 branch) but keeping any non-conflicting changes from base. Edit each file to remove
 the '<<<<<<<', '=======', '>>>>>>>' markers. Then run 'git add' on each resolved
-file. DO NOT run 'git rebase --continue' yourself — the caller will do that. DO NOT
-push, commit, or create branches.
+file. DO NOT run 'git rebase --continue' or 'git merge --continue' yourself — the
+caller will do that. DO NOT push, commit, or create branches.
 
 When done, output a single line: 'RESOLVED'.
 EOF
 )
+  mkdir -p "$WT/.iterations" 2>/dev/null || true   # 독립 호출 시에도 로그 쓰기 보장
+  local claude_exit=0
+  ( cd "$WT" && printf '%s' "$claude_prompt" | claude \
+      --print \
+      --no-session-persistence \
+      --add-dir . \
+      --allowed-tools "$ALLOWED_TOOLS_REBASE" \
+      --output-format text \
+      > ".iterations/${mode_label}-conflict.log" 2>&1 ) || claude_exit=$?
+  if (( claude_exit != 0 )); then
+    return 1
+  fi
+  # claude 세션이 파일을 모두 git add 했는지 확인 (unresolved 잔존 검사).
+  if ( cd "$WT" && git diff --name-only --diff-filter=U 2>/dev/null | grep -q . ); then
+    return 2
+  fi
+  return 0
+}
 
-mkdir -p "$WT/.iterations" 2>/dev/null || true   # 독립 호출 시에도 로그 쓰기 보장
-claude_exit=0
-( cd "$WT" && printf '%s' "$claude_prompt" | claude \
-    --print \
-    --no-session-persistence \
-    --add-dir . \
-    --allowed-tools "$ALLOWED_TOOLS_REBASE" \
-    --output-format text \
-    > .iterations/rebase-conflict.log 2>&1 ) || claude_exit=$?
-
-if (( claude_exit != 0 )); then
+# ----- rebase 경로 (SPEC 169 AC2): 원격 트래킹 부재 → history 재배치 -----
+if [[ "$SYNC_MODE" == "rebase" ]]; then
+  echo "[rebase-phase] rebase onto origin/$DEFAULT_BRANCH"
+  if ( cd "$WT" && git rebase "origin/$DEFAULT_BRANCH" 2>&1 ); then
+    echo "[rebase-phase] rebase 성공 (충돌 없음)"
+    exit 0
+  fi
+  echo "[rebase-phase] rebase 충돌 감지 — claude CLI 자동 해소 시도 (1회)"
+  rc=0
+  resolve_conflicts_via_claude "rebase" || rc=$?
+  if (( rc != 0 )); then
+    ( cd "$WT" && git rebase --abort 2>/dev/null || true )
+    if (( rc == 1 )); then
+      emit_escalation "claude CLI 미설치 또는 세션 실패 — 워크트리 rebase --abort 복구"
+    else
+      emit_escalation "claude 해소 후에도 충돌 잔존 — 워크트리 rebase --abort 복구"
+    fi
+    exit 1
+  fi
+  if ( cd "$WT" && GIT_EDITOR=true git rebase --continue 2>&1 ); then
+    echo "[rebase-phase] rebase 충돌 자동 해소 성공 (claude CLI)"
+    exit 0
+  fi
   ( cd "$WT" && git rebase --abort 2>/dev/null || true )
-  emit_escalation "claude CLI 충돌 해소 세션 실패 (exit $claude_exit) — 워크트리 abort 복구 완료"
+  emit_escalation "claude 해소 후에도 git rebase --continue 실패 — 워크트리 rebase --abort 복구"
   exit 1
 fi
 
-# claude 세션이 파일을 모두 git add 했는지 확인 후 rebase --continue
-if ! ( cd "$WT" && git diff --name-only --diff-filter=U 2>/dev/null | grep -q . ); then
-  if ( cd "$WT" && GIT_EDITOR=true git rebase --continue 2>&1 ); then
-    echo "[rebase-phase] 충돌 자동 해소 성공 (claude CLI)"
-    exit 0
-  fi
+# ----- merge 경로 (SPEC 169 AC3): 원격 트래킹 존재 → 자기 SHA 보존 -----
+# 1차 ff-only: base 변화 없음 또는 feat가 base의 후손인 경우 no-op으로 통과 (불필요 merge commit 회피).
+# 2차 non-ff:  diverged base를 흡수해 새 merge commit 생성. 자기 commit SHA는 그대로 reachable.
+echo "[rebase-phase] merge from origin/$DEFAULT_BRANCH (ff-only 우선 시도)"
+if ( cd "$WT" && git merge --ff-only "origin/$DEFAULT_BRANCH" 2>&1 ); then
+  echo "[rebase-phase] fast-forward 또는 already up-to-date — merge commit 없음"
+  exit 0
 fi
-
-( cd "$WT" && git rebase --abort 2>/dev/null || true )
-emit_escalation "claude CLI 해소 후에도 git rebase --continue 실패 — 워크트리 abort 복구"
+echo "[rebase-phase] non-ff merge 시도 — base 변경분 흡수"
+if ( cd "$WT" && git merge --no-edit "origin/$DEFAULT_BRANCH" 2>&1 ); then
+  echo "[rebase-phase] merge 성공 (merge commit 생성)"
+  exit 0
+fi
+echo "[rebase-phase] merge 충돌 감지 — claude CLI 자동 해소 시도 (1회)"
+rc=0
+resolve_conflicts_via_claude "merge" || rc=$?
+if (( rc != 0 )); then
+  ( cd "$WT" && git merge --abort 2>/dev/null || true )
+  if (( rc == 1 )); then
+    emit_escalation "claude CLI 미설치 또는 세션 실패 — 워크트리 merge --abort 복구"
+  else
+    emit_escalation "claude 해소 후에도 충돌 잔존 — 워크트리 merge --abort 복구"
+  fi
+  exit 1
+fi
+# `git merge --continue` (git 2.12+)는 editor를 띄우므로 GIT_EDITOR=true로 silence.
+if ( cd "$WT" && GIT_EDITOR=true git merge --continue 2>&1 ); then
+  echo "[rebase-phase] merge 충돌 자동 해소 성공 (claude CLI)"
+  exit 0
+fi
+( cd "$WT" && git merge --abort 2>/dev/null || true )
+emit_escalation "claude 해소 후에도 git merge --continue 실패 — 워크트리 merge --abort 복구"
 exit 1

--- a/plugins/autopilot/skills/loop/references/rebase-phase.sh
+++ b/plugins/autopilot/skills/loop/references/rebase-phase.sh
@@ -74,8 +74,13 @@ fi
 # 강제하므로 merge로 base 변경분만 흡수한다. 부재 시(첫 PR 진입 전)는 깨끗한 linear
 # history를 위해 rebase로 재배치한다.
 SYNC_MODE="rebase"
-if ( cd "$WT" && git ls-remote --heads --exit-code origin "$BRANCH" >/dev/null 2>&1 ); then
+ls_remote_rc=0
+( cd "$WT" && git ls-remote --heads --exit-code origin "$BRANCH" >/dev/null 2>&1 ) || ls_remote_rc=$?
+if (( ls_remote_rc == 0 )); then
   SYNC_MODE="merge"
+elif (( ls_remote_rc != 2 )); then
+  emit_escalation "git ls-remote 실패 (exit $ls_remote_rc) — SYNC_MODE 판정 불가 (네트워크/인증 오류 가능, 브랜치 부재(rc=2)와 구분)"
+  exit 1
 fi
 echo "[rebase-phase] sync mode: $SYNC_MODE (origin/$BRANCH $( [[ $SYNC_MODE == merge ]] && echo present || echo absent ))"
 

--- a/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
@@ -805,6 +805,70 @@ CL
   pass "(AC6) 충돌 자동 해소 실패 → 워크트리 복구 + non-zero exit"
 }
 
+# (AC6) 충돌 자동 해소 실패 → 워크트리 복구 + non-zero exit (rebase 경로 — 대칭 케이스)
+# merge 경로(test_sync_conflict_failure_recovers_merge_path)와 동일 구조이나
+# feat 브랜치를 origin에 push하지 않아 ls-remote rc=2 → rebase 경로 분기.
+test_sync_conflict_failure_recovers_rebase_path() {
+  local case_name="conflict_rebase"
+  local project="$WORK_DIR/$case_name"
+  local bare="$WORK_DIR/${case_name}.git"
+  git init -q --bare -b main "$bare"
+  mkdir -p "$project"
+  (
+    cd "$project"
+    git init -q -b main
+    git config user.email "t@e.com"; git config user.name "T"
+    git remote add origin "$bare"
+    echo "initial" > shared.txt
+    git add shared.txt; git commit -q -m "initial"
+    git push -q origin main
+    git remote set-head origin main
+    mkdir -p milestones/regular/loops/169
+    git worktree add -q -b "feat/169-$case_name" "milestones/regular/loops/169/.worktree" HEAD
+    cd milestones/regular/loops/169/.worktree
+    echo "feat version" > shared.txt
+    git add shared.txt; git commit -q -m "feat: conflict"
+    # feat push 생략 — 원격 트래킹 부재 → rebase 경로 분기
+  ) >/dev/null 2>&1 || fail "$case_name setup"
+  (
+    cd "$project"
+    echo "main version" > shared.txt
+    git add shared.txt; git commit -q -m "base: conflict"
+    git push -q origin main
+  ) >/dev/null 2>&1 || fail "$case_name base advance"
+  local wt="$project/milestones/regular/loops/169/.worktree"
+  local feat_sha_before; feat_sha_before=$( cd "$wt" && git rev-parse HEAD )
+
+  local mock_bin="$WORK_DIR/${case_name}_mock"; mkdir -p "$mock_bin"
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+exit 1
+GH
+  chmod +x "$mock_bin/gh"
+  cat > "$mock_bin/claude" <<'CL'
+#!/usr/bin/env bash
+cat >/dev/null
+# 의도적으로 충돌 미해소: exit 0이지만 conflict marker가 worktree에 남아있음.
+exit 0
+CL
+  chmod +x "$mock_bin/claude"
+
+  local rc=0
+  PATH="$mock_bin:$PATH" bash "$SKILL_REFS/rebase-phase.sh" "$wt" "feat/169-$case_name" "$project" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -ne 0 ]] || fail "(AC6 rebase) 충돌 미해소 시 non-zero exit 미발생"
+
+  # rebase-apply/rebase-merge 디렉토리 잔존 부재 (git rebase --abort 호출 흔적)
+  local rebase_apply; rebase_apply=$( cd "$wt" && git rev-parse --git-path rebase-apply 2>/dev/null )
+  local rebase_merge; rebase_merge=$( cd "$wt" && git rev-parse --git-path rebase-merge 2>/dev/null )
+  if { [[ -n "$rebase_apply" && -d "$rebase_apply" ]] || [[ -n "$rebase_merge" && -d "$rebase_merge" ]]; }; then
+    fail "(AC6 rebase) rebase 상태 잔존 — abort 복구 미수행"
+  fi
+  local feat_sha_after; feat_sha_after=$( cd "$wt" && git rev-parse HEAD )
+  [[ "$feat_sha_before" == "$feat_sha_after" ]] \
+    || fail "(AC6 rebase) 충돌 미해소 후 HEAD 이동 (복구 실패): before=$feat_sha_before after=$feat_sha_after"
+  pass "(AC6 rebase) rebase 경로 충돌 자동 해소 실패 → 워크트리 복구 + non-zero exit"
+}
+
 # ----- 실행 -----
 test_spec_verify_command
 test_phase_scripts_arg_validation
@@ -820,6 +884,7 @@ test_sync_rebase_path_no_remote_tracking
 test_sync_merge_path_remote_tracking_exists
 test_sync_no_force_push_and_no_direct_rebase_merge
 test_sync_conflict_failure_recovers_merge_path
+test_sync_conflict_failure_recovers_rebase_path
 
 echo "----------"
 echo "ALL TESTS PASSED"

--- a/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
@@ -607,6 +607,204 @@ test_e_pr_level_dispute_preserved() {
   pass "(e) PR-level dispute · review summary · owner cmd 경로 보존"
 }
 
+# =====================================================================
+# SPEC 169 — Push sync policy: rebase locally, merge on remote
+# =====================================================================
+#
+# 동기화 helper(rebase-phase.sh)가 원격 트래킹 브랜치 존재 여부에 따라 두 경로로
+# 분기하는지, force push가 부재한지, pr/review-fix phase가 직접 git rebase·merge를
+# 호출하지 않고 helper만 통해 sync하는지, 충돌 자동 해소 실패 시 워크트리가
+# 복구되는지 검증한다.
+
+# Helper: 격리 fixture — main 1 commit + feat 1 commit + push 옵션 + origin/main advance.
+# push_feat == "push" 이면 feat 브랜치를 origin으로 push (remote tracking 존재 케이스).
+# push_feat == "nopush" 이면 push 생략 (remote tracking 부재 케이스).
+_sync_setup_diverged_base() {
+  local case_name="$1"
+  local push_feat="$2"
+  local project="$WORK_DIR/$case_name"
+  local bare="$WORK_DIR/${case_name}.git"
+  git init -q --bare -b main "$bare"
+  mkdir -p "$project"
+  (
+    cd "$project"
+    git init -q -b main
+    git config user.email "t@e.com"; git config user.name "T"
+    git remote add origin "$bare"
+    echo "initial" > shared.txt
+    git add shared.txt; git commit -q -m "initial"
+    git push -q origin main
+    # rebase-phase.sh default branch 감지 fallback(git symbolic-ref) 경로용
+    git remote set-head origin main
+    mkdir -p milestones/regular/loops/169
+    git worktree add -q -b "feat/169-${case_name}" "milestones/regular/loops/169/.worktree" HEAD
+    cd milestones/regular/loops/169/.worktree
+    echo "feat change" > feat-only.txt
+    git add feat-only.txt; git commit -q -m "feat: work"
+    if [[ "$push_feat" == "push" ]]; then
+      git push -q -u origin "feat/169-${case_name}"
+    fi
+  ) >/dev/null 2>&1 || fail "$case_name sync setup"
+  # origin/main advance (다른 worker가 base에 새 commit을 push한 시나리오).
+  # 메인 repo는 main에 머물러 있어 worktree(feat) 점유와 충돌하지 않는다.
+  (
+    cd "$project"
+    echo "main advanced" >> shared.txt
+    git add shared.txt; git commit -q -m "base: advance"
+    git push -q origin main
+  ) >/dev/null 2>&1 || fail "$case_name base advance"
+  printf '%s|%s\n' "$project" "$bare"
+}
+
+# (AC2) 원격 트래킹 부재 → rebase 경로 수행 (history 재작성, merge commit 부재)
+test_sync_rebase_path_no_remote_tracking() {
+  local pair; pair=$(_sync_setup_diverged_base "rebase_path" "nopush")
+  local project="${pair%|*}"
+  local wt="$project/milestones/regular/loops/169/.worktree"
+  local feat_sha_before; feat_sha_before=$( cd "$wt" && git rev-parse HEAD )
+
+  local mock_bin="$WORK_DIR/rebase_path_mock"; mkdir -p "$mock_bin"
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+exit 1
+GH
+  chmod +x "$mock_bin/gh"
+
+  PATH="$mock_bin:$PATH" bash "$SKILL_REFS/rebase-phase.sh" "$wt" "feat/169-rebase_path" "$project" \
+    || fail "(AC2) rebase-phase 실패 (rebase 경로 — remote tracking 부재)"
+
+  local feat_sha_after; feat_sha_after=$( cd "$wt" && git rev-parse HEAD )
+  [[ "$feat_sha_before" != "$feat_sha_after" ]] \
+    || fail "(AC2) rebase 경로: HEAD 미변경 (rebase 미수행)"
+  local merge_count; merge_count=$( cd "$wt" && git log --merges --pretty=oneline "$feat_sha_after" | wc -l | tr -d ' ' )
+  [[ "$merge_count" -eq 0 ]] \
+    || fail "(AC2) rebase 경로: merge commit 존재 ($merge_count) — rebase여야 함"
+  # 주의: `git log --pretty=%s | grep -q ...`는 grep -q 조기 종료로 SIGPIPE → pipefail 트립.
+  # 캡처 후 here-string으로 검사.
+  local _subjects; _subjects=$( cd "$wt" && git log --pretty=%s )
+  grep -qE '^feat: work$' <<<"$_subjects" \
+    || fail "(AC2) rebase 경로: feat commit 메시지 손실"
+  pass "(AC2) 원격 트래킹 부재 → rebase 경로"
+}
+
+# (AC3) 원격 트래킹 존재 → merge 경로 수행 (자기 commit SHA 보존, merge commit 생성)
+test_sync_merge_path_remote_tracking_exists() {
+  local pair; pair=$(_sync_setup_diverged_base "merge_path" "push")
+  local project="${pair%|*}"
+  local wt="$project/milestones/regular/loops/169/.worktree"
+  local feat_sha_before; feat_sha_before=$( cd "$wt" && git rev-parse HEAD )
+
+  local mock_bin="$WORK_DIR/merge_path_mock"; mkdir -p "$mock_bin"
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+exit 1
+GH
+  chmod +x "$mock_bin/gh"
+
+  PATH="$mock_bin:$PATH" bash "$SKILL_REFS/rebase-phase.sh" "$wt" "feat/169-merge_path" "$project" \
+    || fail "(AC3) rebase-phase 실패 (merge 경로 — remote tracking 존재)"
+
+  # 자기 commit SHA 보존
+  ( cd "$wt" && git cat-file -e "$feat_sha_before" ) \
+    || fail "(AC3) merge 경로: 자기 commit SHA ($feat_sha_before) 손실"
+  # HEAD는 base 변화 흡수한 merge commit (2 parents)이어야 함 — diverged history
+  local parents; parents=$( cd "$wt" && git rev-list --parents -n 1 HEAD | awk '{print NF-1}' )
+  [[ "$parents" -eq 2 ]] \
+    || fail "(AC3) merge 경로: HEAD가 merge commit 아님 (parents=$parents)"
+  pass "(AC3) 원격 트래킹 존재 → merge 경로 (자기 SHA 보존)"
+}
+
+# (AC4·AC7) Static grep — force push 부재 + 직접 git rebase/merge 부재 (helper 외)
+test_sync_no_force_push_and_no_direct_rebase_merge() {
+  local S="$REPO_ROOT/plugins/autopilot/skills/loop"
+  # AC4: push 경로에서 --force/--force-with-lease 부재 (모든 push-bearing phase)
+  local f
+  for f in rebase-phase.sh pr-phase.sh review-fix-phase.sh; do
+    if grep -E 'git[[:space:]]+push[^|;&)]*--force' "$S/references/$f" >/dev/null 2>&1; then
+      grep -nE 'git[[:space:]]+push[^|;&)]*--force' "$S/references/$f"
+      fail "(AC4) git push --force* 존재: $f"
+    fi
+  done
+  # AC7: pr-phase.sh / review-fix-phase.sh에 직접 git rebase·merge 라인 부재
+  # (주석 라인은 sed로 제외 후 grep — helper 외 phase는 sync를 helper로만 위임).
+  for f in pr-phase.sh review-fix-phase.sh; do
+    local stripped; stripped=$(sed 's/^[[:space:]]*#.*$//' "$S/references/$f")
+    if printf '%s\n' "$stripped" | grep -qE 'git[[:space:]]+(rebase|merge)([[:space:]]|$)'; then
+      printf '%s\n' "$stripped" | grep -nE 'git[[:space:]]+(rebase|merge)([[:space:]]|$)'
+      fail "(AC7) 직접 git rebase/merge 라인 잔존: $f"
+    fi
+  done
+  # rebase-phase.sh는 두 명령 모두 포함해야 함 (helper가 단일 출처)
+  grep -qE 'git[[:space:]]+rebase' "$S/references/rebase-phase.sh" \
+    || fail "(AC7) rebase-phase.sh에 git rebase 부재 (rebase 경로 누락)"
+  grep -qE 'git[[:space:]]+merge' "$S/references/rebase-phase.sh" \
+    || fail "(AC7) rebase-phase.sh에 git merge 부재 (merge 경로 누락)"
+  pass "(AC4·AC7) force push 부재 + helper 외 직접 git rebase/merge 부재"
+}
+
+# (AC6) 충돌 자동 해소 실패 → 워크트리 복구 + non-zero exit (merge 경로)
+test_sync_conflict_failure_recovers_merge_path() {
+  local case_name="conflict_merge"
+  local project="$WORK_DIR/$case_name"
+  local bare="$WORK_DIR/${case_name}.git"
+  git init -q --bare -b main "$bare"
+  mkdir -p "$project"
+  (
+    cd "$project"
+    git init -q -b main
+    git config user.email "t@e.com"; git config user.name "T"
+    git remote add origin "$bare"
+    echo "initial" > shared.txt
+    git add shared.txt; git commit -q -m "initial"
+    git push -q origin main
+    git remote set-head origin main
+    mkdir -p milestones/regular/loops/169
+    git worktree add -q -b "feat/169-$case_name" "milestones/regular/loops/169/.worktree" HEAD
+    cd milestones/regular/loops/169/.worktree
+    echo "feat version" > shared.txt
+    git add shared.txt; git commit -q -m "feat: conflict"
+    git push -q -u origin "feat/169-$case_name"
+  ) >/dev/null 2>&1 || fail "$case_name setup"
+  (
+    cd "$project"
+    echo "main version" > shared.txt
+    git add shared.txt; git commit -q -m "base: conflict"
+    git push -q origin main
+  ) >/dev/null 2>&1 || fail "$case_name base advance"
+  local wt="$project/milestones/regular/loops/169/.worktree"
+  local feat_sha_before; feat_sha_before=$( cd "$wt" && git rev-parse HEAD )
+
+  # gh stub: default branch 감지 fallback 경로 트리거.
+  # claude stub: 충돌을 해소하지 않은 채 exit 0 → script가 unresolved 감지 → abort 경로.
+  local mock_bin="$WORK_DIR/${case_name}_mock"; mkdir -p "$mock_bin"
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+exit 1
+GH
+  chmod +x "$mock_bin/gh"
+  cat > "$mock_bin/claude" <<'CL'
+#!/usr/bin/env bash
+cat >/dev/null
+# 의도적으로 충돌 미해소: exit 0이지만 conflict marker가 worktree에 남아있음.
+exit 0
+CL
+  chmod +x "$mock_bin/claude"
+
+  local rc=0
+  PATH="$mock_bin:$PATH" bash "$SKILL_REFS/rebase-phase.sh" "$wt" "feat/169-$case_name" "$project" >/dev/null 2>&1 || rc=$?
+  [[ "$rc" -ne 0 ]] || fail "(AC6) 충돌 미해소 시 non-zero exit 미발생"
+
+  # MERGE_HEAD 잔존 부재 (git merge --abort 호출 흔적)
+  local merge_head_path; merge_head_path=$( cd "$wt" && git rev-parse --git-path MERGE_HEAD 2>/dev/null )
+  if [[ -n "$merge_head_path" && -f "$merge_head_path" ]]; then
+    fail "(AC6) MERGE_HEAD 잔존 — abort 복구 미수행 ($merge_head_path)"
+  fi
+  local feat_sha_after; feat_sha_after=$( cd "$wt" && git rev-parse HEAD )
+  [[ "$feat_sha_before" == "$feat_sha_after" ]] \
+    || fail "(AC6) 충돌 미해소 후 HEAD 이동 (복구 실패): before=$feat_sha_before after=$feat_sha_after"
+  pass "(AC6) 충돌 자동 해소 실패 → 워크트리 복구 + non-zero exit"
+}
+
 # ----- 실행 -----
 test_spec_verify_command
 test_phase_scripts_arg_validation
@@ -618,6 +816,10 @@ test_b_inline_invalid_thread_reply
 test_c_same_thread_no_duplicate_reply
 test_d_two_threads_two_replies
 test_e_pr_level_dispute_preserved
+test_sync_rebase_path_no_remote_tracking
+test_sync_merge_path_remote_tracking_exists
+test_sync_no_force_push_and_no_direct_rebase_merge
+test_sync_conflict_failure_recovers_merge_path
 
 echo "----------"
 echo "ALL TESTS PASSED"


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가

loop의 자율 push 흐름이 base 동기화 단계에서 *동기화 시점에 자기 브랜치가 원격에 이미 존재하는지*를 검사해 두 경로로 분기한다. 원격 트래킹 브랜치가 없으면 rebase로 base 위에 자기 commit들을 재배치(history 재작성)하고, 이미 존재하면 merge로 base 변경분만 흡수해 자기 commit의 SHA를 보존한다. 어떤 경로에서도 force push는 도입하지 않으며, 분기 자체는 단일 sync helper에 위치해 PR 생성 직전·review-fix iter의 모든 push 직전 호출 지점에서 동일하게 재사용된다. 동기화 중 충돌이 발생하면 기존 sync 모듈의 1회 자동 해소 절차를 그대로 사용하고, 실패 시 보수적 좌절로 복구한다.

## Commits
- e82507b feat(169): sync helper rebase/merge 분기 + pr-phase helper 호출 통일
- df4980a test(169): push sync policy 검증 케이스 4종 추가
- 19b9a07 feat(spec): 169 — Push sync policy: rebase locally, merge on remote

Closes #169
<!-- autopilot:pr-body:end -->