### PR TITLE
Loop이 worktree 내부에서 호출될 때 nested worktree 생성 생략

### DIFF
--- a/milestones/regular/loops/171-loop-must-run-from-main-repo-cwd/SPEC.md
+++ b/milestones/regular/loops/171-loop-must-run-from-main-repo-cwd/SPEC.md
@@ -23,7 +23,7 @@ loop 스킬의 `start` 서브커맨드가 호출될 때, 시스템은 호출 워
 - **AC3** (Optional/조건): 호출 워킹 디렉토리가 보조 worktree로 판정되는 경우, 시스템은 nested worktree 생성을 생략하고 현재 cwd의 worktree를 작업 공간으로 사용한다. SPEC.md·헌법·lock 등 통상 nested worktree 안에 두는 파일은 현재 worktree 안의 동등 경로(또는 `milestones/<m>/loops/<c>/` 안)에 배치한다.
 - **AC4** (Ubiquitous): worktree 검사와 분기 로직은 셸 드라이버 본체에 위치해 스킬을 통한 호출과 셸 드라이버 직접 호출 모두에 동일하게 작동한다.
 - **AC5** (Ubiquitous): 스킬 문서의 호출 방법 절에 "주 작업트리: nested worktree 생성 / 보조 worktree: 현재 worktree 사용 (생략)" 분기 동작이 명시된다.
-- **AC6** (Unwanted/조건): 보조 worktree에서 호출된 경우라도 lock·SPEC 검증 등 기존 안전 검사(SPEC.md 존재·placeholder 없음·`[NEEDS CLARIFICATION]` 없음·락 미보유)는 동일하게 수행한다 — skip 대상은 nested worktree 생성·헌법 복사 등의 *worktree 셋업 단계*만이다.
+- **AC6** (Unwanted/조건): 보조 worktree에서 호출된 경우라도 lock·SPEC 검증 등 기존 안전 검사(SPEC.md 존재·placeholder 없음·미해결 마커 부재·락 미보유)는 동일하게 수행한다 — skip 대상은 nested worktree 생성·헌법 복사 등의 *worktree 셋업 단계*만이다.
 
 ## 범위
 

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -78,8 +78,8 @@ Skill(skill: "spec", args: "<task-id>")
 - `--spec <path>` 지정 시 외부 파일을 `milestones/<m>/loops/<c>/SPEC.md`로 복사 (prepare 대체)
 - `milestones/<m>/loops/<c>/SPEC.md` 존재 + `[NEEDS CLARIFICATION]` 마커 없음 + placeholder 모두 치환됨 (legacy `.loops/<task-id>/SPEC.md` fallback 없음 — v0.2 cutover)
 - 락 미보유 — lock 파일은 `milestones/<m>/loops/<c>/.lock`
-- 워크트리 없으면 생성 (메인 레포 내부 nested 위치 `milestones/<m>/loops/<c>/.worktree/` — `.gitignore`로 추적 차단)
-- 헌법(`references/constitution.md`)을 워크트리의 CLAUDE.md로 복사
+- 호출 cwd 가 git 저장소의 **주 작업트리**(main working tree)인 경우 — 기존 동작 보존: 워크트리 없으면 메인 레포 내부 nested 위치 `milestones/<m>/loops/<c>/.worktree/` 에 생성하고(`.gitignore`로 추적 차단), 헌법(`references/constitution.md`)을 워크트리의 CLAUDE.md로 복사
+- 호출 cwd 가 **보조 worktree** 안인 경우 (SPEC 171) — nested worktree 생성 **생략**, 현재 cwd 의 worktree 를 작업 공간으로 그대로 사용 (헌법 복사 등 worktree 셋업 단계도 skip). 단 락·SPEC 검증 등 안전 검사는 동일하게 수행
 - 락 획득 + 이터레이션 루프
 
 #### 자동 Monitor 가설 (기본 동작)

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -327,6 +327,8 @@ compute_paths() {
   fi
 
   # v0.2 cutover: 워크트리·lock·메타 파일이 모두 milestones/<m>/loops/<c>[-<slug>]/ 단일 트리.
+  # (SPEC 171: PROJECT_ROOT·LOOPS_DIR 의 보조 worktree 기준 재계산은 본 SPEC scope 외 —
+  #  별도 SPEC 으로 보강 검토. 본 SPEC 는 nested worktree 생성 단계만 skip 한다.)
   LOOPS_DIR="$PROJECT_ROOT/milestones/$milestone/loops/$loop_dir_name"
   # LOOPS_DIR_REL: worktree 안의 SPEC.md canonical 경로 prefix.
   # SPEC.md 는 feat 브랜치에 동일 slug-bearing 경로로 commit 되어 worktree 에서
@@ -337,6 +339,21 @@ compute_paths() {
   # 정규화된 task-id 와 발견된 feat 브랜치를 caller 에게 노출.
   TASK_ID_NORMALIZED="$task_id"
   FEAT_BRANCH="$feat_branch"
+}
+
+# SPEC 171: 호출 cwd 가 git 저장소의 *주 작업트리* 인지 *보조 worktree* 인지 판정한다.
+#
+# 판정 기준 (SPEC 171 제약):
+#   - 주 작업트리: top-level 의 .git 이 디렉토리.
+#   - 보조 worktree: top-level 의 .git 이 `gitdir: <main_repo>/.git/worktrees/<name>` 형태의
+#     파일. git 이 보조 worktree 에 항상 적용하는 표준 구조.
+#
+# 반환: 보조 worktree 면 0 (true), 주 작업트리 또는 git 저장소 외부면 non-zero (false).
+# bare repo·submodule·detached HEAD 등 비표준 환경은 보장 범위 외 (SPEC 171 제약).
+is_secondary_worktree() {
+  local top
+  top="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
+  [[ -f "$top/.git" ]]
 }
 
 # feat 브랜치 검색: input-id (정규화된 task-id 의 child 컴포넌트) 만으로 `feat/<id>` 또는
@@ -884,6 +901,14 @@ cmd_start() {
     esac
   done
 
+  # SPEC 171: 호출 cwd 가 주 작업트리인지 보조 worktree 인지 entry 직후 검사. 보조 worktree
+  # 분기에서는 nested .worktree 생성·헌법 복사 등 *worktree 셋업 단계* 만 skip 한다 — lock·
+  # SPEC 검증 등 안전 검사는 두 분기 모두 동일 수행 (AC6).
+  local is_secondary=0
+  if is_secondary_worktree; then
+    is_secondary=1
+  fi
+
   compute_paths "$task_id"
   # 정규화된 task-id를 이후 출력·logging에 사용 (regular/ prefix 포함)
   task_id="$TASK_ID_NORMALIZED"
@@ -948,8 +973,15 @@ cmd_start() {
   # 헌법 §11.2가 워커에게 label 부착 동작을 강제한다 (SPEC 150).
   ensure_label_exists "$LOOP_DONE_LABEL" || true
 
-  # 6. 워크트리 생성 (없는 경우)
-  if [[ ! -d "$WT" ]]; then
+  # 6. 워크트리 생성 (없는 경우) — SPEC 171: 보조 worktree 분기에서는 nested 생성 생략.
+  if (( is_secondary == 1 )); then
+    # SPEC 171 AC3: 보조 worktree 안에서 호출 — nested .worktree 생성·헌법 복사 단계 skip.
+    # 현재 cwd 의 worktree top-level 을 작업 공간으로 그대로 사용한다.
+    # 후속 흐름(BASE_SHA 캡처·iter 실행 경로 정합) 의 세부 조정은 SPEC 171 비-목표로
+    # 명시 — 별도 SPEC 으로 보강 검토.
+    WT="$(git rev-parse --show-toplevel)"
+    echo "[$(now_iso)] 보조 worktree 감지 — nested worktree 생성 생략. 현재 cwd 사용: $WT"
+  elif [[ ! -d "$WT" ]]; then
     echo "[$(now_iso)] 워크트리 생성 시작: $WT"
 
     # 새 nested 정책: WT 부모(loops_dir)는 이미 SPEC.md 존재 시 만들어짐.
@@ -1529,38 +1561,44 @@ EOF
 }
 
 # ----- subcommand 디스패처 -----
-
-if [[ $# -lt 1 ]]; then
-  usage
-fi
-
-SUBCOMMAND="$1"
-shift
-
-case "$SUBCOMMAND" in
-  prepare)
-    cmd_prepare "$@"
-    ;;
-  start)
-    cmd_start "$@"
-    ;;
-  status)
-    cmd_status "${1:-}"
-    ;;
-  stop)
-    cmd_stop "${1:-}"
-    ;;
-  list)
-    cmd_list
-    ;;
-  cleanup)
-    cmd_cleanup "$@"
-    ;;
-  logs)
-    cmd_logs "$@"
-    ;;
-  *)
-    echo "알 수 없는 subcommand: $SUBCOMMAND" >&2
+#
+# SPEC 171: 본 스크립트를 test 가 `source` 로 불러서 함수(예: is_secondary_worktree) 만
+# 단위 검증할 수 있도록, 디스패처는 실행 모드일 때만 동작하게 가드한다.
+# `${BASH_SOURCE[0]} == ${0}` 는 표준 bash 패턴 — script 로 실행 시 둘이 일치, source 시
+# `${0}` 는 호출 셸의 $0 이라 불일치.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [[ $# -lt 1 ]]; then
     usage
-    ;;
-esac
+  fi
+
+  SUBCOMMAND="$1"
+  shift
+
+  case "$SUBCOMMAND" in
+    prepare)
+      cmd_prepare "$@"
+      ;;
+    start)
+      cmd_start "$@"
+      ;;
+    status)
+      cmd_status "${1:-}"
+      ;;
+    stop)
+      cmd_stop "${1:-}"
+      ;;
+    list)
+      cmd_list
+      ;;
+    cleanup)
+      cmd_cleanup "$@"
+      ;;
+    logs)
+      cmd_logs "$@"
+      ;;
+    *)
+      echo "알 수 없는 subcommand: $SUBCOMMAND" >&2
+      usage
+      ;;
+  esac
+fi

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -345,14 +345,15 @@ compute_paths() {
 # 판정 기준 (SPEC 171 제약):
 #   - 주 작업트리: top-level 의 .git 이 디렉토리.
 #   - 보조 worktree: top-level 의 .git 이 `gitdir: <main_repo>/.git/worktrees/<name>` 형태의
-#     파일. git 이 보조 worktree 에 항상 적용하는 표준 구조.
+#     파일. `worktrees` 경로 컴포넌트를 명시 검사해 submodule(`gitdir: ../.git/modules/...`)
+#     이 silent 하게 secondary 분기로 빠지는 것을 차단한다.
 #
-# 반환: 보조 worktree 면 0 (true), 주 작업트리 또는 git 저장소 외부면 non-zero (false).
-# bare repo·submodule·detached HEAD 등 비표준 환경은 보장 범위 외 (SPEC 171 제약).
+# 반환: 보조 worktree 면 0 (true), 주 작업트리·submodule·git 저장소 외부면 non-zero (false).
+# bare repo·detached HEAD 등 그 외 비표준 환경은 보장 범위 외 (SPEC 171 제약).
 is_secondary_worktree() {
   local top
   top="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
-  [[ -f "$top/.git" ]]
+  [[ -f "$top/.git" ]] && grep -qE 'worktrees' "$top/.git"
 }
 
 # feat 브랜치 검색: input-id (정규화된 task-id 의 child 컴포넌트) 만으로 `feat/<id>` 또는

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -353,7 +353,7 @@ compute_paths() {
 is_secondary_worktree() {
   local top
   top="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
-  [[ -f "$top/.git" ]] && grep -qE 'worktrees' "$top/.git"
+  [[ -f "$top/.git" ]] && grep -qE '\.git/worktrees/' "$top/.git"
 }
 
 # feat 브랜치 검색: input-id (정규화된 task-id 의 child 컴포넌트) 만으로 `feat/<id>` 또는

--- a/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
@@ -900,6 +900,12 @@ test_spec_171_is_secondary_worktree_detection() {
     git worktree add -q -b feat/sw-detect "$secondary" HEAD
   ) || fail "is_secondary_worktree setup"
 
+  # 소스 자체가 실패하면 이후 rc 비교가 vacuous pass 가 되므로 먼저 명시 검증.
+  ( cd "$project" && source "$SKILL_REFS/loop.sh" ) >/dev/null 2>&1 \
+    || fail "loop.sh source 실패 (주 작업트리) — 이후 rc 비교가 무효"
+  ( cd "$secondary" && source "$SKILL_REFS/loop.sh" ) >/dev/null 2>&1 \
+    || fail "loop.sh source 실패 (보조 worktree) — 이후 rc 비교가 무효"
+
   # 주 작업트리에서: 함수 호출 → non-zero (false) 기대
   local rc_main=0
   ( cd "$project"; source "$SKILL_REFS/loop.sh"; is_secondary_worktree ) >/dev/null 2>&1 \

--- a/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
@@ -869,6 +869,156 @@ CL
   pass "(AC6 rebase) rebase 경로 충돌 자동 해소 실패 → 워크트리 복구 + non-zero exit"
 }
 
+# ----- SPEC 171: cmd_start 진입 시 주/보조 worktree 분기 (static grep) -----
+test_spec_171_worktree_detection_static() {
+  local S="$REPO_ROOT/plugins/autopilot/skills/loop"
+  # AC1·AC4: loop.sh 본체에 분기 검사 함수 정의 + cmd_start 가 호출
+  grep -qE 'is_secondary_worktree\(\)' "$S/references/loop.sh" \
+    || fail "loop.sh: is_secondary_worktree() 함수 정의 부재 (AC1·AC4)"
+  # cmd_start 함수 본체에서 is_secondary_worktree 호출이 있는지 (entry 직후 분기)
+  awk '/^cmd_start\(\)/,/^}/' "$S/references/loop.sh" | grep -qE 'is_secondary_worktree' \
+    || fail "loop.sh cmd_start: is_secondary_worktree 호출 부재 — entry 분기 미배선 (AC1·AC4)"
+  # AC5: SKILL.md 호출 방법 절에 두 분기 어휘 명시
+  grep -q '주 작업트리' "$S/SKILL.md" \
+    || fail "SKILL.md: '주 작업트리' 어휘 부재 (AC5)"
+  grep -q '보조 worktree' "$S/SKILL.md" \
+    || fail "SKILL.md: '보조 worktree' 어휘 부재 (AC5)"
+  grep -qE '생략|skip' "$S/SKILL.md" \
+    || fail "SKILL.md: 보조 worktree 분기에서 nested wt 생성 '생략|skip' 어휘 부재 (AC5)"
+  pass "SPEC 171 정적: loop.sh 분기 함수·cmd_start 호출·SKILL.md 어휘"
+}
+
+# ----- SPEC 171: is_secondary_worktree 검출 (소스 후 함수 호출) -----
+test_spec_171_is_secondary_worktree_detection() {
+  local project="$WORK_DIR/sw_detect_proj"
+  local secondary="$WORK_DIR/sw_detect_secondary"
+  git init -q -b main "$project"
+  (
+    cd "$project"
+    git config user.email "t@e.com"; git config user.name "T"
+    git commit --allow-empty -q -m initial
+    git worktree add -q -b feat/sw-detect "$secondary" HEAD
+  ) || fail "is_secondary_worktree setup"
+
+  # 주 작업트리에서: 함수 호출 → non-zero (false) 기대
+  local rc_main=0
+  ( cd "$project"; source "$SKILL_REFS/loop.sh"; is_secondary_worktree ) >/dev/null 2>&1 \
+    || rc_main=$?
+  [[ $rc_main -eq 0 ]] && fail "is_secondary_worktree: 주 작업트리에서 0 exit (=true) 반환 — false 기대"
+
+  # 보조 worktree에서: 함수 호출 → 0 exit (true) 기대
+  local rc_sec=0
+  ( cd "$secondary"; source "$SKILL_REFS/loop.sh"; is_secondary_worktree ) >/dev/null 2>&1 \
+    || rc_sec=$?
+  [[ $rc_sec -eq 0 ]] || fail "is_secondary_worktree: 보조 worktree에서 non-zero ($rc_sec) — true 기대"
+
+  pass "SPEC 171: is_secondary_worktree 검출 (주=false, 보조=true)"
+}
+
+# ----- SPEC 171: 보조 worktree cwd 에서 cmd_start 호출 → nested .worktree 생성 생략 (AC3) -----
+test_spec_171_cmd_start_secondary_skips_nested_wt() {
+  local project="$WORK_DIR/sw_skip_proj"
+  local secondary="$WORK_DIR/sw_skip_secondary"
+  git init -q -b main "$project"
+  (
+    cd "$project"
+    git config user.email "t@e.com"; git config user.name "T"
+    git commit --allow-empty -q -m initial
+    git worktree add -q -b feat/171skip "$secondary" HEAD
+    cd "$secondary"
+    mkdir -p milestones/regular/loops/171skip
+    cat > milestones/regular/loops/171skip/SPEC.md <<'SPEC'
+---
+scope:
+  include: ["**"]
+verify: "true"
+---
+# Test SPEC 171 skip
+SPEC
+    git add milestones/regular/loops/171skip/SPEC.md
+    git commit -q -m "spec: 171skip"
+  ) || fail "cmd_start secondary skip: setup"
+
+  local mock_bin="$WORK_DIR/sw_skip_mock"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/claude" <<'CL'
+#!/usr/bin/env bash
+exit 0
+CL
+  chmod +x "$mock_bin/claude"
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+exit 0
+GH
+  chmod +x "$mock_bin/gh"
+
+  local out=""
+  set +e
+  out=$( cd "$secondary" && PATH="$mock_bin:$PATH" MAX_ITERATIONS=1 WALL_CLOCK_MINUTES=1 \
+         bash "$SKILL_REFS/loop.sh" start "171skip" 2>&1 )
+  set -e
+
+  # AC3: 보조 worktree 안에 nested .worktree 가 생성되지 않아야 함
+  [[ -d "$secondary/milestones/regular/loops/171skip/.worktree" ]] \
+    && fail "보조 worktree에서 nested .worktree 생성됨 — AC3 위반. out=$out"
+
+  # AC3: skip 메시지가 출력되어야 함
+  echo "$out" | grep -qE '보조 worktree|nested.*생략|생성 생략' \
+    || fail "보조 worktree skip 메시지 부재 (AC3). out=$out"
+
+  # AC6: SPEC 검증 동작 — SPEC 부재면 die 하는지 별도 케이스에서 확인 가능. 본 케이스는
+  # 정상 SPEC 이라 검증 통과까지 진행했고 nested 생성만 skip 됐다는 사실로 충족.
+  pass "SPEC 171: 보조 worktree cmd_start → nested .worktree 생성 skip (AC3·AC6)"
+}
+
+# ----- SPEC 171: 주 작업트리 cwd 에서 cmd_start 호출 → 기존 nested .worktree 생성 보존 (AC2) -----
+test_spec_171_cmd_start_main_creates_nested_wt() {
+  local project="$WORK_DIR/sw_main_proj"
+  git init -q -b main "$project"
+  (
+    cd "$project"
+    git config user.email "t@e.com"; git config user.name "T"
+    git commit --allow-empty -q -m initial
+    # feat 브랜치에 SPEC.md 커밋한 후 main 으로 복귀
+    git checkout -q -b feat/171main
+    mkdir -p milestones/regular/loops/171main
+    cat > milestones/regular/loops/171main/SPEC.md <<'SPEC'
+---
+scope:
+  include: ["**"]
+verify: "true"
+---
+# Test SPEC 171 main
+SPEC
+    git add milestones/regular/loops/171main/SPEC.md
+    git commit -q -m "spec: 171main"
+    git checkout -q main
+  ) || fail "cmd_start main create: setup"
+
+  local mock_bin="$WORK_DIR/sw_main_mock"
+  mkdir -p "$mock_bin"
+  cat > "$mock_bin/claude" <<'CL'
+#!/usr/bin/env bash
+exit 0
+CL
+  chmod +x "$mock_bin/claude"
+  cat > "$mock_bin/gh" <<'GH'
+#!/usr/bin/env bash
+exit 0
+GH
+  chmod +x "$mock_bin/gh"
+
+  set +e
+  ( cd "$project" && PATH="$mock_bin:$PATH" MAX_ITERATIONS=1 WALL_CLOCK_MINUTES=1 \
+    bash "$SKILL_REFS/loop.sh" start "171main" >/dev/null 2>&1 )
+  set -e
+
+  # AC2: 주 작업트리에서는 nested .worktree 가 그대로 생성되어야 (기존 동작 보존)
+  [[ -d "$project/milestones/regular/loops/171main/.worktree" ]] \
+    || fail "주 작업트리에서 nested .worktree 미생성 — AC2 위반"
+  pass "SPEC 171: 주 작업트리 cmd_start → nested .worktree 생성 보존 (AC2)"
+}
+
 # ----- 실행 -----
 test_spec_verify_command
 test_phase_scripts_arg_validation
@@ -885,6 +1035,10 @@ test_sync_merge_path_remote_tracking_exists
 test_sync_no_force_push_and_no_direct_rebase_merge
 test_sync_conflict_failure_recovers_merge_path
 test_sync_conflict_failure_recovers_rebase_path
+test_spec_171_worktree_detection_static
+test_spec_171_is_secondary_worktree_detection
+test_spec_171_cmd_start_secondary_skips_nested_wt
+test_spec_171_cmd_start_main_creates_nested_wt
 
 echo "----------"
 echo "ALL TESTS PASSED"

--- a/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
@@ -1014,14 +1014,15 @@ exit 0
 GH
   chmod +x "$mock_bin/gh"
 
+  local out_main=""
   set +e
-  ( cd "$project" && PATH="$mock_bin:$PATH" MAX_ITERATIONS=1 WALL_CLOCK_MINUTES=1 \
-    bash "$SKILL_REFS/loop.sh" start "171main" >/dev/null 2>&1 )
+  out_main=$( cd "$project" && PATH="$mock_bin:$PATH" MAX_ITERATIONS=1 WALL_CLOCK_MINUTES=1 \
+    bash "$SKILL_REFS/loop.sh" start "171main" 2>&1 )
   set -e
 
   # AC2: 주 작업트리에서는 nested .worktree 가 그대로 생성되어야 (기존 동작 보존)
   [[ -d "$project/milestones/regular/loops/171main/.worktree" ]] \
-    || fail "주 작업트리에서 nested .worktree 미생성 — AC2 위반"
+    || fail "주 작업트리에서 nested .worktree 미생성 — AC2 위반. out=$out_main"
   pass "SPEC 171: 주 작업트리 cmd_start → nested .worktree 생성 보존 (AC2)"
 }
 

--- a/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-review-fix-phase.sh
@@ -921,6 +921,36 @@ test_spec_171_is_secondary_worktree_detection() {
   pass "SPEC 171: is_secondary_worktree 검출 (주=false, 보조=true)"
 }
 
+# ----- SPEC 171: .git 파일 경로의 worktrees 문자열 false-positive 방지 -----
+test_spec_171_is_secondary_worktree_ignores_worktrees_path_text() {
+  local project="$WORK_DIR/my-worktrees-backup/repo"
+  local gitdir="$WORK_DIR/my-worktrees-backup/gitdir"
+  mkdir -p "$project"
+  git init -q -b main --separate-git-dir "$gitdir" "$project"
+  (
+    cd "$project"
+    git config user.email "t@e.com"; git config user.name "T"
+    git commit --allow-empty -q -m initial
+  ) || fail "is_secondary_worktree false-positive setup"
+
+  local dotgit
+  dotgit=$(cat "$project/.git")
+  [[ "$dotgit" == *worktrees* ]] \
+    || fail "is_secondary_worktree false-positive fixture: .git 파일에 worktrees 문자열이 없음"
+  [[ "$dotgit" != *".git/worktrees/"* ]] \
+    || fail "is_secondary_worktree false-positive fixture: 실제 보조 worktree 경로가 됨"
+
+  ( cd "$project" && source "$SKILL_REFS/loop.sh" ) >/dev/null 2>&1 \
+    || fail "loop.sh source 실패 (worktrees 문자열 포함 별도 gitdir)"
+
+  local rc=0
+  ( cd "$project"; source "$SKILL_REFS/loop.sh"; is_secondary_worktree ) >/dev/null 2>&1 \
+    || rc=$?
+  [[ $rc -eq 0 ]] && fail "is_secondary_worktree: .git 파일 경로 문자열만으로 true 반환 — false 기대"
+
+  pass "SPEC 171: .git 파일 경로의 worktrees 문자열 false-positive 방지"
+}
+
 # ----- SPEC 171: 보조 worktree cwd 에서 cmd_start 호출 → nested .worktree 생성 생략 (AC3) -----
 test_spec_171_cmd_start_secondary_skips_nested_wt() {
   local project="$WORK_DIR/sw_skip_proj"
@@ -1044,6 +1074,7 @@ test_sync_conflict_failure_recovers_merge_path
 test_sync_conflict_failure_recovers_rebase_path
 test_spec_171_worktree_detection_static
 test_spec_171_is_secondary_worktree_detection
+test_spec_171_is_secondary_worktree_ignores_worktrees_path_text
 test_spec_171_cmd_start_secondary_skips_nested_wt
 test_spec_171_cmd_start_main_creates_nested_wt
 


### PR DESCRIPTION
<!-- autopilot:pr-body:begin -->
## 무엇을 만들 것인가

loop 스킬의 `start` 서브커맨드가 호출될 때, 시스템은 호출 워킹 디렉토리가 git 저장소의 *주 작업트리(main working tree)*인지 *보조 worktree*인지 검사한다. 주 작업트리에서 호출된 경우 기존 동작을 그대로 수행해 `milestones/<m>/loops/<c>/.worktree/` nested worktree를 생성·사용한다. **보조 worktree 안에서 호출된 경우 nested worktree 생성을 생략**하고 현재 호출 cwd의 worktree를 그대로 작업 공간으로 사용한다. 이는 spec 워크플로우가 worktree 안에서 SPEC.md를 만든 직후 그 자리에서 loop start를 호출하는 흐름이나, 사용자가 임의 worktree에서 의도적으로 loop을 돌리는 케이스를 지원하기 위함이다. 이전 reject(거부) 접근법은 worktree-내부 호출을 일률 차단해 사용자 마찰을 일으켰던 반면, skip 접근법은 isolation 목적이 이미 충족된 상황(보조 worktree 자체가 격리된 작업 공간)을 인지해 중복 nested worktree 생성을 방지한다. 사용자가 docs만으로도 동일 동작에 도달할 수 있도록 스킬 문서의 호출 방법 절에도 명시 지침을 추가한다.

## Commits
- 9d7638d Merge remote-tracking branch 'origin/main' into feat/171-loop-must-run-from-main-repo-cwd
- 0b5abed feat(spec): 171 — loop 보조 worktree 호출 시 nested wt 생성 생략
- 352eaaa spec(171): AC6 마커 인용 우회 — 본문 substring 제거

Closes #171
<!-- autopilot:pr-body:end -->