### PR TITLE
#223: claude 리뷰 프롬프트를 --json-schema structured output에 정렬

### DIFF
--- a/.github/prompts/claude-pr-review.ko.md
+++ b/.github/prompts/claude-pr-review.ko.md
@@ -9,8 +9,8 @@
 - 이 프롬프트는 특정 병렬 실행 방식을 가정하지 않습니다.
 - 입력으로 제공된 diff/context 범위 안에서 판단합니다.
 - context가 부족하면 추측하지 말고 `needs_context` 또는 `unavailable` verdict를 반환합니다.
-- 최종 응답은 반드시 `submit_pr_review` tool call 하나로만 제출합니다.
-- `submit_pr_review` input은 제공된 JSON schema를 그대로 만족해야 합니다.
+- 최종 응답은 반드시 제공된 JSON schema를 만족하는 구조화 출력(structured output) 하나로만 제출합니다.
+- 구조화 출력은 schema의 모든 required 필드를 채우고 enum·타입을 그대로 따릅니다. 별도 custom tool 이름(예: submit_pr_review)을 가정하지 말고, `--json-schema`가 제공하는 structured-output 메커니즘으로만 제출합니다.
 
 입력:
 - Pull Request metadata
@@ -139,4 +139,4 @@ Evidence requirement:
 
 출력 규칙:
 마크다운 설명, 코드블록, 추가 문장은 출력하지 않습니다.
-반드시 `submit_pr_review` tool call의 input으로만 결과를 제출합니다.
+반드시 제공된 JSON schema를 만족하는 구조화 출력(structured output)으로만 결과를 제출합니다.


### PR DESCRIPTION
## 요약
Claude PR Review의 `--json-schema was provided but Claude did not return structured_output` 실패 수정.

## 근본 원인 (검증)
claude-code-action의 `--json-schema`는 **`StructuredOutput` tool을 주입**해 모델이 그 tool로 결과를 내면 `result.structured_output`이 채워지는 tool 기반 메커니즘이다. 그런데 `claude-pr-review.ko.md`는 워크플로 어디에도 정의되지 않은 **phantom `submit_pr_review` tool** 호출을 지시(3곳)했다. 모델은 그 지시를 따르느라 실제 structured-output을 내지 않고 `subtype: success`로 종료 → `structured_output` 빈 상태로 action이 실패.
(대조: codex 프롬프트는 '직접 JSON 출력'이라 codex 리뷰는 성공.)

## 변경
- `claude-pr-review.ko.md`의 phantom `submit_pr_review` tool 지시 3곳을 '제공된 JSON schema를 만족하는 구조화 출력으로 제출'로 정렬. (custom tool 이름 가정 금지를 명시.)

## 검증 방법
이 PR의 Claude PR Review 체크가 structured_output을 반환하며 성공하는지로 확인. (#222 codex 언어 설정과 별개 task.)

Refs #223