### PR TITLE
fix(ci): claude review structured_output 실패 수정 — 프롬프트 직접 주입

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -153,6 +153,19 @@ jobs:
             printf '\nEOF\n'
           } >> "$GITHUB_OUTPUT"
 
+          # Inline the full review prompt as a step output so the model receives it
+          # directly (mirroring the Codex workflow's stdin injection) instead of
+          # reading a file agentically. The read-then-respond agentic flow caused
+          # claude-code-action to finish with "Result subtype: success" but no
+          # structured_output, failing the --json-schema contract.
+          prompt_delim="CLAUDE_PROMPT_EOF_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
+          {
+            printf 'prompt<<%s\n' "$prompt_delim"
+            cat .claude-review/prompt.md
+            printf '\n\nReturn only the structured review object required by the JSON schema.\n'
+            printf '%s\n' "$prompt_delim"
+          } >> "$GITHUB_OUTPUT"
+
           # Drop the checkout credential before the model action runs so the
           # review model cannot reach the authenticated git remote.
           git config --local --unset-all http.https://github.com/.extraheader || true
@@ -162,9 +175,7 @@ jobs:
         uses: anthropics/claude-code-action@20c8abf165d5f85ab3fc970db9498436377dc9d1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            Read `.claude-review/prompt.md` and perform the PR review according to that file.
-            Return only the structured review object required by the JSON schema.
+          prompt: ${{ steps.prepare-claude-review.outputs.prompt }}
           claude_args: |
             --model ${{ vars.CLAUDE_REVIEW_MODEL || 'claude-sonnet-4-5-20250929' }}
             --json-schema '${{ steps.prepare-claude-review.outputs.schema }}'
@@ -224,6 +235,13 @@ jobs:
                 sed -n '1,400p' "$file"
               done
             } >> "$second_prompt"
+            prompt_delim="CLAUDE_FOLLOWUP_EOF_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
+            {
+              printf 'prompt<<%s\n' "$prompt_delim"
+              cat "$second_prompt"
+              printf '\n\nReturn only the structured review object required by the JSON schema.\n'
+              printf '%s\n' "$prompt_delim"
+            } >> "$GITHUB_OUTPUT"
             printf 'has_extra_context=true\n' >> "$GITHUB_OUTPUT"
           else
             printf 'has_extra_context=false\n' >> "$GITHUB_OUTPUT"
@@ -235,9 +253,7 @@ jobs:
         uses: anthropics/claude-code-action@20c8abf165d5f85ab3fc970db9498436377dc9d1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          prompt: |
-            Read `.claude-review/prompt.follow-up.md` and perform the final PR review according to that file.
-            Return only the structured review object required by the JSON schema.
+          prompt: ${{ steps.prepare-claude-follow-up.outputs.prompt }}
           claude_args: |
             --model ${{ vars.CLAUDE_REVIEW_MODEL || 'claude-sonnet-4-5-20250929' }}
             --json-schema '${{ steps.prepare-claude-review.outputs.schema }}'


### PR DESCRIPTION
## 문제
`Claude PR Review` 워크플로의 "Run Claude review" 스텝이 claude-code-action(`--json-schema`) 호출에서 "Result subtype: success"인데 `structured_output`을 반환하지 않아 `exit 1`로 실패. (예: feat/227-spec head `91af767`, 약 3m45s 실패.)

## 원인
프롬프트가 모델에게 `.claude-review/prompt.md`를 **읽게** 하는 agentic 턴을 거치게 했고, 그 흐름에서 claude-code-action의 structured_output 캡처가 깨졌다. Codex 워크플로는 프롬프트를 stdin으로 직접 주입해 통과한다(같은 schema·같은 PR에서 Codex는 success).

## 수정
Codex 패턴에 맞춰 프롬프트 전문을 step output으로 **인라인 주입**(파일 읽기 제거)하여 모델이 단일 턴에서 schema JSON을 내도록 정렬. `Run Claude review`·`Run Claude follow-up review` 두 스텝 모두 적용.

## 분리 배경
원래 #227(feat/227-spec)에 번들했으나, claude-code-action의 self-modifying-workflow validation(워크플로 파일이 default branch와 **동일**해야 함)에 막혀 분리. 이 PR은 `.github/workflows/**`만 변경하므로 리뷰 워크플로의 `paths-ignore: '.github/workflows/**'`로 리뷰가 트리거되지 않아 validation 실패 없이 머지 가능하다. 머지 후 #227(PR #228)을 rebase하면 그쪽 Claude 체크도 고쳐진 워크플로로 검증된다.

Refs #227
