### PR TITLE
autopilot:loop 스킬 실행 로그를 호출 세션으로 실시간 출력

### DIFF
--- a/milestones/regular/loops/173-autopilot-loop/SPEC.md
+++ b/milestones/regular/loops/173-autopilot-loop/SPEC.md
@@ -1,0 +1,71 @@
+---
+scope:
+  include: ["plugins/autopilot/skills/loop/**", "plugins/autopilot/skills/spec/**", "tests/autopilot/**"]
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+verify: "bash tests/autopilot/test-loop-events-only.sh"
+---
+
+# autopilot:loop 스킬 실행 로그를 호출 세션으로 실시간 출력
+
+## 무엇을 만들 것인가
+
+`autopilot:loop` 스킬을 통해 자율 task를 시작했을 때, 셸 드라이버가 출력하는 모든 비-noise 라인이 호출 세션의 알림 스트림에 실시간으로 전달된다.
+
+기존 동작은 정규식 필터로 핵심 이벤트(이터 시작·종료, halt, escalation, done 등)만 통과시켰지만, 본 변경 후 default 동작은 **빈 줄과 단독 dot 라인만 제외**하고 그 외 모든 출력이 통과하도록 바뀐다 — 이터 내부의 상세 진행, 보조 명령 결과, 디버그·정보 라인 포함. 사용자는 자율 루프의 진행 상태를 더 풍부한 입자도로 실시간 추적할 수 있게 된다.
+
+사용자가 기존 방식(핵심 이벤트만 알림)으로 회귀하고 싶을 때를 위해 opt-out 옵션이 제공된다. `autopilot:spec` 스킬의 최종 결정 단계의 "지금 loop start 호출" 자동 연계 분기에서도 동일 opt-out 선택이 사용자에게 명시적으로 제공되어, 자동 연계 호출의 args에 반영된다.
+
+## 수용 기준 (EARS)
+
+- **AC1 (Event-driven)**: `--events-only` 플래그 없이 사용자가 `autopilot:loop` 스킬을 통해 task를 시작할 때, 시스템은 셸 드라이버 stdout 라인 중 빈 줄과 단독 dot 라인을 제외한 모든 라인을 호출 세션의 알림 스트림으로 전달해야 한다.
+- **AC2 (Event-driven)**: `--events-only` 플래그와 함께 사용자가 `autopilot:loop` 스킬을 통해 task를 시작할 때, 시스템은 기존 핵심 이벤트 정규식 필터(이터 #·HALT·WARN·FAIL·ERROR·rate limit·claude 비정상·에스컬레이션·DONE)만 적용해 핵심 이벤트만 호출 세션의 알림 스트림으로 전달해야 한다.
+- **AC3 (State-driven)**: `autopilot:spec` 스킬이 최종 결정 단계의 "지금 loop start 호출" 분기에 진입한 동안, 시스템은 사용자에게 `--events-only` opt-out 선택을 명시적으로 묻고 그 선택 결과를 자동 연계 호출의 args 구성에 반영해야 한다.
+- **AC4 (Unwanted)**: 사용자가 `autopilot:loop` 스킬을 경유하지 않고 셸 드라이버를 직접 호출하면, 시스템은 `--events-only` 플래그의 효력이 없음을 보장해야 한다 (기존 `--no-monitor` 정책과 일관).
+- **AC5 (Ubiquitous)**: 시스템은 셸 드라이버의 stdout 출력 형식을 변경하지 않아야 한다 — 변경 대상은 스킬의 Monitor 가설 시 사용되는 필터 정의·안내로 한정된다.
+
+## 범위
+
+포함:
+- `plugins/autopilot/skills/loop/SKILL.md` 의 Monitor 자동 가설 default 필터 정의 갱신 (noise-only 제외 의미를 표현하는 패턴으로 교체)
+- `plugins/autopilot/skills/loop/SKILL.md` 에 `--events-only` 플래그 정의 명시 (`--no-monitor` 와 동일 contract — 스킬 차원 옵션, `loop.sh` 로 미전달)
+- `plugins/autopilot/skills/spec/SKILL.md` step 10 결정 다이얼로그에 `--events-only` opt-out 선택 추가 + 자동 연계 args 구성에 반영하는 절차 명시
+- `tests/autopilot/test-loop-events-only.sh` 정적 검증 스크립트 추가 (두 SKILL.md 파일에 대한 grep 기반 검사)
+
+비-목표 / 제외:
+- `plugins/autopilot/skills/loop/references/loop.sh` 셸 드라이버 stdout 자체 형식 변경
+- `Monitor` 도구 자체 구현 변경 (도구의 패턴 입력 표현법은 수용)
+- `logs` 서브커맨드 동작 변경 (`--tail`·`--iter N`)
+- 기타 스킬(`autopilot:dispatch` 등) 수정
+- 셸 드라이버를 직접 호출하는 경로에 대한 하위 호환성 (AC4)
+
+## 검증
+
+이 명령이 0 exit으로 끝나야 합니다:
+
+```
+bash tests/autopilot/test-loop-events-only.sh
+```
+
+스크립트가 검사하는 항목:
+
+[loop SKILL.md]
+1. 기존 핵심 이벤트 정규식 패턴이 default 위치에서 제거됨 (`--events-only` 분기 설명에만 잔존하면 OK)
+2. 새 default 필터가 "noise-only 제외" 의미를 표현하는 패턴으로 정의됨 (빈 줄·단독 dot 제외)
+3. `--events-only` 플래그 정의 섹션이 존재 (명세·contract·`--no-monitor`와 일관 명시)
+4. 셸 드라이버 직접 호출 시 미적용이 명시됨
+
+[spec SKILL.md]
+5. step 10의 "지금 loop start 호출" 분기 설명에 `--events-only` 선택이 언급됨
+6. 자동 연계 args 구성에 그 선택이 반영됨 (예: args 입력 시 `--events-only` 토큰 추가 절차)
+
+## 제약 (있을 때만)
+
+- `Monitor` 도구의 패턴 입력 표현법(정규식 문법·invert match 가능 여부 등)은 도구 구현 세부에 의존하므로, SKILL.md는 패턴의 "의미"만 명시한다.
+- `spec→loop` 자동 연계 계약은 spec 스킬 step 10 다이얼로그 구조에 결합되어 있다. step 10 명세가 먼저 바뀌면 본 옵션 전달 절차도 다시 정렬이 필요하다.
+
+## 위험 (있을 때만)
+
+- raw stdout 전달로 세션 컨텍스트·토큰 소비가 증가할 수 있다. 필요 시 `--events-only` 로 기존 핵심 이벤트 필터로 회귀해 완화한다.

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -73,6 +73,8 @@ Skill(skill: "spec", args: "<task-id>")
 
 `--no-monitor` 플래그는 **SKILL.md 차원 옵션**이다 — 모델이 args 파싱 시 이 토큰을 분리·소비하여 `Monitor` 가설 자체를 생략하고, `loop.sh`로는 **전달하지 않는다** (셸 드라이버는 본 플래그를 모름). 따라서 본 플래그는 **본 스킬을 통한 호출 시점에만** 작용하며, 사용자가 셸 드라이버 `loop.sh start`를 직접 호출하는 경우엔 효력이 없다.
 
+**우선순위 규칙**: `--no-monitor`와 `--events-only`가 동시에 명시되면 `--no-monitor`가 우선 적용된다 — `Monitor` 가설 자체가 생략되므로 `--events-only`의 필터 회귀는 무효화된다.
+
 `spec` 스킬 단계 10의 "지금 loop start 호출" 결정으로 자동 연계되는 경우에도 추가 모니터 결정 질문 없이 본 기본 동작(Monitor 가설 포함)이 그대로 적용된다. 단 spec 스킬은 사용자에게 `--events-only` opt-out 선택을 명시 확인하며 Yes 시 자동 연계 args 끝에 `--events-only` 토큰을 추가한다.
 
 #### DONE 이후 PR 생성·재사용 phase (default)

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -46,7 +46,7 @@ Skill(skill: "spec", args: "<task-id>")
 
 ## Subcommand
 
-### start <task-id> [--max-iterations N] [--wall-clock-minutes N] [--watch] [--spec <path>] [--no-monitor] [--no-pr]
+### start <task-id> [--max-iterations N] [--wall-clock-minutes N] [--watch] [--spec <path>] [--no-monitor] [--events-only] [--no-pr]
 
 검증 후 워크트리·락 생성 + 이터레이션 루프 시작.
 
@@ -60,16 +60,20 @@ Skill(skill: "spec", args: "<task-id>")
 
 #### 자동 Monitor 가설 (기본 동작)
 
-`--no-monitor`를 명시하지 않은 경우, 백그라운드로 띄운 `loop.sh start`의 stdout 스트림 위에 `Monitor` 도구를 즉시 가설하여 핵심 이벤트(이터 시작·종료, halt, escalation, done 등)를 사용자에게 자동 알림한다. 매 시작마다 별도 결정 질문을 묻지 않는다 — 기본 ON이며 비활성화는 호출 시 `--no-monitor` 플래그로만.
+`--no-monitor`를 명시하지 않은 경우, 백그라운드로 띄운 `loop.sh start`의 stdout 스트림 위에 `Monitor` 도구를 즉시 가설하여 셸 드라이버가 출력하는 비-noise 라인을 사용자에게 자동 알림한다. 매 시작마다 별도 결정 질문을 묻지 않는다 — 기본 ON이며 비활성화는 호출 시 `--no-monitor` 플래그로만.
 
 권장 기본값:
 - `persistent: true`
 - `timeout_ms: 3600000` (1시간)
-- 필터 정규식: `이터 #|HALT|WARN|FAIL|ERROR|rate limit|claude 비정상|에스컬레이션|DONE`
+- 필터 의미(default): **빈 줄과 단독 dot(`.`) 라인만 제외**(noise-only exclusion). 그 외 셸 드라이버 stdout 라인(이터 내부 상세 진행·보조 명령 결과·디버그·정보 라인 포함)은 모두 호출 세션의 알림 스트림으로 통과시킨다. 정확한 패턴 입력 표현법(정규식 문법·invert match 가능 여부 등)은 `Monitor` 도구 구현에 위임한다 — 본 SKILL.md는 의미만 명시한다.
+
+##### `--events-only` (opt-out: 기존 핵심 이벤트 필터로 회귀)
+
+`--events-only` 플래그는 `--no-monitor`와 동일한 **SKILL.md 차원 옵션** contract를 가진다 — 모델이 args 파싱 시 이 토큰을 분리·소비하여 `Monitor` 가설의 필터만 기존 핵심 이벤트 정규식(`이터 #|HALT|WARN|FAIL|ERROR|rate limit|claude 비정상|에스컬레이션|DONE`)으로 회귀시키고, `loop.sh`로는 **전달하지 않는다** (셸 드라이버는 본 플래그를 모름). 따라서 본 플래그는 **본 스킬을 통한 호출 시점에만** 작용하며, 사용자가 셸 드라이버 `loop.sh start`를 직접 호출하는 경우엔 효력이 없다. 사용 시점: default raw 라인 전달로 세션 컨텍스트·토큰 소비가 부담스러워 핵심 이벤트(이터 시작·종료·halt·escalation·done 등)만 알림 받고 싶을 때.
 
 `--no-monitor` 플래그는 **SKILL.md 차원 옵션**이다 — 모델이 args 파싱 시 이 토큰을 분리·소비하여 `Monitor` 가설 자체를 생략하고, `loop.sh`로는 **전달하지 않는다** (셸 드라이버는 본 플래그를 모름). 따라서 본 플래그는 **본 스킬을 통한 호출 시점에만** 작용하며, 사용자가 셸 드라이버 `loop.sh start`를 직접 호출하는 경우엔 효력이 없다.
 
-`spec` 스킬 단계 9의 "지금 loop start 호출" 결정으로 자동 연계되는 경우에도 추가 모니터 결정 질문 없이 본 기본 동작(Monitor 가설 포함)이 그대로 적용된다.
+`spec` 스킬 단계 10의 "지금 loop start 호출" 결정으로 자동 연계되는 경우에도 추가 모니터 결정 질문 없이 본 기본 동작(Monitor 가설 포함)이 그대로 적용된다. 단 spec 스킬은 사용자에게 `--events-only` opt-out 선택을 명시 확인하며 Yes 시 자동 연계 args 끝에 `--events-only` 토큰을 추가한다.
 
 #### DONE 이후 PR 생성·재사용 phase (default)
 

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -300,7 +300,8 @@ SPEC.md commit 직후 본 단계는 **자동으로 default 브랜치(main)·feat
 - **dispatch 위임 모드** (§호출 방법 — dispatch 위임 모드): 본 단계의 세 옵션 사용자 질문을 생략하고 `Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계 — task 생성 → SPEC 작성 → 설계 브랜치 준비 → 자율 루프 자동 시작까지 단일 호출에서 완수.
 - **사용자 직접 호출 모드** (default): SPEC.md 경로(§8.1 slug-bearing)·요약 안내 후 `AskUserQuestion`으로 **명시적 결정 입력**(자유 텍스트 종결구 금지 — CLAUDE.md 규칙). 옵션 3개(상호배타):
 
-  - **지금 loop start 호출** (Recommended) — `Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계. 모니터 추가 질문 없이 loop 기본 동작(자동 Monitor 가설 포함, `plugins/autopilot/skills/loop/SKILL.md`) 적용. default `regular`이면 `start <c>` 단축형 동등.
+  - **지금 loop start 호출** (Recommended) — `Skill(skill: "loop", args: "start <m>/<c>")` 자동 연계. loop 기본 동작(자동 Monitor 가설 포함, `plugins/autopilot/skills/loop/SKILL.md`) 적용. default `regular`이면 `start <c>` 단축형 동등.
+    - 이 옵션을 선택하면 **`--events-only` opt-out** 여부를 `AskUserQuestion`으로 명시 확인한다 — Yes 시 자동 연계 args 끝에 `--events-only` 토큰을 추가해 `Skill(skill: "loop", args: "start <m>/<c> --events-only")`로 호출하고, No(default)는 raw-stream Monitor 동작을 유지한다. opt-out 의미·동작은 `plugins/autopilot/skills/loop/SKILL.md`의 `--events-only` 정의 참조.
   - **SPEC만 확정** — 경로 안내·종료. 사용자가 별도 시점에 `Skill(skill: "loop", args: "start <m>/<c>")` 직접 호출.
   - **변경** — 변경 섹션을 묻고 단계 7/8 재진입.
 

--- a/tests/autopilot/test-loop-events-only.sh
+++ b/tests/autopilot/test-loop-events-only.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# SPEC 173: autopilot:loop 스킬 실행 로그를 호출 세션으로 실시간 출력
+#
+# 검증 대상 (정적 grep 기반):
+#
+# [loop SKILL.md]
+# 1. 기존 핵심 이벤트 정규식 패턴이 default 위치에서 제거됨
+#    (`--events-only` 분기 설명에만 잔존하면 OK)
+# 2. 새 default 필터가 "noise-only 제외" 의미를 표현하는 패턴으로 정의됨
+#    (빈 줄·단독 dot 제외)
+# 3. `--events-only` 플래그 정의 섹션이 존재
+#    (명세·contract·`--no-monitor`와 일관 명시)
+# 4. 셸 드라이버 직접 호출 시 미적용이 명시됨
+#
+# [spec SKILL.md]
+# 5. step 10의 "지금 loop start 호출" 분기 설명에 `--events-only` 선택이 언급됨
+# 6. 자동 연계 args 구성에 그 선택이 반영됨
+#
+# 외부 API 호출은 수행하지 않는다.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LOOP_SKILL_MD="$REPO_ROOT/plugins/autopilot/skills/loop/SKILL.md"
+SPEC_SKILL_MD="$REPO_ROOT/plugins/autopilot/skills/spec/SKILL.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "OK: $*"; }
+
+[[ -f "$LOOP_SKILL_MD" ]] || fail "$LOOP_SKILL_MD 부재"
+[[ -f "$SPEC_SKILL_MD" ]] || fail "$SPEC_SKILL_MD 부재"
+
+# 핵심 이벤트 정규식 패턴 (default 필터의 옛 형태) — `--events-only` 분기에만 잔존해야 함.
+KEY_EVENT_REGEX='이터 #|HALT|WARN|FAIL|ERROR|rate limit|claude 비정상|에스컬레이션|DONE'
+
+# ---------------------------------------------------------------------------
+# loop SKILL.md 의 "자동 Monitor 가설 (기본 동작)" 섹션 추출
+# 다음 `#### ` 헤더 또는 `### ` 헤더 직전까지.
+extract_section() {
+  local file="$1" start_marker="$2"
+  awk -v start="$start_marker" '
+    BEGIN { capturing = 0 }
+    {
+      if ($0 ~ "^"start) { capturing = 1; print; next }
+      if (capturing && /^#### / && $0 !~ "^"start) { exit }
+      if (capturing && /^### /) { exit }
+      if (capturing) print
+    }
+  ' "$file"
+}
+
+DEFAULT_MONITOR_SECTION="$(extract_section "$LOOP_SKILL_MD" "#### 자동 Monitor 가설")"
+[[ -n "$DEFAULT_MONITOR_SECTION" ]] \
+  || fail "loop SKILL.md 에서 '#### 자동 Monitor 가설' 섹션을 찾을 수 없음"
+
+# ---------------------------------------------------------------------------
+echo "=== check 1: default 위치에서 기존 핵심 이벤트 정규식 제거 ==="
+# 기본 동작 섹션 내에서 KEY_EVENT_REGEX 패턴 자체가 "기본 필터"로 제시되는지 검사.
+# `--events-only` 옵션 분기 설명 내부에서만 등장해야 함.
+#
+# 검증 전략:
+#   - 기본 동작 섹션에서 `--events-only` 라는 토큰이 나타나는 첫 위치 이전까지의
+#     "default 영역"을 추출
+#   - 그 default 영역 안에 KEY_EVENT_REGEX 가 등장하면 실패
+DEFAULT_BEFORE_OPT="$(awk '
+  /--events-only/ { exit }
+  { print }
+' <<< "$DEFAULT_MONITOR_SECTION")"
+
+if grep -qF -- "$KEY_EVENT_REGEX" <<< "$DEFAULT_BEFORE_OPT"; then
+  fail "check 1: 기존 핵심 이벤트 정규식이 default 필터 위치에 여전히 존재"
+fi
+ok "check 1: default 위치에서 기존 핵심 이벤트 정규식 제거됨"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check 2: 새 default 필터가 noise-only 제외 의미 표현 ==="
+# default 필터 의미 — 빈 줄·단독 dot 만 제외. SKILL.md 가 "빈 줄"·"단독 dot" 어휘로
+# 의미를 명시적으로 기술하는지 검사.
+grep -q "빈 줄" <<< "$DEFAULT_BEFORE_OPT" \
+  || fail "check 2: default 필터 설명에 '빈 줄' 어휘 부재"
+grep -qE "(단독 dot|단독 \\.)" <<< "$DEFAULT_BEFORE_OPT" \
+  || fail "check 2: default 필터 설명에 '단독 dot' 어휘 부재"
+ok "check 2: default 필터가 noise-only 제외 의미로 정의됨 (빈 줄·단독 dot)"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check 3: --events-only 플래그 정의 섹션 존재 ==="
+# `--events-only` 가 plugin 본문에 정의로 등장하고, contract 가 `--no-monitor` 와
+# 일관됨을 명시해야 함.
+grep -q -- "--events-only" "$LOOP_SKILL_MD" \
+  || fail "check 3: loop SKILL.md 에 '--events-only' 토큰 부재"
+
+# `--events-only` 와 `--no-monitor` 가 일관 명시되는 라인이 한 곳이라도 있어야 함.
+grep -q -E -- "--events-only.*--no-monitor|--no-monitor.*--events-only" "$LOOP_SKILL_MD" \
+  || fail "check 3: '--events-only' 와 '--no-monitor' contract 일관 명시 부재"
+ok "check 3: --events-only 플래그 정의 + --no-monitor contract 일관 명시 존재"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check 4: 셸 드라이버 직접 호출 시 미적용 명시 ==="
+# `--events-only` 플래그 정의 부근에서 셸 드라이버 직접 호출 시 효력 없음을 명시.
+# `--no-monitor` 의 기존 정책과 동일하게 SKILL.md 차원 옵션이며 loop.sh 로 전달되지 않음.
+# 다음 어휘 조합 중 적어도 하나가 events-only 관련 문장에 등장하면 통과:
+#   - "직접 호출" + "효력이 없"  (예: "직접 호출하는 경우엔 효력이 없다")
+#   - "SKILL.md 차원 옵션" + "loop.sh 로 ... 전달하지 않"  (--no-monitor 와 동일 contract)
+events_only_context="$(grep -E -A3 -B1 -- "--events-only" "$LOOP_SKILL_MD" || true)"
+if ! { grep -qE "(직접 호출.*효력이 없|효력이 없.*직접 호출)" <<< "$events_only_context" \
+       || grep -qE "SKILL\.md 차원 옵션" <<< "$events_only_context"; }; then
+  fail "check 4: --events-only 가 셸 드라이버 직접 호출 시 미적용임이 명시되지 않음"
+fi
+ok "check 4: 셸 드라이버 직접 호출 시 --events-only 미적용 명시 존재"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check 5: spec SKILL.md step 10 분기에 --events-only 선택 언급 ==="
+# step 10 의 "지금 loop start 호출" 분기 설명에 `--events-only` opt-out 선택이 언급됨.
+# step 10 (## 10 또는 ### 10) 헤딩부터 다음 ## / ### 헤딩 직전까지를 추출.
+STEP10="$(awk '
+  BEGIN { capturing = 0 }
+  /^### 10\. / { capturing = 1; print; next }
+  capturing && /^### / { exit }
+  capturing && /^## / { exit }
+  capturing { print }
+' "$SPEC_SKILL_MD")"
+
+[[ -n "$STEP10" ]] || fail "check 5: spec SKILL.md 에서 '### 10.' step 섹션 추출 실패"
+grep -q -- "--events-only" <<< "$STEP10" \
+  || fail "check 5: spec SKILL.md step 10 에 '--events-only' 언급 부재"
+
+# "지금 loop start 호출" 옵션 라벨 부근에 events-only 가 있어야 함 (둘이 같은 단계에서 언급)
+grep -q "지금 loop start 호출" <<< "$STEP10" \
+  || fail "check 5: spec SKILL.md step 10 에 '지금 loop start 호출' 옵션 라벨 부재"
+ok "check 5: spec SKILL.md step 10 분기에 --events-only opt-out 선택 언급"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== check 6: 자동 연계 args 구성에 --events-only 반영 절차 ==="
+# step 10 의 자동 연계 흐름에서 `--events-only` 선택이 args 에 반영되는 절차 명시.
+# 예: args 입력 시 `--events-only` 토큰을 append 하는 절차 기술.
+# 다음 어휘 조합 중 적어도 하나:
+#   - "args" + "--events-only" 가 같은 라인 (또는 인접 ±1 라인 범위)
+#   - "args 에 --events-only 추가" 같은 절차 표현
+#   - `start <m>/<c> --events-only` 같은 구체 args 예시
+args_context="$(grep -E -A1 -B1 -- "--events-only" <<< "$STEP10" || true)"
+if ! grep -qE "args.*--events-only|--events-only.*args|start [^\\\$]*--events-only" <<< "$args_context"; then
+  fail "check 6: step 10 자동 연계 args 구성에 --events-only 반영 절차 부재"
+fi
+ok "check 6: step 10 자동 연계 args 구성에 --events-only 반영 명시"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "ALL CHECKS PASSED"

--- a/tests/autopilot/test-loop-events-only.sh
+++ b/tests/autopilot/test-loop-events-only.sh
@@ -31,7 +31,7 @@ ok()   { echo "OK: $*"; }
 [[ -f "$SPEC_SKILL_MD" ]] || fail "$SPEC_SKILL_MD 부재"
 
 # 핵심 이벤트 정규식 패턴 (default 필터의 옛 형태) — `--events-only` 분기에만 잔존해야 함.
-KEY_EVENT_REGEX='이터 #|HALT|WARN|FAIL|ERROR|rate limit|claude 비정상|에스컬레이션|DONE'
+KEY_EVENT_REGEX='이터 #|HALT|WARN|FAIL|ERROR|rate limit|claude 비정상|에스컬레이션|완료 신호'
 
 # ---------------------------------------------------------------------------
 # loop SKILL.md 의 "자동 Monitor 가설 (기본 동작)" 섹션 추출


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가

`autopilot:loop` 스킬을 통해 자율 task를 시작했을 때, 셸 드라이버가 출력하는 모든 비-noise 라인이 호출 세션의 알림 스트림에 실시간으로 전달된다.

기존 동작은 정규식 필터로 핵심 이벤트(이터 시작·종료, halt, escalation, done 등)만 통과시켰지만, 본 변경 후 default 동작은 **빈 줄과 단독 dot 라인만 제외**하고 그 외 모든 출력이 통과하도록 바뀐다 — 이터 내부의 상세 진행, 보조 명령 결과, 디버그·정보 라인 포함. 사용자는 자율 루프의 진행 상태를 더 풍부한 입자도로 실시간 추적할 수 있게 된다.

사용자가 기존 방식(핵심 이벤트만 알림)으로 회귀하고 싶을 때를 위해 opt-out 옵션이 제공된다. `autopilot:spec` 스킬의 최종 결정 단계의 "지금 loop start 호출" 자동 연계 분기에서도 동일 opt-out 선택이 사용자에게 명시적으로 제공되어, 자동 연계 호출의 args에 반영된다.

## Commits
- 84d809e feat(loop): SPEC 173 — noise-only default filter + --events-only opt-out
- b36aac6 feat(spec): 173 — autopilot:loop 스킬 실행 로그를 호출 세션으로 실시간 출력

Closes #173
<!-- autopilot:pr-body:end -->