### PR TITLE
chore(autopilot): bump version 0.5.1 → 0.5.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,8 +20,8 @@
     {
       "name": "autopilot",
       "source": "./plugins/autopilot",
-      "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 자기완결적인 loop 스킬로 자율 task lifecycle 관리",
-      "version": "0.2.2",
+      "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop(single-task) + prd/dispatch(multi-task) 4-skill family로 자율 task lifecycle 관리",
+      "version": "0.5.2",
       "category": "automation",
       "tags": ["autonomous", "ralph-loop", "agent-runtime", "self-directed"]
     }

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop(single-task) + prd/dispatch(multi-task) 4-skill family로 자율 task lifecycle 관리",
   "author": {
     "name": "예의상",


### PR DESCRIPTION
## Summary
- `plugins/autopilot/.claude-plugin/plugin.json`: 0.5.1 → 0.5.2 (SoT patch bump)
- `.claude-plugin/marketplace.json` autopilot 항목: 0.2.2 → 0.5.2 + description을 plugin.json과 동기화 (이전 drift 정리)

## Test plan
- [ ] marketplace.json·plugin.json 두 곳의 autopilot 버전이 0.5.2로 일치
- [ ] description 동일 문구 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)