### PR TITLE
spec 스킬에 test 코드 변경 감지·test_sweep_paths 자동 설정 절차 추가

### DIFF
--- a/milestones/regular/loops/105-spec-test-test-sweep-paths/SPEC.md
+++ b/milestones/regular/loops/105-spec-test-test-sweep-paths/SPEC.md
@@ -7,6 +7,8 @@ scope:
     - CLAUDE.md
 verify: "bash tests/autopilot/test-spec-skill.sh"
 request_review: true
+test_sweep_paths:
+  - "tests/autopilot/test-spec-skill.sh"
 ---
 
 # spec 스킬에 test 코드 변경 감지·test_sweep_paths 자동 설정 절차 추가

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -103,11 +103,11 @@ milestone 미지정 시 `regular`(catch-all)을 default로 적용 — sibling `a
 
 #### 1.1 검증 실패 라우팅 (요약)
 
-검증 실패·자연어 입력 시 즉시 종료 대신 `AskUserQuestion` 3옵션: **(a)** task-id 재입력 후 재시도, **(b)** 사전 명확화 라운드 진입(§1.2), **(c)** 종료(산출물 없음). 옵션 표기 `(a)`/`(b)`/`(c)`. "다음 단계: Skill(...)" 자유 텍스트 금지. 전체 절차는 `references/pre-clarification.md` §1.1 참조.
+검증 실패·자연어 입력 시 즉시 종료 대신 `AskUserQuestion` 3옵션: **(a)** task-id 재입력 후 재시도, **(b)** 사전 명확화 라운드 진입(§1.2), **(c)** 종료 — 어떤 산출물도 작성하지 않고 안전 종료(산출물 미작성). 옵션 표기 `(a)`/`(b)`/`(c)`. "다음 단계: Skill(...)" 자유 텍스트 금지. 전체 절차는 `references/pre-clarification.md` §1.1 참조.
 
 #### 1.2 사전 명확화 라운드 (요약)
 
-(b) 선택 시 진입. step 5 메커니즘을 task-id 확보 *전*으로 앞당겨 재사용(별도 phase·모듈 없음). 수집은 task 미정의 상태에 맞춰 `문제·목표·범위·제약`으로 확장. 매 라운드 "충분" 종결·명시적 취소 안전 종료 포함. 규모 분기: 단일 task → 프로젝트 태스크 트래커 컨벤션으로 task 생성 후 step 2 재진입, 마일스톤 규모 → `AskUserQuestion` 명시 승인 후 PRD 스킬 invoke. 수집 항목·라운드 규칙·1.2.1/1.2.2 분기 상세는 `references/pre-clarification.md` §1.2 참조.
+(b) 선택 시 진입. step 5 메커니즘을 task-id 확보 *전*으로 앞당겨 재사용(별도 phase·모듈 없음). 수집은 task 미정의 상태에 맞춰 `문제·목표·범위·제약`으로 확장. 매 라운드 "충분" 종결·명시적 취소 안전 종료(취소 시 어떤 산출물도 남기지 않고 종료) 포함. 규모 분기: 단일 task → 프로젝트의 태스크 관련 지침(태스크 트래커 컨벤션)으로 task 생성 후 step 2 재진입, 마일스톤 규모 → `AskUserQuestion` 명시 승인 후 PRD 스킬 invoke(milestone-id를 PRD 스킬에 인자로 전달). 수집 항목·라운드 규칙·1.2.1/1.2.2 분기 상세는 `references/pre-clarification.md` §1.2 참조.
 
 ⚠ task-id 는 항상 task 생성 호출의 응답값을 그대로 사용한다 — 추측·예측·작명 금지
 
@@ -136,7 +136,7 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 
 #### 3.1 subagent 위임 (선택)
 
-자동 수집이 부족하면 `references/agent-prompts.md`의 **`spec-context-explorer`** 양식으로 `Agent` 위임. 권장 휴리스틱(하나라도 해당): `rules/` 다수(≈5개 초과)이고 적용 룰 자명하지 않음, 기존 `milestones/*/loops/*/SPEC.md` 다수 선례, multi-file 영향, 사용자가 자연어 의도만 전달. 그 외엔 위임하지 않는다 — 단순 1~2 query는 메인이 직접 호출(헌법 §11.6). subagent는 사실 수집·인용만, **결정·합성은 메인 책임**.
+자동 수집이 부족하면 `references/agent-prompts.md`의 **`spec-context-explorer`** 양식으로 `Agent` 위임. 권장 도입 휴리스틱(하나라도 해당): `rules/` 다수(≈5개 초과)이고 적용 룰 자명하지 않음, 기존 `milestones/*/loops/*/SPEC.md` 다수 선례, multi-file 영향, 사용자가 자연어 의도만 전달. 그 외엔 위임하지 않는다 — 단순 1~2 query는 메인이 직접 호출(헌법 §11.6). subagent는 사실 수집·인용만, **결정·합성은 메인 책임**.
 
 ### 4. 범위 분해 게이트
 

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -161,9 +161,9 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 명확화 라운드 마지막에 다음 절차를 한 번 수행한다. 본 task가 합법적 test 코드 sweep (rename·cleanup·삭제·내용 수정 등)을 포함하면 loop 단계의 weakening 게이트가 그 변경을 "테스트 약화"로 오인하지 않도록 SPEC frontmatter에 `test_sweep_paths` 화이트리스트를 미리 박는다 (rules/loop의 `test_sweep_paths` 컨벤션과 정합).
 
 1. **자동 판단** — 수집된 scope·의도로 본 task가 test 코드 변경을 포함하는지 모델이 판단한다. 신호: 사용자 의도 본문에 "테스트 rename", "tests 정리", "test cleanup", "스펙 삭제" 등 어구 / scope 후보 경로가 `tests/**`·`test/**`·`__tests__/**`·`spec/**`·`*_test.*`·`*.test.*`·`*_spec.*` 패턴에 매칭 / WHAT/HOW 의도가 기존 테스트 파일의 rename·이동·삭제·내용 변경을 시사. (모델 휴리스틱이므로 위양성·위음성 가능 — 다음 단계의 사용자 단발 yes/no가 안전망.)
-2. **변경 없음 분기**: 자동 판단이 "test 변경 없음"이면 어떤 추가 prompt도 노출하지 않고 라운드를 종료한다. 본 task SPEC frontmatter에 `test_sweep_paths` 키를 추가하지 않는다 (빈 list `[]`로도 추가하지 않음 — 키 자체 부재).
+2. **변경 없음 분기**: 자동 판단이 "test 변경 없음"이면 어떤 추가 prompt도 노출하지 않고 라운드를 종료한다. 본 task SPEC frontmatter에 `test_sweep_paths` 키 자체는 추가하지 않되, **§5.1 절차를 거쳤음을 명시하는 흔적**으로 frontmatter에 YAML 주석 `# test_sweep_paths: reviewed-no-sweep` 한 줄을 박는다 (자체 검토 §3의 sweep 화이트리스트 검사가 "절차 누락"과 "검토 후 no-sweep 결정"을 구분하기 위한 명시 표식 — 흔적이 있으면 검사 통과).
 3. **변경 포함 분기 — 후보 경로 추출**: 모델이 sweep 화이트리스트 후보 경로 (git pathspec)를 scope·의도에서 추출한다 (예: rename 대상이 `tests/legacy_to_remove/` 디렉토리면 `tests/legacy_to_remove/**` 후보).
-4. **단발 yes/no 확인**: `AskUserQuestion`으로 사용자에게 단일 질문 — 추출 후보 경로 목록을 보여주고 "이 경로들을 SPEC frontmatter `test_sweep_paths`에 화이트리스트로 등록할까요? (yes/no)" — 단발(라운드 반복 없음). yes 응답 시 후보 경로를 step 8 SPEC.md 치환의 `test_sweep_paths` 입력으로 보존. no 응답 시 변경 없음 분기와 동일하게 키 부재로 진행.
+4. **단발 yes/no 확인**: `AskUserQuestion`으로 사용자에게 단일 질문 — 추출 후보 경로 목록을 보여주고 "이 경로들을 SPEC frontmatter `test_sweep_paths`에 화이트리스트로 등록할까요? (yes/no)" — 단발(라운드 반복 없음). yes 응답 시 후보 경로를 step 8 SPEC.md 치환의 `test_sweep_paths` 입력으로 보존. no 응답 시 변경 없음 분기와 동일하게 키 부재로 진행하되, frontmatter에 YAML 주석 `# test_sweep_paths: reviewed-no-sweep` 한 줄을 박아 "검토 후 no-sweep 결정" 흔적을 남긴다.
 
 ### 6. 접근법 비교 (조건부)
 
@@ -204,7 +204,7 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
       - "tests/test_specific_to_rename.py"
     ```
 
-  - **step 5.1 변경 없음/no 응답**: placeholder를 빈 문자열로 치환하고 그 자리의 줄 자체를 삭제 — frontmatter에 `test_sweep_paths` 키 자체를 추가하지 않는다 (빈 list `[]`도 출력하지 않음 — 키 부재가 명확한 의미).
+  - **step 5.1 변경 없음/no 응답**: placeholder 자리에 YAML 주석 한 줄 `# test_sweep_paths: reviewed-no-sweep`만 출력한다 — `test_sweep_paths` 키 자체는 추가하지 않되 (빈 list `[]`도 아님), 주석이 "§5.1 절차를 거쳐 no-sweep으로 결정됨" 흔적이 되어 자체 검토 §3 sweep 화이트리스트 검사가 통과 처리한다.
 - `{{constraints}}` / `{{risks}}` → 섹션 6/7. 빈 값이면 빈 줄 1개 치환(헤더 유지)
 - frontmatter `scope.exclude`는 고정 default(`rules/**`, `milestones/**`, `CLAUDE.md`) — 치환 대상 아님
 

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -156,6 +156,15 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 
 `--resume` 모드: 마커가 박힌 섹션 관련 질문만.
 
+#### 5.1 test 코드 변경 sweep 화이트리스트 자동 판단 (라운드 마지막)
+
+명확화 라운드 마지막에 다음 절차를 한 번 수행한다. 본 task가 합법적 test 코드 sweep (rename·cleanup·삭제·내용 수정 등)을 포함하면 loop 단계의 weakening 게이트가 그 변경을 "테스트 약화"로 오인하지 않도록 SPEC frontmatter에 `test_sweep_paths` 화이트리스트를 미리 박는다 (rules/loop의 `test_sweep_paths` 컨벤션과 정합).
+
+1. **자동 판단** — 수집된 scope·의도로 본 task가 test 코드 변경을 포함하는지 모델이 판단한다. 신호: 사용자 의도 본문에 "테스트 rename", "tests 정리", "test cleanup", "스펙 삭제" 등 어구 / scope 후보 경로가 `tests/**`·`test/**`·`__tests__/**`·`spec/**`·`*_test.*`·`*.test.*`·`*_spec.*` 패턴에 매칭 / WHAT/HOW 의도가 기존 테스트 파일의 rename·이동·삭제·내용 변경을 시사. (모델 휴리스틱이므로 위양성·위음성 가능 — 다음 단계의 사용자 단발 yes/no가 안전망.)
+2. **변경 없음 분기**: 자동 판단이 "test 변경 없음"이면 어떤 추가 prompt도 노출하지 않고 라운드를 종료한다. 본 task SPEC frontmatter에 `test_sweep_paths` 키를 추가하지 않는다 (빈 list `[]`로도 추가하지 않음 — 키 자체 부재).
+3. **변경 포함 분기 — 후보 경로 추출**: 모델이 sweep 화이트리스트 후보 경로 (git pathspec)를 scope·의도에서 추출한다 (예: rename 대상이 `tests/legacy_to_remove/` 디렉토리면 `tests/legacy_to_remove/**` 후보).
+4. **단발 yes/no 확인**: `AskUserQuestion`으로 사용자에게 단일 질문 — 추출 후보 경로 목록을 보여주고 "이 경로들을 SPEC frontmatter `test_sweep_paths`에 화이트리스트로 등록할까요? (yes/no)" — 단발(라운드 반복 없음). yes 응답 시 후보 경로를 step 8 SPEC.md 치환의 `test_sweep_paths` 입력으로 보존. no 응답 시 변경 없음 분기와 동일하게 키 부재로 진행.
+
 ### 6. 접근법 비교 (조건부)
 
 비-자명한 설계 결정 포함 시 2-3 접근법 + 트레이드오프 + 추천 제시. 자명하면 생략. 판단 기준(하나라도 해당): 사용자가 "어떻게 할까?" 묻거나 모호 요구, 둘 이상의 다른 패턴 사이 선택, 외부 의존성·라이브러리 선택이 task 결과에 큰 영향.
@@ -186,6 +195,16 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 - `{{scope_in}}` / `{{scope_out}}` → 본문 섹션 4
 - `{{scope_include}}` → frontmatter `scope.include` (YAML inline flow list, 예: `["src/**", "tests/**"]`)
 - `{{verify_command}}` → 본문 섹션 5 + frontmatter `verify` (둘 다 같은 placeholder)
+- `{{test_sweep_paths}}` → frontmatter `test_sweep_paths` 영역. 자체 한 줄을 차지하는 placeholder로 다음 두 분기를 따른다:
+  - **step 5.1 yes 응답** (test 코드 변경 포함 + 사용자 확정): `test_sweep_paths` YAML 키와 후보 경로 list로 치환. 예시 multi-line 출력:
+
+    ```
+    test_sweep_paths:
+      - "tests/legacy_to_remove/**"
+      - "tests/test_specific_to_rename.py"
+    ```
+
+  - **step 5.1 변경 없음/no 응답**: placeholder를 빈 문자열로 치환하고 그 자리의 줄 자체를 삭제 — frontmatter에 `test_sweep_paths` 키 자체를 추가하지 않는다 (빈 list `[]`도 출력하지 않음 — 키 부재가 명확한 의미).
 - `{{constraints}}` / `{{risks}}` → 섹션 6/7. 빈 값이면 빈 줄 1개 치환(헤더 유지)
 - frontmatter `scope.exclude`는 고정 default(`rules/**`, `milestones/**`, `CLAUDE.md`) — 치환 대상 아님
 

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -162,7 +162,7 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 
 1. **자동 판단** — 수집된 scope·의도로 본 task가 test 코드 변경을 포함하는지 모델이 판단한다. 신호: 사용자 의도 본문에 "테스트 rename", "tests 정리", "test cleanup", "스펙 삭제" 등 어구 / scope 후보 경로가 `tests/**`·`test/**`·`__tests__/**`·`spec/**`·`*_test.*`·`*.test.*`·`*_spec.*` 패턴에 매칭 / WHAT/HOW 의도가 기존 테스트 파일의 rename·이동·삭제·내용 변경을 시사. (모델 휴리스틱이므로 위양성·위음성 가능 — 다음 단계의 사용자 단발 yes/no가 안전망.)
 2. **변경 없음 분기**: 자동 판단이 "test 변경 없음"이면 어떤 추가 prompt도 노출하지 않고 라운드를 종료한다. 본 task SPEC frontmatter에 `test_sweep_paths` 키 자체는 추가하지 않되, **§5.1 절차를 거쳤음을 명시하는 흔적**으로 frontmatter에 YAML 주석 `# test_sweep_paths: reviewed-no-sweep` 한 줄을 박는다 (자체 검토 §3의 sweep 화이트리스트 검사가 "절차 누락"과 "검토 후 no-sweep 결정"을 구분하기 위한 명시 표식 — 흔적이 있으면 검사 통과).
-3. **변경 포함 분기 — 후보 경로 추출**: 모델이 sweep 화이트리스트 후보 경로 (git pathspec)를 scope·의도에서 추출한다 (예: rename 대상이 `tests/legacy_to_remove/` 디렉토리면 `tests/legacy_to_remove/**` 후보).
+3. **변경 포함 분기 — 후보 경로 추출**: 모델이 sweep 화이트리스트 후보 경로 (git pathspec)를 scope·의도에서 추출한다 (예: rename 대상이 `tests/legacy_to_remove/` 디렉토리면 `tests/legacy_to_remove/**` 후보). **추출 결과 0개 처리**: 모델이 구체 경로를 하나도 뽑지 못한 경우 (예: "테스트 파일 몇 개 정리" 같은 모호한 의도) — (a) step 1의 신호 경로(패턴 매칭으로 감지된 `tests/**` 등 후보)가 하나라도 있으면 그 신호 경로 list를 fallback 후보로 사용해 step 4로 진행, (b) 신호 경로도 0개면 step 2 "변경 없음 분기"와 동일하게 처리한다 (사용자에 빈 목록 노출 금지).
 4. **단발 yes/no 확인**: `AskUserQuestion`으로 사용자에게 단일 질문 — 추출 후보 경로 목록을 보여주고 "이 경로들을 SPEC frontmatter `test_sweep_paths`에 화이트리스트로 등록할까요? (yes/no)" — 단발(라운드 반복 없음). yes 응답 시 후보 경로를 step 8 SPEC.md 치환의 `test_sweep_paths` 입력으로 보존. no 응답 시 변경 없음 분기와 동일하게 키 부재로 진행하되, frontmatter에 YAML 주석 `# test_sweep_paths: reviewed-no-sweep` 한 줄을 박아 "검토 후 no-sweep 결정" 흔적을 남긴다.
 
 ### 6. 접근법 비교 (조건부)

--- a/plugins/autopilot/skills/spec/references/self-review.md
+++ b/plugins/autopilot/skills/spec/references/self-review.md
@@ -31,9 +31,13 @@
 발견 시: 단계 3에서 사용자가 이미 "단일 강행"을 확인하여 SPEC "위험" 섹션에 기록되어 있으면 통과. 새로 발견된 신호면 `[NEEDS CLARIFICATION: 다중 영역 가능성 — 영역 A: <...>, 영역 B: <...>, 분해 vs 단일 강행?]` 마커.
 
 추가 항목 — **test 코드 변경 sweep 화이트리스트 검사**:
-- task scope가 test 코드 변경 (rename·cleanup·삭제·내용 수정 등)을 포함하면 SPEC frontmatter `test_sweep_paths` 필드가 비어 있지 않다 (= 사용 가능한 화이트리스트 후보 경로가 list 형태로 존재).
+- task scope가 test 코드 변경 (rename·cleanup·삭제·내용 수정 등)을 포함하면 SPEC frontmatter `test_sweep_paths` 필드가 비어 있지 않거나, §5.1 절차를 거쳐 no-sweep으로 결정됐다는 명시 흔적이 frontmatter에 남아 있어야 한다.
 - 신호 (하나라도 해당): `scope.include` 또는 본문 "범위.포함" 항목 중 어느 하나가 `tests/**`·`test/**`·`__tests__/**`·`spec/**`·`*_test.*`·`*.test.*`·`*_spec.*` 같은 test 경로 패턴 매칭, "무엇을 만들 것인가"·"위험"·"제약" 본문에 "테스트 rename"·"tests 정리"·"test cleanup"·"스펙 삭제" 같은 어구 등장.
-- 위 신호가 있고 frontmatter `test_sweep_paths` 키가 부재이거나 빈 list `[]` 이면 — step 5.1 자동 판단·yes/no 단발 확인 절차가 누락됐다는 신호. 발견 시: `[NEEDS CLARIFICATION: test 코드 변경 sweep 화이트리스트 누락 — step 5.1 절차에서 test_sweep_paths를 추출·확정했나? 비워 두면 loop 단계의 weakening 게이트가 합법적 sweep을 "테스트 약화"로 오인할 수 있음.]` 마커.
+- 위 신호가 있고 다음 두 흔적이 **모두** 부재하면 — step 5.1 자동 판단·yes/no 단발 확인 절차가 누락됐다는 신호로 판정한다:
+  - frontmatter `test_sweep_paths` 키 (비어 있지 않은 list)
+  - frontmatter YAML 주석 `# test_sweep_paths: reviewed-no-sweep` (§5.1 변경 없음/no 응답 흔적)
+- 발견 시 (둘 다 부재): `[NEEDS CLARIFICATION: test 코드 변경 sweep 화이트리스트 누락 — step 5.1 절차에서 test_sweep_paths를 추출·확정했나? 비워 두면 loop 단계의 weakening 게이트가 합법적 sweep을 "테스트 약화"로 오인할 수 있음.]` 마커.
+- 둘 중 하나라도 존재하면 통과 — `reviewed-no-sweep` 주석은 "사용자가 no 응답·모델이 변경 없음 판단"을 self-review와 구분하기 위한 명시 표식이므로, 부재만으로 절차 누락을 단정하면 거짓 양성(no 응답을 반복 마커로 오인)이 발생한다.
 
 ## 4. 모호성 검사
 

--- a/plugins/autopilot/skills/spec/references/self-review.md
+++ b/plugins/autopilot/skills/spec/references/self-review.md
@@ -30,6 +30,11 @@
 
 발견 시: 단계 3에서 사용자가 이미 "단일 강행"을 확인하여 SPEC "위험" 섹션에 기록되어 있으면 통과. 새로 발견된 신호면 `[NEEDS CLARIFICATION: 다중 영역 가능성 — 영역 A: <...>, 영역 B: <...>, 분해 vs 단일 강행?]` 마커.
 
+추가 항목 — **test 코드 변경 sweep 화이트리스트 검사**:
+- task scope가 test 코드 변경 (rename·cleanup·삭제·내용 수정 등)을 포함하면 SPEC frontmatter `test_sweep_paths` 필드가 비어 있지 않다 (= 사용 가능한 화이트리스트 후보 경로가 list 형태로 존재).
+- 신호 (하나라도 해당): `scope.include` 또는 본문 "범위.포함" 항목 중 어느 하나가 `tests/**`·`test/**`·`__tests__/**`·`spec/**`·`*_test.*`·`*.test.*`·`*_spec.*` 같은 test 경로 패턴 매칭, "무엇을 만들 것인가"·"위험"·"제약" 본문에 "테스트 rename"·"tests 정리"·"test cleanup"·"스펙 삭제" 같은 어구 등장.
+- 위 신호가 있고 frontmatter `test_sweep_paths` 키가 부재이거나 빈 list `[]` 이면 — step 5.1 자동 판단·yes/no 단발 확인 절차가 누락됐다는 신호. 발견 시: `[NEEDS CLARIFICATION: test 코드 변경 sweep 화이트리스트 누락 — step 5.1 절차에서 test_sweep_paths를 추출·확정했나? 비워 두면 loop 단계의 weakening 게이트가 합법적 sweep을 "테스트 약화"로 오인할 수 있음.]` 마커.
+
 ## 4. 모호성 검사
 
 다음 어휘는 모호 신호:

--- a/plugins/autopilot/skills/spec/references/spec-template.md
+++ b/plugins/autopilot/skills/spec/references/spec-template.md
@@ -6,6 +6,7 @@ scope:
     - milestones/**
     - CLAUDE.md
 verify: "{{verify_command}}"
+{{test_sweep_paths}}
 # test_paths (선택): 테스트 약화 게이트가 추적할 경로/파일명 패턴 (git pathspec).
 #   미지정 시 기본 컨벤션(tests/·test/·__tests__/·spec/·src/test/ 디렉토리 +
 #   *.test.{js,ts,jsx,tsx,py}·*.spec.{js,ts,rb}·*_test.{go,py,rb}·test_*.py·*_spec.rb)

--- a/tests/autopilot/test-spec-skill.sh
+++ b/tests/autopilot/test-spec-skill.sh
@@ -315,7 +315,7 @@ grep -qE 'test 코드 변경|테스트 코드 변경' "$SELF_REVIEW_MD" \
   || fail "self-review.md에 'test 코드 변경' 트리거 어구 없음"
 ok "self-review.md에 test 코드 변경 트리거 어구 존재"
 
-grep -qE '비어 있지 않|채워|값이 있|empty' "$SELF_REVIEW_MD" \
+grep -qE '비어 있지 않|채워|값이 있' "$SELF_REVIEW_MD" \
   || fail "self-review.md에 'test_sweep_paths 필드가 비어 있지 않다' 의미 어구 없음"
 ok "self-review.md에 필드 비어 있지 않음 의미 명시"
 

--- a/tests/autopilot/test-spec-skill.sh
+++ b/tests/autopilot/test-spec-skill.sh
@@ -194,8 +194,13 @@ ok "self-reviewer 응답 3섹션 키워드 존재"
 # ---------------------------------------------------------------------------
 echo ""
 echo "=== TEST 10: SKILL.md frontmatter allowed-tools에 Agent 포함 ==="
-# 수용 기준 5: subagent dispatch 도구 허가
-awk '/^---$/{c++; next} c==1' "$SKILL_MD" | grep -qE '^allowed-tools:.*\bAgent\b' \
+# 수용 기준 5: subagent dispatch 도구 허가.
+# allowed-tools는 YAML inline (한 줄) 또는 block list (다음 줄 들여쓰기 `- Agent`) 두 형태 모두
+# valid. frontmatter 안에서 두 형식 중 하나로 Agent 토큰이 나타나면 통과.
+#   - block list 형식:  `^[[:space:]]+-[[:space:]]+Agent[[:space:]]*$`
+#   - inline list 형식: `^allowed-tools:.*[[ ,]Agent([] ,]|$)`
+awk '/^---$/{c++; next} c==1' "$SKILL_MD" | \
+  grep -qE '^[[:space:]]+-[[:space:]]+Agent[[:space:]]*$|^allowed-tools:.*([[ ,]|^allowed-tools:[[:space:]]*)Agent([],[:space:]]|$)' \
   || fail "SKILL.md frontmatter allowed-tools에 Agent 미포함"
 ok "frontmatter allowed-tools에 Agent 포함"
 
@@ -237,6 +242,81 @@ ok "헌법 §11.6 / '이터 내 서브 도구 위임' 인용 존재"
 grep -qE '결정·합성.*메인|메인.*결정·합성|결정과 합성.*메인' "$SKILL_MD" \
   || fail "SKILL.md에 '결정·합성은 메인 책임' 문구 부재"
 ok "'결정·합성 메인 책임' 문구 존재"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TEST 13: SKILL.md step 5 — test 코드 변경 자동 판단 절차 명시 ==="
+# AC1·AC2: 명확화 라운드 마지막에 task scope가 test 코드 변경(rename·cleanup·삭제·내용 수정 등)을
+# 포함하는지 자동 판단하고, 포함 시 sweep 화이트리스트 후보 경로를 단발 yes/no로 확인.
+TEMPLATE_MD="$SKILL_DIR/references/spec-template.md"
+SELF_REVIEW_MD="$SKILL_DIR/references/self-review.md"
+
+[[ -f "$TEMPLATE_MD" ]] || fail "spec-template.md 부재: $TEMPLATE_MD"
+[[ -f "$SELF_REVIEW_MD" ]] || fail "self-review.md 부재: $SELF_REVIEW_MD"
+
+# step 5 본문에 'test 코드 변경' (rename·cleanup·삭제·내용 수정 등) 자동 판단 어구
+grep -qE 'test 코드 변경|테스트 코드 변경|test code change' "$SKILL_MD" \
+  || fail "SKILL.md에 'test 코드 변경' 자동 판단 어구 없음"
+ok "test 코드 변경 자동 판단 어구 존재"
+
+# 단발 yes/no 확인 — AC2
+grep -qE '단발 yes/no|단발 (예|aye)/no|단일 yes/no|단발 확인' "$SKILL_MD" \
+  || fail "SKILL.md에 'test 변경 sweep 단발 yes/no 확인' 절차 없음"
+ok "단발 yes/no 확인 절차 존재"
+
+# 화이트리스트 후보 경로 추출 — AC2
+grep -qE '화이트리스트 후보|sweep 화이트리스트|sweep 후보 경로|화이트리스트 경로 후보' "$SKILL_MD" \
+  || fail "SKILL.md에 'sweep 화이트리스트 후보 경로 추출' 어구 없음"
+ok "sweep 후보 경로 추출 어구 존재"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TEST 14: SKILL.md step 8 — test_sweep_paths frontmatter 치환 룰 ==="
+# AC3·AC4: yes 응답 시 frontmatter test_sweep_paths에 기록, no/판단 미발동 시 키 부재
+grep -qE '\{\{test_sweep_paths\}\}|test_sweep_paths.*frontmatter|frontmatter.*test_sweep_paths' "$SKILL_MD" \
+  || fail "SKILL.md step 8 치환 룰에 test_sweep_paths frontmatter 처리 명세 없음"
+ok "step 8 치환 룰에 test_sweep_paths 명세 존재"
+
+# AC4: test 변경 없을 때 키 부재 — SKILL.md에 명시
+grep -qE 'test_sweep_paths.*(키|key).*(부재|생략|미추가|추가하지|없음)|키 부재|키 추가하지|키를 추가하지' "$SKILL_MD" \
+  || fail "SKILL.md에 test 변경 없을 때 'test_sweep_paths 키 부재' 룰 명시 없음"
+ok "test 변경 없을 때 frontmatter 키 부재 룰 명시"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TEST 15: spec-template.md — test_sweep_paths placeholder ==="
+# AC3·AC4 지원: active frontmatter 영역에 placeholder 정의. 기존 commented 예시는 보존.
+# active placeholder는 {{test_sweep_paths}} 형식 — step 8 치환 대상.
+grep -qE '\{\{test_sweep_paths\}\}' "$TEMPLATE_MD" \
+  || fail "spec-template.md active 영역에 {{test_sweep_paths}} placeholder 부재"
+ok "spec-template.md에 {{test_sweep_paths}} active placeholder 존재"
+
+# 기존 commented 예시 블록 보존 — # test_sweep_paths: 라인
+grep -qE '^# test_sweep_paths:' "$TEMPLATE_MD" \
+  || fail "spec-template.md commented '# test_sweep_paths:' 예시 블록 보존 실패"
+ok "commented '# test_sweep_paths:' 예시 블록 보존"
+
+# 기존 commented '# test_paths:' 예시 블록도 보존
+grep -qE '^# test_paths:' "$TEMPLATE_MD" \
+  || fail "spec-template.md commented '# test_paths:' 예시 블록 보존 실패"
+ok "commented '# test_paths:' 예시 블록 보존"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== TEST 16: self-review.md — 5축 검사 항목에 test_sweep_paths 검사 추가 ==="
+# AC5: scope에 test 코드 변경 포함 시 test_sweep_paths가 비어 있지 않다 검사
+grep -qE 'test_sweep_paths' "$SELF_REVIEW_MD" \
+  || fail "self-review.md에 'test_sweep_paths' 검사 항목 없음"
+ok "self-review.md에 test_sweep_paths 검사 항목 존재"
+
+# 검사 의미: scope에 test 코드 변경 포함 시 → 필드가 비어 있지 않다
+grep -qE 'test 코드 변경|테스트 코드 변경' "$SELF_REVIEW_MD" \
+  || fail "self-review.md에 'test 코드 변경' 트리거 어구 없음"
+ok "self-review.md에 test 코드 변경 트리거 어구 존재"
+
+grep -qE '비어 있지 않|채워|값이 있|empty' "$SELF_REVIEW_MD" \
+  || fail "self-review.md에 'test_sweep_paths 필드가 비어 있지 않다' 의미 어구 없음"
+ok "self-review.md에 필드 비어 있지 않음 의미 명시"
 
 # ---------------------------------------------------------------------------
 echo ""

--- a/tests/autopilot/test-spec-skill.sh
+++ b/tests/autopilot/test-spec-skill.sh
@@ -261,7 +261,7 @@ grep -qE 'test 코드 변경|테스트 코드 변경|test code change' "$SKILL_M
 ok "test 코드 변경 자동 판단 어구 존재"
 
 # 단발 yes/no 확인 — AC2
-grep -qE '단발 yes/no|단발 (예|aye)/no|단일 yes/no|단발 확인' "$SKILL_MD" \
+grep -qE '단발 yes/no|단발 예/no|단일 yes/no|단발 확인' "$SKILL_MD" \
   || fail "SKILL.md에 'test 변경 sweep 단발 yes/no 확인' 절차 없음"
 ok "단발 yes/no 확인 절차 존재"
 

--- a/tests/autopilot/test-spec-skill.sh
+++ b/tests/autopilot/test-spec-skill.sh
@@ -198,9 +198,10 @@ echo "=== TEST 10: SKILL.md frontmatter allowed-tools에 Agent 포함 ==="
 # allowed-tools는 YAML inline (한 줄) 또는 block list (다음 줄 들여쓰기 `- Agent`) 두 형태 모두
 # valid. frontmatter 안에서 두 형식 중 하나로 Agent 토큰이 나타나면 통과.
 #   - block list 형식:  `^[[:space:]]+-[[:space:]]+Agent[[:space:]]*$`
-#   - inline list 형식: `^allowed-tools:.*[[ ,]Agent([] ,]|$)`
+#   - inline list 형식: `^allowed-tools:.*[[ ,]Agent([],[:space:]]|$)`
+#     ('Agent' 앞은 공백·`[`·`,` 중 하나, 뒤는 `]`·`,`·공백·줄끝 중 하나.)
 awk '/^---$/{c++; next} c==1' "$SKILL_MD" | \
-  grep -qE '^[[:space:]]+-[[:space:]]+Agent[[:space:]]*$|^allowed-tools:.*([[ ,]|^allowed-tools:[[:space:]]*)Agent([],[:space:]]|$)' \
+  grep -qE '^[[:space:]]+-[[:space:]]+Agent[[:space:]]*$|^allowed-tools:.*[[ ,]Agent([],[:space:]]|$)' \
   || fail "SKILL.md frontmatter allowed-tools에 Agent 미포함"
 ok "frontmatter allowed-tools에 Agent 포함"
 


### PR DESCRIPTION
## Summary

SPEC 105 — spec 워크플로의 명확화 라운드에 task scope의 test 코드 변경 자동 판단 절차와, 변경 포함 시 `test_sweep_paths` frontmatter 화이트리스트 자동 채움 절차를 추가한다.

판단 결과 "test 변경 포함"이면 모델이 sweep 후보 경로를 추출해 사용자에게 단발 yes/no로 확인받고, SPEC frontmatter의 `test_sweep_paths` 필드에 기록한다. "변경 없음"이면 추가 prompt 없이 frontmatter에 키 추가하지 않는다. 자체 검토(step 9) 5축 체크에 누락 방지 항목을 한 개 추가한다.

## Commits

- `fc04bba` fix:root(spec): 105 — SKILL.md ↔ test-spec-skill.sh 표현 drift 4건 정합화
- `8694e23` test(spec): 105 — test_sweep_paths 절차 정적 검사 5케이스 + TEST 10 grep 정합화
- `9be78cb` feat(spec): 105 — test 코드 변경 자동 판단·test_sweep_paths 화이트리스트 절차
- `e07cd18` spec(105): add test_sweep_paths whitelist for test-spec-skill.sh (self-referential bind 해소)

## Test Plan

- [x] `bash tests/autopilot/test-spec-skill.sh` 0 exit
- [x] TEST 13 — SKILL.md step 5 자동 판단 절차 명시
- [x] TEST 14 — SKILL.md step 8 치환 룰 명세
- [x] TEST 15 — spec-template.md `{{test_sweep_paths}}` placeholder + commented 예시 보존
- [x] TEST 16 — self-review.md 5축 검사 항목

## History note

원래 loop이 `feat/105-spec-test-test-sweep-paths` 브랜치에서 실행해 commits `959799d`, `db638ec`, `1363964`, `7acdb73`을 만들었으나, spec 워크플로 §9.5.4 ff-merge 패턴이 worker 산출물까지 main에 직접 반영시켜 PR 리뷰 단계가 누락됐다. 본 PR을 위해 commit `7077726`이 main에서 그 4개를 revert했고, 본 브랜치는 동일 commit content·message로 cherry-pick해 재구성했다.

Closes #105