### PR TITLE
refactor(loop/dispatch): DONE sentinel 제거 — 라벨 단일 경로 통합 (SPEC 175)

### DIFF
--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -28,7 +28,7 @@ description: "milestone 단위 PRD를 child SPEC들로 자동 분해해 DAG(wave
    → 게이트 ② 최종 확인 (DAG 레벨 wave·child·예상 verify·의존성 표 + 사용자 승인. SPEC 자체는 각 wave 진입 시 비로소 작성)
    → wave 단위 순차 실행 (wave 안 child 간은 병렬):
      · 게이트 ③ spec 위임 (per-wave): 그 wave 의 각 child 분해 plan 항목에 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") — task-id 는 spec 이 task 생성 단계에서 결정. spec 의 dispatch-위임 모드 auto-loop-start 로 그 wave 의 child loop 가 자동 시작
-     · sentinel watch (Bash(dispatch.sh watch_wave ...)) — 이 wave 의 DONE/ESCALATION 감시
+     · sentinel watch (Bash(dispatch.sh watch_wave ...)) — 이 wave 의 완료 라벨(`LOOP_DONE_LABEL`)/ESCALATION.md 감시
      · 성공 시 다음 wave 의 게이트 ③ per-wave 로 진행. wave 끝까지 반복
        (sentinel watch · fail-fast 는 per-wave 단계에 포함 — 마일스톤 레벨 별도 sentinel 없음)
    → wave 모두 통과 후 최종 보고
@@ -93,14 +93,14 @@ spec 스킬은 dispatch 위임 모드를 인식해 step 10 사용자 최종 검�
 for wave in waves:
   # 1) per-wave 게이트 ③ spec 위임: 그 wave 의 각 child 에 Skill(skill: "spec", args: "--milestone <m> <자연어 task 설명>") 호출.
   #    spec 의 dispatch-위임 모드 auto-loop-start 로 그 wave 의 child loop 가 자동 시작된다.
-  #    이전 wave 들의 loop 는 그 wave 의 watch_wave 가 이미 DONE 으로 종료한 상태 — 의존 산출물 준비 완료.
+  #    이전 wave 들의 loop 는 그 wave 의 watch_wave 가 이미 완료(exit 100)로 종료한 상태 — 의존 산출물 준비 완료.
   #    dispatch 는 별도 `loop start` 호출 없이 sentinel watch 만 수행 (중복 시작 방지).
 
   while wave 진행 중:
     # references/dispatch.sh watch_wave <m> child1 child2 ...
-    각 child의 sentinel 파일 watch (sleep 2s + test -e 단순 폴링):
-      milestones/<m>/loops/<c>/.worktree/DONE                  → 성공
-      milestones/<m>/loops/<c>/.worktree/.loop/ESCALATION.md   → 실패
+    각 child의 sentinel watch (sleep 2s 폴링):
+      task 저장소 child issue 에 LOOP_DONE_LABEL 라벨 부착                → 성공 (SPEC 175)
+      milestones/<m>/loops/<c>/.worktree/.loop/ESCALATION.md             → 실패
 
     누군가 ESCALATION (watch_wave exit 101):
       watch_wave가 나머지 진행 중 child들에 kill -TERM (fail-fast, 자동)
@@ -108,7 +108,7 @@ for wave in waves:
       ESCALATION 카테고리·보고서 사용자 제시
       다음 wave 차단 + 종료 (재계획은 사용자)
 
-    모두 DONE (watch_wave exit 100):
+    모두 완료 라벨 부착 (watch_wave exit 100):
       DISPATCH_LOG.md 기록 → 다음 wave 의 per-wave 게이트 ③ spec 위임으로 진입
 
     타임아웃 (watch_wave exit 102):
@@ -124,13 +124,13 @@ for wave in waves:
 
 | exit | 의미 | child stop 처리 | 모델 후속 행동 |
 |---|---|---|---|
-| `100` | wave 내 모든 child DONE | 불필요 | DISPATCH_LOG에 wave 성공 기록 → 다음 wave 진입 |
+| `100` | wave 내 모든 child 가 완료 라벨(`LOOP_DONE_LABEL`) 부착 | 불필요 | DISPATCH_LOG에 wave 성공 기록 → 다음 wave 진입 |
 | `101` | wave 내 누군가 ESCALATION (fail-fast) | watch_wave가 자동 stop | DISPATCH_LOG에 escalation 기록, ESCALATION.md 본문·카테고리 사용자 제시, **다음 wave 차단**, 재계획은 사용자 책임 |
 | `102` | `WATCH_TIMEOUT_SECONDS` 초과 (기본 7200s) | watch_wave가 자동 stop | DISPATCH_LOG에 timeout 기록, 진행 단계·partial 결과 사용자 제시, **다음 wave 차단**, `dispatch resume <m>`으로 이어갈지 사용자 결정 |
 
 이 외 exit code는 dispatch 자체 결함을 의미하므로 즉시 abort + 사용자에게 stderr·exit code 그대로 보고.
 
-**기존 loop과의 분업** — 워크트리·lock·iteration 상한·헌법 준수는 모두 `loop.sh`가 처리. dispatch는 sentinel 파일(`DONE`·`.loop/ESCALATION.md`) **존재만** 감시. 외부 셸 루프 표준 유지(in-process Stop 훅 미사용).
+**기존 loop과의 분업** — 워크트리·lock·iteration 상한·헌법 준수는 모두 `loop.sh`가 처리. dispatch는 두 sentinel 신호 — task 저장소 child issue 의 `LOOP_DONE_LABEL` 라벨(성공, SPEC 175) 과 워크트리 안 `.loop/ESCALATION.md` 파일(실패) — **존재만** 감시. 외부 셸 루프 표준 유지(in-process Stop 훅 미사용).
 
 ## Subcommand
 

--- a/plugins/autopilot/skills/dispatch/references/dispatch.sh
+++ b/plugins/autopilot/skills/dispatch/references/dispatch.sh
@@ -3,7 +3,7 @@
 #
 # 책임:
 #   - milestone-level ops (status/stop/list/cleanup/logs)
-#   - sentinel watch (wave 내 child loop들의 DONE/.loop/ESCALATION.md 폴링)
+#   - sentinel watch (wave 내 child loop 들의 완료 라벨·.loop/ESCALATION.md 폴링)
 #   - DISPATCH_LOG.md 기록
 #
 # **하지 않는 일**:
@@ -31,6 +31,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# task 저장소 라벨 헬퍼 공유 (SPEC 175 AC6) — loop.sh 와 동일한
+# task_status_is_done·task_label_present·LOOP_DONE_LABEL 단일 출처를 source.
+# 위치: plugins/autopilot/skills/loop/references/task-storage.sh.
+# shellcheck source=../../loop/references/task-storage.sh
+source "$SCRIPT_DIR/../../loop/references/task-storage.sh"
 
 # ----- 헬퍼 -----
 
@@ -93,14 +99,19 @@ child_archive_path() {
   echo "$PROJECT_ROOT/milestones/$milestone/loops/$child"
 }
 
-# child의 sentinel 상태: done / escalated / running / idle / missing
+# child 의 sentinel 상태: done / escalated / running / idle / missing.
+# 완료(`done`) 검출은 task 저장소(GitHub Issue)의 LOOP_DONE_LABEL 라벨 단일 의존
+# (SPEC 175 AC1). loop.sh 와 동일 helper(task_status_is_done) 를 source 해 공유.
+# ESCALATION 은 워크트리 안의 .loop/ESCALATION.md 파일 sentinel 유지 (SPEC 175 비-목표).
 child_state() {
   local milestone="$1"
   local child="$2"
   local wt="$(child_wt_path "$milestone" "$child")"
   local lock="$(child_lock_path "$milestone" "$child")"
 
-  if [[ -f "$wt/DONE" ]]; then
+  # done 신호 — task 저장소 라벨 단일 의존. gh 부재·매핑 실패는 task_status_is_done
+  # 가 1(판정 불가) 로 폴백하므로 자연스럽게 다음 분기로 떨어진다.
+  if task_status_is_done "$milestone/$child" 2>/dev/null; then
     echo "done"
     return
   fi
@@ -325,8 +336,9 @@ cmd_cleanup() {
             continue
             ;;
         esac
-        if [[ -f "$wt/DONE" ]]; then
-          echo "[$(now_iso)] cleanup $m/$child (DONE 신호 있음, archival 포함)"
+        # cleanup 대상은 done 상태 child — 검출은 child_state(라벨 단일 의존, SPEC 175).
+        if [[ "$(child_state "$m" "$child")" == "done" ]]; then
+          echo "[$(now_iso)] cleanup $m/$child (완료 라벨 부착, archival 포함)"
           # 메타 파일 archival — loop.sh cmd_cleanup의 step 4와 동일 로직.
           # loop.sh delegation 대신 inline 재구현 — git worktree로 등록되지
           # 않은 mock·legacy 워크트리에서도 정리가 일관되게 동작하도록.
@@ -389,7 +401,7 @@ cmd_log_event() {
 #
 # 여러 child의 sentinel 파일을 폴링.
 # 한 명이라도 ESCALATION.md를 만들면 다른 child들 stop + exit 101.
-# 모두 DONE이면 exit 100.
+# 모두 완료 라벨(LOOP_DONE_LABEL) 부착이면 exit 100.
 # 타임아웃 시 exit 102.
 
 cmd_watch_wave() {
@@ -452,7 +464,7 @@ cmd_watch_wave() {
     fi
 
     if [[ $all_done -eq 1 ]]; then
-      log_event_internal "watch_wave ALL DONE children=[${children[*]}]"
+      log_event_internal "watch_wave ALL DONE (LOOP_DONE_LABEL) children=[${children[*]}]"
       exit 100
     fi
 

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -17,7 +17,6 @@ allowed-tools:
   - Bash(git -C * stash pop *)
   - Bash(git -C * stash show *)
   - Bash(rm */ESCALATION.md)
-  - Bash(rm */DONE)
   - Bash(ps -p *)
   - Bash(cat */*.lock)
 ---
@@ -65,15 +64,15 @@ Skill(skill: "spec", args: "<task-id>")
 권장 기본값:
 - `persistent: true`
 - `timeout_ms: 3600000` (1시간)
-- 필터 정규식: `이터 #|HALT|WARN|FAIL|ERROR|rate limit|claude 비정상|에스컬레이션|DONE`
+- 필터 정규식: `이터 #|HALT|WARN|FAIL|ERROR|rate limit|claude 비정상|에스컬레이션|완료 신호`
 
 `--no-monitor` 플래그는 **SKILL.md 차원 옵션**이다 — 모델이 args 파싱 시 이 토큰을 분리·소비하여 `Monitor` 가설 자체를 생략하고, `loop.sh`로는 **전달하지 않는다** (셸 드라이버는 본 플래그를 모름). 따라서 본 플래그는 **본 스킬을 통한 호출 시점에만** 작용하며, 사용자가 셸 드라이버 `loop.sh start`를 직접 호출하는 경우엔 효력이 없다.
 
 `spec` 스킬 단계 9의 "지금 loop start 호출" 결정으로 자동 연계되는 경우에도 추가 모니터 결정 질문 없이 본 기본 동작(Monitor 가설 포함)이 그대로 적용된다.
 
-#### DONE 이후 PR 생성·재사용 phase (default)
+#### 완료 라벨 부착 이후 PR 생성·재사용 phase (default)
 
-task가 `DONE`에 도달한 직후 같은 워크트리에서 PR 생성(또는 동일 브랜치의 open PR 재사용) 단계가 **default로 자동 실행**됩니다 (SPEC 103 AC1). 건너뛰려면 `--no-pr` 플래그를 명시(SPEC 103 AC2).
+task 가 완료 신호(`LOOP_DONE_LABEL` 라벨 부착)에 도달한 직후 같은 워크트리에서 PR 생성(또는 동일 브랜치의 open PR 재사용) 단계가 **default로 자동 실행**됩니다 (SPEC 103 AC1). 건너뛰려면 `--no-pr` 플래그를 명시(SPEC 103 AC2).
 
 활성화 시 동작:
 - default 브랜치 자동 감지 (`gh repo view` → `git symbolic-ref refs/remotes/origin/HEAD`)
@@ -93,7 +92,7 @@ task가 `DONE`에 도달한 직후 같은 워크트리에서 PR 생성(또는 �
 
 기존 PR body의 사용자 수기 편집 보호를 위해 자동 영역은 `<!-- autopilot:pr-body:begin --> ... <!-- autopilot:pr-body:end -->` marker fence 안에만 작성됩니다.
 
-#### DONE 이후 PR 리뷰 자동 fix 루프 (SPEC 123, `request_review: true` opt-in)
+#### 완료 라벨 부착 이후 PR 리뷰 자동 fix 루프 (SPEC 123, `request_review: true` opt-in)
 
 SPEC frontmatter에 `request_review: true`가 지정된 task만 본 흐름을 진입합니다. PR 생성·재사용이 성공한 직후 다음 sub-phase가 차례·일부 background로 실행됩니다:
 
@@ -164,7 +163,8 @@ start 첫 호출에 자동:
 |---|---|
 | `constitution.md` | 워커 헌법. start 시점에 워크트리 CLAUDE.md로 복사 |
 | `loop.sh` | 외부 셸 드라이버. 모든 subcommand의 핵심 로직 |
-| `pr-phase.sh` | DONE 이후 PR 생성·재사용 단계 |
+| `task-storage.sh` | task 저장소 라벨 검출 공통 헬퍼 (loop.sh·dispatch.sh 공유, SPEC 175) |
+| `pr-phase.sh` | 완료 라벨 부착 이후 PR 생성·재사용 단계 |
 | `operational-guide.md` | 사용자용 운영 가이드 (워크플로·환경 변수·객관 게이트 표·의존성) |
 | `status-format.md` | status 출력 형식 가이드 |
 | `troubleshooting.md` | 차단 신호 카테고리별 처리 가이드 |

--- a/plugins/autopilot/skills/loop/references/cleanup-phase.sh
+++ b/plugins/autopilot/skills/loop/references/cleanup-phase.sh
@@ -37,7 +37,7 @@ emit_escalation() { echo "ESCALATION cleanup-phase: $*"; }
 
 # ----- 1. 미커밋 변경 사전 검사 (위험: cleanup 손실 차단) -----
 # 워크트리에 staged·unstaged·untracked가 남아 있으면 worktree remove 시 손실 위험.
-# untracked는 본 task의 .iterations/·CLAUDE.md·DONE 등 info/exclude로 가려져 있어
+# untracked는 본 task의 .iterations/·CLAUDE.md 등 info/exclude로 가려져 있어
 # 보통 status에 안 나타난다. 그래도 safety-net으로 staged·unstaged만 검사.
 dirty=$( cd "$WT" && git status --porcelain --untracked-files=no 2>/dev/null || true )
 if [[ -n "$dirty" ]]; then
@@ -47,7 +47,7 @@ if [[ -n "$dirty" ]]; then
 fi
 
 # ----- 2. worktree remove -----
-# autopilot 워크트리는 info/exclude된 ephemeral 파일(.iterations/·DONE·CLAUDE.md)을
+# autopilot 워크트리는 info/exclude된 ephemeral 파일(.iterations/·CLAUDE.md)을
 # 항상 보유한다. 위 사전 검사로 staged/unstaged 변경 부재를 이미 확인했으므로
 # --force로 ephemeral 파일도 함께 정리. (사용자 수기 변경은 untracked로 들어와도
 # `--untracked-files=no`를 통과하므로 사전 검사가 catch하지 못함. 사용자가 워크트리

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -26,7 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # ----- allowed-tools (SPEC 123 AC18) -----
 #
-# DONE 이후 PR 생애주기 자동화 phase 그룹(rebase·review-fix·cleanup)의 *자식 claude CLI
+# 완료 신호 이후 PR 생애주기 자동화 phase 그룹(rebase·review-fix·cleanup)의 *자식 claude CLI
 # 세션*(rebase 충돌 자동 해소, review-fix iter) 전용 도구 권한. review-fix-phase가
 # `--allowed-tools "$AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS"` 형태로 전달한다.
 #
@@ -61,9 +61,12 @@ export AUTOPILOT_REBASE_ALLOWED_TOOLS
 # 완료 신호의 검출 키는 task 식별자에 부속된 label 이름이다 (헌법 §12, SKILL.md).
 # 워커가 완료 시 `[done]` prefix comment(가독·로그)와 본 label 추가(검출 키)를 모두
 # 수행해야 드라이버가 done으로 판정한다. comment 본문은 더 이상 단일 검출 키가 아니다.
-# 환경 변수 override 허용 — 단, label 이름은 프로젝트 수준에서 단일 위치에 고정되어
-# task storage adapter 다중 분기를 만들지 않는다 (SPEC 134 §비-목표).
-LOOP_DONE_LABEL="${LOOP_DONE_LABEL:-loop:done}"
+#
+# LOOP_DONE_LABEL·task_issue_number·task_label_present·ensure_label_exists·
+# task_status_is_done 는 dispatch.sh 와 공유 (SPEC 175 AC6) — task-storage.sh
+# 단일 출처를 양쪽이 source 한다.
+# shellcheck source=./task-storage.sh
+source "$SCRIPT_DIR/task-storage.sh"
 
 # ----- 헬퍼 -----
 
@@ -102,93 +105,9 @@ normalize_task_id() {
   fi
 }
 
-# ----- task ↔ GitHub issue 매핑 (헌법 §11, rules/context.md) -----
-# task-id의 마지막 컴포넌트(예: 'regular/124' → '124')가 숫자면 issue number로 직접 사용.
-# 그 외 문자열이면 `gh issue list --search`로 첫 매칭 lookup. 실패 시 빈 출력 + return 1.
-# 호출자(halt·iterate·cmd_status)는 매핑 실패 시 graceful degrade한다.
-# M4-b 인라인 — M4-c에서 재시도/backoff 추가.
-task_issue_number() {
-  local task_id="${1:-$TASK_ID}"
-  local child="${task_id##*/}"
-  if [[ "$child" =~ ^[0-9]+$ ]]; then
-    printf '%s\n' "$child"
-    return 0
-  fi
-  if ! command -v gh >/dev/null 2>&1; then
-    return 1
-  fi
-  local n
-  n=$(gh issue list --search "$task_id" --json number --jq '.[0].number' 2>/dev/null || true)
-  if [[ -n "$n" && "$n" != "null" ]]; then
-    printf '%s\n' "$n"
-    return 0
-  fi
-  return 1
-}
-
-# task issue에 특정 label이 붙어 있는지 boolean 검사 (SPEC 134 AC3).
-# 인자: $1=task-id (생략 시 $TASK_ID), $2=label 이름 (필수).
-# 반환: 0=label 존재, 1=label 부재 또는 판정 불가 (issue 매핑 실패·gh 부재 포함).
-# 구현은 단일 GitHub 호출(`gh issue view --json labels`)로 한정 — adapter 인터페이스
-# 신설 없음 (SPEC 134 §비-목표).
-task_label_present() {
-  local task_id="${1:-$TASK_ID}"
-  local label="${2:-}"
-  [[ -z "$label" ]] && return 1
-  local issue
-  issue=$(task_issue_number "$task_id" 2>/dev/null) || return 1
-  if ! command -v gh >/dev/null 2>&1; then
-    return 1
-  fi
-  # gh CLI의 `--jq`는 단일 expression 인자만 받아 jq의 `--arg`를 통과시키지 않으므로
-  # name 목록만 추출해 셸에서 정확 일치 비교 (grep -F -x).
-  local names
-  names=$(gh issue view "$issue" --json labels \
-    --jq '.labels[].name' 2>/dev/null || true)
-  [[ -z "$names" ]] && return 1
-  printf '%s\n' "$names" | grep -qxF "$label" && return 0
-  return 1
-}
-
-# task storage에 label이 존재하는지 확인하고, 없으면 자동 생성 (SPEC 134 AC5).
-# 인자: $1=label 이름 (필수).
-# 권한 부족·gh 부재 시 best-effort로 stderr WARN + 비-0 반환 (비차단 진행).
-# SPEC 134 §위험 "label 자동 생성 권한 부족" — runtime 실패는 verify 범위 밖.
-ensure_label_exists() {
-  local label="${1:-}"
-  [[ -z "$label" ]] && return 1
-  if ! command -v gh >/dev/null 2>&1; then
-    return 1
-  fi
-  # 존재 여부 확인 — `gh label list --search`는 prefix·substring을 함께 반환할 수
-  # 있으므로 name 목록만 추출 후 셸에서 정확 일치 비교 (gh `--jq`는 jq `--arg`를
-  # 통과시키지 않아 셸 비교가 안전).
-  local names
-  names=$(gh label list --search "$label" --json name \
-    --jq '.[].name' 2>/dev/null || true)
-  if [[ -n "$names" ]] && printf '%s\n' "$names" | grep -qxF "$label"; then
-    return 0
-  fi
-  # 미존재 — 생성 시도. race 또는 권한 부족 시 WARN.
-  if ! gh label create "$label" \
-        --description "autopilot loop 완료 신호 (드라이버 검출 키)" \
-        >/dev/null 2>&1; then
-    echo "[$(now_iso)] WARN: label '$label' 자동 생성 실패 — 권한 부족·race·gh 응답 비정상. 수동 생성 필요." >&2
-    return 1
-  fi
-  echo "[$(now_iso)] label '$label' 자동 생성 완료." >&2
-  return 0
-}
-
-# task issue의 완료 신호 검사 (헌법 §12, SPEC 134 AC2).
-# 정식 검출 키: task issue에 LOOP_DONE_LABEL 값과 일치하는 label이 붙어 있는지.
-# comment 본문은 가독·로그 채널이며 판정에 사용되지 않는다 — 워커가 [done] prefix
-# comment 발행과 함께 label 추가 두 동작을 모두 수행해야 0(done)을 반환한다.
-# 반환: 0=done, 1=done 아님(판정 불가 포함).
-task_status_is_done() {
-  local task_id="${1:-$TASK_ID}"
-  task_label_present "$task_id" "$LOOP_DONE_LABEL"
-}
+# ----- task ↔ GitHub issue 매핑 -----
+# task_issue_number·task_label_present·ensure_label_exists·task_status_is_done
+# 정의는 task-storage.sh 단일 출처 (SPEC 175 AC6 — dispatch.sh 와 공유).
 
 # task issue의 차단 신호 검사 (헌법 §5·§12, SPEC 134 §제약).
 # 정식 검출 키: Project Status field 값(`Blocked`) 단일 의존. comment 본문은 가독·
@@ -642,11 +561,12 @@ diff_vs_scope() {
     # 프레임워크 파일은 항상 scope 검사에서 제외 (워커 프레임워크 메타파일)
     # CLAUDE.md는 SPEC scope.exclude로 통제 — skip-worktree로 보통은 diff에 안 잡히지만,
     # 워커가 unskip + commit하면 여기서 정상 catch되어야 함 (워크트리 셋업 직후 자동 skip 처리).
-    # SPEC.md(워커 명세)와 DONE(종료 신호)은 milestones/<m>/loops/<c>/ 단일 트리 안에 있으므로
-    # 그 경로 패턴으로 제외. 이터간 메타(handoff/notes/done/blocked)는 task issue
-    # body·prefix comments로 위임됐으므로 워크트리 파일이 존재하지 않는다 (헌법 §11).
+    # SPEC.md(워커 명세)는 milestones/<m>/loops/<c>/ 단일 트리 안에 있으므로 그 경로 패턴으로
+    # 제외. 종료 신호는 task 저장소 LOOP_DONE_LABEL 라벨 단일 의존이라 워크트리 파일이 없다
+    # (SPEC 175). 이터간 메타(handoff/notes/done/blocked)는 task issue body·prefix
+    # comments로 위임됐으므로 워크트리 파일이 존재하지 않는다 (헌법 §11).
     case "$file" in
-      milestones/*/loops/*/SPEC.md|DONE) continue ;;
+      milestones/*/loops/*/SPEC.md) continue ;;
     esac
 
     # exclude 패턴 매칭 → 위반
@@ -953,7 +873,7 @@ cmd_start() {
         shift 2
         ;;
       --no-pr)
-        # AC2 (SPEC 103): PR 자동 생성 opt-out. 지정 시 DONE 직후 PR phase 건너뜀.
+        # AC2 (SPEC 103): PR 자동 생성 opt-out. 지정 시 완료 라벨 부착 직후 PR phase 건너뜀.
         # default(없음): PR phase가 실행됨 (AC1).
         no_pr=1
         shift
@@ -1074,13 +994,14 @@ cmd_start() {
     # 워크트리에는 메타 파일을 시드·commit하지 않는다 — feat 브랜치 HEAD가 그대로 BASE SHA가 된다.
 
     # 워크트리 로컬 비추적 등록 — .iterations/는 iter raw 로그, 어떤 git 브랜치에도
-    # commit되지 않음. DONE은 종료 신호로 worktree-local.
+    # commit되지 않음. 완료 신호는 task 저장소 라벨 단일 의존이라 워크트리 파일이 없다
+    # (SPEC 175) — exclude 패턴에서 제외.
     # 등록 위치 선택: --git-common-dir (공유 commondir의 info/exclude).
     # 배경: git은 워크트리별 $GIT_DIR/info/exclude(--git-dir)도 참조하지만 그 효과는
-    #       해당 워크트리에만 한정된다. 본 패턴(CLAUDE.md·.iterations/·DONE)은 본 task의
+    #       해당 워크트리에만 한정된다. 본 패턴(CLAUDE.md·.iterations/)은 본 task의
     #       워크트리 동안만 필요하지만, autopilot worktree는 task별로 새로 생성되므로
     #       commondir에 idempotent하게 누적해도 충돌·중복은 없다. 단순성을 위해 commondir
-    #       선택. 다른 워크트리·메인 트리에도 위 3 패턴이 untracked로 노출되지 않게
+    #       선택. 다른 워크트리·메인 트리에도 위 2 패턴이 untracked로 노출되지 않게
     #       정합되는 부수 효과는 의도된 것 (모두 ephemeral·메타 파일).
     local wt_common_dir
     wt_common_dir="$(git -C "$WT" rev-parse --git-common-dir)"
@@ -1088,7 +1009,7 @@ cmd_start() {
     mkdir -p "$wt_common_dir/info"
     local exclude_file="$wt_common_dir/info/exclude"
     touch "$exclude_file"
-    for pat in "CLAUDE.md" ".iterations/" "DONE"; do
+    for pat in "CLAUDE.md" ".iterations/"; do
       grep -qxF "$pat" "$exclude_file" 2>/dev/null || echo "$pat" >> "$exclude_file"
     done
 
@@ -1112,7 +1033,7 @@ cmd_start() {
     set -e
 
     if [[ $iter_status -eq 100 ]]; then
-      echo "[$(now_iso)] DONE 신호 감지. 정상 종료."
+      echo "[$(now_iso)] 완료 신호(LOOP_DONE_LABEL) 감지. 정상 종료."
 
       # PR 생성·재사용 phase. SPEC 103 AC1: default로 실행 (opt-in 플래그 불필요).
       # SPEC 103 AC2: --no-pr 플래그가 지정되면 건너뜀.
@@ -1599,7 +1520,7 @@ Subcommands:
   status [<task-id>]      상태 조회
   stop <task-id>          실행 중 정지
   list                    전체 task 상태
-  cleanup <task-id>       DONE 후 정리
+  cleanup <task-id>       완료 라벨 부착 후 정리
   logs <task-id>          로그 조회
 
 자세한 내용: references/operational-guide.md (autopilot/skills/loop/)

--- a/plugins/autopilot/skills/loop/references/operational-guide.md
+++ b/plugins/autopilot/skills/loop/references/operational-guide.md
@@ -28,10 +28,10 @@ milestones/<m>/loops/<c>/
 ├── .lock                      # 동시 실행 락 (gitignored)
 └── .worktree/                 # git 워크트리 (gitignored)
     ├── CLAUDE.md              # 헌법 복사본
-    ├── DONE                   # 정상 완료 신호 (있을 때만)
     ├── .iterations/<n>.log    # 매 이터 stdout 캡처 (gitignored, worktree-local)
     └── milestones/<m>/loops/<c>/
         └── SPEC.md            # feat 브랜치 commit으로 자연 노출
+# 완료 신호는 task 저장소의 LOOP_DONE_LABEL 라벨 단일 의존 — 워크트리 sentinel 파일 없음 (SPEC 175)
 # 이터간 상태(계획·교훈·인계·차단·완료)는 워크트리에 두지 않고 task 메모리·task 신호로 위임 (헌법 §11)
 ```
 
@@ -49,7 +49,7 @@ loop.sh start   <task-id> [옵션]      # 검증 후 워크트리·락 생성 + 
 loop.sh status  [<task-id>]           # 상태 조회 (전체 또는 단일)
 loop.sh stop    <task-id>             # 실행 중 정지 (SIGTERM)
 loop.sh list                          # 전체 task 상태 (status 별칭)
-loop.sh cleanup <task-id> [--force]   # DONE 후 정리
+loop.sh cleanup <task-id> [--force]   # 완료 라벨 부착 후 정리
 loop.sh logs    <task-id> [옵션]      # 로그 조회
 ```
 
@@ -61,7 +61,7 @@ LOOP_SH="$HOME/.claude/plugins/autopilot/skills/loop/references/loop.sh"
 Skill(skill: "spec", args: "auth-refactor")   # 대화형 SPEC.md 생성
 bash "$LOOP_SH" start auth-refactor           # 루프 시작
 bash "$LOOP_SH" logs auth-refactor --tail  # 별도 터미널에서 모니터링
-# 정지: Ctrl+C, DONE 파일 생성, 또는 완료·차단 신호 발행 시 자동 종료
+# 정지: Ctrl+C, 또는 완료(LOOP_DONE_LABEL 부착)·차단 신호 발행 시 자동 종료
 ```
 
 ## 외부 SPEC 파일 전달 (--spec 플래그)
@@ -89,7 +89,7 @@ bash "$LOOP_SH" status auth-refactor # 단일 task 상태
 bash "$LOOP_SH" stop auth-refactor   # SIGTERM + 5초 대기 + 락 해제
 ```
 
-## DONE 후 머지 및 정리
+## 완료 라벨 부착 후 머지 및 정리
 
 ```bash
 # feat/<task-id>[-<slug>] 브랜치를 PR base로 — request_review opt-in 시 자동 push·PR 생성

--- a/plugins/autopilot/skills/loop/references/pr-phase.sh
+++ b/plugins/autopilot/skills/loop/references/pr-phase.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# pr-phase.sh — loop DONE 이후 PR 생성·재사용 단계
+# pr-phase.sh — loop 완료 라벨 부착 이후 PR 생성·재사용 단계
 #
 # 사용:
 #   bash pr-phase.sh <worktree> <branch> <task-id> <project-root>

--- a/plugins/autopilot/skills/loop/references/task-storage.sh
+++ b/plugins/autopilot/skills/loop/references/task-storage.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# task-storage.sh — task 저장소(GitHub Issue) 라벨 검출 공통 헬퍼.
+#
+# loop.sh·dispatch.sh 가 함께 source 하는 헬퍼. 완료 검출의 단일 출처는
+# task 식별자에 부속된 LOOP_DONE_LABEL 라벨이다(헌법 §12, SPEC 134/150/175).
+# 본 파일은 source 전용이며 단독 실행하지 않는다.
+#
+# 매체: GitHub Issue + label. 환경: gh CLI 인증을 전제.
+#
+# Provides:
+#   LOOP_DONE_LABEL                       — 완료 검출 키 (기본 'loop:done')
+#   task_issue_number  <task-id>          — task-id → issue number 매핑
+#   task_label_present <task-id> <label>  — label 부착 여부 (0=있음)
+#   task_status_is_done <task-id>         — LOOP_DONE_LABEL 부착 여부
+#   ensure_label_exists <label>           — 미존재 시 자동 생성 (best-effort)
+#
+# task-id 기본값은 환경 변수 $TASK_ID — loop.sh 의 이터 컨텍스트에서 자연 set.
+# dispatch.sh 등 다른 호출자는 task-id 를 명시적으로 넘긴다.
+
+# 완료 신호의 검출 키. 환경 변수 override 허용 — 단, 프로젝트 수준에서 단일 위치에
+# 고정되어 task storage adapter 다중 분기를 만들지 않는다 (SPEC 134 §비-목표).
+LOOP_DONE_LABEL="${LOOP_DONE_LABEL:-loop:done}"
+
+# 내부 전용 — ensure_label_exists 의 stderr WARN 라인 타임스탬프.
+# loop.sh 의 now_iso 와 식별 분리하여 source 순서·재정의 충돌 방지.
+_task_storage_now_iso() {
+  date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# task ↔ GitHub issue 매핑 (헌법 §11, rules/context.md).
+# task-id 의 마지막 컴포넌트(예: 'regular/124' → '124')가 숫자면 issue number 로 직접 사용.
+# 그 외 문자열이면 `gh issue list --search` 로 첫 매칭 lookup. 실패 시 빈 출력 + return 1.
+# 호출자(halt·iterate·cmd_status·dispatch child_state)는 매핑 실패 시 graceful degrade 한다.
+task_issue_number() {
+  local task_id="${1:-${TASK_ID:-}}"
+  local child="${task_id##*/}"
+  if [[ "$child" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$child"
+    return 0
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+  local n
+  n=$(gh issue list --search "$task_id" --json number --jq '.[0].number' 2>/dev/null || true)
+  if [[ -n "$n" && "$n" != "null" ]]; then
+    printf '%s\n' "$n"
+    return 0
+  fi
+  return 1
+}
+
+# task issue 에 특정 label 이 붙어 있는지 boolean 검사 (SPEC 134 AC3).
+# 인자: $1=task-id (생략 시 $TASK_ID), $2=label 이름 (필수).
+# 반환: 0=label 존재, 1=label 부재 또는 판정 불가 (issue 매핑 실패·gh 부재 포함).
+# 구현은 단일 GitHub 호출(`gh issue view --json labels`)로 한정 — adapter 인터페이스
+# 신설 없음 (SPEC 134 §비-목표).
+task_label_present() {
+  local task_id="${1:-${TASK_ID:-}}"
+  local label="${2:-}"
+  [[ -z "$label" ]] && return 1
+  local issue
+  issue=$(task_issue_number "$task_id" 2>/dev/null) || return 1
+  if ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+  # gh CLI 의 `--jq` 는 단일 expression 인자만 받아 jq 의 `--arg` 를 통과시키지 않으므로
+  # name 목록만 추출해 셸에서 정확 일치 비교 (grep -F -x).
+  local names
+  names=$(gh issue view "$issue" --json labels \
+    --jq '.labels[].name' 2>/dev/null || true)
+  [[ -z "$names" ]] && return 1
+  printf '%s\n' "$names" | grep -qxF "$label" && return 0
+  return 1
+}
+
+# task storage 에 label 이 존재하는지 확인하고, 없으면 자동 생성 (SPEC 134 AC5).
+# 인자: $1=label 이름 (필수).
+# 권한 부족·gh 부재 시 best-effort 로 stderr WARN + 비-0 반환 (비차단 진행).
+# SPEC 134 §위험 "label 자동 생성 권한 부족" — runtime 실패는 verify 범위 밖.
+ensure_label_exists() {
+  local label="${1:-}"
+  [[ -z "$label" ]] && return 1
+  if ! command -v gh >/dev/null 2>&1; then
+    return 1
+  fi
+  # 존재 여부 확인 — `gh label list --search` 는 prefix·substring 을 함께 반환할 수
+  # 있으므로 name 목록만 추출 후 셸에서 정확 일치 비교 (gh `--jq` 는 jq `--arg` 를
+  # 통과시키지 않아 셸 비교가 안전).
+  local names
+  names=$(gh label list --search "$label" --json name \
+    --jq '.[].name' 2>/dev/null || true)
+  if [[ -n "$names" ]] && printf '%s\n' "$names" | grep -qxF "$label"; then
+    return 0
+  fi
+  # 미존재 — 생성 시도. race 또는 권한 부족 시 WARN.
+  if ! gh label create "$label" \
+        --description "autopilot loop 완료 신호 (드라이버 검출 키)" \
+        >/dev/null 2>&1; then
+    echo "[$(_task_storage_now_iso)] WARN: label '$label' 자동 생성 실패 — 권한 부족·race·gh 응답 비정상. 수동 생성 필요." >&2
+    return 1
+  fi
+  echo "[$(_task_storage_now_iso)] label '$label' 자동 생성 완료." >&2
+  return 0
+}
+
+# task issue 의 완료 신호 검사 (헌법 §12, SPEC 134 AC2, SPEC 175 AC1).
+# 정식 검출 키: task issue 에 LOOP_DONE_LABEL 값과 일치하는 label 이 붙어 있는지.
+# comment 본문은 가독·로그 채널이며 판정에 사용되지 않는다 — 워커가 [done] prefix
+# comment 발행과 함께 label 추가 두 동작을 모두 수행해야 0(done) 을 반환한다.
+# 반환: 0=done, 1=done 아님(판정 불가 포함).
+task_status_is_done() {
+  local task_id="${1:-${TASK_ID:-}}"
+  task_label_present "$task_id" "$LOOP_DONE_LABEL"
+}

--- a/plugins/autopilot/skills/loop/references/task-storage.sh
+++ b/plugins/autopilot/skills/loop/references/task-storage.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# source-only — do not execute directly
 # task-storage.sh — task 저장소(GitHub Issue) 라벨 검출 공통 헬퍼.
 #
 # loop.sh·dispatch.sh 가 함께 source 하는 헬퍼. 완료 검출의 단일 출처는

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -55,7 +55,6 @@ allowed-tools:
   - Bash(git -C * stash pop *)
   - Bash(git -C * stash show *)
   - Bash(rm */ESCALATION.md)
-  - Bash(rm */DONE)
   - Bash(ps -p *)
   - Bash(cat */*.lock)
 ---

--- a/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
+++ b/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
@@ -11,20 +11,25 @@
 #   T3. worktree 경로 — `milestones/<m>/loops/<input-id>-<slug>/.worktree`.
 #   T4. SPEC.md 경로 정합 — spec 작성 경로 = loop 읽기 경로 = pr-phase 읽기 경로.
 #   T5. 모호성 die — 동일 input-id 매칭 브랜치 2+ 일 때 비-zero exit + 안내.
+#   T6. dispatch.sh child_state — issue 에 LOOP_DONE_LABEL 라벨이 부착되면
+#       워크트리 안 sentinel 파일 부재에도 "done" 상태를 보고해야 한다
+#       (SPEC 175 AC2: 라벨 단일 의존).
 #
-# 셋업: 임시 git fixture · mock claude (DONE 즉시 생성) · yq 필요.
+# 셋업: 임시 git fixture · mock claude (stdin 소비 + JSON 응답) · yq 필요.
 
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 LOOP_SH="$REPO_ROOT/plugins/autopilot/skills/loop/references/loop.sh"
 PR_PHASE_SH="$REPO_ROOT/plugins/autopilot/skills/loop/references/pr-phase.sh"
+DISPATCH_SH="$REPO_ROOT/plugins/autopilot/skills/dispatch/references/dispatch.sh"
 SPEC_SKILL_MD="$REPO_ROOT/plugins/autopilot/skills/spec/SKILL.md"
 # 슬러그 도출 코드 조각의 단일 출처 (SKILL.md §9.5 → references/feat-branch-commit.md).
 SPEC_FEAT_REF="$REPO_ROOT/plugins/autopilot/skills/spec/references/feat-branch-commit.md"
 
 [[ -f "$LOOP_SH" ]]      || { echo "FAIL setup: loop.sh missing: $LOOP_SH" >&2; exit 1; }
 [[ -f "$PR_PHASE_SH" ]]  || { echo "FAIL setup: pr-phase.sh missing: $PR_PHASE_SH" >&2; exit 1; }
+[[ -f "$DISPATCH_SH" ]]  || { echo "FAIL setup: dispatch.sh missing: $DISPATCH_SH" >&2; exit 1; }
 [[ -f "$SPEC_SKILL_MD" ]]|| { echo "FAIL setup: SKILL.md missing: $SPEC_SKILL_MD" >&2; exit 1; }
 [[ -f "$SPEC_FEAT_REF" ]]|| { echo "FAIL setup: feat-branch-commit.md missing: $SPEC_FEAT_REF" >&2; exit 1; }
 
@@ -57,22 +62,24 @@ MAIN_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 # baseline empty commit (suppressor 오탐 방지)
 git commit --allow-empty -q -m "chore: baseline"
 
-# mock claude — stdin 소비 + DONE 생성 + JSON 응답
+# mock claude — stdin 소비 + JSON 응답.
+# 완료 신호는 task 저장소(GitHub Issue)의 `loop:done` label 부착이 단일 검출 키이며
+# (SPEC 134/150/175), 파일 sentinel 은 없다 — mock 도 파일을 만들지 않는다.
 MOCK_BIN="$WORK_DIR/mock-bin"
 mkdir -p "$MOCK_BIN"
 cat > "$MOCK_BIN/claude" <<'MOCKEOF'
 #!/usr/bin/env bash
 cat > /dev/null
-touch DONE
 echo '{"result":"mock","usage":{"input_tokens":1,"output_tokens":1}}'
 MOCKEOF
 chmod +x "$MOCK_BIN/claude"
 
 # mock gh — task_status_is_done 를 만족시키는 최소 stub.
-# 배경: loop.sh 는 done 신호를 task 저장소의 `loop:done` label 단일 의존으로 감지한다
-#       (SPEC 134/150). mock claude 가 `DONE` 파일을 만들어도 loop.sh 는 보지 않는다.
-#       본 테스트는 real GitHub 이 없으므로 gh stub 으로 label 존재를 흉내내 iter #1
-#       직후 task_status_is_done 이 0(done) 을 반환하도록 한다.
+# 배경: loop.sh·dispatch.sh 는 done 신호를 task 저장소의 `loop:done` label 단일
+#       의존으로 감지한다 (SPEC 134/150/175). 파일 sentinel 은 제거되었으므로
+#       라벨 부착이 done 검출의 유일한 경로다. 본 테스트는 real GitHub 이 없으므로
+#       gh stub 으로 label 존재를 흉내내 iter #1 직후 task_status_is_done 이
+#       0(done) 을 반환하도록 한다.
 # 처리:
 #   - gh issue list  : "1" (task_issue_number 가 lookup 성공하게)
 #   - gh issue view  : "loop:done" (task_label_present 가 hit)
@@ -273,5 +280,37 @@ echo "$T5_OUT" | grep -qE '여러 feat 브랜치|모호|ambig' \
 
 echo "OK T5: 모호성 die"
 
+# ──────────────────────────────────────────────────────────────────────────────
+# T6. dispatch.sh child_state — label 단일 의존 (SPEC 175 AC2)
+# ──────────────────────────────────────────────────────────────────────────────
+# 배경: 이전 contract 에서 dispatch.sh 는 `[[ -f $wt/DONE ]]` 파일 sentinel 로
+#       child 완료를 판정했으나, 어떤 코드 경로도 그 파일을 만들지 않아 dead code
+#       였다. SPEC 175 는 loop.sh 와 동일하게 task 저장소의 `loop:done` 라벨 단일
+#       의존으로 통합한다. mock gh 가 `loop:done` 을 echo 하므로, child issue 가
+#       라벨 부착된 상태를 흉내내고 dispatch status 가 "done" 을 보고하는지 확인.
+#
+# fixture: milestones/wave-m/loops/123/.worktree (sentinel 파일 일절 없음).
+#          child id "123" 은 숫자라 task_issue_number 가 gh issue list 우회.
+T6_M="wave-m"
+T6_C="123"
+T6_WT="$PROJECT/milestones/${T6_M}/loops/${T6_C}/.worktree"
+mkdir -p "$T6_WT"
+
+set +e
+T6_OUT=$(bash "$DISPATCH_SH" status "$T6_M" 2>&1)
+T6_RC=$?
+set -e
+
+if [[ $T6_RC -ne 0 ]]; then
+  echo "FAIL T6a: dispatch.sh status rc=$T6_RC" >&2
+  echo "$T6_OUT" >&2
+  exit 1
+fi
+echo "$T6_OUT" | grep -qE "^[[:space:]]*${T6_C}[[:space:]]+done$" \
+  || { echo "FAIL T6: dispatch child_state did not report 'done' for label-only completion (SPEC 175 AC2)" >&2
+       echo "$T6_OUT" >&2; exit 1; }
+
+echo "OK T6: dispatch child_state — label 단일 의존"
+
 echo ""
-echo "ALL TESTS PASSED (T1–T5)"
+echo "ALL TESTS PASSED (T1–T6)"


### PR DESCRIPTION
## Summary
- loop·dispatch 완료 검출을 GitHub Issue 라벨(`LOOP_DONE_LABEL`, 기본 `loop:done`) 단일 의존으로 통합
- DONE 파일 sentinel 잔존(dead code·문서·테스트 mock·운영 가이드 트리) 일괄 제거
- `loop/references/task-storage.sh` 신설로 loop·dispatch 공용 helper 공유

## Test plan
- [x] `bash plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh` (T1–T6 PASS, 워커 보고)
- [x] `! grep -rn -F 'touch DONE' plugins/autopilot/skills`
- [x] `! grep -rnE -- '-f.*/DONE' plugins/autopilot/skills/{loop,dispatch}/references`
- [x] `! grep -F '├── DONE' plugins/autopilot/skills/loop/references/operational-guide.md`
- [ ] 리뷰어 수동: dispatch `child_state` 의 gh API rate-limit 영향 후속 task 분리 여부 확인

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)