### PR TITLE
chore(autopilot): bump version 0.10.0 → 0.11.0 (MINOR)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "autopilot",
       "source": "./plugins/autopilot",
       "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch 3-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션. forge·task 연동은 외부 지침으로 분리.",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "category": "automation",
       "tags": ["autonomous", "ralph-loop", "agent-runtime", "self-directed"]
     }

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch 3-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션. forge·task 연동은 외부 지침으로 분리.",
   "author": {
     "name": "예의상",


### PR DESCRIPTION
0.10.0 이후 per-spec 디렉토리 레이아웃 신규 기능(spec/dispatch/loop 산출 경로 전환)이 워치 디렉토리(plugins/)에 머지되어 SemVer MINOR bump.

- SoT `plugins/autopilot/.claude-plugin/plugin.json`: 0.10.0 → 0.11.0
- 파생 위치 `.claude-plugin/marketplace.json` autopilot 핀: 0.10.0 → 0.11.0 (동기화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)