### PR TITLE
feat(ci): PR 자동 리뷰 inline 전용화 — issue 코멘트 평가 금지

### DIFF
--- a/.github/prompts/claude-pr-review.ko.md
+++ b/.github/prompts/claude-pr-review.ko.md
@@ -62,9 +62,10 @@
 - context가 없어도 안전하게 approve할 수 있으면 `context_requests`를 비워둡니다.
 - 추가 context를 받은 2차 리뷰에서는 더 이상 필요한 파일이 없을 때 최종 verdict를 반환합니다.
 
-코멘트 규칙:
-- diff의 변경 라인 또는 변경 range에 정확히 연결할 수 있는 문제는 inline comment로 보고합니다.
-- 변경되지 않은 연관 파일에서 발견된 문제이거나, 여러 파일에 걸친 문제라 inline으로 표현하기 어려우면 issue-level comment로 보고합니다.
+코멘트 규칙 (inline 전용):
+- 모든 finding은 코드 라인에 붙는 inline comment로만 보고합니다. `comment_type`은 항상 `inline`입니다. issue-level(요약) comment로 finding을 보고하지 않습니다.
+- 각 finding은 diff의 변경 라인(또는 변경 range)에 anchor합니다. `line`(필요 시 `start_line`)은 반드시 변경된 diff 라인의 양수 정수여야 합니다 — null이면 안 됩니다.
+- 변경되지 않은 연관 파일에서 발견된 문제이거나 여러 파일에 걸친 문제라 변경 라인에 직접 anchor할 수 없으면, 가장 가까운 변경 hunk 라인에 inline으로 붙이고 본문 첫 줄에 실제 문제 위치(파일·라인)를 명시합니다. 예: `실제 위치: src/foo.ts:42`.
 - 다른 리뷰어가 이미 실질적으로 같은 문제를 남겼다면 중복 코멘트하지 말고 skipped_duplicates에 기록합니다.
 - 기존 Claude finding과 같은 문제를 반복하지 않습니다.
 - 다른 리뷰어가 만든 thread/comment는 resolve하거나 수정하지 않습니다.
@@ -77,7 +78,7 @@
 {
   "owner": "claude",
   "fingerprint": "<stable-fingerprint>",
-  "kind": "inline|issue",
+  "kind": "inline",
   "severity": "blocking|non_blocking|question",
   "status": "active|resolved",
   "head_sha": "<head-sha>"

--- a/.github/prompts/codex-pr-review.ko.md
+++ b/.github/prompts/codex-pr-review.ko.md
@@ -73,9 +73,10 @@
 - context가 없어도 안전하게 approve할 수 있으면 `context_requests`를 비워둡니다.
 - 추가 context를 받은 2차 리뷰에서는 더 이상 필요한 파일이 없을 때 최종 verdict를 반환합니다.
 
-코멘트 규칙:
-- diff의 변경 라인 또는 변경 range에 정확히 연결할 수 있는 문제는 inline comment로 보고합니다.
-- 변경되지 않은 연관 파일에서 발견된 문제이거나, 여러 파일에 걸친 문제라 inline으로 표현하기 어려우면 issue-level comment로 보고합니다.
+코멘트 규칙 (inline 전용):
+- 모든 finding은 코드 라인에 붙는 inline comment로만 보고합니다. `comment_type`은 항상 `inline`입니다. issue-level(요약) comment로 finding을 보고하지 않습니다.
+- 각 finding은 diff의 변경 라인(또는 변경 range)에 anchor합니다. `line`(필요 시 `start_line`)은 반드시 변경된 diff 라인의 양수 정수여야 합니다 — null이면 안 됩니다.
+- 변경되지 않은 연관 파일에서 발견된 문제이거나 여러 파일에 걸친 문제라 변경 라인에 직접 anchor할 수 없으면, 가장 가까운 변경 hunk 라인에 inline으로 붙이고 본문 첫 줄에 실제 문제 위치(파일·라인)를 명시합니다. 예: `실제 위치: src/foo.ts:42`.
 - 다른 리뷰어가 이미 실질적으로 같은 문제를 남겼다면 중복 코멘트하지 말고 skipped_duplicates에 기록합니다.
 - 기존 Codex finding과 같은 문제를 반복하지 않습니다.
 - 최신 push가 기존 Codex finding을 해결했으면 resolved_threads에 기록합니다.
@@ -90,7 +91,7 @@
 {
   "owner": "codex",
   "fingerprint": "<stable-fingerprint>",
-  "kind": "inline|issue",
+  "kind": "inline",
   "severity": "blocking|non_blocking|question",
   "status": "active|resolved",
   "head_sha": "<head-sha>"

--- a/.github/prompts/codex-pr-review.schema.json
+++ b/.github/prompts/codex-pr-review.schema.json
@@ -123,7 +123,7 @@
           },
           "comment_type": {
             "type": "string",
-            "enum": ["inline", "issue"]
+            "enum": ["inline"]
           },
           "file": { "type": "string" },
           "line": {

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -322,7 +322,7 @@ jobs:
                     and (.confidence_score | type == "number")
                     and (.fingerprint | type == "string")
                     and (.review_perspective | IN("guideline","bug","history","previous_pr","code_comment","cross_file"))
-                    and (.comment_type | IN("inline","issue"))
+                    and (.comment_type | IN("inline"))
                     and (.file | type == "string")
                     and (.title | type == "string")
                     and (.body | type == "string")
@@ -330,7 +330,7 @@ jobs:
                     and (.duplicate_of | (type == "string" or . == null))
                     and (.line | (. == null or (type == "number" and . == (. | floor) and . >= 1)))
                     and (.start_line | (. == null or (type == "number" and . == (. | floor) and . >= 1)))
-                    and (if .comment_type == "inline" then ((.line | type == "number") or (.start_line | type == "number")) else true end)
+                    and ((.line | type == "number") or (.start_line | type == "number"))
                   ] | all)
               and (.context_requests | type == "array")
               and ([.context_requests[]? | (.files | type == "array")] | all)
@@ -410,11 +410,12 @@ jobs:
             }
 
             const findings = result.findings || [];
-            // inline candidate: comment_type=inline AND line is a positive integer on the diff
-            const isInline = (f) => f.comment_type === 'inline'
-              && typeof f.line === 'number' && f.line > 0;
-            const inlineFindings = findings.filter(isInline);
-            const issueFindings = findings.filter((f) => !isInline(f));
+            // inline-only policy: every finding is posted as an inline comment.
+            // There is no issue-level finding channel. Findings that cannot anchor
+            // directly to a changed line are anchored by the model to the nearest
+            // changed hunk line (with the real location stated in the body), so we
+            // never route a finding into an issue comment.
+            const inlineFindings = findings;
 
             const verdict = result.verdict;
             const mayApprove = !!result.automation_safety?.may_approve;
@@ -423,7 +424,7 @@ jobs:
             const blockingHi = findings.filter((f) =>
               f.severity === 'blocking' && (f.confidence_score ?? 0) >= 80).length;
 
-            // Event decision — same gating as before, generalized for inline+issue.
+            // Event decision — unchanged gating (verdict logic is out of scope).
             let event;
             if (findings.length === 0 && verdict === 'approve' && mayApprove && !diffTruncated) {
               event = 'APPROVE';
@@ -433,40 +434,34 @@ jobs:
               event = 'COMMENT';
             }
 
-            // Review body — summary + issue-level findings.
-            // Inline findings are posted per-line; not duplicated in body.
-            const renderIssue = (f, i) => {
-              const loc = f.file + ((typeof f.line === 'number' && f.line > 0) ? `:${f.line}` : '');
-              return `${i + 1}. [${f.severity}/${f.confidence_score}] ${f.title}\n   ${loc}\n   ${f.body}\n   Suggestion: ${f.suggestion}`;
-            };
-            const issueBlock = issueFindings.length === 0
-              ? '_No issue-level findings._'
-              : `### Issue-level findings\n\n${issueFindings.map(renderIssue).join('\n\n')}`;
-            const inlineNote = inlineFindings.length > 0
-              ? `\n\n_${inlineFindings.length} inline finding${inlineFindings.length === 1 ? '' : 's'} posted on the diff._`
-              : '';
+            // Review body carries NO finding evaluations (inline-only policy):
+            // findings live as inline comments. The formal review body holds only
+            // the hidden idempotency marker, plus an approval line when the verdict
+            // is approve. Non-approve reviews still submit the event (to carry the
+            // inline comments) but with no issue-level summary text.
             const marker = `<!-- ${prefix} head_sha=${head_sha} verdict=${verdict} -->`;
-            const body = ['## Claude PR Review',
-                          '',
-                          (result.summary || ''),
-                          '',
-                          issueBlock + inlineNote,
-                          '',
-                          marker].join('\n');
+            const body = (verdict === 'approve'
+              ? ['## Claude PR Review', '',
+                 '_Approved by automated review. Findings, if any, are posted as inline comments._',
+                 '', marker]
+              : [marker]).join('\n');
 
             // Inline review comments — path/line/body (start_line for multi-line range).
             // The hidden marker lets us later identify self-owned threads so we
             // can resolve them when the corresponding source has been fixed.
             const inlineMarker = '<!-- claude-review-inline -->';
             const inlineComments = inlineFindings.map((f) => {
+              // Anchor to f.line; fall back to f.start_line so a finding is never
+              // dropped (validation guarantees at least one is a positive int).
+              const anchor = (typeof f.line === 'number' && f.line > 0) ? f.line : f.start_line;
               const c = {
                 path: f.file,
                 body: `**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${inlineMarker}`,
                 side: 'RIGHT',
-                line: f.line,
+                line: anchor,
               };
               if (typeof f.start_line === 'number'
-                  && f.start_line >= 1 && f.start_line < f.line) {
+                  && f.start_line >= 1 && f.start_line < anchor) {
                 c.start_line = f.start_line;
                 c.start_side = 'RIGHT';
               }
@@ -506,7 +501,7 @@ jobs:
               try {
                 await submit(event);
                 submitOk = true;
-                core.info(`Submitted ${event} review (${inlineComments.length} inline + ${issueFindings.length} issue findings).`);
+                core.info(`Submitted ${event} review (${inlineComments.length} inline findings).`);
               } catch (e) {
                 if (event === 'APPROVE') {
                   core.warning(`APPROVE failed (${e.status || ''} ${e.message}); falling back to COMMENT.`);
@@ -520,11 +515,12 @@ jobs:
               }
             }
 
-            // If review submission failed but we have inline findings, surface
-            // them in the managed PR comment so review content isn't lost.
+            // inline-only policy: do NOT fall back to dumping findings into an
+            // issue comment — that would place finding evaluations in an
+            // issue-level comment (AC2). If createReview failed, the findings stay
+            // unposted and the failure is surfaced in the workflow log only.
             if (!skipSubmit && !submitOk && inlineFindings.length > 0) {
-              fs.writeFileSync('.claude-review/inline-fallback-needed', '');
-              core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) will appear in managed PR comment instead of inline.`);
+              core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) could not be posted. Not dumping to an issue comment (inline-only policy); see logs.`);
             }
 
             // Auto-dismiss prior self CHANGES_REQUESTED reviews when this verdict is approve.
@@ -612,17 +608,10 @@ jobs:
             const fs = require('fs');
             const result = JSON.parse(fs.readFileSync('.claude-review/result.json', 'utf8'));
             const marker = process.env.CLAUDE_REVIEW_MARKER;
-            const findings = result.findings || [];
-            const isInline = (f) => f.comment_type === 'inline'
-              && typeof f.line === 'number' && f.line > 0;
-            const inlineFindings = findings.filter(isInline);
-            const issueFindings = findings.filter((f) => !isInline(f));
             const approvalFailed = fs.existsSync('.claude-review/approval-failed');
-            // Did the formal review (createReview) fail to post inline findings?
-            // If so we MUST surface findings in the managed comment regardless of
-            // verdict — otherwise inline finding detail is lost entirely. This
-            // overrides the verdict=approve gate (codex blocking finding on #232).
-            const inlineFallback = fs.existsSync('.claude-review/inline-fallback-needed');
+            // inline-only policy: findings live as inline comments. The managed
+            // (issue-level) comment NEVER renders finding evaluations — it is an
+            // approval-only comment, posted solely when the verdict is approve.
 
             // Find any prior managed comment from this workflow up-front; we may
             // need to supersede it even when the current verdict is non-approve.
@@ -638,21 +627,19 @@ jobs:
               c.body?.includes(marker)
             );
 
-            // Verdict gate: only verdict=approve gets a full managed comment,
-            // UNLESS the formal review failed to post (inlineFallback) — then
-            // we always need to surface findings somewhere.
+            // Verdict gate: the managed issue-level comment is posted ONLY on
+            // verdict=approve (AC3 — no issue-level summary comment otherwise).
             // If a prior commit posted an approve managed comment and the current
-            // verdict is non-approve (and no inlineFallback), replace it with a
-            // supersede notice so PR conversation accurately reflects the latest
-            // verdict (otherwise the stale approve would falsely advertise the PR).
-            const showFullBody = result.verdict === 'approve' || inlineFallback;
+            // verdict is non-approve, replace it with a supersede notice so the PR
+            // conversation reflects the latest verdict (no stale approve left).
+            const showFullBody = result.verdict === 'approve';
             if (result.eligibility?.status !== 'reviewed' || !showFullBody) {
               if (previous) {
                 const supersede = [
                   marker,
                   '## Claude PR Review',
                   '',
-                  `_Superseded by later review (current verdict: \`${result.verdict || 'unavailable'}\`). See the formal review for details._`,
+                  `_Superseded by later review (current verdict: \`${result.verdict || 'unavailable'}\`). See inline comments for any findings._`,
                 ].join('\n');
                 await github.rest.issues.updateComment({
                   owner: context.repo.owner,
@@ -662,45 +649,24 @@ jobs:
                 });
                 core.info(`Superseded stale managed comment (new verdict=${result.verdict || 'none'}).`);
               } else {
-                core.info(`Managed Claude review comment is only posted on verdict=approve or inline-fallback (current verdict: ${result.verdict || 'none'}, inlineFallback=false); no prior comment to supersede; skipping.`);
+                core.info(`Managed Claude review comment is only posted on verdict=approve (current verdict: ${result.verdict || 'none'}); no prior comment to supersede; skipping.`);
               }
               return;
             }
 
-            // Full body path (verdict=approve OR inline-fallback).
-            const renderIssue = (f, i) => [
-                  `${i + 1}. [${f.severity}/${f.confidence_score}] ${f.title}`,
-                  `${f.file}${(typeof f.line === 'number' && f.line > 0) ? `:${f.line}` : ''}`,
-                  f.body,
-                  `Suggestion: ${f.suggestion}`,
-                ].join('\n');
-            const issueText = issueFindings.length > 0
-              ? `### Issue-level findings\n\n${issueFindings.map(renderIssue).join('\n\n')}`
-              : '';
-            // inlineFallback defined above (controls verdict-gate).
-            const inlineDetailText = (inlineFallback && inlineFindings.length > 0)
-              ? `### Inline findings (review submission failed; included here for visibility)\n\n${inlineFindings.map(renderIssue).join('\n\n')}`
-              : '';
-            const inlineNote = (inlineFindings.length > 0 && !inlineFallback)
-              ? `_${inlineFindings.length} inline finding${inlineFindings.length === 1 ? '' : 's'} posted on the diff._`
-              : '';
-            const counts = `Findings: ${findings.length} total (${inlineFindings.length} inline · ${issueFindings.length} issue)`;
+            // Approve path: approval-expressing comment ONLY — no finding evaluation
+            // bodies, counts, or per-finding rendering (AC2/AC4).
             const summaryText = approvalFailed
-              ? 'Claude review found no findings, but formal approval could not be submitted by this workflow token.'
-              : (result.summary || 'No findings. (summary unavailable)');
+              ? 'Claude review found no blocking findings, but formal approval could not be submitted by this workflow token.'
+              : (result.summary || 'Approved — no blocking findings.');
             const body = [
               marker,
               '## Claude PR Review',
               '',
-              `Verdict: \`${result.verdict}\``,
-              '',
-              counts,
+              'Verdict: `approve`',
               '',
               summaryText,
-              issueText ? `\n${issueText}` : '',
-              inlineDetailText ? `\n${inlineDetailText}` : '',
-              inlineNote ? `\n${inlineNote}` : '',
-            ].filter((line, i, arr) => !(line === '' && arr[i-1] === '')).join('\n');
+            ].join('\n');
 
             // Reuse the pre-fetched `previous` comment for update/create decision.
             if (previous) {

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -242,11 +242,12 @@ jobs:
             }
 
             const findings = result.findings || [];
-            // inline candidate: comment_type=inline AND line is a positive integer on the diff
-            const isInline = (f) => f.comment_type === 'inline'
-              && typeof f.line === 'number' && f.line > 0;
-            const inlineFindings = findings.filter(isInline);
-            const issueFindings = findings.filter((f) => !isInline(f));
+            // inline-only policy: every finding is posted as an inline comment.
+            // There is no issue-level finding channel. Findings that cannot anchor
+            // directly to a changed line are anchored by the model to the nearest
+            // changed hunk line (with the real location stated in the body), so we
+            // never route a finding into an issue comment.
+            const inlineFindings = findings;
 
             const verdict = result.verdict;
             const mayApprove = !!result.automation_safety?.may_approve;
@@ -255,7 +256,7 @@ jobs:
             const blockingHi = findings.filter((f) =>
               f.severity === 'blocking' && (f.confidence_score ?? 0) >= 80).length;
 
-            // Event decision — same gating as before, generalized for inline+issue.
+            // Event decision — unchanged gating (verdict logic is out of scope).
             let event;
             if (findings.length === 0 && verdict === 'approve' && mayApprove && !diffTruncated) {
               event = 'APPROVE';
@@ -265,26 +266,17 @@ jobs:
               event = 'COMMENT';
             }
 
-            // Review body — summary + issue-level findings.
-            // Inline findings are posted per-line; not duplicated in body.
-            const renderIssue = (f, i) => {
-              const loc = f.file + ((typeof f.line === 'number' && f.line > 0) ? `:${f.line}` : '');
-              return `${i + 1}. [${f.severity}/${f.confidence_score}] ${f.title}\n   ${loc}\n   ${f.body}\n   Suggestion: ${f.suggestion}`;
-            };
-            const issueBlock = issueFindings.length === 0
-              ? '_No issue-level findings._'
-              : `### Issue-level findings\n\n${issueFindings.map(renderIssue).join('\n\n')}`;
-            const inlineNote = inlineFindings.length > 0
-              ? `\n\n_${inlineFindings.length} inline finding${inlineFindings.length === 1 ? '' : 's'} posted on the diff._`
-              : '';
+            // Review body carries NO finding evaluations (inline-only policy):
+            // findings live as inline comments. The formal review body holds only
+            // the hidden idempotency marker, plus an approval line when the verdict
+            // is approve. Non-approve reviews still submit the event (to carry the
+            // inline comments) but with no issue-level summary text.
             const marker = `<!-- ${prefix} head_sha=${head_sha} verdict=${verdict} -->`;
-            const body = ['## Codex PR Review',
-                          '',
-                          (result.summary || ''),
-                          '',
-                          issueBlock + inlineNote,
-                          '',
-                          marker].join('\n');
+            const body = (verdict === 'approve'
+              ? ['## Codex PR Review', '',
+                 '_Approved by automated review. Findings, if any, are posted as inline comments._',
+                 '', marker]
+              : [marker]).join('\n');
 
             // Inline review comments — path/line/body (start_line for multi-line range).
             // Inline review comments — path/line/body (start_line for multi-line range).
@@ -292,14 +284,17 @@ jobs:
             // can resolve them when the corresponding source has been fixed.
             const inlineMarker = '<!-- codex-review-inline -->';
             const inlineComments = inlineFindings.map((f) => {
+              // Anchor to f.line; fall back to f.start_line so a finding is never
+              // dropped (validation guarantees at least one is a positive int).
+              const anchor = (typeof f.line === 'number' && f.line > 0) ? f.line : f.start_line;
               const c = {
                 path: f.file,
                 body: `**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${inlineMarker}`,
                 side: 'RIGHT',
-                line: f.line,
+                line: anchor,
               };
               if (typeof f.start_line === 'number'
-                  && f.start_line >= 1 && f.start_line < f.line) {
+                  && f.start_line >= 1 && f.start_line < anchor) {
                 c.start_line = f.start_line;
                 c.start_side = 'RIGHT';
               }
@@ -339,7 +334,7 @@ jobs:
               try {
                 await submit(event);
                 submitOk = true;
-                core.info(`Submitted ${event} review (${inlineComments.length} inline + ${issueFindings.length} issue findings).`);
+                core.info(`Submitted ${event} review (${inlineComments.length} inline findings).`);
               } catch (e) {
                 if (event === 'APPROVE') {
                   core.warning(`APPROVE failed (${e.status || ''} ${e.message}); falling back to COMMENT.`);
@@ -353,11 +348,12 @@ jobs:
               }
             }
 
-            // If review submission failed but we have inline findings, surface
-            // them in the managed PR comment so review content isn't lost.
+            // inline-only policy: do NOT fall back to dumping findings into an
+            // issue comment — that would place finding evaluations in an
+            // issue-level comment (AC2). If createReview failed, the findings stay
+            // unposted and the failure is surfaced in the workflow log only.
             if (!skipSubmit && !submitOk && inlineFindings.length > 0) {
-              fs.writeFileSync('.codex-review/inline-fallback-needed', '');
-              core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) will appear in managed PR comment instead of inline.`);
+              core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) could not be posted. Not dumping to an issue comment (inline-only policy); see logs.`);
             }
 
             // Auto-dismiss prior self CHANGES_REQUESTED reviews when this verdict is approve.
@@ -445,17 +441,10 @@ jobs:
             const fs = require('fs');
             const result = JSON.parse(fs.readFileSync('.codex-review/result.json', 'utf8'));
             const marker = process.env.CODEX_REVIEW_MARKER;
-            const findings = result.findings || [];
-            const isInline = (f) => f.comment_type === 'inline'
-              && typeof f.line === 'number' && f.line > 0;
-            const inlineFindings = findings.filter(isInline);
-            const issueFindings = findings.filter((f) => !isInline(f));
             const approvalFailed = fs.existsSync('.codex-review/approval-failed');
-            // Did the formal review (createReview) fail to post inline findings?
-            // If so we MUST surface findings in the managed comment regardless of
-            // verdict — otherwise inline finding detail is lost entirely. This
-            // overrides the verdict=approve gate (codex blocking finding on #232).
-            const inlineFallback = fs.existsSync('.codex-review/inline-fallback-needed');
+            // inline-only policy: findings live as inline comments. The managed
+            // (issue-level) comment NEVER renders finding evaluations — it is an
+            // approval-only comment, posted solely when the verdict is approve.
 
             // Find any prior managed comment from this workflow up-front; we may
             // need to supersede it even when the current verdict is non-approve.
@@ -471,21 +460,19 @@ jobs:
               c.body?.includes(marker)
             );
 
-            // Verdict gate: only verdict=approve gets a full managed comment,
-            // UNLESS the formal review failed to post (inlineFallback) — then
-            // we always need to surface findings somewhere.
+            // Verdict gate: the managed issue-level comment is posted ONLY on
+            // verdict=approve (AC3 — no issue-level summary comment otherwise).
             // If a prior commit posted an approve managed comment and the current
-            // verdict is non-approve (and no inlineFallback), replace it with a
-            // supersede notice so PR conversation accurately reflects the latest
-            // verdict (otherwise the stale approve would falsely advertise the PR).
-            const showFullBody = result.verdict === 'approve' || inlineFallback;
+            // verdict is non-approve, replace it with a supersede notice so the PR
+            // conversation reflects the latest verdict (no stale approve left).
+            const showFullBody = result.verdict === 'approve';
             if (result.eligibility?.status !== 'reviewed' || !showFullBody) {
               if (previous) {
                 const supersede = [
                   marker,
                   '## Codex PR Review',
                   '',
-                  `_Superseded by later review (current verdict: \`${result.verdict || 'unavailable'}\`). See the formal review for details._`,
+                  `_Superseded by later review (current verdict: \`${result.verdict || 'unavailable'}\`). See inline comments for any findings._`,
                 ].join('\n');
                 await github.rest.issues.updateComment({
                   owner: context.repo.owner,
@@ -495,45 +482,24 @@ jobs:
                 });
                 core.info(`Superseded stale managed comment (new verdict=${result.verdict || 'none'}).`);
               } else {
-                core.info(`Managed Codex review comment is only posted on verdict=approve or inline-fallback (current verdict: ${result.verdict || 'none'}, inlineFallback=false); no prior comment to supersede; skipping.`);
+                core.info(`Managed Codex review comment is only posted on verdict=approve (current verdict: ${result.verdict || 'none'}); no prior comment to supersede; skipping.`);
               }
               return;
             }
 
-            // Full body path (verdict=approve OR inline-fallback).
-            const renderIssue = (f, i) => [
-                  `${i + 1}. [${f.severity}/${f.confidence_score}] ${f.title}`,
-                  `${f.file}${(typeof f.line === 'number' && f.line > 0) ? `:${f.line}` : ''}`,
-                  f.body,
-                  `Suggestion: ${f.suggestion}`,
-                ].join('\n');
-            const issueText = issueFindings.length > 0
-              ? `### Issue-level findings\n\n${issueFindings.map(renderIssue).join('\n\n')}`
-              : '';
-            // inlineFallback defined above (controls verdict-gate).
-            const inlineDetailText = (inlineFallback && inlineFindings.length > 0)
-              ? `### Inline findings (review submission failed; included here for visibility)\n\n${inlineFindings.map(renderIssue).join('\n\n')}`
-              : '';
-            const inlineNote = (inlineFindings.length > 0 && !inlineFallback)
-              ? `_${inlineFindings.length} inline finding${inlineFindings.length === 1 ? '' : 's'} posted on the diff._`
-              : '';
-            const counts = `Findings: ${findings.length} total (${inlineFindings.length} inline · ${issueFindings.length} issue)`;
+            // Approve path: approval-expressing comment ONLY — no finding evaluation
+            // bodies, counts, or per-finding rendering (AC2/AC4).
             const summaryText = approvalFailed
-              ? 'Codex review found no findings, but formal approval could not be submitted by this workflow token.'
-              : (result.summary || 'No findings. (summary unavailable)');
+              ? 'Codex review found no blocking findings, but formal approval could not be submitted by this workflow token.'
+              : (result.summary || 'Approved — no blocking findings.');
             const body = [
               marker,
               '## Codex PR Review',
               '',
-              `Verdict: \`${result.verdict}\``,
-              '',
-              counts,
+              'Verdict: `approve`',
               '',
               summaryText,
-              issueText ? `\n${issueText}` : '',
-              inlineDetailText ? `\n${inlineDetailText}` : '',
-              inlineNote ? `\n${inlineNote}` : '',
-            ].filter((line, i, arr) => !(line === '' && arr[i-1] === '')).join('\n');
+            ].join('\n');
 
             // Reuse the pre-fetched `previous` comment for update/create decision.
             if (previous) {

--- a/docs/claude/pr-review-workflow.md
+++ b/docs/claude/pr-review-workflow.md
@@ -25,11 +25,12 @@ PR을 pinned `@anthropic-ai/claude-code` CLI(`claude -p`)로 직접 호출하여
 5. checkout credential extraheader 제거 + `GH_TOKEN` unset → **scratch cwd**(`mktemp -d`)에서 `claude -p --output-format json --json-schema "$schema" --strict-mcp-config --setting-sources "" --no-session-persistence` 실행.
 6. envelope JSON의 `.result` 텍스트에서 첫 `{` ~ 마지막 `}` 추출 → jq 파싱 → 11개 required 필드 검증 → `.claude-review/result.json` 저장.
 7. 모델이 `needs_context`를 반환하면 요청한 파일을 PR head에서 fetch(최대 5개, 400줄 절단)해 follow-up 프롬프트로 재호출.
-8. `verdict`에 따라 GitHub review 제출:
-   - `approve` + safety pass: `gh pr review --approve` (body 없음)
-   - `request_changes` + blocking finding(confidence ≥ 80): `gh pr review --request-changes`
-   - `comment`/`needs_context`/기타: `gh pr review --comment`
-9. managed issue comment를 marker(`<!-- claude-api-pr-review -->`) 기반으로 create/update.
+8. `verdict`에 따라 GitHub review event를 `pulls.createReview`로 제출. **모든 finding은 inline 코멘트로만** 게시한다(inline-only 정책):
+   - `approve` + safety pass: `APPROVE` (review body는 finding 평가 없이 승인 표현만)
+   - `request_changes` + blocking finding(confidence ≥ 80): `REQUEST_CHANGES` (body는 마커만, 평가 없음)
+   - `comment`/`needs_context`/기타: `COMMENT` (body는 마커만, 평가 없음)
+   - 변경 라인에 직접 anchor할 수 없는 finding도 issue 코멘트로 떨어뜨리지 않고, 모델이 가장 가까운 변경 hunk 라인에 inline으로 붙이고 본문에 실제 위치(파일·라인)를 명시한다.
+9. managed issue comment(marker `<!-- claude-api-pr-review -->`)는 **verdict=approve일 때만** 게시하며, 승인 표현만 담고 finding 평가 본문은 포함하지 않는다(AC2~AC4). approve가 아니면 게시하지 않고, 직전 approve 코멘트가 있으면 supersede 표시로 갱신한다.
 
 ## 구성
 

--- a/docs/codex/pr-review-workflow.md
+++ b/docs/codex/pr-review-workflow.md
@@ -16,11 +16,12 @@
 3. `.github/prompts/codex-pr-review.ko.md`를 system prompt처럼 붙인다.
 4. `codex exec --output-schema .github/prompts/codex-pr-review.schema.json`을 stdin 기반으로 실행한다.
 5. JSON schema를 검증한다.
-6. `verdict`에 따라 GitHub review를 제출한다.
-   - `approve`: `gh pr review --approve`
-   - `request_changes`: `gh pr review --request-changes`
-   - `comment`, `needs_context`, `unavailable`: `gh pr review --comment`
-7. managed issue comment를 marker 기반으로 create/update한다.
+6. `verdict`에 따라 GitHub review event를 `pulls.createReview`로 제출한다. **모든 finding은 inline 코멘트로만** 게시한다(inline-only 정책).
+   - `approve`: `APPROVE` (review body는 finding 평가 없이 승인 표현만)
+   - `request_changes`: `REQUEST_CHANGES` (body는 마커만, 평가 없음)
+   - `comment`, `needs_context`, `unavailable`: `COMMENT` (body는 마커만, 평가 없음)
+   - 변경 라인에 직접 anchor할 수 없는 finding도 issue 코멘트로 떨어뜨리지 않고, 가장 가까운 변경 hunk 라인에 inline으로 붙이고 본문에 실제 위치(파일·라인)를 명시한다.
+7. managed issue comment(marker 기반)는 **verdict=approve일 때만** 게시하며, 승인 표현만 담고 finding 평가 본문은 포함하지 않는다. approve가 아니면 게시하지 않고, 직전 approve 코멘트가 있으면 supersede 표시로 갱신한다.
 
 ## 단계적 고도화 계획
 
@@ -30,7 +31,7 @@
 - stdin으로 prompt를 전달해 shell `ARG_MAX` 한계를 피한다.
 - JSON schema로 최종 응답을 강제한다.
 - confidence score 80 미만 finding은 게시하지 않는다.
-- inline comment는 아직 생성하지 않고 summary review body에 묶는다.
+- (구) 초기 MVP는 inline comment 없이 summary review body에 묶었으나, 현재는 모든 finding을 inline 코멘트로만 게시한다(inline-only 정책).
 
 완료 기준:
 - JSON schema 검증이 실패하면 approve하지 않는다.
@@ -39,13 +40,13 @@
 
 ### Phase 2: Inline Comment Adapter
 
-- changed diff line에 매핑 가능한 finding만 GitHub inline review comment로 게시한다.
-- changed line에 매핑되지 않는 finding은 managed issue comment로 유지한다.
+- 모든 finding을 GitHub inline review comment로 게시한다(inline-only 정책).
+- changed line에 직접 매핑되지 않는 finding도 issue comment로 떨어뜨리지 않고, 가장 가까운 변경 hunk 라인에 inline으로 붙이고 본문에 실제 위치를 명시한다.
 - comment marker에 `fingerprint`, `head_sha`, `severity`, `status`를 저장한다.
 - 같은 fingerprint가 이미 존재하면 중복 게시하지 않는다.
 
 완료 기준:
-- diff line 매핑 실패 시 inline 대신 issue-level finding으로 degrade한다.
+- diff line 매핑이 어려운 finding도 가장 가까운 변경 라인에 inline으로 남기며 issue-level로 degrade하지 않는다.
 - 기존 다른 reviewer가 같은 이슈를 남겼으면 `skipped_duplicates`로 기록하고 게시하지 않는다.
 
 ### Phase 3: Thread Lifecycle

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -121,14 +121,20 @@ grep -qF 'IN("approve","request_changes","comment","needs_context","unavailable"
   || fail "verdict enum 검증 부재"
 grep -qF 'IN("guideline","bug","history","previous_pr","code_comment","cross_file")' "$WORKFLOW" \
   || fail "findings[].review_perspective enum 검증 부재 (schema required)"
-grep -qF 'IN("inline","issue")' "$WORKFLOW" \
-  || fail "findings[].comment_type enum 검증 부재 (schema required, 라우팅에 사용)"
+grep -qF 'IN("inline")' "$WORKFLOW" \
+  || fail "findings[].comment_type enum 검증이 inline 전용이 아님 (inline-only 정책: 모든 finding 은 inline)"
+if grep -qF 'IN("inline","issue")' "$WORKFLOW"; then
+  fail "comment_type 에 issue 가 잔존 — inline-only 정책에서 finding 은 issue 채널로 가지 않음"
+fi
 grep -qF '.fingerprint | type == "string"' "$WORKFLOW" \
   || fail "findings[].fingerprint 검증 부재 (schema required, dedup 에 사용)"
 grep -qF '.duplicate_of | (type == "string" or . == null)' "$WORKFLOW" \
   || fail "findings[].duplicate_of nullable 검증 부재"
-grep -qF 'if .comment_type == "inline"' "$WORKFLOW" \
-  || fail "inline comment_type 의 line/start_line 조건부 검증 부재 (inline 위치 정보 없으면 GitHub API 400)"
+grep -qF 'and ((.line | type == "number") or (.start_line | type == "number"))' "$WORKFLOW" \
+  || fail "모든 finding 의 line/start_line 필수 검증 부재 (inline-only: 모든 finding 이 변경 라인에 anchor 되어야 함, 없으면 fallback)"
+if grep -qF 'if .comment_type == "inline"' "$WORKFLOW"; then
+  fail "comment_type 조건부 line 검증 잔존 — inline-only 정책에서는 모든 finding 이 무조건 line 을 가져야 함"
+fi
 grep -qF '.line | (. == null or (type == "number" and . == (. | floor) and . >= 1))' "$WORKFLOW" \
   || fail "findings[].line 검증이 스키마 contract(integer ≥1 또는 null)를 강제하지 않음"
 grep -qF '.start_line | (. == null or (type == "number" and . == (. | floor) and . >= 1))' "$WORKFLOW" \
@@ -211,15 +217,22 @@ grep -q 'issues.createComment' "$WORKFLOW" \
 ok "check 6: marker 기반 update/create 코멘트 경로 존재"
 
 echo ""
-echo "=== check 7: verdict submission via Pulls REST API with inline comments + auto-dismiss ==="
+echo "=== check 7: verdict submission via Pulls REST API with inline-only comments + auto-dismiss ==="
 # Submit step is now a github-script step that calls pulls.createReview directly
 # so it can post inline review comments AND auto-dismiss stale CHANGES_REQUESTED.
 grep -qF 'github.rest.pulls.createReview' "$WORKFLOW" \
   || fail "Pulls REST createReview 호출 부재 — inline comments 게시 불가 (gh pr review 로는 inline 미지원)"
 grep -qF 'comments: inlineComments' "$WORKFLOW" \
   || fail "createReview 의 comments[] 배열에 inline findings 전달 부재"
-grep -qF "comment_type === 'inline'" "$WORKFLOW" \
-  || fail "inline/issue findings 분기 처리 부재 (comment_type 사용 안 함)"
+# inline-only 정책: 모든 finding 이 inline. issue 채널 분기/렌더가 없어야 한다.
+grep -qF 'inline-only' "$WORKFLOW" \
+  || fail "inline-only 정책 주석/마커 부재 (모든 finding 을 inline 으로 게시한다는 의도 명시 필요)"
+if grep -qF 'issueFindings' "$WORKFLOW"; then
+  fail "issueFindings 분기 잔존 — inline-only 정책에서 issue 채널 finding 라우팅 금지"
+fi
+if grep -qF 'Issue-level findings' "$WORKFLOW"; then
+  fail "'Issue-level findings' 렌더 잔존 — issue-level 코멘트에 finding 평가 본문 포함 금지 (AC2)"
+fi
 grep -qF "side: 'RIGHT'" "$WORKFLOW" \
   || fail "inline comment 의 side='RIGHT' 지정 부재"
 grep -qF 'start_line' "$WORKFLOW" \
@@ -238,10 +251,17 @@ grep -qF 'confidence_score' "$WORKFLOW" \
   || fail "confidence_score gate 부재"
 grep -qF '>= 80' "$WORKFLOW" \
   || fail "confidence_score >= 80 threshold 부재"
-grep -qF 'Managed Claude review comment is only posted on verdict=approve or inline-fallback' "$WORKFLOW" \
-  || fail "managed comment 게이트가 verdict=approve OR inline-fallback 가 아님 (inline finding 유실 위험)"
-grep -qF "result.verdict === 'approve' || inlineFallback" "$WORKFLOW" \
-  || fail "showFullBody 결정이 verdict=approve OR inlineFallback 가 아님"
+# 요약(issue-level) managed comment 는 approve 일 때만. inline-fallback 경로 제거(AC2/AC3).
+grep -qF 'Managed Claude review comment is only posted on verdict=approve' "$WORKFLOW" \
+  || fail "managed comment 게이트가 verdict=approve 전용이 아님 (AC3)"
+grep -qF "result.verdict === 'approve'" "$WORKFLOW" \
+  || fail "showFullBody 결정이 verdict=approve 조건을 사용하지 않음"
+if grep -qF 'inlineFallback' "$WORKFLOW"; then
+  fail "inlineFallback 경로 잔존 — createReview 실패 시 finding 을 issue 코멘트로 덤프하면 AC2 위반"
+fi
+if grep -qF 'inline-fallback-needed' "$WORKFLOW"; then
+  fail "inline-fallback-needed marker 잔존 — inline-only 정책에서 제거되어야 함"
+fi
 grep -qF '!showFullBody' "$WORKFLOW" \
   || fail "early-return 조건이 showFullBody 변수를 사용하지 않음"
 # supersede stale approve managed comment when latest verdict is non-approve
@@ -260,7 +280,7 @@ grep -qF 'isResolved' "$WORKFLOW" \
   || fail "isResolved 조건 검사 부재 (이미 resolved thread skip)"
 grep -qF 'reviewThreads(first: 100)' "$WORKFLOW" \
   || fail "GraphQL reviewThreads 쿼리 부재"
-ok "check 7: createReview + inline comments + safety gates + COMMENT fallback"
+ok "check 7: createReview + inline-only findings + safety gates + approve-only managed comment"
 
 echo ""
 echo "=== check 7b: formal review idempotent per (head_sha, verdict) ==="
@@ -287,16 +307,19 @@ grep -qF 'Superseded by later review' "$WORKFLOW" \
 ok "check 7c: verdict=approve 시 옛 자기 CHANGES_REQUESTED reviews 자동 dismiss"
 
 echo ""
-echo "=== check 7d: inline-fallback in managed comment when createReview fails ==="
-grep -qF "fs.writeFileSync('.claude-review/inline-fallback-needed'" "$WORKFLOW" \
-  || fail "createReview 실패 시 inline-fallback-needed marker 생성 부재 — inline findings 가 어디에도 게시 안 됨 (codex finding 흡수 미완)"
-grep -qF "fs.existsSync('.claude-review/inline-fallback-needed')" "$WORKFLOW" \
-  || fail "Post step 에서 inline-fallback marker 확인 부재"
-grep -qF 'inlineDetailText' "$WORKFLOW" \
-  || fail "inline-fallback 시 inline findings 상세를 managed comment 본문에 포함하지 않음 (실제 review 결과 유실)"
-grep -qF 'review submission failed; included here for visibility' "$WORKFLOW" \
-  || fail "inline-fallback 본문 헤더 부재"
-ok "check 7d: createReview 실패 시 inline findings 가 managed comment 본문으로 폴백됨"
+echo "=== check 7d: managed comment 은 finding 평가 본문을 렌더하지 않는다 (inline-only) ==="
+# inline-only 정책: finding 평가는 inline 코멘트 전용. managed(issue-level) comment 에
+# finding 상세를 렌더하던 inlineDetailText / renderIssue 경로는 제거되어야 한다 (AC2/AC4).
+if grep -qF 'inlineDetailText' "$WORKFLOW"; then
+  fail "inlineDetailText 잔존 — managed comment 에 inline finding 상세 렌더 금지 (AC2)"
+fi
+if grep -qF 'renderIssue' "$WORKFLOW"; then
+  fail "renderIssue 잔존 — issue-level 코멘트에 finding 평가 본문 렌더 금지 (AC2)"
+fi
+if grep -qF 'review submission failed; included here for visibility' "$WORKFLOW"; then
+  fail "inline-fallback 본문 헤더 잔존 — inline-only 정책에서 제거되어야 함"
+fi
+ok "check 7d: managed comment 에 finding 평가 렌더 경로 제거됨"
 
 echo ""
 echo "=== check 8a: 출력 언어 untrusted block 끝에 재강조 (영어 응답 예방) ==="
@@ -319,6 +342,32 @@ grep -q 'confidence_score < 80' "$PROMPT" \
 grep -q 'structured output' "$PROMPT" \
   || fail "prompt structured output 규칙 부재"
 ok "check 8: prompt 핵심 정책 존재"
+
+echo ""
+echo "=== check 8b: inline-only 코멘트 정책 (prompt + schema) ==="
+# 모든 finding 은 inline 코멘트로만. anchor 불가 finding 도 가장 가까운 변경 라인에 inline,
+# 본문에 실제 위치 명시. issue-level 코멘트로 finding 을 보고하지 않는다 (AC1/AC2/AC5).
+grep -q 'inline' "$PROMPT" \
+  || fail "prompt inline 코멘트 정책 부재"
+grep -q '가장 가까운 변경' "$PROMPT" \
+  || fail "prompt 에 anchor 불가 finding 을 가장 가까운 변경 라인에 inline 으로 붙이는 지침 부재 (AC5)"
+grep -q '실제 위치' "$PROMPT" \
+  || fail "prompt 에 inline 본문에 실제 문제 위치(파일·라인) 명시 지침 부재 (AC5)"
+if grep -q 'issue-level comment로 보고' "$PROMPT"; then
+  fail "prompt 가 finding 을 issue-level comment 로 보고하도록 지시함 — inline-only 정책 위반"
+fi
+grep -qF '"kind": "inline"' "$PROMPT" \
+  || fail "prompt hidden marker 의 kind 가 inline 전용이 아님"
+if grep -qF 'inline|issue' "$PROMPT"; then
+  fail "prompt 에 inline|issue 잔존 — inline-only 정책에서 kind 는 inline 만"
+fi
+# schema: comment_type enum 은 inline 전용
+grep -qF '"inline"' "$SCHEMA" \
+  || fail "schema comment_type 에 inline 값 부재"
+if grep -qF '"issue"' "$SCHEMA"; then
+  fail "schema comment_type enum 에 issue 잔존 — inline-only 정책에서 제거되어야 함"
+fi
+ok "check 8b: prompt·schema 가 inline-only + 강제 anchoring 정책을 반영"
 
 echo ""
 echo "=== check 9: privileged job checks out trusted base, not PR-controlled code ==="

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -168,8 +168,15 @@ grep -qF 'github.rest.pulls.createReview' "$WORKFLOW" \
   || fail "Pulls REST createReview 호출 부재 — inline comments 게시 불가 (gh pr review 로는 inline 미지원)"
 grep -qF 'comments: inlineComments' "$WORKFLOW" \
   || fail "createReview 의 comments[] 배열에 inline findings 전달 부재"
-grep -qF "comment_type === 'inline'" "$WORKFLOW" \
-  || fail "inline/issue findings 분기 처리 부재 (comment_type 사용 안 함)"
+# inline-only 정책: 모든 finding 이 inline. issue 채널 분기/렌더가 없어야 한다.
+grep -qF 'inline-only' "$WORKFLOW" \
+  || fail "inline-only 정책 주석/마커 부재 (모든 finding 을 inline 으로 게시한다는 의도 명시 필요)"
+if grep -qF 'issueFindings' "$WORKFLOW"; then
+  fail "issueFindings 분기 잔존 — inline-only 정책에서 issue 채널 finding 라우팅 금지"
+fi
+if grep -qF 'Issue-level findings' "$WORKFLOW"; then
+  fail "'Issue-level findings' 렌더 잔존 — issue-level 코멘트에 finding 평가 본문 포함 금지 (AC2)"
+fi
 grep -qF "side: 'RIGHT'" "$WORKFLOW" \
   || fail "inline comment 의 side='RIGHT' 지정 부재"
 grep -qF 'start_line' "$WORKFLOW" \
@@ -188,10 +195,17 @@ grep -qF 'confidence_score' "$WORKFLOW" \
   || fail "confidence_score gate 부재"
 grep -qF '>= 80' "$WORKFLOW" \
   || fail "confidence_score >= 80 threshold 부재"
-grep -qF 'Managed Codex review comment is only posted on verdict=approve or inline-fallback' "$WORKFLOW" \
-  || fail "managed comment 게이트가 verdict=approve OR inline-fallback 가 아님 (inline finding 유실 위험)"
-grep -qF "result.verdict === 'approve' || inlineFallback" "$WORKFLOW" \
-  || fail "showFullBody 결정이 verdict=approve OR inlineFallback 가 아님"
+# 요약(issue-level) managed comment 는 approve 일 때만. inline-fallback 경로 제거(AC2/AC3).
+grep -qF 'Managed Codex review comment is only posted on verdict=approve' "$WORKFLOW" \
+  || fail "managed comment 게이트가 verdict=approve 전용이 아님 (AC3)"
+grep -qF "result.verdict === 'approve'" "$WORKFLOW" \
+  || fail "showFullBody 결정이 verdict=approve 조건을 사용하지 않음"
+if grep -qF 'inlineFallback' "$WORKFLOW"; then
+  fail "inlineFallback 경로 잔존 — createReview 실패 시 finding 을 issue 코멘트로 덤프하면 AC2 위반"
+fi
+if grep -qF 'inline-fallback-needed' "$WORKFLOW"; then
+  fail "inline-fallback-needed marker 잔존 — inline-only 정책에서 제거되어야 함"
+fi
 grep -qF '!showFullBody' "$WORKFLOW" \
   || fail "early-return 조건이 showFullBody 변수를 사용하지 않음"
 # supersede stale approve managed comment when latest verdict is non-approve
@@ -237,16 +251,19 @@ grep -qF 'Superseded by later review' "$WORKFLOW" \
 ok "check 10c: verdict=approve 시 옛 자기 CHANGES_REQUESTED reviews 자동 dismiss"
 
 echo ""
-echo "=== check 10d: inline-fallback in managed comment when createReview fails ==="
-grep -qF "fs.writeFileSync('.codex-review/inline-fallback-needed'" "$WORKFLOW" \
-  || fail "createReview 실패 시 inline-fallback-needed marker 생성 부재 — inline findings 유실 위험"
-grep -qF "fs.existsSync('.codex-review/inline-fallback-needed')" "$WORKFLOW" \
-  || fail "Post step 에서 inline-fallback marker 확인 부재"
-grep -qF 'inlineDetailText' "$WORKFLOW" \
-  || fail "inline-fallback 시 inline findings 상세를 managed comment 본문에 포함하지 않음"
-grep -qF 'review submission failed; included here for visibility' "$WORKFLOW" \
-  || fail "inline-fallback 본문 헤더 부재"
-ok "check 10d: createReview 실패 시 inline findings managed comment 폴백"
+echo "=== check 10d: managed comment 은 finding 평가 본문을 렌더하지 않는다 (inline-only) ==="
+# inline-only 정책: finding 평가는 inline 코멘트 전용. managed(issue-level) comment 에
+# finding 상세를 렌더하던 inlineDetailText / renderIssue 경로는 제거되어야 한다 (AC2/AC4).
+if grep -qF 'inlineDetailText' "$WORKFLOW"; then
+  fail "inlineDetailText 잔존 — managed comment 에 inline finding 상세 렌더 금지 (AC2)"
+fi
+if grep -qF 'renderIssue' "$WORKFLOW"; then
+  fail "renderIssue 잔존 — issue-level 코멘트에 finding 평가 본문 렌더 금지 (AC2)"
+fi
+if grep -qF 'review submission failed; included here for visibility' "$WORKFLOW"; then
+  fail "inline-fallback 본문 헤더 잔존 — inline-only 정책에서 제거되어야 함"
+fi
+ok "check 10d: managed comment 에 finding 평가 렌더 경로 제거됨"
 
 echo ""
 echo "=== check 11b: 출력 언어 untrusted block 끝에 재강조 (영어 응답 예방) ==="
@@ -272,6 +289,32 @@ if grep -q '동일 head_sha에 대해 Codex 리뷰가 이미 완료' "$PROMPT"; 
   fail "prompt 가 동일 head_sha 기존 Codex 리뷰만으로 리뷰를 skip 하도록 지시함"
 fi
 ok "check 11: prompt 핵심 정책 존재"
+
+echo ""
+echo "=== check 11c: inline-only 코멘트 정책 (prompt + schema) ==="
+# 모든 finding 은 inline 코멘트로만. anchor 불가 finding 도 가장 가까운 변경 라인에 inline,
+# 본문에 실제 위치 명시. issue-level 코멘트로 finding 을 보고하지 않는다 (AC1/AC2/AC5).
+grep -q 'inline' "$PROMPT" \
+  || fail "prompt inline 코멘트 정책 부재"
+grep -q '가장 가까운 변경' "$PROMPT" \
+  || fail "prompt 에 anchor 불가 finding 을 가장 가까운 변경 라인에 inline 으로 붙이는 지침 부재 (AC5)"
+grep -q '실제 위치' "$PROMPT" \
+  || fail "prompt 에 inline 본문에 실제 문제 위치(파일·라인) 명시 지침 부재 (AC5)"
+if grep -q 'issue-level comment로 보고' "$PROMPT"; then
+  fail "prompt 가 finding 을 issue-level comment 로 보고하도록 지시함 — inline-only 정책 위반"
+fi
+grep -qF '"kind": "inline"' "$PROMPT" \
+  || fail "prompt hidden marker 의 kind 가 inline 전용이 아님"
+if grep -qF 'inline|issue' "$PROMPT"; then
+  fail "prompt 에 inline|issue 잔존 — inline-only 정책에서 kind 는 inline 만"
+fi
+# schema: comment_type enum 은 inline 전용
+grep -qF '"inline"' "$SCHEMA" \
+  || fail "schema comment_type 에 inline 값 부재"
+if grep -qF '"issue"' "$SCHEMA"; then
+  fail "schema comment_type enum 에 issue 잔존 — inline-only 정책에서 제거되어야 함"
+fi
+ok "check 11c: prompt·schema 가 inline-only + 강제 anchoring 정책을 반영"
 
 echo ""
 echo "=== check 12: schema requires automation safety and context fields ==="


### PR DESCRIPTION
## 무엇을

codex·claude PR 자동 리뷰가 피드백을 게시하는 방식을 **inline 전용**으로 바꾼다.

- 모든 피드백 finding은 코드 라인에 붙는 **inline 코멘트로만** 게시한다.
- issue-level(요약) 코멘트에는 finding 평가 본문을 넣지 않는다.
- 요약/managed 코멘트는 **approve일 때만** 승인 표시로 게시한다(verdict ≠ approve면 미게시).
- diff 변경 라인에 직접 anchor할 수 없는 finding(미변경 연관 파일·교차 파일)은 issue 코멘트로 떨어뜨리지 않고, **가장 가까운 변경 hunk 라인에 강제 inline** + 본문 첫 줄에 실제 위치(파일·라인) 명시한다.

## 변경

- 워크플로 2: `codex-review.yml`, `claude-review.yml` — issue-level finding 채널 제거, managed 코멘트 approve 전용 게이트.
- 프롬프트 2: `codex-pr-review.ko.md`, `claude-pr-review.ko.md` — 코멘트 규칙을 inline 전용 + 강제 anchoring으로 재작성.
- 스키마 1: `codex-pr-review.schema.json` — `comment_type` enum → `["inline"]`, `line` 필수화(드롭 방지).
- 문서 2: `docs/codex/pr-review-workflow.md`, `docs/claude/pr-review-workflow.md`.
- 계약 테스트 2: 현 contract에 재정합.

## 검증

- 계약 테스트 3종 PASS (codex / claude / review-context), fresh re-run·rebase 후 재확인.
- 버전 워치 디렉토리(`plugins`) 미변경 → 버전업 불필요.

SPEC: `docs/specs/2026-05-30-pr-review-inline-only-feedback/SPEC.md` (EARS 수용 기준 7개)

🤖 Generated with [Claude Code](https://claude.com/claude-code)