### PR TITLE
spec SKILL.md — task-id 추측 금지 anti-pattern 룰 명시

### DIFF
--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -110,11 +110,15 @@ milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `a
 
 (b) 선택 시 진입. step 5 메커니즘을 task-id 확보 *전*으로 앞당겨 재사용(별도 phase·모듈 없음). 수집은 task 미정의 상태에 맞춰 `문제·목표·범위·제약`으로 확장. 매 라운드 "충분" 종결·명시적 취소 안전 종료 포함. 규모 분기: 단일 task → 프로젝트 태스크 트래커 컨벤션으로 task 생성 후 step 2 재진입, 마일스톤 규모 → `AskUserQuestion` 명시 승인 후 PRD 스킬 invoke. 수집 항목·라운드 규칙·1.2.1/1.2.2 분기 상세는 `references/pre-clarification.md` §1.2 참조.
 
+⚠ task-id 는 항상 task 생성 호출의 응답값을 그대로 사용한다 — 추측·예측·작명 금지
+
 ### 2. task 상태 정합 (일반·--resume 두 모드 공통)
 
 **사전 검사 통과 직후** 실행. task-id로 식별되는 외부 task를 조회해 4갈래 분기로 설계 상태로 정합. 일반·`--resume` 모드 공통.
 
 4갈래 요약: **(a)** task 부재 → 새 task 생성·task 상태를 설계 상태로 설정·task-id 교체·사전 검사 재적용. **(b)** 기존 설계 상태 → 변경 없이 진행(resume). **(c)** 기존 설계 이전 상태 → 설계 상태로 전이. **(d)** 기존 설계 이후 상태 → 새 task 생성·task-id 교체(a와 동일).
+
+⚠ task-id 는 항상 task 생성 호출의 응답값을 그대로 사용한다 — 추측·예측·작명 금지
 
 백엔드 매핑 위임(추상 ↔ 구체 매핑은 `rules/context.md` 단일 출처), 조회·생성·편집·상태 전이 호출의 추상화, (a)·(d) 새 task title/body 수집(고정 2줄 본문, `<m>`/`<new-task-id>` 2단계 치환), 호출 실패 abort, 범위 외(loop start 설계 상태 → 진행 상태 전이는 본 단계 책임 아님)의 전체 절차는 `references/task-state-alignment.md` 참조.
 


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가

spec 스킬의 SKILL.md 본문에서 task-id 생성·교체와 관련된 두 위치 — step 2 (task 상태 정합 4갈래 분기 (a)) 와 §1.2 사전 명확화 라운드 요약 — 에 "task-id 는 항상 task 생성 호출의 응답값을 그대로 사용한다 — 추측·예측·작명 금지" 라는 부정 명령을 한 줄씩 명시한다.

배경: 현행 SKILL.md 본문은 "새 task 생성·task-id 교체"·"task 생성 단계에서 결정" 같은 긍정 기술만 두고 부정 명령은 두지 않는다. 그 결과, 호출 모델이 로컬 `milestones/regular/loops/` 디렉토리에 보이는 기존 숫자 패턴(예: 65/69/71/72/73/75/78/79)에서 다음 번호를 추측·예측하는 경향이 반복 관측된다. id 발급의 강제 진술은 `references/task-state-alignment.md` 의 "task 생성 호출 시점엔 아직 발급되지 않은 값" 절에 보존돼 있으나, SKILL.md 본문만 훑는 경로에서는 그 attractor 가 노출되지 않아 효과가 부족하다. 본 변경의 목적은 SKILL.md 본문만 읽고도 "id 는 외부 응답값" 이라는 강제 규칙이 즉시 보이도록 만드는 것이다.

## Commits
- c673ca2 Merge remote-tracking branch 'origin/main' into feat/177-spec-skill-md-task-id-anti-pattern
- 5b7f5d2 feat(spec/177): SKILL.md 본문에 task-id anti-pattern 한 줄 명시

Closes #177
<!-- autopilot:pr-body:end -->