### PR TITLE
fix(dispatch): ps·pgrep 부재 환경 견고화 + 통합 테스트 git ident 가드

### DIFF
--- a/plugins/autopilot/skills/dispatch/references/dispatch.sh
+++ b/plugins/autopilot/skills/dispatch/references/dispatch.sh
@@ -191,15 +191,17 @@ loop_start_bg() {
 
 # kill_tree <pid> [<sig>] — pid 와 그 자손 프로세스를 재귀적으로 kill.
 # subshell 만 죽이면 손자(자손 프로세스) 가 orphan 으로 남으므로 트리 재귀가 필요.
-# pgrep 가 없는 환경에서는 ps 폴백.
+# pgrep 가 없으면 ps 폴백, ps 마저 없으면 자손 열거를 건너뛰고 pid 만 직접 kill.
+# set -euo pipefail 하에서 pgrep·ps 부재가 비0 종료로 스크립트를 죽이지 않도록
+# command -v 로 존재를 먼저 확인하고 파이프라인 끝에 `|| true` 가드를 둔다.
 kill_tree() {
   local pid="$1"; local sig="${2:-TERM}"
   local children=""
   if command -v pgrep >/dev/null 2>&1; then
     children=$(pgrep -P "$pid" 2>/dev/null || true)
-  else
+  elif command -v ps >/dev/null 2>&1; then
     children=$(ps -o pid= -o ppid= 2>/dev/null \
-                | awk -v p="$pid" '$2==p { print $1 }')
+                | awk -v p="$pid" '$2==p { print $1 }' || true)
   fi
   local c
   for c in $children; do

--- a/tests/autopilot/test-dispatch-integration.sh
+++ b/tests/autopilot/test-dispatch-integration.sh
@@ -7,6 +7,11 @@
 
 set -euo pipefail
 
+# 일부 CI/loop 환경이 GIT_AUTHOR_*/GIT_COMMITTER_* 를 빈 문자열로 export 하면
+# git config(user.name/email)를 덮어써 git commit 이 "empty ident name" 으로 실패한다.
+# 임시 repo 의 로컬 config 가 적용되도록 빈 ident 환경변수를 해제한다.
+unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL 2>/dev/null || true
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 DISPATCH_SH="$REPO_ROOT/plugins/autopilot/skills/dispatch/references/dispatch.sh"
 [[ -x "$DISPATCH_SH" ]] || { echo "FAIL: dispatch.sh 실행 권한 없음"; exit 1; }


### PR DESCRIPTION
## 배경

`docs/specs/2026-05-29-dispatch-spec-list-driven-orchestrator.md` 구현 검증 중 발견한 **두 가지 환경 취약점**을 수정합니다. dispatch 오케스트레이션 로직(SPEC 수용 기준)은 변경하지 않으며, 정적 verify 게이트는 유지됩니다.

## 검증 결과 (실측)

- 정적 verify 게이트: **PASS**
- 스킬 구조 테스트(`test-dispatch-skill.sh`): **12/12**
- 격리 통합 테스트(`test-dispatch-integration.sh`): **17/17, exit 0**

두 실패 모두 dispatch 구현 결함이 아니라 **최소 실행 환경(격리 샌드박스 서브셸)의 도구/환경변수 부재**가 원인이었습니다.

## 변경

### 1. `dispatch.sh` `kill_tree` 견고화
`pgrep`·`ps`가 **둘 다 없는** 최소 환경에서, wave timeout 시 자손 프로세스를 열거하는 `ps … | awk` 폴백이 `set -euo pipefail` 하에서 127로 죽어 dispatch 전체를 crash 시켰습니다(timeout rc=2 대신 127).
- `command -v ps`로 존재를 확인하는 `elif` 분기로 변경하고 파이프라인 끝에 `|| true` 가드 추가.
- 자손 열거가 불가능하면 건너뛰고 pid만 직접 best-effort kill 하며 의도된 timeout rc=2를 유지.
- `pgrep`/`ps`가 있는 정상 환경에서의 동작은 동일.

### 2. `test-dispatch-integration.sh` git ident 가드
빈 `GIT_AUTHOR_*`/`GIT_COMMITTER_*` 환경변수가 임시 repo의 로컬 `git config`를 덮어써 setup의 `git commit`이 `fatal: empty ident name`(exit 128)으로 실패했습니다. 해당 env를 `unset`해 로컬 config가 적용되도록 수정.

## 테스트

```
bash tests/autopilot/test-dispatch-integration.sh   # 17/17, exit 0
bash tests/autopilot/test-dispatch-skill.sh          # 12/12, exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)