### PR TITLE
autopilot 스킬 지침의 특정 SPEC 참조 제거

### DIFF
--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -99,7 +99,7 @@ for wave in waves:
   while wave 진행 중:
     # references/dispatch.sh watch_wave <m> child1 child2 ...
     각 child의 sentinel watch (sleep 2s 폴링):
-      task 저장소 child issue 에 LOOP_DONE_LABEL 라벨 부착                → 성공 (SPEC 175)
+      task 저장소 child issue 에 LOOP_DONE_LABEL 라벨 부착                → 성공
       milestones/<m>/loops/<c>/.worktree/.loop/ESCALATION.md             → 실패
 
     누군가 ESCALATION (watch_wave exit 101):
@@ -130,7 +130,7 @@ for wave in waves:
 
 이 외 exit code는 dispatch 자체 결함을 의미하므로 즉시 abort + 사용자에게 stderr·exit code 그대로 보고.
 
-**기존 loop과의 분업** — 워크트리·lock·iteration 상한·헌법 준수는 모두 `loop.sh`가 처리. dispatch는 두 sentinel 신호 — task 저장소 child issue 의 `LOOP_DONE_LABEL` 라벨(성공, SPEC 175) 과 워크트리 안 `.loop/ESCALATION.md` 파일(실패) — **존재만** 감시. 외부 셸 루프 표준 유지(in-process Stop 훅 미사용).
+**기존 loop과의 분업** — 워크트리·lock·iteration 상한·헌법 준수는 모두 `loop.sh`가 처리. dispatch는 두 sentinel 신호 — task 저장소 child issue 의 `LOOP_DONE_LABEL` 라벨(성공) 과 워크트리 안 `.loop/ESCALATION.md` 파일(실패) — **존재만** 감시. 외부 셸 루프 표준 유지(in-process Stop 훅 미사용).
 
 ## Subcommand
 

--- a/plugins/autopilot/skills/dispatch/references/dispatch.sh
+++ b/plugins/autopilot/skills/dispatch/references/dispatch.sh
@@ -32,7 +32,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# task 저장소 라벨 헬퍼 공유 (SPEC 175 AC6) — loop.sh 와 동일한
+# task 저장소 라벨 헬퍼 공유 — loop.sh 와 동일한
 # task_status_is_done·task_label_present·LOOP_DONE_LABEL 단일 출처를 source.
 # 위치: plugins/autopilot/skills/loop/references/task-storage.sh.
 # shellcheck source=../../loop/references/task-storage.sh
@@ -100,9 +100,9 @@ child_archive_path() {
 }
 
 # child 의 sentinel 상태: done / escalated / running / idle / missing.
-# 완료(`done`) 검출은 task 저장소(GitHub Issue)의 LOOP_DONE_LABEL 라벨 단일 의존
-# (SPEC 175 AC1). loop.sh 와 동일 helper(task_status_is_done) 를 source 해 공유.
-# ESCALATION 은 워크트리 안의 .loop/ESCALATION.md 파일 sentinel 유지 (SPEC 175 비-목표).
+# 완료(`done`) 검출은 task 저장소(GitHub Issue)의 LOOP_DONE_LABEL 라벨 단일 의존.
+# loop.sh 와 동일 helper(task_status_is_done) 를 source 해 공유.
+# ESCALATION 은 워크트리 안의 .loop/ESCALATION.md 파일 sentinel 유지.
 child_state() {
   local milestone="$1"
   local child="$2"
@@ -336,7 +336,7 @@ cmd_cleanup() {
             continue
             ;;
         esac
-        # cleanup 대상은 done 상태 child — 검출은 child_state(라벨 단일 의존, SPEC 175).
+        # cleanup 대상은 done 상태 child — 검출은 child_state(라벨 단일 의존).
         if [[ "$(child_state "$m" "$child")" == "done" ]]; then
           echo "[$(now_iso)] cleanup $m/$child (완료 라벨 부착, archival 포함)"
           # 메타 파일 archival — loop.sh cmd_cleanup의 step 4와 동일 로직.

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -77,14 +77,14 @@ Skill(skill: "spec", args: "<task-id>")
 
 #### 완료 라벨 부착 이후 PR 생성·재사용 phase (default)
 
-task 가 완료 신호(`LOOP_DONE_LABEL` 라벨 부착)에 도달한 직후 같은 워크트리에서 PR 생성(또는 동일 브랜치의 open PR 재사용) 단계가 **default로 자동 실행**됩니다 (SPEC 103 AC1). 건너뛰려면 `--no-pr` 플래그를 명시(SPEC 103 AC2).
+task 가 완료 신호(`LOOP_DONE_LABEL` 라벨 부착)에 도달한 직후 같은 워크트리에서 PR 생성(또는 동일 브랜치의 open PR 재사용) 단계가 **default로 자동 실행**됩니다. 건너뛰려면 `--no-pr` 플래그를 명시합니다.
 
 활성화 시 동작:
 - default 브랜치 자동 감지 (`gh repo view` → `git symbolic-ref refs/remotes/origin/HEAD`)
-- push 직전에 `origin/<base>`로부터 `git fetch` + 단일 sync helper(`references/rebase-phase.sh`)로 base 동기화 (SPEC 169) — helper가 `git ls-remote --heads origin <branch>`로 원격 트래킹 브랜치 존재 여부를 판정해 두 경로로 분기한다:
+- push 직전에 `origin/<base>`로부터 `git fetch` + 단일 sync helper(`references/rebase-phase.sh`)로 base 동기화 — helper가 `git ls-remote --heads origin <branch>`로 원격 트래킹 브랜치 존재 여부를 판정해 두 경로로 분기한다:
   - **부재 → rebase 경로**: `git rebase origin/<base>`로 history 재배치 (첫 PR 진입 전 깨끗한 linear history)
   - **존재 → merge 경로**: `git merge --ff-only` → 실패 시 non-ff `git merge --no-edit`로 base 변경분만 흡수 (자기 commit SHA 보존, force push 회피)
-- 어떤 경로에서도 force push(`--force`·`--force-with-lease` 포함)는 도입되지 않는다 (SPEC 169 AC4). 충돌 시 claude CLI 세션 1회로 자동 해소 시도(SPEC 169 AC5), 실패 시 해당 모드의 `--abort`로 워크트리 복구 + non-zero exit (보수적 좌절, SPEC 169 AC6)
+- 어떤 경로에서도 force push(`--force`·`--force-with-lease` 포함)는 도입되지 않는다. 충돌 시 claude CLI 세션 1회로 자동 해소 시도, 실패 시 해당 모드의 `--abort`로 워크트리 복구 + non-zero exit (보수적 좌절)
 - 현재 브랜치를 `origin`으로 push
 - 동일 head 브랜치에 open PR이 없으면 **새 PR 생성**, 있으면 **기존 PR을 in-place로 갱신** (제목·body 동기화)
 - PR 제목 = SPEC 문서의 H1, body = SPEC "무엇을 만들 것인가" 본문 + base..HEAD commit log
@@ -93,20 +93,20 @@ task 가 완료 신호(`LOOP_DONE_LABEL` 라벨 부착)에 도달한 직후 같�
 - 성공 시 PR URL·state(open)를 stdout으로 출력, worktree·local 브랜치 보존
 - push·pr create·pr edit 중 하나라도 실패하면 non-zero exit으로 단계 중단 (워크트리는 유지)
 - default 브랜치 감지 실패 시 push·pr 호출 전 abort
-- PR 생성·갱신 직후 **Monitor 단계** 진입 (SPEC 103 AC5): PR check가 모두 완료(success/failure)됐는데 PR state가 OPEN이고 reviewDecision이 없는 "stuck" 패턴을 감지하면 `gh pr checks <num> --rerun`을 호출. 최대 **3회** 재트리거하고 상한 도달 시 stderr에 사용자 개입 안내. MERGED·CLOSED 상태 전이 또는 리뷰 활동(reviewDecision set) 감지 시 즉시 종료. check 진행 중·정보 없음도 stuck 아닌 것으로 간주해 종료. 상한 도달은 경고이며 loop 자체는 정상 종료
-- **Cleanup 안내 단계** (SPEC 103 AC6): Monitor가 PR state를 MERGED 또는 CLOSED로 감지해 종료할 때 셸 드라이버는 "cleanup 후보" 안내(=PR 번호·상태·자동 삭제 차단·수동 cleanup 명령 위치)를 stdout에 명시 출력하고 worktree·feat 브랜치는 그대로 보존한다. 본 스킬을 통한 호출에서 cleanup 안내가 감지되면 `AskUserQuestion`으로 "worktree·feat 브랜치 cleanup 승인?"을 명시 확인하고 사용자의 명시 승인이 있을 때만 `cleanup` 서브커맨드를 호출한다 — 승인 없이 자동 삭제 금지
+- PR 생성·갱신 직후 **Monitor 단계** 진입: PR check가 모두 완료(success/failure)됐는데 PR state가 OPEN이고 reviewDecision이 없는 "stuck" 패턴을 감지하면 `gh pr checks <num> --rerun`을 호출. 최대 **3회** 재트리거하고 상한 도달 시 stderr에 사용자 개입 안내. MERGED·CLOSED 상태 전이 또는 리뷰 활동(reviewDecision set) 감지 시 즉시 종료. check 진행 중·정보 없음도 stuck 아닌 것으로 간주해 종료. 상한 도달은 경고이며 loop 자체는 정상 종료
+- **Cleanup 안내 단계**: Monitor가 PR state를 MERGED 또는 CLOSED로 감지해 종료할 때 셸 드라이버는 "cleanup 후보" 안내(=PR 번호·상태·자동 삭제 차단·수동 cleanup 명령 위치)를 stdout에 명시 출력하고 worktree·feat 브랜치는 그대로 보존한다. 본 스킬을 통한 호출에서 cleanup 안내가 감지되면 `AskUserQuestion`으로 "worktree·feat 브랜치 cleanup 승인?"을 명시 확인하고 사용자의 명시 승인이 있을 때만 `cleanup` 서브커맨드를 호출한다 — 승인 없이 자동 삭제 금지
 
 `--no-pr` 플래그는 셸 드라이버(`loop.sh`)에 직접 전달되며, PR phase 진입 자체를 차단합니다. 이전 버전에서 `request_review: true`로 opt-in을 사용하던 호출자는 별도 마이그레이션이 필요 없습니다(default가 ON으로 변경됐으므로 동일 동작). 이전 버전에서 `request_review: false`(또는 키 미지정)로 PR을 차단하던 호출자는 `--no-pr`로 동일 동작을 재현해야 합니다.
 
 기존 PR body의 사용자 수기 편집 보호를 위해 자동 영역은 `<!-- autopilot:pr-body:begin --> ... <!-- autopilot:pr-body:end -->` marker fence 안에만 작성됩니다.
 
-#### 완료 라벨 부착 이후 PR 리뷰 자동 fix 루프 (SPEC 123, `request_review: true` opt-in)
+#### 완료 라벨 부착 이후 PR 리뷰 자동 fix 루프 (`request_review: true` opt-in)
 
 SPEC frontmatter에 `request_review: true`가 지정된 task만 본 흐름을 진입합니다. PR 생성·재사용이 성공한 직후 다음 sub-phase가 차례·일부 background로 실행됩니다:
 
 | 단계 | 스크립트 | 역할 |
 |---|---|---|
-| pre-PR sync | `references/rebase-phase.sh` | default 브랜치로부터 워크트리 feat 브랜치 동기화 (SPEC 169). 원격 트래킹 부재면 rebase, 존재면 merge 경로. 충돌 시 claude CLI 1회 자동 해소, 실패 시 해당 모드의 `--abort`로 복구 + ESCALATION abort. |
+| pre-PR sync | `references/rebase-phase.sh` | default 브랜치로부터 워크트리 feat 브랜치 동기화. 원격 트래킹 부재면 rebase, 존재면 merge 경로. 충돌 시 claude CLI 1회 자동 해소, 실패 시 해당 모드의 `--abort`로 복구 + ESCALATION abort. |
 | review-fix 루프 (background) | `references/review-fix-phase.sh` | 30초 주기 폴링 (PR comments · review threads · summary). 새 이벤트마다 base 재동기화(sync helper — merge 경로) → claude CLI fix → commit+push → (필요 시) 1개 반박 코멘트. |
 | 자동 머지 (auto-merge) | `references/review-fix-phase.sh` 내부 | reviewDecision `APPROVED` 또는 owner의 종료 코멘트(`/done`·`합격`·`통과`)로 `gh pr merge --squash` 수행. PR이 이미 `merged`이면 자동 머지 건너뜀. |
 | cleanup | `references/cleanup-phase.sh` | PR `merged` 후 worktree 제거 + 로컬 feat `branch -D` + origin feat `push --delete`. |
@@ -150,9 +150,9 @@ review-fix-phase의 silent-fail 검출기(연속 idle 폴링 후 stuck 패턴 es
 | 환경변수 | 기본값 | floor | 의미 |
 |---|---|---|---|
 | `LOOP_REVIEW_IDLE_THRESHOLD` | 3 | 3 | 새 이벤트 0건이 N회 연속 폴링되면 silent-fail 패턴 평가 |
-| `LOOP_REVIEW_PR_GRACE_SECS` | 300 (5분) | 0 | PR 생성 직후 N초 동안은 silent-fail 검출기 평가 자체를 skip — GitHub Actions check 등록 지연·큐 지연 흡수 (SPEC 181). 0으로 설정 시 grace 비활성화 |
+| `LOOP_REVIEW_PR_GRACE_SECS` | 300 (5분) | 0 | PR 생성 직후 N초 동안은 silent-fail 검출기 평가 자체를 skip — GitHub Actions check 등록 지연·큐 지연 흡수. 0으로 설정 시 grace 비활성화 |
 
-검출기는 `statusCheckRollup`의 전체 check 수가 0이면(check 미등록·정보 부족) 해당 폴링 회차의 ESCALATION을 발동하지 않고 카운터만 리셋합니다 (SPEC 181 AC2). 전체 check 수가 0보다 크고 pending 0 + 다른 활동(리뷰·코멘트·inline·owner cmd) 모두 0일 때만 진짜 stuck으로 escalate합니다 (AC3).
+검출기는 `statusCheckRollup`의 전체 check 수가 0이면(check 미등록·정보 부족) 해당 폴링 회차의 ESCALATION을 발동하지 않고 카운터만 리셋합니다. 전체 check 수가 0보다 크고 pending 0 + 다른 활동(리뷰·코멘트·inline·owner cmd) 모두 0일 때만 진짜 stuck으로 escalate합니다.
 
 요구: `gh` CLI 설치 + OAuth 인증.
 
@@ -182,7 +182,7 @@ start 첫 호출에 자동:
 |---|---|
 | `constitution.md` | 워커 헌법. start 시점에 워크트리 CLAUDE.md로 복사 |
 | `loop.sh` | 외부 셸 드라이버. 모든 subcommand의 핵심 로직 |
-| `task-storage.sh` | task 저장소 라벨 검출 공통 헬퍼 (loop.sh·dispatch.sh 공유, SPEC 175) |
+| `task-storage.sh` | task 저장소 라벨 검출 공통 헬퍼 (loop.sh·dispatch.sh 공유) |
 | `pr-phase.sh` | 완료 라벨 부착 이후 PR 생성·재사용 단계 |
 | `operational-guide.md` | 사용자용 운영 가이드 (워크플로·환경 변수·객관 게이트 표·의존성) |
 | `status-format.md` | status 출력 형식 가이드 |

--- a/plugins/autopilot/skills/loop/references/cleanup-phase.sh
+++ b/plugins/autopilot/skills/loop/references/cleanup-phase.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# cleanup-phase.sh — SPEC 123 M3
+# cleanup-phase.sh
 #
 # PR이 MERGED 상태로 전이된 직후 호출되어 워크트리·로컬 feat·원격 feat 브랜치를
 # 차례로 정리하고, 추상 상태를 "Done"으로 전이한다.
@@ -7,7 +7,7 @@
 # 사용:
 #   bash cleanup-phase.sh <worktree> <branch> <task-id> <project-root>
 #
-# 동작 (SPEC 123 AC16·AC17):
+# 동작:
 #   1. 사전 검사: 워크트리에 미커밋 변경 없음 (git status --porcelain 비어 있음)
 #   2. git worktree remove <wt>
 #   3. git branch -D <branch>            (로컬 feat 삭제)
@@ -16,7 +16,7 @@
 #      (환경변수 LOOP_PROJECT_ID·LOOP_STATUS_FIELD_ID·LOOP_STATUS_DONE_OPTION_ID 부재 시
 #       무음 skip하여 phase 자체는 계속 진행)
 #   6. 어떤 단계가 비-zero exit이면 stdout에 "ESCALATION cleanup-phase: ..." emit
-#      후 비-zero exit (SPEC 123 AC19).
+#      후 비-zero exit.
 
 set -euo pipefail
 

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 # ----- 스크립트 자신의 디렉토리 (references/) -----
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# ----- allowed-tools (SPEC 123 AC18) -----
+# ----- allowed-tools -----
 #
 # 완료 신호 이후 PR 생애주기 자동화 phase 그룹(rebase·review-fix·cleanup)의 *자식 claude CLI
 # 세션*(rebase 충돌 자동 해소, review-fix iter) 전용 도구 권한. review-fix-phase가
@@ -56,15 +56,14 @@ Bash(ls:*),\
 Read,Edit,Write,Glob,Grep"
 export AUTOPILOT_REBASE_ALLOWED_TOOLS
 
-# ----- task storage 검출 키 (SPEC 134 AC4) -----
+# ----- task storage 검출 키 -----
 #
 # 완료 신호의 검출 키는 task 식별자에 부속된 label 이름이다 (헌법 §12, SKILL.md).
 # 워커가 완료 시 `[done]` prefix comment(가독·로그)와 본 label 추가(검출 키)를 모두
 # 수행해야 드라이버가 done으로 판정한다. comment 본문은 더 이상 단일 검출 키가 아니다.
 #
 # LOOP_DONE_LABEL·task_issue_number·task_label_present·ensure_label_exists·
-# task_status_is_done 는 dispatch.sh 와 공유 (SPEC 175 AC6) — task-storage.sh
-# 단일 출처를 양쪽이 source 한다.
+# task_status_is_done 는 dispatch.sh 와 공유 — task-storage.sh 단일 출처를 양쪽이 source 한다.
 # shellcheck source=./task-storage.sh
 source "$SCRIPT_DIR/task-storage.sh"
 
@@ -107,15 +106,15 @@ normalize_task_id() {
 
 # ----- task ↔ GitHub issue 매핑 -----
 # task_issue_number·task_label_present·ensure_label_exists·task_status_is_done
-# 정의는 task-storage.sh 단일 출처 (SPEC 175 AC6 — dispatch.sh 와 공유).
+# 정의는 task-storage.sh 단일 출처 (dispatch.sh 와 공유).
 
-# task issue의 차단 신호 검사 (헌법 §5·§12, SPEC 134 §제약).
+# task issue의 차단 신호 검사 (헌법 §5·§12).
 # 정식 검출 키: Project Status field 값(`Blocked`) 단일 의존. comment 본문은 가독·
 # 로그 채널이며 판정에 사용되지 않는다 — 워커가 [blocked] prefix comment 발행과
 # 함께 Status=Blocked 전이 두 동작을 모두 수행해야 0(blocked)을 반환한다.
 # graceful degradation: AUTOPILOT_PROJECT_ITEM_ID 미설정·gh 부재·GraphQL 실패는
-# 1(판정 불가)로 조용히 폴백한다 (검출 키를 comment로 이중화하지 않는다 — SPEC 134
-# §제약 "판정 키는 label·status 단일 의존을 깨지 않는다"). 침묵 폴백 이유: 본 함수는
+# 1(판정 불가)로 조용히 폴백한다 (검출 키를 comment로 이중화하지 않는다 —
+# "판정 키는 label·status 단일 의존을 깨지 않는다"). 침묵 폴백 이유: 본 함수는
 # `list` 서브커맨드의 task별 순회와 `--watch` 모드의 60초 polling 루프에서 호출되어
 # WARN을 매번 출력하면 로그 플러딩 — 미설정 환경에서 idle 판정으로 자연 폴백하는 게
 # 설계 의도다. 디버깅 시 `gh api graphql` 직접 호출로 원인 분리.
@@ -298,7 +297,7 @@ compute_paths() {
   local milestone="${task_id%%/*}"
   local child="${task_id#*/}"
 
-  # SPEC 116 단일 컨벤션: feat 브랜치 이름의 slug 가 디렉토리 이름의 suffix.
+  # 단일 컨벤션: feat 브랜치 이름의 slug 가 디렉토리 이름의 suffix.
   # find_feat_branch 가 input-id (child) 만으로 `feat/<child>-<slug>` 또는 `feat/<child>` 를 찾는다.
   # 매칭 없음(rc=1)은 legacy/uninitialized 상태로 간주해 slug-less fallback.
   # 매칭 2+ (rc=2)는 모호성으로 즉시 die.
@@ -340,7 +339,7 @@ compute_paths() {
 }
 
 # feat 브랜치 검색: input-id (정규화된 task-id 의 child 컴포넌트) 만으로 `feat/<id>` 또는
-# `feat/<id>-<slug>` 패턴을 찾는다. SPEC 116 단일 컨벤션 — milestone prefix 는 사용하지 않는다.
+# `feat/<id>-<slug>` 패턴을 찾는다. 단일 컨벤션 — milestone prefix 는 사용하지 않는다.
 #
 # 반환:
 #   0 + stdout 에 단일 브랜치 이름     — 매칭 정확히 1개
@@ -367,7 +366,7 @@ find_feat_branch() {
   return 0
 }
 
-# feat 브랜치 이름에서 slug 추출. SPEC 116 단일 컨벤션 — `feat/<child>-<slug>` 패턴의 suffix.
+# feat 브랜치 이름에서 slug 추출. 단일 컨벤션 — `feat/<child>-<slug>` 패턴의 suffix.
 # 인자: $1 = child(input-id), $2 = branch 이름.
 # stdout: slug, 또는 빈 문자열(slug-less 브랜치·형식 불일치 시).
 slug_from_feat_branch() {
@@ -545,7 +544,7 @@ diff_vs_scope() {
   exclude_patterns=$(echo "$scope_yaml" | yq '.scope.exclude[]' 2>/dev/null || true)
   # 커밋된 diff: BASE..HEAD (워크트리 생성 시점부터 누적 변경) — HEAD~1..HEAD는 한 이터에 commit이
   # 2개 이상(워커 코드 commit + 드라이버 메타 commit) 발생할 때 가장 최근 commit만 보여 직전 commit의
-  # 위반을 false-negative로 통과시키는 결함이 있다 (SPEC 81). BASE..HEAD는 누적이라 모든 이터의
+  # 위반을 false-negative로 통과시키는 결함이 있다. BASE..HEAD는 누적이라 모든 이터의
   # 모든 commit을 포함하지만, 이전 이터의 in-scope commit은 재검사돼도 동일하게 통과한다.
   # 작업 트리 변경: claude 비정상 종료로 미커밋 변경이 남는 경우 추가로 차단.
   committed=$(cd "$WT" && git diff --name-only "$base_sha" HEAD 2>/dev/null || true)
@@ -562,8 +561,8 @@ diff_vs_scope() {
     # CLAUDE.md는 SPEC scope.exclude로 통제 — skip-worktree로 보통은 diff에 안 잡히지만,
     # 워커가 unskip + commit하면 여기서 정상 catch되어야 함 (워크트리 셋업 직후 자동 skip 처리).
     # SPEC.md(워커 명세)는 milestones/<m>/loops/<c>/ 단일 트리 안에 있으므로 그 경로 패턴으로
-    # 제외. 종료 신호는 task 저장소 LOOP_DONE_LABEL 라벨 단일 의존이라 워크트리 파일이 없다
-    # (SPEC 175). 이터간 메타(handoff/notes/done/blocked)는 task issue body·prefix
+    # 제외. 종료 신호는 task 저장소 LOOP_DONE_LABEL 라벨 단일 의존이라 워크트리 파일이 없다.
+    # 이터간 메타(handoff/notes/done/blocked)는 task issue body·prefix
     # comments로 위임됐으므로 워크트리 파일이 존재하지 않는다 (헌법 §11).
     case "$file" in
       milestones/*/loops/*/SPEC.md) continue ;;
@@ -607,7 +606,7 @@ grep_new_suppressors() {
   # 커밋된 diff(BASE..HEAD) + working tree 변경 양쪽 검사 (미커밋 suppressor도 catch).
   # SPEC.md는 워커 명세(헌법 인용 등 false positive 발생)이므로 검사 제외.
   # 이터간 메타는 task issue body·prefix comments로 위임됐으므로 워크트리 파일 검사 대상 아님 (헌법 §11).
-  # BASE..HEAD 근거는 diff_vs_scope 주석 참조 (SPEC 81).
+  # BASE..HEAD 근거는 diff_vs_scope 주석 참조.
   local base_sha="$1"
   cd "$WT" || return
   local meta_exclude=(
@@ -624,7 +623,7 @@ grep_new_suppressors() {
 
 check_secrets() {
   command -v gitleaks >/dev/null 2>&1 || return 0
-  # BASE..HEAD 누적 commit + 미커밋 staged 양쪽 검사. BASE..HEAD 근거는 diff_vs_scope 주석 참조 (SPEC 81).
+  # BASE..HEAD 누적 commit + 미커밋 staged 양쪽 검사. BASE..HEAD 근거는 diff_vs_scope 주석 참조.
   # 비고: gitleaks는 unstaged-tracked 변경의 직접 스캔 옵션이 없음 (--no-git은 워크트리
   #       전체 스캔이라 노이즈 큼) → unstaged-tracked는 본 게이트의 의도된 미커버.
   #       헌법이 매 이터 commit 강제하므로 일반 흐름에선 gap 없음.
@@ -637,7 +636,7 @@ check_secrets() {
 
 # 워크트리 생성 시점의 부모 브랜치 HEAD SHA를 읽어 반환. 부재·빈값이면 비-0 exit.
 # BASE 메타는 `$WT/.iterations/BASE_SHA` 단일 파일 (info/exclude로 자기 참조 회피).
-# 워크트리 생성 시 1회 기록되며 이후 변경되지 않는다 (SPEC 81 AC1).
+# 워크트리 생성 시 1회 기록되며 이후 변경되지 않는다.
 read_base_sha() {
   local f="$WT/.iterations/BASE_SHA"
   [[ -f "$f" ]] || return 1
@@ -780,13 +779,13 @@ iterate() {
     CLAUDE_FAIL_STREAK=0
   fi
 
-  # 종료 신호 검사 (먼저) — 헌법 §12, SPEC 150.
+  # 종료 신호 검사 (먼저) — 헌법 §12.
   # 검출 키: task 저장소에 LOOP_DONE_LABEL이 붙어 있는지 (task_status_is_done) 단일 의존.
   if task_status_is_done "$TASK_ID"; then
     return 100   # 메인 루프에서 정상 종료 처리
   fi
   # 워커가 진행 불가 보고 시 task issue에 [blocked] prefix comment + Status=Blocked 전이 (헌법 §5.2).
-  # 드라이버는 Project Status=Blocked 단일 의존으로 차단 신호를 감지한다 (SPEC 134 §제약).
+  # 드라이버는 Project Status=Blocked 단일 의존으로 차단 신호를 감지한다.
   if task_status_is_blocked "$TASK_ID"; then
     return 101   # 메인 루프에서 [blocked] 처리
   fi
@@ -802,8 +801,8 @@ iterate() {
     halt "의존성 변경 — 매니페스트 해시 변경"
   fi
 
-  # BASE SHA 메타 — 워크트리 생성 시점의 부모 브랜치 HEAD. 게이트 diff 비교 기준 (SPEC 81 AC2).
-  # 부재 시 명확한 에러로 halt (AC6: false-positive 통과 차단).
+  # BASE SHA 메타 — 워크트리 생성 시점의 부모 브랜치 HEAD. 게이트 diff 비교 기준.
+  # 부재 시 명확한 에러로 halt (false-positive 통과 차단).
   local base_sha
   if ! base_sha=$(read_base_sha); then
     halt "BASE SHA 메타 부재 — 워크트리 ${WT}의 .iterations/BASE_SHA 파일이 없습니다. 본 변경 이전에 생성된 pre-existing 워크트리로 의심됩니다. cleanup 후 재생성 필요 (loop.sh cleanup ${TASK_ID})."
@@ -873,8 +872,8 @@ cmd_start() {
         shift 2
         ;;
       --no-pr)
-        # AC2 (SPEC 103): PR 자동 생성 opt-out. 지정 시 완료 라벨 부착 직후 PR phase 건너뜀.
-        # default(없음): PR phase가 실행됨 (AC1).
+        # PR 자동 생성 opt-out. 지정 시 완료 라벨 부착 직후 PR phase 건너뜀.
+        # default(없음): PR phase가 실행됨.
         no_pr=1
         shift
         ;;
@@ -942,10 +941,10 @@ cmd_start() {
   # 5. 락 획득
   acquire_lock
 
-  # 5.5. 완료 신호 label self-bootstrap (SPEC 134 AC5).
+  # 5.5. 완료 신호 label self-bootstrap.
   # task storage에 LOOP_DONE_LABEL이 없으면 자동 생성. 권한 부족·gh 부재 시
   # WARN 후 비차단 — 워커가 label 추가에 실패하면 완료 검출이 누락되므로
-  # 헌법 §11.2가 워커에게 label 부착 동작을 강제한다 (SPEC 150).
+  # 헌법 §11.2가 워커에게 label 부착 동작을 강제한다.
   ensure_label_exists "$LOOP_DONE_LABEL" || true
 
   # 6. 워크트리 생성 (없는 경우)
@@ -964,7 +963,7 @@ cmd_start() {
       die "feat 브랜치 ${BRANCH} 워크트리 HEAD에 SPEC.md 부재 (기대: $WT/$LOOPS_DIR_REL/SPEC.md)"
     fi
 
-    # BASE SHA 메타 캡처 (SPEC 81 AC1) — 워크트리 생성 직후, baseline commit 전.
+    # BASE SHA 메타 캡처 — 워크트리 생성 직후, baseline commit 전.
     # 게이트(scope·suppressor·secret)의 BASE..HEAD diff 기준점. BASE_SHA는 git add된 적
     # 없는 untracked 파일이므로 `git diff --name-only` 시야 밖 — 자기 참조 게이트 검사에
     # 잡히지 않는다. info/exclude는 별개 효과로 워크트리 git status에서 `.iterations/`
@@ -994,8 +993,8 @@ cmd_start() {
     # 워크트리에는 메타 파일을 시드·commit하지 않는다 — feat 브랜치 HEAD가 그대로 BASE SHA가 된다.
 
     # 워크트리 로컬 비추적 등록 — .iterations/는 iter raw 로그, 어떤 git 브랜치에도
-    # commit되지 않음. 완료 신호는 task 저장소 라벨 단일 의존이라 워크트리 파일이 없다
-    # (SPEC 175) — exclude 패턴에서 제외.
+    # commit되지 않음. 완료 신호는 task 저장소 라벨 단일 의존이라 워크트리 파일이 없으므로
+    # exclude 패턴에서 제외.
     # 등록 위치 선택: --git-common-dir (공유 commondir의 info/exclude).
     # 배경: git은 워크트리별 $GIT_DIR/info/exclude(--git-dir)도 참조하지만 그 효과는
     #       해당 워크트리에만 한정된다. 본 패턴(CLAUDE.md·.iterations/)은 본 task의
@@ -1035,15 +1034,15 @@ cmd_start() {
     if [[ $iter_status -eq 100 ]]; then
       echo "[$(now_iso)] 완료 신호(LOOP_DONE_LABEL) 감지. 정상 종료."
 
-      # PR 생성·재사용 phase. SPEC 103 AC1: default로 실행 (opt-in 플래그 불필요).
-      # SPEC 103 AC2: --no-pr 플래그가 지정되면 건너뜀.
+      # PR 생성·재사용 phase. default로 실행 (opt-in 플래그 불필요).
+      # --no-pr 플래그가 지정되면 건너뜀.
       # 워크트리·로컬 브랜치는 후속 단계(리뷰 모니터·자동 fix)를 위해 보존한다.
       if (( no_pr == 1 )); then
         echo "[$(now_iso)] --no-pr 플래그 감지 — PR phase 건너뜀"
       else
-        # ----- SPEC 123: request_review opt-in 감지 (PR phase 진입 *전*에 확정) -----
-        # AC#1·#3: opt-in 활성 시 PR phase 진입 *직전*에 pre-PR rebase 실행.
-        # AC#4·#12·#16·#17: opt-in 활성 시 PR phase 직후 review-fix-phase background dispatch.
+        # ----- request_review opt-in 감지 (PR phase 진입 *전*에 확정) -----
+        # opt-in 활성 시 PR phase 진입 *직전*에 pre-PR rebase 실행.
+        # opt-in 활성 시 PR phase 직후 review-fix-phase background dispatch.
         local spec_md="$WT/$LOOPS_DIR_REL/SPEC.md"
         local request_review_val=""
         if [[ -f "$spec_md" ]]; then
@@ -1155,7 +1154,7 @@ cmd_status() {
   PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
     || die "git 저장소 안에서 실행해야 합니다."
 
-  # filter 지정 시 task-id 검증 + 정규화 (단일 컴포넌트 → regular/) + SPEC 116
+  # filter 지정 시 task-id 검증 + 정규화 (단일 컴포넌트 → regular/) +
   # slug-bearing 디렉토리 매핑 (feat 브랜치 발견 시).
   if [[ -n "$filter_task_id" ]]; then
     validate_task_id "$filter_task_id"
@@ -1235,7 +1234,7 @@ cmd_status() {
     if [[ -f "$lock_file" ]]; then
       state="running"
     elif [[ -d "$wt" ]]; then
-      # 차단 신호는 task issue의 Project Status=Blocked 단일 의존 (SPEC 134 §제약).
+      # 차단 신호는 task issue의 Project Status=Blocked 단일 의존.
       # gh 부재·미설정 시 task_status_is_blocked가 1을 반환해 자연스럽게 idle로 떨어진다.
       if task_status_is_blocked "$tid"; then
         state="blocked"
@@ -1410,7 +1409,7 @@ cmd_cleanup() {
     *) die "워크트리 경로 형식 부적절 (기대: */milestones/<m>/loops/<c>/.worktree): $WT" ;;
   esac
 
-  # 3. 완료 확인 — task 저장소 label 단일 의존 (SPEC 150).
+  # 3. 완료 확인 — task 저장소 label 단일 의존.
   if ! task_status_is_done "$task_id" && [[ $force -eq 0 ]]; then
     die "task $task_id 에 완료 신호가 없습니다 (LOOP_DONE_LABEL 미부착).\n--force 없이 cleanup하려면 먼저 task 저장소에 label이 붙어야 합니다: $0 cleanup $task_id --force"
   fi

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -1154,8 +1154,7 @@ cmd_status() {
   PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" \
     || die "git 저장소 안에서 실행해야 합니다."
 
-  # filter 지정 시 task-id 검증 + 정규화 (단일 컴포넌트 → regular/) +
-  # slug-bearing 디렉토리 매핑 (feat 브랜치 발견 시).
+  # filter 지정 시 task-id 검증 + 정규화 (단일 컴포넌트 → regular/) + slug-bearing 디렉토리 매핑 (feat 브랜치 발견 시).
   if [[ -n "$filter_task_id" ]]; then
     validate_task_id "$filter_task_id"
     filter_task_id="$(normalize_task_id "$filter_task_id")"

--- a/plugins/autopilot/skills/loop/references/operational-guide.md
+++ b/plugins/autopilot/skills/loop/references/operational-guide.md
@@ -31,7 +31,7 @@ milestones/<m>/loops/<c>/
     ├── .iterations/<n>.log    # 매 이터 stdout 캡처 (gitignored, worktree-local)
     └── milestones/<m>/loops/<c>/
         └── SPEC.md            # feat 브랜치 commit으로 자연 노출
-# 완료 신호는 task 저장소의 LOOP_DONE_LABEL 라벨 단일 의존 — 워크트리 sentinel 파일 없음 (SPEC 175)
+# 완료 신호는 task 저장소의 LOOP_DONE_LABEL 라벨 단일 의존 — 워크트리 sentinel 파일 없음
 # 이터간 상태(계획·교훈·인계·차단·완료)는 워크트리에 두지 않고 task 메모리·task 신호로 위임 (헌법 §11)
 ```
 

--- a/plugins/autopilot/skills/loop/references/pr-phase.sh
+++ b/plugins/autopilot/skills/loop/references/pr-phase.sh
@@ -58,10 +58,10 @@ if [[ -z "$DEFAULT_BRANCH" ]]; then
 fi
 
 # ----- SPEC 제목·본문 추출 (M3) -----
-# TASK_ID 는 정규화된 '<milestone>/<child>' 형태. SPEC 116 단일 컨벤션:
+# TASK_ID 는 정규화된 '<milestone>/<child>' 형태. 단일 컨벤션:
 # SPEC.md 는 워크트리 안의 `milestones/<m>/loops/<child>-<slug>/SPEC.md` 단일 경로에서 읽는다.
 # slug 는 $BRANCH (`feat/<child>-<slug>`) 이름에서 추출 — spec 스킬·loop 드라이버와 동일 키.
-# SPEC 116 EARS AC4: "다른 경로 fallback은 없다" — slug-less 경로는 의도적으로 미지원.
+# 다른 경로 fallback은 없다 — slug-less 경로는 의도적으로 미지원.
 SPEC_MILESTONE="${TASK_ID%%/*}"
 SPEC_CHILD="${TASK_ID#*/}"
 SPEC_SLUG_FROM_BRANCH=""
@@ -70,7 +70,7 @@ if [[ "$BRANCH" == "${SPEC_BRANCH_PREFIX}-"* ]]; then
   SPEC_SLUG_FROM_BRANCH="${BRANCH#${SPEC_BRANCH_PREFIX}-}"
 fi
 if [[ -z "$SPEC_SLUG_FROM_BRANCH" ]]; then
-  echo "ERROR: slug 추출 실패 — BRANCH='$BRANCH'가 'feat/${SPEC_CHILD}-<slug>' 형식 아님. SPEC 116 단일 컨벤션 위반." >&2
+  echo "ERROR: slug 추출 실패 — BRANCH='$BRANCH'가 'feat/${SPEC_CHILD}-<slug>' 형식 아님. 단일 컨벤션 위반." >&2
   exit 1
 fi
 SPEC_FILE="$WT/milestones/${SPEC_MILESTONE}/loops/${SPEC_CHILD}-${SPEC_SLUG_FROM_BRANCH}/SPEC.md"
@@ -113,13 +113,13 @@ collect_commit_log() {
 # SHA를 재작성하면 PR body '## Commits' 섹션이 구 SHA를 표시하기 때문. SPEC_TITLE·WHAT_SECTION은
 # sync 영향을 받지 않으므로 위에서 미리 추출해 둔다.
 
-# ----- base 동기화 (SPEC 169) -----
+# ----- base 동기화 -----
 # 단일 sync helper(rebase-phase.sh)를 통해 fetch + 동기화를 수행한다. helper가 원격 트래킹
 # 브랜치 존재 여부를 검사해 rebase / merge 경로로 분기하므로 본 phase는 직접 `git rebase`·
-# `git merge`를 호출하지 않는다 (SPEC 169 AC7). force push도 helper·본 phase 모두에서 부재
-# (AC4). 충돌 자동 해소(1회) 및 실패 시 워크트리 abort 복구는 helper 책임.
+# `git merge`를 호출하지 않는다. force push도 helper·본 phase 모두에서 부재.
+# 충돌 자동 해소(1회) 및 실패 시 워크트리 abort 복구는 helper 책임.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-echo "[pr-phase] base 동기화 → $SCRIPT_DIR/rebase-phase.sh (SPEC 169 sync helper)"
+echo "[pr-phase] base 동기화 → $SCRIPT_DIR/rebase-phase.sh (sync helper)"
 if ! bash "$SCRIPT_DIR/rebase-phase.sh" "$WT" "$BRANCH" "$PROJECT_ROOT"; then
   echo "ERROR: base 동기화 실패 — PR 단계 abort (helper의 ESCALATION 로그 참조)" >&2
   exit 1
@@ -217,7 +217,7 @@ else
   echo "PR state: open"
 fi
 
-# ----- Monitor: stuck PR check 재트리거 (SPEC 103 M4/AC5) -----
+# ----- Monitor: stuck PR check 재트리거 -----
 # PR 생성·갱신 직후 같은 셸에서 동기적으로 PR check 상태를 polling한다.
 # "stuck" 패턴 = (1) PR state OPEN + (2) reviewDecision 없음 (리뷰 미발생) +
 #                (3) check가 모두 완료(COMPLETED state)된 상태.
@@ -242,11 +242,11 @@ else
     monitor_pr_state=$( cd "$WT" && gh pr view "$monitor_pr_number" --json state --jq '.state' 2>/dev/null || printf '' )
     if [[ "$monitor_pr_state" == "MERGED" || "$monitor_pr_state" == "CLOSED" ]]; then
       echo "[pr-phase] PR 상태=$monitor_pr_state — Monitor 종료 (lifecycle 완료 단계)"
-      # SPEC 103 M5/AC6: cleanup 후보 안내. 자동 삭제는 하지 않으며 사용자 명시 승인 필요.
+      # cleanup 후보 안내. 자동 삭제는 하지 않으며 사용자 명시 승인 필요.
       # 셸 드라이버는 안내만 출력하고, 실제 cleanup은 사용자가 'loop.sh cleanup <task-id>'를
       # 명시 호출하거나 SKILL 계층에서 AskUserQuestion 승인을 거친 뒤에만 수행한다.
       echo "[pr-phase] cleanup 후보: PR #$monitor_pr_number 가 $monitor_pr_state 상태 — worktree·feat 브랜치 정리 가능."
-      echo "[pr-phase] 자동 삭제하지 않습니다 (AC6). 명시 승인 후 'loop.sh cleanup <task-id>'로 수동 정리하세요."
+      echo "[pr-phase] 자동 삭제하지 않습니다. 명시 승인 후 'loop.sh cleanup <task-id>'로 수동 정리하세요."
       break
     fi
 

--- a/plugins/autopilot/skills/loop/references/rebase-phase.sh
+++ b/plugins/autopilot/skills/loop/references/rebase-phase.sh
@@ -23,7 +23,7 @@
 #   6. 어떤 단계든 비-zero exit 시 stdout 첫 줄에 "ESCALATION" prefix를 출력해
 #      caller(loop.sh·pr-phase.sh·review-fix-phase.sh)가 종료 신호로 감지하게 한다.
 #
-# 파일명은 `rebase-phase.sh` 로 유지 — 의미는 "sync helper" 이며 본 스크립트가 두 모드를 모두 책임진다.
+# 파일명은 `rebase-phase.sh` 로 유지(rename은 환경변수·문서 파급 회피) — 의미는 "sync helper" 이며 본 스크립트가 두 모드를 모두 책임진다.
 
 set -euo pipefail
 

--- a/plugins/autopilot/skills/loop/references/rebase-phase.sh
+++ b/plugins/autopilot/skills/loop/references/rebase-phase.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# rebase-phase.sh — SPEC 123 M1 + SPEC 169 push sync policy
+# rebase-phase.sh — push sync policy
 #
 # PR 생성·재사용 직전, 그리고 review-fix 루프의 각 fix iter 직전에 호출되는 단일 sync helper.
 # 워크트리의 feat 브랜치를 default 브랜치로 동기화한다.
 #
-# 동기화 모드 (SPEC 169):
+# 동기화 모드:
 #   - 원격 트래킹 브랜치 부재 → rebase 경로 (history 재배치, 깨끗한 linear history)
 #   - 원격 트래킹 브랜치 존재 → merge 경로 (자기 commit SHA 보존, force push 회피)
 # 두 경로 어디서도 force push(`--force`·`--force-with-lease` 포함)를 도입하지 않는다.
@@ -18,13 +18,12 @@
 #   3. `git ls-remote --heads origin <branch>`로 원격 브랜치 존재 여부 판정 → SYNC_MODE
 #   4. rebase 경로: `git rebase origin/<default>`
 #      merge  경로: `git merge --ff-only origin/<default>` → 실패 시 non-ff `git merge --no-edit`
-#   5. 충돌 시 claude CLI 세션 1회로 자동 해소 시도 (SPEC 123 AC2 / SPEC 169 AC5).
+#   5. 충돌 시 claude CLI 세션 1회로 자동 해소 시도.
 #      - claude 미설치·세션 실패·해소 후 잔존 → 해당 모드의 abort 명령으로 워크트리 복구 + 비-zero exit.
 #   6. 어떤 단계든 비-zero exit 시 stdout 첫 줄에 "ESCALATION" prefix를 출력해
 #      caller(loop.sh·pr-phase.sh·review-fix-phase.sh)가 종료 신호로 감지하게 한다.
 #
-# 파일명은 SPEC 169 이후에도 `rebase-phase.sh` 그대로 유지(rename은 환경변수·문서 파급 회피로 SPEC 범위 외).
-# 의미는 "sync helper" — 본 스크립트 자체는 두 모드를 모두 책임진다.
+# 파일명은 `rebase-phase.sh` 로 유지 — 의미는 "sync helper" 이며 본 스크립트가 두 모드를 모두 책임진다.
 
 set -euo pipefail
 
@@ -68,7 +67,7 @@ if ! ( cd "$WT" && git fetch origin "$DEFAULT_BRANCH" 2>&1 ); then
   exit 1
 fi
 
-# ----- 동기화 모드 판정 (SPEC 169 AC1) -----
+# ----- 동기화 모드 판정 -----
 # `git ls-remote --heads --exit-code origin <branch>`는 원격에 해당 ref가 있으면 0,
 # 없으면 2를 반환. 원격에 자기 브랜치가 이미 존재하면 history 재작성이 force push를
 # 강제하므로 merge로 base 변경분만 흡수한다. 부재 시(첫 PR 진입 전)는 깨끗한 linear
@@ -85,8 +84,7 @@ fi
 echo "[rebase-phase] sync mode: $SYNC_MODE (origin/$BRANCH $( [[ $SYNC_MODE == merge ]] && echo present || echo absent ))"
 
 # allowed-tools는 caller(loop.sh)에서 export한 환경 변수 또는 본 스크립트 기본값.
-# 환경 변수 이름은 SPEC 169 이후에도 `AUTOPILOT_REBASE_ALLOWED_TOOLS` 유지 — rename은
-# SPEC 169 범위 외(파급 회피).
+# 환경 변수 이름은 `AUTOPILOT_REBASE_ALLOWED_TOOLS` 로 고정.
 ALLOWED_TOOLS_REBASE="${AUTOPILOT_REBASE_ALLOWED_TOOLS:-Bash(git add:*),Bash(git status:*),Bash(git diff:*),Bash(cat:*),Bash(ls:*),Read,Edit,Write}"
 
 # ----- 공통 충돌 해소 helper (claude CLI 1회) -----
@@ -140,7 +138,7 @@ EOF
   return 0
 }
 
-# ----- rebase 경로 (SPEC 169 AC2): 원격 트래킹 부재 → history 재배치 -----
+# ----- rebase 경로: 원격 트래킹 부재 → history 재배치 -----
 if [[ "$SYNC_MODE" == "rebase" ]]; then
   echo "[rebase-phase] rebase onto origin/$DEFAULT_BRANCH"
   if ( cd "$WT" && git rebase "origin/$DEFAULT_BRANCH" 2>&1 ); then
@@ -168,7 +166,7 @@ if [[ "$SYNC_MODE" == "rebase" ]]; then
   exit 1
 fi
 
-# ----- merge 경로 (SPEC 169 AC3): 원격 트래킹 존재 → 자기 SHA 보존 -----
+# ----- merge 경로: 원격 트래킹 존재 → 자기 SHA 보존 -----
 # 1차 ff-only: base 변화 없음 또는 feat가 base의 후손인 경우 no-op으로 통과 (불필요 merge commit 회피).
 # 2차 non-ff:  diverged base를 흡수해 새 merge commit 생성. 자기 commit SHA는 그대로 reachable.
 echo "[rebase-phase] merge from origin/$DEFAULT_BRANCH (ff-only 우선 시도)"

--- a/plugins/autopilot/skills/loop/references/review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/references/review-fix-phase.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# review-fix-phase.sh — SPEC 123 M2
+# review-fix-phase.sh
 #
 # DONE → PR 생성·재사용이 끝난 직후 background로 띄워지는 리뷰 fix 루프.
 # request_review: true opt-in일 때만 loop.sh가 호출한다.
@@ -7,28 +7,28 @@
 # 사용:
 #   bash review-fix-phase.sh <worktree> <branch> <task-id> <project-root> <pr-number>
 #
-# 동작 (SPEC 123 AC4·AC5·AC6·AC7·AC8·AC9·AC10·AC11·AC12·AC13·AC14·AC15·AC16):
+# 동작:
 #   1. 추상 상태 "리뷰 관련 상태" (Review) 전이 — gh project item-edit (envvar 부재 시 skip).
 #   2. LOOP_REVIEW_POLL_SECS(기본 30초) 주기로 폴링:
-#        a. PR state — MERGED → cleanup-phase 호출 후 종료 (auto-merge skip, AC13).
-#                       CLOSED(unmerged) → 모든 후속 단계 skip 후 종료 (AC15).
-#        b. reviewDecision == APPROVED → gh pr merge 시도, 성공 시 cleanup → 종료 (AC14).
+#        a. PR state — MERGED → cleanup-phase 호출 후 종료 (auto-merge skip).
+#                       CLOSED(unmerged) → 모든 후속 단계 skip 후 종료.
+#        b. reviewDecision == APPROVED → gh pr merge 시도, 성공 시 cleanup → 종료.
 #        c. owner의 코멘트 본문에 '/done' OR '합격' OR '통과' → gh pr merge → cleanup → 종료.
 #        d. 신규 PR-level comments · review threads · review summary 수집:
 #             - last-seen ID dedup, 없으면 sleep로 돌아감.
 #             - 새 이벤트 발견 시:
-#                 i.  요약 한 줄 stdout emit (AC6).
-#                 ii. rebase-phase.sh 호출 (AC7).
-#                 iii. claude CLI fix 세션 (AC8).
-#                 iv. 코드 변경 시 commit + push (AC9).
-#                 v.  세션 결과가 "DISPUTE: ..."로 시작하면 그 본문을 1개 PR 코멘트로 게시 (AC10).
-#                     AC11: 이 외 어떤 GitHub 게시도 수행하지 않음.
+#                 i.  요약 한 줄 stdout emit.
+#                 ii. rebase-phase.sh 호출.
+#                 iii. claude CLI fix 세션.
+#                 iv. 코드 변경 시 commit + push.
+#                 v.  세션 결과가 "DISPUTE: ..."로 시작하면 그 본문을 1개 PR 코멘트로 게시.
+#                     이 외 어떤 GitHub 게시도 수행하지 않음.
 #   3. LOOP_REVIEW_MAX_ITER 도달 시 무한 폴링 방지로 종료 (안전장치).
-#   4. 어느 단계든 비-zero exit은 stdout "ESCALATION review-fix-phase: ..." emit 후 종료 (AC19).
+#   4. 어느 단계든 비-zero exit은 stdout "ESCALATION review-fix-phase: ..." emit 후 종료.
 
 set -euo pipefail
 
-# ===== silent-fail 평가 (SPEC 181) — 단위 테스트 가능 =====
+# ===== silent-fail 평가 — 단위 테스트 가능 =====
 # 인자(8): fetch_fail pending total_checks reviews comments inline elapsed grace
 # stdout(택일): ESCALATE_FETCH_FAIL | GRACE_SKIP | EMPTY_ROLLUP_SKIP | ESCALATE_STUCK | RESET_COUNTER
 #
@@ -55,7 +55,7 @@ evaluate_silent_fail() {
   echo "RESET_COUNTER"
 }
 
-# ===== grace 기간 (silent-fail 조기 호출 방지) — SPEC 181 =====
+# ===== grace 기간 (silent-fail 조기 호출 방지) =====
 # 환경변수: LOOP_REVIEW_PR_GRACE_SECS
 # 기본값:  300 (5분) — GitHub Actions check 등록·큐 지연 흡수
 # floor:   0  (음수 입력 시 0으로 clamp — grace=0은 grace 비활성화 동등)
@@ -123,16 +123,16 @@ touch "$SEEN_FILE"
 is_seen() { grep -qxF "$1" "$SEEN_FILE" 2>/dev/null; }
 mark_seen() { echo "$1" >> "$SEEN_FILE"; }
 
-# 반박 코멘트 1회 게시 가드 — PR-level dispute에 한정 (SPEC 153 AC6 기존 동작 보존).
-# 인라인 thread reply는 별도 REPLIED_THREADS_FILE로 thread 단위 dedup (SPEC 153 AC4·AC5).
+# 반박 코멘트 1회 게시 가드 — PR-level dispute에 한정.
+# 인라인 thread reply는 별도 REPLIED_THREADS_FILE로 thread 단위 dedup.
 DISPUTE_FILE="$WT/.iterations/review-fix-dispute-posted"
 
 # 인라인 thread "응답 완료" 추적 — 본 phase 사이클 동안 같은 thread를 두 번 처리하지
-# 않게 가드 (AC4). FIX(코드 변경)·DISPUTE(thread reply) 두 액션 모두 처리 직후
+# 않게 가드. FIX(코드 변경)·DISPUTE(thread reply) 두 액션 모두 처리 직후
 # `mark_thread_replied`로 기록된다 — 그렇지 않으면 다음 iter의 polling이 같은 thread를
 # 다시 발견해 claude가 중복 FIX/DISPUTE를 emit할 수 있다 (불필요한 commit·reply).
-# 파일명은 SPEC 153 초기 명칭 보존(과거 호환), 의미는 "responded" 확장.
-# 서로 다른 thread들은 각각 처리 가능 (AC5: phase 단위 상한 없음).
+# 파일명은 초기 명칭 보존(과거 호환), 의미는 "responded" 확장.
+# 서로 다른 thread들은 각각 처리 가능 (phase 단위 상한 없음).
 REPLIED_THREADS_FILE="$WT/.iterations/review-fix-replied-threads"
 touch "$REPLIED_THREADS_FILE"
 
@@ -339,11 +339,11 @@ while (( iter < MAX_ITER )); do
   if [[ -z "$new_events" ]]; then
     CONSECUTIVE_IDLE=$((CONSECUTIVE_IDLE + 1))
     if (( CONSECUTIVE_IDLE >= CONSECUTIVE_IDLE_THRESHOLD )); then
-      # silent-fail / stuck 패턴 평가 — evaluate_silent_fail에 위임 (SPEC 181).
+      # silent-fail / stuck 패턴 평가 — evaluate_silent_fail에 위임.
       # 입력: fetch 실패 플래그 + rollup·활동 카운트 + PR 생성 후 경과 시간 + grace 기간.
       last_fetch_fail=$( cat "$FETCH_FAIL_FILE" 2>/dev/null || echo 0 )
       # statusCheckRollup·createdAt을 한 번에 fetch해 jq 필터 3종 적용 — API 호출·레이턴시 절감.
-      # SPEC 181 AC2: total_checks=0(빈 rollup)을 "체크 모두 완료"로 오판하지 않기 위해 별도 산출.
+      # total_checks=0(빈 rollup)을 "체크 모두 완료"로 오판하지 않기 위해 별도 산출.
       rollup_json=$( cd "$WT" && gh pr view "$PR_NUMBER" --json statusCheckRollup,createdAt 2>/dev/null || echo "" )
       pending_checks=$( printf '%s' "$rollup_json" | jq '[.statusCheckRollup[]? | select((.status // "COMPLETED") != "COMPLETED")] | length' 2>/dev/null || echo "" )
       total_checks=$( printf '%s' "$rollup_json" | jq '.statusCheckRollup | length' 2>/dev/null || echo "" )
@@ -415,7 +415,7 @@ while (( iter < MAX_ITER )); do
   fix_prompt_threads=$( cd "$WT" && gh api "repos/{owner}/{repo}/pulls/$PR_NUMBER/comments" 2>/dev/null || echo "[]" )
   fix_prompt_body=$(printf 'PR comments + reviews:\n%s\n\nReview thread inline comments:\n%s\n' "$fix_prompt_header" "$fix_prompt_threads")
   # Inline thread roots (in_reply_to_id == null) — 각 root이 INLINE per-thread 응답 1건의 대상.
-  # SPEC 153에서 thread_id == comment_id (root.id). (iv-A) 파서가 INLINE 라인을 읽으므로
+  # thread_id == comment_id (root.id). (iv-A) 파서가 INLINE 라인을 읽으므로
   # 본 변수를 프롬프트에 명시 주입해 dead-code 갭을 차단.
   # 이미 처리된 thread는 REPLIED_THREADS_FILE 기준으로 사전 제외 — (iv-A) dedup이
   # 후처리만 막을 뿐 claude의 edit·comment 자체는 이미 수행되므로, 프롬프트 진입 전에
@@ -441,29 +441,29 @@ $new_events
 Full PR comment/review context (for reference):
 $fix_prompt_body
 
-Active inline review threads requiring per-thread response (SPEC 153):
+Active inline review threads requiring per-thread response:
 $fix_prompt_inline_threads
 
 Goal:
   PR-level comments and review summaries (batched, collective verdict):
     - If reviewer is correct → fix the code (Edit/Write).
     - If reviewer is wrong → emit a single line: 'DISPUTE: <one-line dispute body>'
-      (the caller posts it as ONE PR-level comment — AC6 보존).
+      (the caller posts it as ONE PR-level comment).
 
-  EACH active inline review thread listed above (per-thread 1:1 response, SPEC 153 AC1·AC2·AC3):
+  EACH active inline review thread listed above (per-thread 1:1 response):
     - If reviewer is correct → fix the referenced code, then emit ONE line:
         INLINE <thread_id> <thread_id> FIX
-      AC2 fallback: 코드 변경 시도가 실패(빌드/테스트 실패·구문 오류 등)할 경우
+      Fallback: 코드 변경 시도가 실패(빌드/테스트 실패·구문 오류 등)할 경우
       해당 thread에 대해 INLINE <thread_id> <thread_id> DISPUTE <one-line 실패 사유>로
-      전환해 응답한다 (FIX → reply 자동 fallback, AC1 "정확히 하나" 보장 유지).
+      전환해 응답한다 (FIX → reply 자동 fallback, "정확히 하나" 보장 유지).
     - If reviewer is wrong → emit ONE line:
         INLINE <thread_id> <thread_id> DISPUTE <one-line dispute body>
-    - 보수적 판정 (SPEC §제약 요건): 타당성이 불확실하면 FIX 분기로 결정한다
+    - 보수적 판정: 타당성이 불확실하면 FIX 분기로 결정한다
       (DISPUTE 남발 방지·reviewer-bot 갈등 완화).
     - The INLINE line format depends on action:
         FIX:     INLINE <thread_id> <comment_id> FIX                       (4 tokens, no body)
         DISPUTE: INLINE <thread_id> <comment_id> DISPUTE <body...>         (5 tokens, body required)
-      Whitespace-separated. SPEC 153에서 thread_id와 comment_id는 같은 정수
+      Whitespace-separated. thread_id와 comment_id는 같은 정수
       (root comment DB id). FIX 라인에 본문이 붙어도 파서는 skip하므로 기능 영향
       없지만, 형식 일관성을 위해 FIX는 4토큰만 출력한다.
 
@@ -501,12 +501,12 @@ EOF
       || { echo "WARN: fix commit/push 실패 (iter $iter) — 다음 iter 재시도 (phase 계속)" >&2; sleep "$POLL_SECS"; continue; }
   fi
 
-  # (iv-A) INLINE per-comment thread reply POST (SPEC 153 AC1·AC3·AC4·AC5)
+  # (iv-A) INLINE per-comment thread reply POST
   # claude 출력에서 `INLINE <thread_id> <comment_id> <action> <body...>` 라인을 파싱.
   # action == DISPUTE 인 경우 해당 inline thread에 reply 1개 POST. thread_id 기준 dedup으로
-  # 같은 phase 사이클 동안 같은 thread는 최대 1 reply (AC4). 서로 다른 thread들은 각각 reply 가능 (AC5).
+  # 같은 phase 사이클 동안 같은 thread는 최대 1 reply. 서로 다른 thread들은 각각 reply 가능.
   # action == FIX는 claude가 이미 코드 변경을 적용했음을 의미 — 위 (iii) commit/push 경로가 처리.
-  # PR-level dispute(DISPUTE: ...) 본문은 본 블록과 무관, 아래 (iv-B)가 처리 — AC6 기존 동작 보존.
+  # PR-level dispute(DISPUTE: ...) 본문은 본 블록과 무관, 아래 (iv-B)가 처리.
   #
   # 구조: INLINE 파서·dedup 마킹은 OWNER_REPO 유무와 무관하게 항상 수행한다 —
   # FIX 액션도 dedup이 필요하므로(다음 iter 중복 commit 방지) OWNER_REPO 미식별 시에도
@@ -568,8 +568,8 @@ EOF
     fi
   done < <( grep -E '^INLINE[[:space:]]' "$WT/$fix_log" 2>/dev/null || true )
 
-  # (iv-B) PR-level DISPUTE 본문 감지 → PR 코멘트 1회 게시 (AC10·AC11 — SPEC 123 기존 경로)
-  # `DISPUTE: <body>` 라인은 PR-level 의견 — gh pr comment 경로 (AC6 보존).
+  # (iv-B) PR-level DISPUTE 본문 감지 → PR 코멘트 1회 게시
+  # `DISPUTE: <body>` 라인은 PR-level 의견 — gh pr comment 경로.
   # INLINE 라인은 본 블록 패턴(^DISPUTE:)에 일치하지 않으므로 영향 없음.
   dispute_line=$( grep -m1 -E '^DISPUTE:' "$WT/$fix_log" 2>/dev/null || true )
   if [[ -n "$dispute_line" && ! -f "$DISPUTE_FILE" ]]; then

--- a/plugins/autopilot/skills/loop/references/task-storage.sh
+++ b/plugins/autopilot/skills/loop/references/task-storage.sh
@@ -2,7 +2,7 @@
 # task-storage.sh — task 저장소(GitHub Issue) 라벨 검출 공통 헬퍼.
 #
 # loop.sh·dispatch.sh 가 함께 source 하는 헬퍼. 완료 검출의 단일 출처는
-# task 식별자에 부속된 LOOP_DONE_LABEL 라벨이다(헌법 §12, SPEC 134/150/175).
+# task 식별자에 부속된 LOOP_DONE_LABEL 라벨이다(헌법 §12).
 # 본 파일은 source 전용이며 단독 실행하지 않는다.
 #
 # 매체: GitHub Issue + label. 환경: gh CLI 인증을 전제.
@@ -18,7 +18,7 @@
 # dispatch.sh 등 다른 호출자는 task-id 를 명시적으로 넘긴다.
 
 # 완료 신호의 검출 키. 환경 변수 override 허용 — 단, 프로젝트 수준에서 단일 위치에
-# 고정되어 task storage adapter 다중 분기를 만들지 않는다 (SPEC 134 §비-목표).
+# 고정되어 task storage adapter 다중 분기를 만들지 않는다.
 LOOP_DONE_LABEL="${LOOP_DONE_LABEL:-loop:done}"
 
 # 내부 전용 — ensure_label_exists 의 stderr WARN 라인 타임스탬프.
@@ -50,11 +50,11 @@ task_issue_number() {
   return 1
 }
 
-# task issue 에 특정 label 이 붙어 있는지 boolean 검사 (SPEC 134 AC3).
+# task issue 에 특정 label 이 붙어 있는지 boolean 검사.
 # 인자: $1=task-id (생략 시 $TASK_ID), $2=label 이름 (필수).
 # 반환: 0=label 존재, 1=label 부재 또는 판정 불가 (issue 매핑 실패·gh 부재 포함).
 # 구현은 단일 GitHub 호출(`gh issue view --json labels`)로 한정 — adapter 인터페이스
-# 신설 없음 (SPEC 134 §비-목표).
+# 신설 없음.
 task_label_present() {
   local task_id="${1:-${TASK_ID:-}}"
   local label="${2:-}"
@@ -74,10 +74,10 @@ task_label_present() {
   return 1
 }
 
-# task storage 에 label 이 존재하는지 확인하고, 없으면 자동 생성 (SPEC 134 AC5).
+# task storage 에 label 이 존재하는지 확인하고, 없으면 자동 생성.
 # 인자: $1=label 이름 (필수).
 # 권한 부족·gh 부재 시 best-effort 로 stderr WARN + 비-0 반환 (비차단 진행).
-# SPEC 134 §위험 "label 자동 생성 권한 부족" — runtime 실패는 verify 범위 밖.
+# "label 자동 생성 권한 부족" — runtime 실패는 verify 범위 밖.
 ensure_label_exists() {
   local label="${1:-}"
   [[ -z "$label" ]] && return 1
@@ -104,7 +104,7 @@ ensure_label_exists() {
   return 0
 }
 
-# task issue 의 완료 신호 검사 (헌법 §12, SPEC 134 AC2, SPEC 175 AC1).
+# task issue 의 완료 신호 검사 (헌법 §12).
 # 정식 검출 키: task issue 에 LOOP_DONE_LABEL 값과 일치하는 label 이 붙어 있는지.
 # comment 본문은 가독·로그 채널이며 판정에 사용되지 않는다 — 워커가 [done] prefix
 # comment 발행과 함께 label 추가 두 동작을 모두 수행해야 0(done) 을 반환한다.

--- a/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test-loop-review-fix-phase.sh — SPEC 123 rebase·review-fix·cleanup phase 테스트
+# test-loop-review-fix-phase.sh — rebase·review-fix·cleanup phase 테스트
 #
 # 검증 대상:
 #  - rebase-phase.sh / review-fix-phase.sh / cleanup-phase.sh 존재·실행권
@@ -46,7 +46,7 @@ test_spec_verify_command() {
   grep -qE 'review-fix|rebase|cleanup' "$S/SKILL.md"                       || fail "SKILL.md: phase 어휘 부재"
   grep -qE '상태 전이|Status'          "$S/SKILL.md"                       || fail "SKILL.md: 상태 어휘 부재"
   grep -qE '자동 머지|auto[- ]?merge'  "$S/SKILL.md"                       || fail "SKILL.md: 자동 머지 어휘 부재"
-  # SPEC 153 prompt → 파서 contract 정적 검증 — claude mock이 stdin을 무시하므로
+  # prompt → 파서 contract 정적 검증 — claude mock이 stdin을 무시하므로
   # 런타임 테스트만으로는 prompt가 INLINE 포맷 출력을 지시하는지 확인 불가.
   # production source에서 prompt-출력 contract의 양쪽이 모두 INLINE 어휘를 갖는지 grep.
   grep -qE 'INLINE[[:space:]]+<thread_id>'  "$S/references/review-fix-phase.sh" \
@@ -225,7 +225,7 @@ GH
 }
 
 # =====================================================================
-# SPEC 153 — inline review thread comment 1:1 응답 테스트 케이스 (a)~(e)
+# inline review thread comment 1:1 응답 테스트 케이스 (a)~(e)
 # =====================================================================
 #
 # 공통 셋업: 격리 main repo + bare remote + worktree(feat/153-test) + 1개 commit.
@@ -608,7 +608,7 @@ test_e_pr_level_dispute_preserved() {
 }
 
 # =====================================================================
-# SPEC 169 — Push sync policy: rebase locally, merge on remote
+# Push sync policy: rebase locally, merge on remote
 # =====================================================================
 #
 # 동기화 helper(rebase-phase.sh)가 원격 트래킹 브랜치 존재 여부에 따라 두 경로로

--- a/plugins/autopilot/skills/spec/SKILL.md
+++ b/plugins/autopilot/skills/spec/SKILL.md
@@ -209,7 +209,7 @@ find . -maxdepth 3 -type d \( -name 'tests' -o -name 'test' -o -name '__tests__'
 
 - `milestones/<m>/loops/<c>-<slug>/SPEC.md`
 
-`<slug>` 가 빈 문자열로 환원되면 fallback 경로를 만들지 않는다 — SPEC 116 EARS AC4(단일 컨벤션, 다른 경로 fallback 없음) 위반이고 sibling pr-phase 도 슬러그 없는 브랜치는 abort. 빈 slug 시 `references/feat-branch-commit.md` §9.5.3 실패 처리로 분기·§1 H1 제목 수정(step 7 재진입) 요청.
+`<slug>` 가 빈 문자열로 환원되면 fallback 경로를 만들지 않는다 — 단일 컨벤션이고 sibling pr-phase 도 슬러그 없는 브랜치는 abort. 빈 slug 시 `references/feat-branch-commit.md` §9.5.3 실패 처리로 분기·§1 H1 제목 수정(step 7 재진입) 요청.
 
 `<c>` 는 input task-id (단계 1 통과값). 본 디렉토리 이름의 `<slug>` 가 sibling `autopilot:loop` 이 발견하는 feat 브랜치 `feat/<c>-<slug>` 의 `<slug>` 와 동일해 spec→loop 라운드트립이 단일 컨벤션으로 정합. `mkdir -p` 후 `SPEC.md` 기록.
 

--- a/plugins/autopilot/skills/spec/references/feat-branch-commit.md
+++ b/plugins/autopilot/skills/spec/references/feat-branch-commit.md
@@ -15,11 +15,11 @@ SPEC §1 제목(첫 H1, `# ` 다음 텍스트)에서 `<slug>`를 도출:
 3. 연속된 `-`를 단일 `-`로 압축
 4. 시작·끝의 `-` 제거
 
-결과가 빈 문자열이면 fallback 브랜치(`feat/<c>` 단독)·fallback 디렉토리(`milestones/<m>/loops/<c>/`)를 만들지 않는다 — SPEC 116 EARS AC4 단일 컨벤션 위반이며 sibling pr-phase 도 동일 이유로 abort. 빈 slug 발생 시 §9.5.3 실패 처리로 분기해 사용자에게 §1 H1 제목 수정(step 7 재진입)을 요청한다. 같은 SPEC 제목은 항상 같은 slug 를 만든다.
+결과가 빈 문자열이면 fallback 브랜치(`feat/<c>` 단독)·fallback 디렉토리(`milestones/<m>/loops/<c>/`)를 만들지 않는다 — 단일 컨벤션이며 sibling pr-phase 도 동일 이유로 abort. 빈 slug 발생 시 §9.5.3 실패 처리로 분기해 사용자에게 §1 H1 제목 수정(step 7 재진입)을 요청한다. 같은 SPEC 제목은 항상 같은 slug 를 만든다.
 
 구현 예 (bash) — **본 코드 조각이 슬러그 도출의 단일 출처(single source of truth)**이며 안전장치(`references/test-spec-loop-contract.sh`)가 이 위치를 검사한다.
 
-H1 제목 추출은 BSD sed (macOS) 와 GNU sed 의 `{...}` 블록 + `q` 구문 차이로 인해 awk 기반으로 작성한다 — 기존 `sed -n '/^---$/,/^---$/!{/^# /{s/^# //p; q;}}'` 패턴은 BSD sed 에서 `extra characters at the end of } command` 로 실패한다 (SPEC 108):
+H1 제목 추출은 BSD sed (macOS) 와 GNU sed 의 `{...}` 블록 + `q` 구문 차이로 인해 awk 기반으로 작성한다 — 기존 `sed -n '/^---$/,/^---$/!{/^# /{s/^# //p; q;}}'` 패턴은 BSD sed 에서 `extra characters at the end of } command` 로 실패한다:
 
 ```bash
 title=$(awk '
@@ -36,7 +36,7 @@ awk 동작: `fm` 플래그가 frontmatter `---` 라인을 토글하므로 frontm
 
 ## 9.5.2 브랜치 생성·commit 절차
 
-본 단계의 모든 경로 참조는 진입점 §8.1 에서 결정된 slug-bearing 디렉토리 — `milestones/<m>/loops/<c>-<slug>/SPEC.md` — 와 정합하게 동일 `<slug>` 를 사용한다. 브랜치 이름의 `<slug>` 와 디렉토리 이름의 `<slug>` 는 반드시 같다. `<slug>` 가 빈 문자열이면 §9.5.1 의 빈-slug 실패 처리로 사전 분기되므로 본 단계는 항상 non-empty `<slug>` 를 가정한다 (SPEC 116 단일 컨벤션, EARS AC4 — fallback 없음).
+본 단계의 모든 경로 참조는 진입점 §8.1 에서 결정된 slug-bearing 디렉토리 — `milestones/<m>/loops/<c>-<slug>/SPEC.md` — 와 정합하게 동일 `<slug>` 를 사용한다. 브랜치 이름의 `<slug>` 와 디렉토리 이름의 `<slug>` 는 반드시 같다. `<slug>` 가 빈 문자열이면 §9.5.1 의 빈-slug 실패 처리로 사전 분기되므로 본 단계는 항상 non-empty `<slug>` 를 가정한다 (단일 컨벤션 — fallback 없음).
 
 1. `git status --porcelain`으로 main 작업트리 상태 스냅샷 캡처. unstaged·untracked가 있으면 그 사실을 인지 (다음 단계의 git 동작이 영향 안 주도록 명시적 경로 사용).
 2. 현재 브랜치 이름 보존: `orig_branch=$(git rev-parse --abbrev-ref HEAD)`.
@@ -54,7 +54,7 @@ awk 동작: `fm` 플래그가 frontmatter `---` 라인을 토글하므로 frontm
 - 부분 결과 정리: 생성된 feat 브랜치가 있으면 `git branch -D "$branch"`로 삭제 (단, 그 브랜치에 다른 commit이 없을 때만; 의심스러우면 사용자에게 알리고 수동 정리 안내).
 - 원래 브랜치 복귀: `git checkout "$orig_branch"`.
 - 사용자에게 명시적으로 실패 사유와 복구 방법 안내. SPEC.md는 `milestones/<m>/loops/<c>-<slug>/SPEC.md` 에 그대로 남기되, loop 진행은 다음 단계에서 사용자가 결정.
-- **빈 slug 케이스 (§9.5.1)**: 슬러그화 결과가 빈 문자열이면 본 §9.5.2 진입 전에 abort 한다. SPEC.md 는 step 8 의 §8.1 단일 경로 가정에 의해 빈 slug 에서는 작성되지 않으며, 사용자에게 §1 H1 제목 수정을 요청해 step 7 재진입한다 (SPEC 116 단일 컨벤션 — fallback 없음).
+- **빈 slug 케이스 (§9.5.1)**: 슬러그화 결과가 빈 문자열이면 본 §9.5.2 진입 전에 abort 한다. SPEC.md 는 step 8 의 §8.1 단일 경로 가정에 의해 빈 slug 에서는 작성되지 않으며, 사용자에게 §1 H1 제목 수정을 요청해 step 7 재진입한다 (단일 컨벤션 — fallback 없음).
 
 §9.5.4 절차(원격 default 브랜치 동기화·fast-forward merge·원격 push) 중 실패 분기:
 
@@ -114,4 +114,4 @@ awk 동작: `fm` 플래그가 frontmatter `---` 라인을 토글하므로 frontm
 
 ## 9.5.5 self-referential 호출 면제
 
-본 §9.5.4 절차를 정의·도입하는 SPEC (예: SPEC 149) 을 작성·수락하는 *현재* spec 호출 자체에는 본 §9.5.4 새 동작을 적용하지 않는다. 이는 다음 일반 규약을 따른 것이다: **spec 호출이 정의·도입하는 새 contract 는 그 호출의 산출물(경로·브랜치·동작)에 선행 적용하지 않으며, 새 contract 는 해당 SPEC 이 default 브랜치에 merge 된 후의 다음 spec 호출부터 적용된다**. 따라서 현재 호출은 §9.5.2 까지만 (feat 브랜치 분기·SPEC commit·원래 브랜치 복귀) 수행하고, default 브랜치 ff-merge·원격 push 는 본 SPEC 이 merge 된 후의 다음 spec 호출부터 적용된다.
+본 §9.5.4 절차를 정의·도입하는 SPEC 을 작성·수락하는 *현재* spec 호출 자체에는 본 §9.5.4 새 동작을 적용하지 않는다. 이는 다음 일반 규약을 따른 것이다: **spec 호출이 정의·도입하는 새 contract 는 그 호출의 산출물(경로·브랜치·동작)에 선행 적용하지 않으며, 새 contract 는 해당 SPEC 이 default 브랜치에 merge 된 후의 다음 spec 호출부터 적용된다**. 따라서 현재 호출은 §9.5.2 까지만 (feat 브랜치 분기·SPEC commit·원래 브랜치 복귀) 수행하고, default 브랜치 ff-merge·원격 push 는 본 SPEC 이 merge 된 후의 다음 spec 호출부터 적용된다.

--- a/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
+++ b/plugins/autopilot/skills/spec/references/test-spec-loop-contract.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# test-spec-loop-contract.sh — SPEC 116 verify
+# test-spec-loop-contract.sh
 #
 # spec↔loop feat 브랜치·worktree 경로 단일 규약 contract verifier.
 #
-# 검사 항목 (SPEC 116 수용 기준 매핑):
+# 검사 항목:
 #   T1. slug 도출 결정성 — canonical 알고리즘이 "Foo Bar" → "foo-bar".
 #       + spec SKILL.md 가 canonical 알고리즘을 문서화하고 있는지 (drift guard).
 #       + spec SKILL.md 가 slug-bearing SPEC.md 경로를 참조하는지.
@@ -13,7 +13,7 @@
 #   T5. 모호성 die — 동일 input-id 매칭 브랜치 2+ 일 때 비-zero exit + 안내.
 #   T6. dispatch.sh child_state — issue 에 LOOP_DONE_LABEL 라벨이 부착되면
 #       워크트리 안 sentinel 파일 부재에도 "done" 상태를 보고해야 한다
-#       (SPEC 175 AC2: 라벨 단일 의존).
+#       (라벨 단일 의존).
 #
 # 셋업: 임시 git fixture · mock claude (stdin 소비 + JSON 응답) · yq 필요.
 
@@ -63,8 +63,8 @@ MAIN_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 git commit --allow-empty -q -m "chore: baseline"
 
 # mock claude — stdin 소비 + JSON 응답.
-# 완료 신호는 task 저장소(GitHub Issue)의 `loop:done` label 부착이 단일 검출 키이며
-# (SPEC 134/150/175), 파일 sentinel 은 없다 — mock 도 파일을 만들지 않는다.
+# 완료 신호는 task 저장소(GitHub Issue)의 `loop:done` label 부착이 단일 검출 키이며,
+# 파일 sentinel 은 없다 — mock 도 파일을 만들지 않는다.
 MOCK_BIN="$WORK_DIR/mock-bin"
 mkdir -p "$MOCK_BIN"
 cat > "$MOCK_BIN/claude" <<'MOCKEOF'
@@ -76,7 +76,7 @@ chmod +x "$MOCK_BIN/claude"
 
 # mock gh — task_status_is_done 를 만족시키는 최소 stub.
 # 배경: loop.sh·dispatch.sh 는 done 신호를 task 저장소의 `loop:done` label 단일
-#       의존으로 감지한다 (SPEC 134/150/175). 파일 sentinel 은 제거되었으므로
+#       의존으로 감지한다. 파일 sentinel 은 제거되었으므로
 #       라벨 부착이 done 검출의 유일한 경로다. 본 테스트는 real GitHub 이 없으므로
 #       gh stub 으로 label 존재를 흉내내 iter #1 직후 task_status_is_done 이
 #       0(done) 을 반환하도록 한다.
@@ -132,7 +132,7 @@ grep -qF "sed -e 's/--*/-/g'" "$SPEC_FEAT_REF" \
 grep -qF "milestones/<m>/loops/<c>-<slug>" "$SPEC_SKILL_MD" \
   || { echo "FAIL T1e: SKILL.md missing slug-bearing directory reference (milestones/<m>/loops/<c>-<slug>)" >&2; exit 1; }
 
-# T1f: slug-less fallback 경로·브랜치가 SKILL.md 에 살아 있으면 SPEC 116 EARS AC4 위반.
+# T1f: slug-less fallback 경로·브랜치가 SKILL.md 에 살아 있으면 단일 컨벤션 위반.
 # 구 문구(회귀하면 fail):
 #   - "milestones/<m>/loops/<c>/SPEC.md` (fallback)" / "(slug fallback)"
 #   - "branch=\"feat/<c>\"" / "feat/<task-id>` 단독으로 fallback"
@@ -218,7 +218,7 @@ WT_SPEC="$EXPECTED_WT/${DIR_REL}/SPEC.md"
   || { echo "FAIL T4a: worktree 안 SPEC.md 부재: $WT_SPEC" >&2; exit 1; }
 
 # pr-phase.sh 의 SPEC_FILE 도출 — feat 브랜치 이름의 slug를 사용해야 한다.
-# SPEC 116 EARS AC4: "다른 경로 fallback은 없다" — slug-less 경로는 미지원, 단일 컨벤션.
+# 다른 경로 fallback은 없다 — slug-less 경로는 미지원, 단일 컨벤션.
 # 동일 도출 로직을 본 테스트에서 재현해 결과가 slug-bearing 경로와 일치하는지 확인.
 PR_TASK_ID="regular/${INPUT_ID}"
 PR_BRANCH="feat/${INPUT_ID}-${SLUG}"
@@ -248,7 +248,7 @@ if ! grep -qE '\$\{?BRANCH#' "$PR_PHASE_SH"; then
   exit 1
 fi
 
-# T4d: pr-phase.sh 에 slug-less fallback 경로가 없는지 검사 — SPEC 116 EARS AC4 "다른 경로 fallback은 없다".
+# T4d: pr-phase.sh 에 slug-less fallback 경로가 없는지 검사 — "다른 경로 fallback은 없다".
 # 구 fallback 패턴: `${SPEC_CHILD}/SPEC.md` (slug-bearing 분기의 else 측에서 SPEC_CHILD 만 사용).
 # 신 컨벤션: slug 추출 실패 시 즉시 abort, 다른 경로 시도 금지.
 if grep -nE 'SPEC_FILE=.*loops/\$\{?SPEC_CHILD\}?/SPEC\.md' "$PR_PHASE_SH" >/dev/null; then
@@ -281,11 +281,11 @@ echo "$T5_OUT" | grep -qE '여러 feat 브랜치|모호|ambig' \
 echo "OK T5: 모호성 die"
 
 # ──────────────────────────────────────────────────────────────────────────────
-# T6. dispatch.sh child_state — label 단일 의존 (SPEC 175 AC2)
+# T6. dispatch.sh child_state — label 단일 의존
 # ──────────────────────────────────────────────────────────────────────────────
 # 배경: 이전 contract 에서 dispatch.sh 는 `[[ -f $wt/DONE ]]` 파일 sentinel 로
 #       child 완료를 판정했으나, 어떤 코드 경로도 그 파일을 만들지 않아 dead code
-#       였다. SPEC 175 는 loop.sh 와 동일하게 task 저장소의 `loop:done` 라벨 단일
+#       였다. 현재 contract 는 loop.sh 와 동일하게 task 저장소의 `loop:done` 라벨 단일
 #       의존으로 통합한다. mock gh 가 `loop:done` 을 echo 하므로, child issue 가
 #       라벨 부착된 상태를 흉내내고 dispatch status 가 "done" 을 보고하는지 확인.
 #
@@ -307,7 +307,7 @@ if [[ $T6_RC -ne 0 ]]; then
   exit 1
 fi
 echo "$T6_OUT" | grep -qE "^[[:space:]]*${T6_C}[[:space:]]+done$" \
-  || { echo "FAIL T6: dispatch child_state did not report 'done' for label-only completion (SPEC 175 AC2)" >&2
+  || { echo "FAIL T6: dispatch child_state did not report 'done' for label-only completion" >&2
        echo "$T6_OUT" >&2; exit 1; }
 
 echo "OK T6: dispatch child_state — label 단일 의존"


### PR DESCRIPTION
## Summary
- autopilot 4개 스킬(dispatch/loop/spec/prd)의 `SKILL.md`·`references/**`·`tests/**` 14개 파일에서 'SPEC 81/103/108/116/123/134/149/150/153/169/175/181' 등 **특정 SPEC 번호 참조와 근거 인용 절**을 통째로 제거
- 번호는 머지 후 의미가 흐려지고 지침 가독성을 떨어뜨리므로, 번호 + 그 SPEC을 인용해 도입 이유를 설명하던 절 모두 삭제하고 문맥상 자명한 설명만 잔존
- 코드 동작 변경 없음 — 주석·docstring·테스트 메시지·prompt 헤더만 수정 (`bash -n` 9개 스크립트 통과 확인)

## Test plan
- [ ] `bash -n` 통과한 9개 스크립트가 기존 테스트에서도 정상 동작하는지 (필요 시 spec contract verify·review-fix phase test 회귀)
- [ ] SKILL.md 사용자 가독성: 번호 없이도 의도가 자명한지 spot-check
- [ ] `grep -rnE 'SPEC[ -]?[0-9]+' plugins/autopilot/skills/` 결과가 비어 있는지 (이미 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)