### PR TITLE
review-fix-phase silent-fail false-positive: statusCheckRollup 빈 상태 오판

### DIFF
--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -139,6 +139,17 @@ review-fix 루프는 다음 중 하나가 감지되면 종료합니다:
 
 상수는 `loop.sh`의 `AUTOPILOT_REVIEW_FIX_ALLOWED_TOOLS` / `AUTOPILOT_REBASE_ALLOWED_TOOLS` 에 정의되며, 환경 변수로 자식 phase 스크립트에 export됩니다. 사용자 대화형 세션의 `settings.json`은 본 등록의 영향을 받지 않습니다 — autopilot 워커 컨텍스트에만 한정됩니다.
 
+##### silent-fail 검출기 환경변수
+
+review-fix-phase의 silent-fail 검출기(연속 idle 폴링 후 stuck 패턴 escalate)는 다음 환경변수로 조절됩니다.
+
+| 환경변수 | 기본값 | floor | 의미 |
+|---|---|---|---|
+| `LOOP_REVIEW_IDLE_THRESHOLD` | 3 | 3 | 새 이벤트 0건이 N회 연속 폴링되면 silent-fail 패턴 평가 |
+| `LOOP_REVIEW_PR_GRACE_SECS` | 300 (5분) | 0 | PR 생성 직후 N초 동안은 silent-fail 검출기 평가 자체를 skip — GitHub Actions check 등록 지연·큐 지연 흡수 (SPEC 181). 0으로 설정 시 grace 비활성화 |
+
+검출기는 `statusCheckRollup`의 전체 check 수가 0이면(check 미등록·정보 부족) 해당 폴링 회차의 ESCALATION을 발동하지 않고 카운터만 리셋합니다 (SPEC 181 AC2). 전체 check 수가 0보다 크고 pending 0 + 다른 활동(리뷰·코멘트·inline·owner cmd) 모두 0일 때만 진짜 stuck으로 escalate합니다 (AC3).
+
 요구: `gh` CLI 설치 + OAuth 인증.
 
 ### status [<task-id>] / stop <task-id> / list / cleanup <task-id> [--force] / logs <task-id> [--tail | --iter N]

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -342,11 +342,11 @@ while (( iter < MAX_ITER )); do
       # silent-fail / stuck 패턴 평가 — evaluate_silent_fail에 위임 (SPEC 181).
       # 입력: fetch 실패 플래그 + rollup·활동 카운트 + PR 생성 후 경과 시간 + grace 기간.
       last_fetch_fail=$( cat "$FETCH_FAIL_FILE" 2>/dev/null || echo 0 )
-      pending_checks=$( cd "$WT" && gh pr view "$PR_NUMBER" --json statusCheckRollup \
-                          --jq '[.statusCheckRollup[]? | select((.status // "COMPLETED") != "COMPLETED")] | length' 2>/dev/null || echo "" )
+      # statusCheckRollup을 한 번만 fetch해 두 jq 필터를 적용 — API 호출·레이턴시 절감.
       # SPEC 181 AC2: total_checks=0(빈 rollup)을 "체크 모두 완료"로 오판하지 않기 위해 별도 산출.
-      total_checks=$( cd "$WT" && gh pr view "$PR_NUMBER" --json statusCheckRollup \
-                        --jq '.statusCheckRollup | length' 2>/dev/null || echo "" )
+      rollup_json=$( cd "$WT" && gh pr view "$PR_NUMBER" --json statusCheckRollup 2>/dev/null || echo "" )
+      pending_checks=$( printf '%s' "$rollup_json" | jq '[.statusCheckRollup[]? | select((.status // "COMPLETED") != "COMPLETED")] | length' 2>/dev/null || echo "" )
+      total_checks=$( printf '%s' "$rollup_json" | jq '.statusCheckRollup | length' 2>/dev/null || echo "" )
       total_reviews=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviews --jq '.reviews | length' 2>/dev/null || echo "" )
       total_comments=$( cd "$WT" && gh pr view "$PR_NUMBER" --json comments --jq '.comments | length' 2>/dev/null || echo "" )
       # inline review thread comments는 `/pulls/{n}/comments` REST endpoint에 별도로 산다 —

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -28,6 +28,47 @@
 
 set -euo pipefail
 
+# ===== silent-fail 평가 (SPEC 181) — 단위 테스트 가능 =====
+# 인자(8): fetch_fail pending total_checks reviews comments inline elapsed grace
+# stdout(택일): ESCALATE_FETCH_FAIL | GRACE_SKIP | EMPTY_ROLLUP_SKIP | ESCALATE_STUCK | RESET_COUNTER
+#
+# 우선순위:
+#   1) fetch_fail == 1                       → ESCALATE_FETCH_FAIL  (grace 무관 — fetch 실패는 즉시 escalate)
+#   2) elapsed < grace                       → GRACE_SKIP           (PR 생성 직후 — Actions check 등록 전)
+#   3) total_checks가 양의 정수가 아님       → EMPTY_ROLLUP_SKIP    (rollup 비어 있음·gh fetch 실패 등 — 정보 부족)
+#   4) pending=0 + reviews/comments/inline=0 → ESCALATE_STUCK       (진짜 stuck — AC3 회귀 보존)
+#   5) 그 외                                  → RESET_COUNTER       (자연 idle)
+evaluate_silent_fail() {
+  local last_fetch_fail="$1" pending="$2" total_checks="$3" reviews="$4" comments="$5" inline="$6" elapsed="$7" grace="$8"
+  if [[ "$last_fetch_fail" == "1" ]]; then
+    echo "ESCALATE_FETCH_FAIL"; return 0
+  fi
+  if (( elapsed < grace )); then
+    echo "GRACE_SKIP"; return 0
+  fi
+  if ! [[ "$total_checks" =~ ^[1-9][0-9]*$ ]]; then
+    echo "EMPTY_ROLLUP_SKIP"; return 0
+  fi
+  if [[ "$pending" == "0" && "$reviews" == "0" && "$comments" == "0" && "$inline" == "0" ]]; then
+    echo "ESCALATE_STUCK"; return 0
+  fi
+  echo "RESET_COUNTER"
+}
+
+# ===== grace 기간 (silent-fail 조기 호출 방지) — SPEC 181 =====
+# 환경변수: LOOP_REVIEW_PR_GRACE_SECS
+# 기본값:  300 (5분) — GitHub Actions check 등록·큐 지연 흡수
+# floor:   0  (음수 입력 시 0으로 clamp — grace=0은 grace 비활성화 동등)
+GRACE_SECS="${LOOP_REVIEW_PR_GRACE_SECS:-300}"
+if (( GRACE_SECS < 0 )); then
+  GRACE_SECS=0
+fi
+
+# 테스트 모드 진입점: 함수만 expose 후 main 로직 skip (단위 테스트 진입점).
+if [[ -n "${REVIEW_FIX_PHASE_TEST_MODE:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
 WT="${1:-}"
 BRANCH="${2:-}"
 TASK_ID="${3:-}"
@@ -298,28 +339,51 @@ while (( iter < MAX_ITER )); do
   if [[ -z "$new_events" ]]; then
     CONSECUTIVE_IDLE=$((CONSECUTIVE_IDLE + 1))
     if (( CONSECUTIVE_IDLE >= CONSECUTIVE_IDLE_THRESHOLD )); then
-      # silent-fail / stuck 패턴 검사 — false positive 방지를 위해 두 패턴으로 분리.
+      # silent-fail / stuck 패턴 평가 — evaluate_silent_fail에 위임 (SPEC 181).
+      # 입력: fetch 실패 플래그 + rollup·활동 카운트 + PR 생성 후 경과 시간 + grace 기간.
       last_fetch_fail=$( cat "$FETCH_FAIL_FILE" 2>/dev/null || echo 0 )
-      if [[ "$last_fetch_fail" == "1" ]]; then
-        emit_escalation "silent-fail 감지 (stuck): ${CONSECUTIVE_IDLE}회 연속 idle 중 이벤트 fetch 호출 실패 — 사용자 개입 필요 (PR #$PR_NUMBER)"
-        exit 1
-      fi
-      # PR check 완료 + 활동 부재 — 셋 다 명시적으로 "0"일 때만 trigger (값이 비어
-      # 있으면 자체 fetch 실패이므로 위 분기에서 처리; 안전을 위해 false 처리).
       pending_checks=$( cd "$WT" && gh pr view "$PR_NUMBER" --json statusCheckRollup \
                           --jq '[.statusCheckRollup[]? | select((.status // "COMPLETED") != "COMPLETED")] | length' 2>/dev/null || echo "" )
+      # SPEC 181 AC2: total_checks=0(빈 rollup)을 "체크 모두 완료"로 오판하지 않기 위해 별도 산출.
+      total_checks=$( cd "$WT" && gh pr view "$PR_NUMBER" --json statusCheckRollup \
+                        --jq '.statusCheckRollup | length' 2>/dev/null || echo "" )
       total_reviews=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviews --jq '.reviews | length' 2>/dev/null || echo "" )
       total_comments=$( cd "$WT" && gh pr view "$PR_NUMBER" --json comments --jq '.comments | length' 2>/dev/null || echo "" )
       # inline review thread comments는 `/pulls/{n}/comments` REST endpoint에 별도로 산다 —
       # `gh pr view --json comments`는 `/issues/{n}/comments`(PR-level conversation)만 반영하므로
       # claude-review가 inline만 게시한 케이스에서 false-positive ESCALATION을 막으려면 추가 체크.
       total_inline=$( cd "$WT" && gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" --jq 'length' 2>/dev/null || echo "" )
-      if [[ "$pending_checks" == "0" && "$total_reviews" == "0" && "$total_comments" == "0" && "$total_inline" == "0" ]]; then
-        emit_escalation "silent-fail 감지 (stuck): ${CONSECUTIVE_IDLE}회 연속 idle + PR check 완료 + 리뷰·코멘트·inline·owner cmd 모두 부재 — 사용자 개입 필요 (PR #$PR_NUMBER)"
-        exit 1
-      fi
-      # 자연 idle (리뷰어 응답 대기 등) — 카운터만 리셋, 폴링 계속
-      CONSECUTIVE_IDLE=0
+      # PR 생성 후 경과 시간 — jq의 fromdateiso8601로 ISO 8601 → epoch 변환.
+      # fetch 실패·파싱 실패 시 0 → elapsed가 매우 커져 grace 비활성화와 동등 (기존 동작으로 degrade, 안전).
+      pr_created_ts=$( cd "$WT" && gh pr view "$PR_NUMBER" --json createdAt --jq '.createdAt | fromdateiso8601' 2>/dev/null || echo 0 )
+      now_ts=$( date -u +%s )
+      elapsed=$(( now_ts - pr_created_ts ))
+
+      action=$(evaluate_silent_fail "$last_fetch_fail" "$pending_checks" "$total_checks" \
+                                     "$total_reviews" "$total_comments" "$total_inline" \
+                                     "$elapsed" "$GRACE_SECS")
+      case "$action" in
+        ESCALATE_FETCH_FAIL)
+          emit_escalation "silent-fail 감지 (stuck): ${CONSECUTIVE_IDLE}회 연속 idle 중 이벤트 fetch 호출 실패 — 사용자 개입 필요 (PR #$PR_NUMBER)"
+          exit 1
+          ;;
+        ESCALATE_STUCK)
+          emit_escalation "silent-fail 감지 (stuck): ${CONSECUTIVE_IDLE}회 연속 idle + PR check 완료 + 리뷰·코멘트·inline·owner cmd 모두 부재 — 사용자 개입 필요 (PR #$PR_NUMBER)"
+          exit 1
+          ;;
+        GRACE_SKIP)
+          echo "[review-fix-phase] silent-fail check skip — PR 생성 후 ${elapsed}s (grace ${GRACE_SECS}s) — Actions check 등록 대기" >&2
+          CONSECUTIVE_IDLE=0
+          ;;
+        EMPTY_ROLLUP_SKIP)
+          echo "[review-fix-phase] silent-fail check skip — statusCheckRollup 비어 있음 (check 미등록 / fetch 실패) — 정보 부족, 다음 임계까지 폴링 계속" >&2
+          CONSECUTIVE_IDLE=0
+          ;;
+        *)
+          # RESET_COUNTER — 자연 idle (리뷰어 응답 대기 등) — 카운터만 리셋, 폴링 계속
+          CONSECUTIVE_IDLE=0
+          ;;
+      esac
     fi
     sleep "$POLL_SECS"
     continue

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -342,9 +342,9 @@ while (( iter < MAX_ITER )); do
       # silent-fail / stuck 패턴 평가 — evaluate_silent_fail에 위임 (SPEC 181).
       # 입력: fetch 실패 플래그 + rollup·활동 카운트 + PR 생성 후 경과 시간 + grace 기간.
       last_fetch_fail=$( cat "$FETCH_FAIL_FILE" 2>/dev/null || echo 0 )
-      # statusCheckRollup을 한 번만 fetch해 두 jq 필터를 적용 — API 호출·레이턴시 절감.
+      # statusCheckRollup·createdAt을 한 번에 fetch해 jq 필터 3종 적용 — API 호출·레이턴시 절감.
       # SPEC 181 AC2: total_checks=0(빈 rollup)을 "체크 모두 완료"로 오판하지 않기 위해 별도 산출.
-      rollup_json=$( cd "$WT" && gh pr view "$PR_NUMBER" --json statusCheckRollup 2>/dev/null || echo "" )
+      rollup_json=$( cd "$WT" && gh pr view "$PR_NUMBER" --json statusCheckRollup,createdAt 2>/dev/null || echo "" )
       pending_checks=$( printf '%s' "$rollup_json" | jq '[.statusCheckRollup[]? | select((.status // "COMPLETED") != "COMPLETED")] | length' 2>/dev/null || echo "" )
       total_checks=$( printf '%s' "$rollup_json" | jq '.statusCheckRollup | length' 2>/dev/null || echo "" )
       total_reviews=$( cd "$WT" && gh pr view "$PR_NUMBER" --json reviews --jq '.reviews | length' 2>/dev/null || echo "" )
@@ -353,9 +353,10 @@ while (( iter < MAX_ITER )); do
       # `gh pr view --json comments`는 `/issues/{n}/comments`(PR-level conversation)만 반영하므로
       # claude-review가 inline만 게시한 케이스에서 false-positive ESCALATION을 막으려면 추가 체크.
       total_inline=$( cd "$WT" && gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" --jq 'length' 2>/dev/null || echo "" )
-      # PR 생성 후 경과 시간 — jq의 fromdateiso8601로 ISO 8601 → epoch 변환.
-      # fetch 실패·파싱 실패 시 0 → elapsed가 매우 커져 grace 비활성화와 동등 (기존 동작으로 degrade, 안전).
-      pr_created_ts=$( cd "$WT" && gh pr view "$PR_NUMBER" --json createdAt --jq '.createdAt | fromdateiso8601' 2>/dev/null || echo 0 )
+      # PR 생성 후 경과 시간 — 위 rollup_json fetch에 createdAt도 함께 받았으므로 별도 호출 불요.
+      # jq의 fromdateiso8601로 ISO 8601 → epoch 변환.
+      # 파싱 실패 시 0 → elapsed가 매우 커져 grace 비활성화와 동등 (기존 동작으로 degrade, 안전).
+      pr_created_ts=$( printf '%s' "$rollup_json" | jq '.createdAt | fromdateiso8601' 2>/dev/null || echo 0 )
       now_ts=$( date -u +%s )
       elapsed=$(( now_ts - pr_created_ts ))
 

--- a/tests/autopilot/test-review-fix-silent-fail.sh
+++ b/tests/autopilot/test-review-fix-silent-fail.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# test-review-fix-silent-fail.sh — SPEC 181
+# review-fix-phase silent-fail false-positive: statusCheckRollup 빈 상태 오판 회귀 검사.
+#
+# evaluate_silent_fail()를 단위 호출해 4가지 statusCheckRollup mock 시나리오와
+# grace 기간 동작·환경변수 명시(정적 검사)를 검증한다. 실제 gh CLI/PR 접근 없음.
+
+set -uo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$THIS_DIR/../.." && pwd)"
+SCRIPT="$ROOT/plugins/autopilot/skills/loop/references/review-fix-phase.sh"
+SKILL_MD="$ROOT/plugins/autopilot/skills/loop/SKILL.md"
+
+if [[ ! -f "$SCRIPT" ]]; then
+  echo "FAIL: review-fix-phase.sh 미존재 ($SCRIPT)" >&2
+  exit 1
+fi
+
+PASSED=0
+FAILED=0
+
+pass() { echo "PASS: $*"; PASSED=$((PASSED + 1)); }
+fail() { echo "FAIL: $*" >&2; FAILED=$((FAILED + 1)); }
+
+# evaluate_silent_fail 단위 호출 헬퍼.
+# 인자: fetch_fail pending total_checks reviews comments inline elapsed grace
+run_eval() {
+  local fetch_fail="$1" pending="$2" total="$3" reviews="$4" comments="$5" inline="$6" elapsed="$7" grace="$8"
+  REVIEW_FIX_PHASE_TEST_MODE=1 SCRIPT_PATH="$SCRIPT" \
+    bash -c '
+      set -uo pipefail
+      # shellcheck disable=SC1090
+      source "$SCRIPT_PATH"
+      evaluate_silent_fail "$@"
+    ' _ "$fetch_fail" "$pending" "$total" "$reviews" "$comments" "$inline" "$elapsed" "$grace" 2>/dev/null
+}
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    pass "$desc"
+  else
+    fail "$desc — expected '$expected', got '$actual'"
+  fi
+}
+
+# ---------- (a-i) 빈 rollup + grace 기간 안 → GRACE_SKIP (AC1) ----------
+got=$(run_eval 0 0 0 0 0 0 60 300)
+assert_eq "(a-i) 빈 rollup + grace 안 → GRACE_SKIP" "GRACE_SKIP" "$got"
+
+# ---------- (a-ii) 빈 rollup + grace 기간 밖 → EMPTY_ROLLUP_SKIP (AC2) ----------
+got=$(run_eval 0 0 0 0 0 0 600 300)
+assert_eq "(a-ii) 빈 rollup + grace 밖 → EMPTY_ROLLUP_SKIP" "EMPTY_ROLLUP_SKIP" "$got"
+
+# ---------- (b) [COMPLETED] + 활동 0 + grace 후 → ESCALATE_STUCK (AC3 회귀 보존) ----------
+got=$(run_eval 0 0 1 0 0 0 600 300)
+assert_eq "(b) [COMPLETED] + 활동 0 + grace 후 → ESCALATE_STUCK" "ESCALATE_STUCK" "$got"
+
+# ---------- (c) [IN_PROGRESS] → pending=1 → RESET_COUNTER (기존 동작 회귀) ----------
+got=$(run_eval 0 1 1 0 0 0 600 300)
+assert_eq "(c) [IN_PROGRESS] pending=1 → RESET_COUNTER" "RESET_COUNTER" "$got"
+
+# ---------- (d) [COMPLETED, IN_PROGRESS] → pending=1, total=2 → RESET_COUNTER (기존 동작 회귀) ----------
+got=$(run_eval 0 1 2 0 0 0 600 300)
+assert_eq "(d) [COMPLETED, IN_PROGRESS] pending=1 → RESET_COUNTER" "RESET_COUNTER" "$got"
+
+# ---------- (e) fetch_fail=1 — grace보다 우선 ESCALATE_FETCH_FAIL ----------
+got=$(run_eval 1 0 0 0 0 0 60 300)
+assert_eq "(e) fetch_fail=1 → ESCALATE_FETCH_FAIL (grace보다 우선)" "ESCALATE_FETCH_FAIL" "$got"
+
+# ---------- (f) 활동 있음 (reviews>0) + 빈 rollup + grace 후 → RESET_COUNTER ----------
+# total_checks=0이면 EMPTY_ROLLUP_SKIP 분기가 먼저 잡지만, 안전 회귀: pending=0+활동>0 케이스도 escalate 안 함.
+got=$(run_eval 0 0 1 1 0 0 600 300)
+assert_eq "(f) [COMPLETED] + reviews>0 + grace 후 → RESET_COUNTER" "RESET_COUNTER" "$got"
+
+# ---------- AC4 정적 검사 — env var name, 기본값, floor 명시 ----------
+if grep -q 'LOOP_REVIEW_PR_GRACE_SECS' "$SCRIPT"; then
+  pass "(AC4) env var name 'LOOP_REVIEW_PR_GRACE_SECS' script에 명시"
+else
+  fail "(AC4) env var name 'LOOP_REVIEW_PR_GRACE_SECS' script에 미명시"
+fi
+
+if grep -qE 'LOOP_REVIEW_PR_GRACE_SECS:-300' "$SCRIPT"; then
+  pass "(AC4) 기본값 300s (5분) script에 명시"
+else
+  fail "(AC4) 기본값 300s 미명시"
+fi
+
+if grep -qE 'GRACE_SECS[[:space:]]*<[[:space:]]*0' "$SCRIPT"; then
+  pass "(AC4) GRACE_SECS floor 처리 script에 명시"
+else
+  fail "(AC4) GRACE_SECS floor 처리 미명시"
+fi
+
+# ---------- AC4 SKILL.md 명시 ----------
+if [[ -f "$SKILL_MD" ]] && grep -q 'LOOP_REVIEW_PR_GRACE_SECS' "$SKILL_MD"; then
+  pass "(AC4) SKILL.md에 env var 명시"
+else
+  fail "(AC4) SKILL.md에 env var 미명시"
+fi
+
+# ---------- 요약 ----------
+TOTAL=$((PASSED + FAILED))
+echo ""
+echo "총 $TOTAL 검사 — PASS: $PASSED, FAIL: $FAILED"
+if (( FAILED > 0 )); then
+  exit 1
+fi
+exit 0

--- a/tests/autopilot/test-review-fix-silent-fail.sh
+++ b/tests/autopilot/test-review-fix-silent-fail.sh
@@ -53,6 +53,12 @@ assert_eq "(a-i) 빈 rollup + grace 안 → GRACE_SKIP" "GRACE_SKIP" "$got"
 got=$(run_eval 0 0 0 0 0 0 600 300)
 assert_eq "(a-ii) 빈 rollup + grace 밖 → EMPTY_ROLLUP_SKIP" "EMPTY_ROLLUP_SKIP" "$got"
 
+# ---------- (a-iii) [COMPLETED] + grace 기간 안 → GRACE_SKIP (grace 우선) ----------
+# total_checks>0이라도 grace 안이면 ESCALATE_STUCK이 아닌 GRACE_SKIP 반환 — grace 분기가
+# total_checks 분기보다 우선 (evaluate_silent_fail 우선순위 2 > 3·4).
+got=$(run_eval 0 0 1 0 0 0 60 300)
+assert_eq "(a-iii) [COMPLETED] + grace 안 → GRACE_SKIP" "GRACE_SKIP" "$got"
+
 # ---------- (b) [COMPLETED] + 활동 0 + grace 후 → ESCALATE_STUCK (AC3 회귀 보존) ----------
 got=$(run_eval 0 0 1 0 0 0 600 300)
 assert_eq "(b) [COMPLETED] + 활동 0 + grace 후 → ESCALATE_STUCK" "ESCALATE_STUCK" "$got"
@@ -98,6 +104,14 @@ if [[ -f "$SKILL_MD" ]] && grep -q 'LOOP_REVIEW_PR_GRACE_SECS' "$SKILL_MD"; then
   pass "(AC4) SKILL.md에 env var 명시"
 else
   fail "(AC4) SKILL.md에 env var 미명시"
+fi
+
+# ---------- LOOP_REVIEW_IDLE_THRESHOLD 문서·구현 일치 (drift 방지) ----------
+# 환경변수가 SKILL.md에 문서화돼 있다면 script에서도 실제 읽혀야 한다. drift 방어용 정적 검사.
+if grep -q 'LOOP_REVIEW_IDLE_THRESHOLD' "$SCRIPT"; then
+  pass "LOOP_REVIEW_IDLE_THRESHOLD script에서 읽힘 (문서·구현 일치)"
+else
+  fail "LOOP_REVIEW_IDLE_THRESHOLD script에서 미사용 (문서·구현 불일치)"
 fi
 
 # ---------- 요약 ----------

--- a/tests/autopilot/test-review-fix-silent-fail.sh
+++ b/tests/autopilot/test-review-fix-silent-fail.sh
@@ -75,8 +75,8 @@ assert_eq "(d) [COMPLETED, IN_PROGRESS] pending=1 → RESET_COUNTER" "RESET_COUN
 got=$(run_eval 1 0 0 0 0 0 60 300)
 assert_eq "(e) fetch_fail=1 → ESCALATE_FETCH_FAIL (grace보다 우선)" "ESCALATE_FETCH_FAIL" "$got"
 
-# ---------- (f) 활동 있음 (reviews>0) + 빈 rollup + grace 후 → RESET_COUNTER ----------
-# total_checks=0이면 EMPTY_ROLLUP_SKIP 분기가 먼저 잡지만, 안전 회귀: pending=0+활동>0 케이스도 escalate 안 함.
+# ---------- (f) 활동 있음 (reviews>0) + total=1 + pending=0 + grace 후 → RESET_COUNTER ----------
+# total_checks=1·reviews=1: EMPTY_ROLLUP_SKIP 분기를 통과시켜 pending=0+활동>0 케이스의 escalate 회피를 검증.
 got=$(run_eval 0 0 1 1 0 0 600 300)
 assert_eq "(f) [COMPLETED] + reviews>0 + grace 후 → RESET_COUNTER" "RESET_COUNTER" "$got"
 


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가
`autopilot:loop`의 review-fix-phase silent-fail 검출기가 `statusCheckRollup`이 빈 상태일 때를 "체크 모두 완료"로 오판해 PR 생성 직후 조기 ESCALATION을 트리거하는 false-positive를 제거한다. `0 pending of 0 total`(정보 없음)과 `0 pending of N total`(진짜 완료)을 구분하고, PR 생성 직후 grace 기간 도입으로 GitHub Actions check가 등록되기 전까지의 일시적 빈 rollup을 흡수한다.

## Commits
- 69a0702 fix:root(spec/181): review-fix-phase silent-fail false-positive — statusCheckRollup 빈 상태 오판

Closes #181
<!-- autopilot:pr-body:end -->