### PR TITLE
fix(ci): 리뷰 워크플로 inline thread auto-resolve 복구 — GraphQL 봇 login 매칭

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -548,11 +548,13 @@ jobs:
                 }
               }
 
-              // Resolve inline review threads whose source has been fixed.
-              // Condition: GitHub flagged the thread as outdated (the source
-              // line moved/changed) AND the latest verdict is approve (we
-              // consider the issue resolved). We only touch self-owned threads
-              // — identified by the hidden inline marker we embed above.
+              // Resolve our own inline review threads when the latest verdict
+              // is approve — a fresh approve supersedes all prior self inline
+              // findings (same intent as the dismiss-on-approve above). We only
+              // touch self-owned threads, identified by the hidden inline marker
+              // we embed above. Not gated on isOutdated: this path runs only on a
+              // clean approve (no current-round inline findings), so there are no
+              // live threads to resolve by mistake.
               try {
                 const threadResp = await github.graphql(`
                   query($owner:String!, $repo:String!, $pr:Int!) {
@@ -562,7 +564,6 @@ jobs:
                           nodes {
                             id
                             isResolved
-                            isOutdated
                             comments(first: 1) {
                               nodes { author { login } body }
                             }
@@ -572,10 +573,16 @@ jobs:
                     }
                   }`, { owner, repo, pr: pull_number });
                 const threads = threadResp.repository?.pullRequest?.reviewThreads?.nodes || [];
-                const myInlineThreads = threads.filter((t) =>
-                  t.isOutdated && !t.isResolved &&
-                  t.comments?.nodes?.[0]?.author?.login === botLogin &&
-                  (t.comments.nodes[0].body || '').includes(inlineMarker));
+                // GraphQL Actor.login omits the REST "[bot]" suffix (returns
+                // "github-actions"), so the REST botLogin never matches here —
+                // accept both forms.
+                const botLoginGql = botLogin.replace(/\[bot\]$/, '');
+                const myInlineThreads = threads.filter((t) => {
+                  const author = t.comments?.nodes?.[0]?.author?.login;
+                  return !t.isResolved &&
+                    (author === botLogin || author === botLoginGql) &&
+                    (t.comments.nodes[0].body || '').includes(inlineMarker);
+                });
                 for (const t of myInlineThreads) {
                   try {
                     await github.graphql(`
@@ -584,7 +591,7 @@ jobs:
                           thread { id isResolved }
                         }
                       }`, { id: t.id });
-                    core.info(`Resolved outdated self inline thread ${t.id}.`);
+                    core.info(`Resolved self inline thread ${t.id}.`);
                   } catch (e) {
                     core.warning(`Failed to resolve thread ${t.id}: ${e.message}`);
                   }

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -381,11 +381,13 @@ jobs:
                 }
               }
 
-              // Resolve inline review threads whose source has been fixed.
-              // Condition: GitHub flagged the thread as outdated (the source
-              // line moved/changed) AND the latest verdict is approve (we
-              // consider the issue resolved). We only touch self-owned threads
-              // — identified by the hidden inline marker we embed above.
+              // Resolve our own inline review threads when the latest verdict
+              // is approve — a fresh approve supersedes all prior self inline
+              // findings (same intent as the dismiss-on-approve above). We only
+              // touch self-owned threads, identified by the hidden inline marker
+              // we embed above. Not gated on isOutdated: this path runs only on a
+              // clean approve (no current-round inline findings), so there are no
+              // live threads to resolve by mistake.
               try {
                 const threadResp = await github.graphql(`
                   query($owner:String!, $repo:String!, $pr:Int!) {
@@ -395,7 +397,6 @@ jobs:
                           nodes {
                             id
                             isResolved
-                            isOutdated
                             comments(first: 1) {
                               nodes { author { login } body }
                             }
@@ -405,10 +406,16 @@ jobs:
                     }
                   }`, { owner, repo, pr: pull_number });
                 const threads = threadResp.repository?.pullRequest?.reviewThreads?.nodes || [];
-                const myInlineThreads = threads.filter((t) =>
-                  t.isOutdated && !t.isResolved &&
-                  t.comments?.nodes?.[0]?.author?.login === botLogin &&
-                  (t.comments.nodes[0].body || '').includes(inlineMarker));
+                // GraphQL Actor.login omits the REST "[bot]" suffix (returns
+                // "github-actions"), so the REST botLogin never matches here —
+                // accept both forms.
+                const botLoginGql = botLogin.replace(/\[bot\]$/, '');
+                const myInlineThreads = threads.filter((t) => {
+                  const author = t.comments?.nodes?.[0]?.author?.login;
+                  return !t.isResolved &&
+                    (author === botLogin || author === botLoginGql) &&
+                    (t.comments.nodes[0].body || '').includes(inlineMarker);
+                });
                 for (const t of myInlineThreads) {
                   try {
                     await github.graphql(`
@@ -417,7 +424,7 @@ jobs:
                           thread { id isResolved }
                         }
                       }`, { id: t.id });
-                    core.info(`Resolved outdated self inline thread ${t.id}.`);
+                    core.info(`Resolved self inline thread ${t.id}.`);
                   } catch (e) {
                     core.warning(`Failed to resolve thread ${t.id}: ${e.message}`);
                   }

--- a/docs/specs/2026-05-30-github-review-workflow-inline-thread-auto-resolve-login.md
+++ b/docs/specs/2026-05-30-github-review-workflow-inline-thread-auto-resolve-login.md
@@ -1,0 +1,54 @@
+---
+scope:
+  include:
+    - .github/workflows/claude-review.yml
+    - .github/workflows/codex-review.yml
+    - tests/claude/test-claude-review-workflow.sh
+    - tests/codex/test-codex-review-workflow.sh
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+ears_language: ko
+---
+
+# GitHub review workflow inline thread auto-resolve 봇 login 매칭 수정
+
+## 무엇을 만들 것인가
+<!-- WHAT/HOW 방어선: 무엇을 만들지만 적고 구현 방법·파일·라이브러리·클래스명은 제약으로 이동. -->
+PR 리뷰 워크플로는 최신 verdict가 approve일 때, 자신이 과거에 단 inline review thread를 자동으로 resolved 상태로 전환하려 한다. 그러나 self thread 식별이 GitHub GraphQL API가 반환하는 봇 작성자 login 형식과 어긋나, 식별이 항상 실패하고 어떤 thread도 resolve되지 않는다. 또한 resolve가 "소스 라인이 outdated인 thread"로만 제한되어, 최신 approve로 supersede된 유효 thread가 남는다.
+
+이 두 가지를 고쳐, verdict가 approve일 때 워크플로가 자신이 단 미해결 inline thread를 안정적으로 resolve하도록 한다. self thread 식별은 워크플로가 코멘트 본문에 심는 self-식별 마커를 1차 기준으로 삼고, 작성자 봇 식별은 GraphQL이 돌려주는 login 형식과 어긋나지 않아야 한다. REST API 기반 봇 식별 경로(기존 리뷰 멱등성·이전 리뷰 dismiss)는 동작을 그대로 유지한다. 동일 동작을 두 리뷰 워크플로 모두에 적용하고, 회귀를 막는 테스트 가드를 둔다.
+
+## 수용 기준 (EARS)
+<!-- EARS 5패턴과 언어 규칙은 references/ears-patterns.md. 각 기준은 관찰 가능하고 독립 검증 가능해야 함. -->
+1. When 최신 verdict가 approve이고 봇이 작성한 inline review thread가 미해결(unresolved) 상태이며 self-식별 마커를 포함할 때, 시스템은 그 thread를 resolved 상태로 전환해야 한다.
+2. While 위 조건이 성립하는 thread를 식별하는 동안, 시스템은 thread의 outdated 여부와 무관하게 그 thread를 resolve 대상으로 삼아야 한다.
+3. If GraphQL API가 봇 작성자의 login을 REST 형식(접미사 `[bot]` 포함)과 다른 형식으로 반환하더라도, 시스템은 해당 thread를 자신이 작성한 thread로 식별해야 한다.
+4. 시스템은 REST API 기반 봇 식별 경로(기존 리뷰 멱등성 검사, 이전 CHANGES_REQUESTED 리뷰 dismiss)의 봇 식별 동작을 변경 없이 유지해야 한다.
+5. 시스템은 Claude·Codex 두 리뷰 워크플로에서 동일한 self inline thread resolve 동작을 제공해야 한다.
+6. 시스템은 두 워크플로 테스트 스위트에, self-thread 식별이 GraphQL이 반환하는 봇 login 형식과 어긋나면 실패하는 회귀 가드를 포함해야 하며, resolve 동작이 thread의 outdated 여부에 의존하도록 강제하는 단언을 두지 않아야 한다.
+
+## 범위
+포함:
+- 두 리뷰 워크플로의 self inline thread resolve 필터 — 작성자 봇 식별과 outdated 게이트 로직
+- 두 워크플로 테스트의 auto-resolve 체크 블록
+
+비-목표 / 제외:
+- resolve 전체를 가두는 verdict=approve 게이트(verdictIsApprove) 자체의 변경
+- REST 비교 경로에서 쓰는 봇 login 상수의 REST 형식 값 변경
+- inline 코멘트 게시 로직·self-식별 마커 문자열 변경
+- resolveReviewThread 외의 thread lifecycle(재-open 등) 추가
+
+## 검증
+<!-- 검증 기준의 단일 출처는 위 "수용 기준 (EARS)"다. 검증을 실행하는 진입 명령(테스트·lint·빌드)은 SPEC이 선언하지 않는다. -->
+이 SPEC의 인수 바는 위 **수용 기준 (EARS)**이다. 각 기준이 관찰 가능하게 충족되면 충족된 것으로 본다. 검증을 실행하는 진입 명령은 SPEC이 아니라 프로젝트 규칙(`rules/`)이 단일 출처로 정의한다.
+
+## 제약 (있을 때만)
+- REST 비교(기존 리뷰 멱등성, 이전 리뷰 dismiss)에서 쓰는 봇 login 상수의 REST 형식 값은 바꾸지 않는다 — 그 경로에서는 REST 형식이 정확하다.
+- self inline thread 식별은 코멘트 본문에 심은 self-식별 마커를 1차 식별자로 유지한다.
+- 두 워크플로에 동일하게 적용한다.
+
+## 위험 (있을 때만)
+- GraphQL이 향후 봇 login 형식을 다시 바꿀 위험 — self-식별 마커를 1차 식별자로 유지하고 봇 login 비교를 형식 차이에 강인하게 처리하여 완화한다(구체 방식은 구현 결정).
+- outdated 게이트 완화로 verdict=approve 시점에 아직 유효한 self thread까지 resolve될 가능성 — resolve 경로는 현재 라운드 inline finding이 0건인 approve에서만 진입하므로 현재 라운드 thread 오해소 위험은 없고, 과거 thread는 최신 approve가 supersede한다는 기존 dismiss-on-approve 의미와 일치한다.

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -249,13 +249,13 @@ grep -qF 'Superseded by later review' "$WORKFLOW" \
   || fail "verdict!=approve 일 때 옛 approve managed comment supersede 분기 부재 (stale approve 가 PR 대화에 남음)"
 grep -qF 'Superseded stale managed comment' "$WORKFLOW" \
   || fail "supersede core.info log 부재"
-# auto-resolve outdated self inline threads on verdict=approve
+# auto-resolve self inline threads on verdict=approve (outdated 무관)
 grep -qF "<!-- claude-review-inline -->" "$WORKFLOW" \
   || fail "inline comment 의 self-identification marker (claude-review-inline) 부재"
 grep -qF 'resolveReviewThread' "$WORKFLOW" \
-  || fail "GraphQL resolveReviewThread mutation 호출 부재 — outdated inline thread 자동 resolve 안 됨"
-grep -qF 'isOutdated' "$WORKFLOW" \
-  || fail "isOutdated 조건 검사 부재 (소스가 변경된 thread 만 resolve 해야 함)"
+  || fail "GraphQL resolveReviewThread mutation 호출 부재 — self inline thread 자동 resolve 안 됨"
+grep -qF 'botLoginGql' "$WORKFLOW" \
+  || fail "GraphQL author login 형식 정규화(botLoginGql) 부재 — GraphQL은 'github-actions' 반환, REST '[bot]' 형식만 비교하면 self thread 매칭 실패로 resolve 안 됨"
 grep -qF 'isResolved' "$WORKFLOW" \
   || fail "isResolved 조건 검사 부재 (이미 resolved thread skip)"
 grep -qF 'reviewThreads(first: 100)' "$WORKFLOW" \

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -199,13 +199,13 @@ grep -qF 'Superseded by later review' "$WORKFLOW" \
   || fail "verdict!=approve 일 때 옛 approve managed comment supersede 분기 부재 (stale approve 가 PR 대화에 남음)"
 grep -qF 'Superseded stale managed comment' "$WORKFLOW" \
   || fail "supersede core.info log 부재"
-# auto-resolve outdated self inline threads on verdict=approve
+# auto-resolve self inline threads on verdict=approve (outdated 무관)
 grep -qF "<!-- codex-review-inline -->" "$WORKFLOW" \
   || fail "inline comment 의 self-identification marker (codex-review-inline) 부재"
 grep -qF 'resolveReviewThread' "$WORKFLOW" \
-  || fail "GraphQL resolveReviewThread mutation 호출 부재 — outdated inline thread 자동 resolve 안 됨"
-grep -qF 'isOutdated' "$WORKFLOW" \
-  || fail "isOutdated 조건 검사 부재 (소스가 변경된 thread 만 resolve 해야 함)"
+  || fail "GraphQL resolveReviewThread mutation 호출 부재 — self inline thread 자동 resolve 안 됨"
+grep -qF 'botLoginGql' "$WORKFLOW" \
+  || fail "GraphQL author login 형식 정규화(botLoginGql) 부재 — GraphQL은 'github-actions' 반환, REST '[bot]' 형식만 비교하면 self thread 매칭 실패로 resolve 안 됨"
 grep -qF 'isResolved' "$WORKFLOW" \
   || fail "isResolved 조건 검사 부재 (이미 resolved thread skip)"
 grep -qF 'reviewThreads(first: 100)' "$WORKFLOW" \


### PR DESCRIPTION
## 문제
PR 리뷰 워크플로(claude/codex)는 verdict=approve 시 자신이 단 inline review thread를 `resolveReviewThread`로 자동 해결하려 한다. 그러나 한 번도 동작하지 않아 inline thread가 영구히 미해소로 남았다.

**근본 원인 (라이브 데이터로 확정):** thread 필터가 GraphQL `author.login`을 REST 형식 상수 `github-actions[bot]`과 비교한다. GitHub **GraphQL** API는 봇 actor의 login을 `github-actions`(typename `Bot`, 접미사 `[bot]` 없음)로 반환하므로 `author.login === botLogin`이 항상 false → `myInlineThreads`가 항상 비어 mutation이 호출되지 않는다. (REST `r.user.login`은 `github-actions[bot]`로 맞게 반환됨.)

**증거:** 이 레포 PR #242에 `isResolved=false`, `author.login='github-actions'`, inline 마커 보유한 미해소 self thread 2건 잔존.

## 수정
- **두 워크플로**: REST(`[bot]`)·GraphQL 두 login 형식 모두 수용 (`botLoginGql = botLogin.replace(/\[bot\]$/, '')`). REST 비교 경로(멱등성·dismiss)·`botLogin` 값·self-마커 문자열 불변.
- **isOutdated 게이트 제거**: resolve는 clean approve(현재 라운드 inline finding 0건)에서만 진입하므로 현재 라운드 thread 오해소 위험 없음. 과거 thread는 최신 approve가 supersede — 같은 블록의 기존 dismiss-on-approve 의미와 정합.
- **테스트**: `isOutdated` 의존 단언을 `botLoginGql` 회귀 가드로 교체 (claude/codex 양쪽).

## 검증
- 두 테스트 스위트 통과 (`test-claude-review-workflow.sh`, `test-codex-review-workflow.sh`).
- 임베드 `github-script` JS 6블록 `node --check` 통과.
- 신규 필터를 PR #242 thread 형태로 시뮬레이션 → 막혀 있던 2건 선택, REST 형식 수용, resolved·사람 작성 thread 제외.

SPEC: `docs/specs/2026-05-30-github-review-workflow-inline-thread-auto-resolve-login.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)