### PR TITLE
fix(ci): review 워크플로 중복 approve dismiss 누락 + extra-context 디렉터리 가드

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -362,9 +362,10 @@ jobs:
             while IFS= read -r requested_file; do
               [ -n "$requested_file" ] || continue
               case "$requested_file" in
-                /*|*..*) continue ;;
+                /*|*..*|*/) continue ;;
               esac
-              if git cat-file -e "$PR_HEAD_SHA:$requested_file" 2>/dev/null; then
+              # blob(파일)일 때만 가져온다. tree(디렉터리)는 cat-file -e도 통과하므로 타입으로 가드.
+              if [ "$(git cat-file -t "$PR_HEAD_SHA:$requested_file" 2>/dev/null)" = "blob" ]; then
                 mkdir -p ".review-extra-context/$(dirname "$requested_file")"
                 git show "$PR_HEAD_SHA:$requested_file" > ".review-extra-context/$requested_file"
               fi
@@ -476,15 +477,18 @@ jobs:
             const existingReviews = await github.paginate(
               github.rest.pulls.listReviews,
               { owner, repo, pull_number, per_page: 100 });
+            // 중복 감지 시 즉시 return하지 않는다 — 제출(submit)만 건너뛰고
+            // approve verdict 후처리(이전 CHANGES_REQUESTED dismiss·outdated thread resolve)는 계속 실행한다.
+            let skipSubmit = false;
             if (existingReviews.some((r) =>
                 r.user?.login === botLogin && (r.body || '').includes(marker))) {
-              core.info(`Formal Claude review for ${head_sha} verdict=${verdict} already exists; skipping duplicate.`);
-              return;
+              core.info(`Formal Claude review for ${head_sha} verdict=${verdict} already exists; skipping duplicate submission.`);
+              skipSubmit = true;
             }
-            if (event === 'APPROVE' && existingReviews.some((r) =>
+            if (!skipSubmit && event === 'APPROVE' && existingReviews.some((r) =>
                 r.user?.login === botLogin && r.state === 'APPROVED' && r.commit_id === head_sha)) {
-              core.info(`Formal Claude approval already exists for ${head_sha}; skipping duplicate.`);
-              return;
+              core.info(`Formal Claude approval already exists for ${head_sha}; skipping duplicate submission.`);
+              skipSubmit = true;
             }
 
             // Submit. Workflow token cannot self-approve — fall back to COMMENT if APPROVE 403/422s.
@@ -498,25 +502,27 @@ jobs:
 
             let actualEvent = event;
             let submitOk = false;
-            try {
-              await submit(event);
-              submitOk = true;
-              core.info(`Submitted ${event} review (${inlineComments.length} inline + ${issueFindings.length} issue findings).`);
-            } catch (e) {
-              if (event === 'APPROVE') {
-                core.warning(`APPROVE failed (${e.status || ''} ${e.message}); falling back to COMMENT.`);
-                fs.writeFileSync('.claude-review/approval-failed', '');
-                actualEvent = 'COMMENT';
-                try { await submit('COMMENT'); submitOk = true; }
-                catch (e2) { core.warning(`Fallback COMMENT also failed (${e2.status || ''} ${e2.message}); continuing.`); }
-              } else {
-                core.warning(`Review submission failed (${e.status || ''} ${e.message}); continuing.`);
+            if (!skipSubmit) {
+              try {
+                await submit(event);
+                submitOk = true;
+                core.info(`Submitted ${event} review (${inlineComments.length} inline + ${issueFindings.length} issue findings).`);
+              } catch (e) {
+                if (event === 'APPROVE') {
+                  core.warning(`APPROVE failed (${e.status || ''} ${e.message}); falling back to COMMENT.`);
+                  fs.writeFileSync('.claude-review/approval-failed', '');
+                  actualEvent = 'COMMENT';
+                  try { await submit('COMMENT'); submitOk = true; }
+                  catch (e2) { core.warning(`Fallback COMMENT also failed (${e2.status || ''} ${e2.message}); continuing.`); }
+                } else {
+                  core.warning(`Review submission failed (${e.status || ''} ${e.message}); continuing.`);
+                }
               }
             }
 
             // If review submission failed but we have inline findings, surface
             // them in the managed PR comment so review content isn't lost.
-            if (!submitOk && inlineFindings.length > 0) {
+            if (!skipSubmit && !submitOk && inlineFindings.length > 0) {
               fs.writeFileSync('.claude-review/inline-fallback-needed', '');
               core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) will appear in managed PR comment instead of inline.`);
             }

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -187,9 +187,10 @@ jobs:
             while IFS= read -r requested_file; do
               [ -n "$requested_file" ] || continue
               case "$requested_file" in
-                /*|*..*) continue ;;
+                /*|*..*|*/) continue ;;
               esac
-              if git cat-file -e "$PR_HEAD_SHA:$requested_file" 2>/dev/null; then
+              # blob(파일)일 때만 가져온다. tree(디렉터리)는 cat-file -e도 통과하므로 타입으로 가드.
+              if [ "$(git cat-file -t "$PR_HEAD_SHA:$requested_file" 2>/dev/null)" = "blob" ]; then
                 mkdir -p ".review-extra-context/$(dirname "$requested_file")"
                 git show "$PR_HEAD_SHA:$requested_file" > ".review-extra-context/$requested_file"
               fi
@@ -309,15 +310,18 @@ jobs:
             const existingReviews = await github.paginate(
               github.rest.pulls.listReviews,
               { owner, repo, pull_number, per_page: 100 });
+            // 중복 감지 시 즉시 return하지 않는다 — 제출(submit)만 건너뛰고
+            // approve verdict 후처리(이전 CHANGES_REQUESTED dismiss·outdated thread resolve)는 계속 실행한다.
+            let skipSubmit = false;
             if (existingReviews.some((r) =>
                 r.user?.login === botLogin && (r.body || '').includes(marker))) {
-              core.info(`Formal Codex review for ${head_sha} verdict=${verdict} already exists; skipping duplicate.`);
-              return;
+              core.info(`Formal Codex review for ${head_sha} verdict=${verdict} already exists; skipping duplicate submission.`);
+              skipSubmit = true;
             }
-            if (event === 'APPROVE' && existingReviews.some((r) =>
+            if (!skipSubmit && event === 'APPROVE' && existingReviews.some((r) =>
                 r.user?.login === botLogin && r.state === 'APPROVED' && r.commit_id === head_sha)) {
-              core.info(`Formal Codex approval already exists for ${head_sha}; skipping duplicate.`);
-              return;
+              core.info(`Formal Codex approval already exists for ${head_sha}; skipping duplicate submission.`);
+              skipSubmit = true;
             }
 
             // Submit. Workflow token cannot self-approve — fall back to COMMENT if APPROVE 403/422s.
@@ -331,25 +335,27 @@ jobs:
 
             let actualEvent = event;
             let submitOk = false;
-            try {
-              await submit(event);
-              submitOk = true;
-              core.info(`Submitted ${event} review (${inlineComments.length} inline + ${issueFindings.length} issue findings).`);
-            } catch (e) {
-              if (event === 'APPROVE') {
-                core.warning(`APPROVE failed (${e.status || ''} ${e.message}); falling back to COMMENT.`);
-                fs.writeFileSync('.codex-review/approval-failed', '');
-                actualEvent = 'COMMENT';
-                try { await submit('COMMENT'); submitOk = true; }
-                catch (e2) { core.warning(`Fallback COMMENT also failed (${e2.status || ''} ${e2.message}); continuing.`); }
-              } else {
-                core.warning(`Review submission failed (${e.status || ''} ${e.message}); continuing.`);
+            if (!skipSubmit) {
+              try {
+                await submit(event);
+                submitOk = true;
+                core.info(`Submitted ${event} review (${inlineComments.length} inline + ${issueFindings.length} issue findings).`);
+              } catch (e) {
+                if (event === 'APPROVE') {
+                  core.warning(`APPROVE failed (${e.status || ''} ${e.message}); falling back to COMMENT.`);
+                  fs.writeFileSync('.codex-review/approval-failed', '');
+                  actualEvent = 'COMMENT';
+                  try { await submit('COMMENT'); submitOk = true; }
+                  catch (e2) { core.warning(`Fallback COMMENT also failed (${e2.status || ''} ${e2.message}); continuing.`); }
+                } else {
+                  core.warning(`Review submission failed (${e.status || ''} ${e.message}); continuing.`);
+                }
               }
             }
 
             // If review submission failed but we have inline findings, surface
             // them in the managed PR comment so review content isn't lost.
-            if (!submitOk && inlineFindings.length > 0) {
+            if (!skipSubmit && !submitOk && inlineFindings.length > 0) {
               fs.writeFileSync('.codex-review/inline-fallback-needed', '');
               core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) will appear in managed PR comment instead of inline.`);
             }


### PR DESCRIPTION
## 무엇을 / 왜

PR #235 Codex 리뷰가 낸 **blocking 2건**과 PR #238 리뷰 **실패** 원인(둘 다 review 워크플로 코드)을 수정한다.

### 1. 중복 approve 시 stale CHANGES_REQUESTED dismiss 누락 (blocking)
`claude-review.yml`·`codex-review.yml`에서 현재 head에 이미 같은 리뷰/APPROVED가 있으면 **즉시 `return`** 하여, 그 아래의 "verdict=approve 시 이전 CHANGES_REQUESTED 리뷰 dismiss" 후처리가 실행되지 않았다. 가장 흔한 재실행(최신 approve) 경로에서 자동 dismiss가 무력화되어 stale request-changes가 남아 PR 상태가 계속 변경요청으로 보였다.

→ `skipSubmit` 플래그로 전환: 중복이면 **제출만 건너뛰고** approve 후처리(dismiss·outdated thread resolve)는 계속 실행. inline-fallback 기록도 `!skipSubmit`로 가드.

### 2. extra-context 디렉터리 경로 가드 (#238 리뷰 실패 원인 · #239 SPEC 구현)
리뷰어가 추가 context로 **디렉터리(git tree)** 경로를 요청하면 `git cat-file -e`가 통과해 파일로 취급, `git show <sha>:<dir> > .review-extra-context/<dir>`(이미 디렉터리)로 리다이렉트하다 `set -e`로 죽었다(`Is a directory`).

→ **blob 타입일 때만** 가져오고(`git cat-file -t … = blob`), 트레일링슬래시 경로는 건너뛴다.

## 범위

- `.github/workflows/claude-review.yml`, `.github/workflows/codex-review.yml` (양쪽 동일 적용).
- plugins 외 변경이라 버전 bump 없음(versioning watch=plugins).

## 검증

- 두 워크플로 YAML `yq eval` 파싱 통과.
- 편집은 최소·대칭(두 파일 동일 패치), brace 균형 확인.
- 런타임 검증: 머지 후 재실행 시 ① 중복 approve에서도 이전 CHANGES_REQUESTED가 dismiss되는지 ② 디렉터리 context 요청 시 워크플로가 실패하지 않는지 확인.

## 관련

- #239(디렉터리 가드 SPEC)를 본 PR이 구현 — 머지 시 #239는 닫아도 됨.
- 본 수정이 main에 들어가면, #235의 해당 blocking findings(merge로 유입된 워크플로 코드 대상)도 해소된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)