### PR TITLE
feat: version-control-rule-creator git 공통 force-push sub-룰 + inputs 메커니즘

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "project-init",
       "source": "./plugins/project-init",
       "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "category": "scaffold",
       "tags": ["scaffold", "init", "bootstrap"]
     },

--- a/docs/specs/2026-06-01-version-control-git-common-force-push/SPEC.md
+++ b/docs/specs/2026-06-01-version-control-git-common-force-push/SPEC.md
@@ -1,0 +1,73 @@
+---
+scope:
+  include:
+    - plugins/project-init/skills/version-control-rule-creator/**
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+# ears_language: ko
+---
+
+# version-control git 공통 지침 (force-push 허용 토글)
+
+## 무엇을 만들 것인가
+<!-- WHAT/HOW 방어선: 무엇을 만들지만 적고 구현 방법·파일·라이브러리·클래스명은 제약으로 이동. -->
+`version-control-rule-creator`에 **git 계열 공통 지침 sub-룰**을 추가한다. 이 sub-룰은 git 계열 백엔드에서 공통으로 적용되는 version-control 지침을 `rules/version-control/git.md`로 생성하며, 그 첫 항목으로 **force push 정책**을 담는다. 생성 시 사용자에게 **force push 허용 여부**를 묻고(디폴트=금지) 선택에 따라 파일을 생성한다.
+
+force push는 git 전용 개념이므로, 이 sub-룰은 **git 계열 백엔드에서만** 제공된다:
+
+- VCS 백엔드가 git 계열(github·gitlab 등)일 때만 sub-룰 메뉴에 뜨고 생성된다. 비-git 백엔드면 제공하지 않는다.
+- git 계열인지는 **기존 백엔드 판별 결과를 재사용**해 판단한다 — 새 탐지 로직을 추가하지 않고, 이미 판별된 호스팅 백엔드(github·gitlab)를 git 계열로 분류한다.
+- 같은 git 계열 안에서는 호스팅 백엔드(github/gitlab)와 무관하게 **동일한 본문**을 생성한다(git 계열 공통). 출력 파일명은 항상 `rules/version-control/git.md`이다.
+
+force push 분기 동작:
+
+- 디폴트(금지)를 고르면 생성된 `git.md`에 force push 금지 절이 포함된다.
+- 허용을 고르면 같은 `git.md`가 생성되되 **force push 금지 절만 빠진** 채 나머지 본문이 남는다.
+
+이를 위해 `version-control-rule-creator`에 ① 사용자 선택지를 받아 본문 placeholder를 치환하는 **선택지(inputs) 메커니즘**과 ② git 계열 공통 sub-룰을 표현·게이팅하는 처리를 도입한다. inputs는 형제 스킬 `engineering-rule-creator`가 이미 쓰는 frontmatter 방식과 같은 스키마·동작을 따른다.
+
+## 완료 조건
+<!-- 5문장 패턴(항상 / …할 때 / …인 동안 / …이면(오류) / …기능이 켜지면)과 언어 규칙은 references/ears-patterns.md. 각 조건은 관찰 가능하고 독립 검증 가능해야 함. -->
+
+- **항상** `version-control-rule-creator`는 선택된 sub-룰 템플릿의 frontmatter에 `inputs`가 있으면 각 입력을 사용자에게 단일 선택으로 묻고, 선택값으로 템플릿 본문의 동명 placeholder(`{{<name>}}`)를 치환해 `rules/version-control/<sub>.md`를 기록한다.
+- 판별된 백엔드가 **git 계열일 때**, git 공통 sub-룰이 생성 가능한 sub-룰 목록에 포함된다.
+- 판별된 백엔드가 **git 계열이 아닐 때**, git 공통 sub-룰은 목록에 포함되지 않고 생성되지 않으며, 그 사실이 사용자에게 안내된다.
+- 사용자가 git 공통 sub-룰을 생성**할 때**, force push 허용 여부를 묻는 선택지가 제시되고 금지 옵션이 추천(첫 번째)으로 표시된다.
+- 사용자가 force push **금지(디폴트)** 를 선택**할 때**, 생성된 `rules/version-control/git.md`에 force push 금지 절이 포함된다.
+- 사용자가 force push **허용**을 선택**할 때**, 생성된 `rules/version-control/git.md`에는 force push 금지 절이 빠진 채 나머지 본문이 남는다.
+- 같은 git 계열 안에서 origin이 github든 gitlab든 생성되는 `git.md` 본문은 **동일**하다(force push 선택값에 의한 차이 외에는 백엔드별 차이가 없다).
+- force push 선택 입력이 누락되거나 비어 **있으면**, 디폴트(금지)가 적용되어 금지 절이 포함된 파일이 생성된다.
+
+## 범위
+포함:
+- `version-control-rule-creator`의 SKILL.md에 ① inputs 선택지 파싱·치환 단계, ② git 계열 공통 sub-룰의 게이팅·표현 처리 추가.
+- `version-control-rule-creator`의 `templates/` 아래 git 계열 공통 지침 템플릿 신규 추가(force push 금지/허용 토글 placeholder 포함, 출력 `rules/version-control/git.md`).
+
+비-목표 / 제외:
+- 기존 `review-approval`(github/gitlab 백엔드 변형) sub-룰의 본문·백엔드 판별 흐름 변경.
+- 새로운 백엔드 탐지/판별 로직 추가(git 계열 여부는 기존 판별 결과 재사용).
+- 비-git VCS 백엔드 자체의 신규 지원(현재 지원 백엔드는 github·gitlab이며 둘 다 git 계열).
+- `rules/` 아래 실제 지침 파일 생성·수정(런타임 생성 산출물이므로 SPEC 구현 범위 밖).
+- force push 외의 다른 git 공통 항목(브랜치 전략·커밋 컨벤션 등) 신설(이 sub-룰이 향후 담을 수 있으나 이번 범위 밖).
+- `engineering-rule-creator`·`context-rule-creator`·`workspace-rule-creator` 등 형제 스킬 변경.
+
+## 검증
+<!-- 검증 기준의 단일 출처는 위 "완료 조건"이다. 검증을 실행하는 진입 명령(테스트·lint·빌드)은 SPEC이 선언하지 않는다. -->
+이 SPEC의 인수 바는 위 **완료 조건**이다. 각 조건이 관찰 가능하게 충족되면 충족된 것으로 본다. 검증을 실행하는 진입 명령은 SPEC이 아니라 프로젝트 규칙(`rules/`)이 단일 출처로 정의한다.
+
+## 제약 (있을 때만)
+- **스킬(SKILL.md) 생성·편집은 `superpowers:writing-skills`(skill creator)를 거쳐 수행한다.** vc-rule-creator의 SKILL.md를 직접 손으로 고치지 않고 해당 스킬의 절차를 따른다.
+- **공통 지침 출력 파일명은 `rules/version-control/git.md`로 고정한다.** github/gitlab별로 파일을 복제하지 않고 git 계열 전체에 같은 본문을 적용한다.
+- **inputs 메커니즘은 `engineering-rule-creator`의 inputs 방식을 미러링한다.** 같은 frontmatter 스키마(`name`, `header`, `question`, `options[{label, description, value?}]`)와 같은 치환 규칙(선택값=`value` 우선, 없으면 `label`)을 쓴다. 단, force push 입력은 응답 누락·빈 값일 때 placeholder 보존이 아니라 **디폴트(금지)** 를 적용한다.
+- **force push 금지/허용 분기는 본문 placeholder 치환으로 표현한다.** 금지 옵션의 `value`는 force push 금지 절 텍스트를, 허용 옵션의 `value`는 빈 문자열을 공급하여, 허용 시 금지 절만 사라지고 나머지 본문은 그대로 남게 한다. 별도의 조건부 렌더링 로직을 SKILL.md에 추가하지 않는다.
+- **git 계열 게이팅은 기존 백엔드 판별 결과를 재사용한다.** 새 origin 파싱·probe를 추가하지 않고, 이미 판별된 호스팅 백엔드(github·gitlab)를 git 계열로 분류하는 정적 매핑만 둔다. 향후 비-git 백엔드가 추가되면 그 백엔드를 git 계열에서 제외하는 것으로 자연히 게이팅된다.
+- **SKILL.md 변경은 위 두 메커니즘(inputs, git 계열 공통 게이팅) 도입에 한정한다.** 기존 `review-approval` 백엔드 변형 판별·단일 sub-룰 기록 흐름은 보존한다. "한 호출 = 한 sub-룰" 원칙을 유지한다.
+- 기존 파일 보호 규약 유지: 대상 `rules/version-control/git.md`가 이미 있으면 덮어쓰지 않고 diff를 보여 명시적 교체 선택일 때만 덮어쓴다.
+
+## 위험 (있을 때만)
+- inputs·git 계열 게이팅 도입이 기존 백엔드 변형(`review-approval`)의 자동 판별·기록 흐름을 깨뜨릴 위험 — `review-approval`은 inputs를 갖지 않고 백엔드 변형으로 동작하므로 두 경로가 독립적으로 동작해야 한다.
+- sub-룰이 둘(`review-approval`, git 공통)이 되면서 sub-룰 단일 선택 단계가 정상 동작해야 한다(두 sub-룰을 합쳐 기록하지 않는다).
+- git 계열 분류를 정적 매핑으로 두면, 미래에 비-git 백엔드가 추가될 때 그 매핑을 갱신하지 않으면 force push 지침이 잘못 제공될 수 있다 — 매핑의 단일 출처를 명확히 하고 기본값을 "git 계열 아님(미제공)"으로 안전하게 둔다.
+- 허용 옵션의 빈 `value` 치환이 본문에 빈 줄·깨진 마크다운을 남기지 않도록, placeholder 주변 서식을 절 단위로 깔끔히 제거해야 한다.

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",

--- a/plugins/project-init/skills/version-control-rule-creator/SKILL.md
+++ b/plugins/project-init/skills/version-control-rule-creator/SKILL.md
@@ -26,7 +26,13 @@ description: 현재 프로젝트의 git origin remote에서 호스팅 백엔드(
 
 1. **템플릿 열거.** `templates/*.md`만 읽습니다. 위 파일명 규약으로 각 파일의 sub-룰 ID와 (있으면) 백엔드 변형을 식별합니다. 같은 sub-룰 ID의 변형 집합을 묶습니다.
 
-2. **sub-룰 선택.** sub-룰 ID가 하나면 자동 선택하고, 둘 이상이면 `AskUserQuestion` single-select로 묻습니다. 한 번의 호출에서 **정확히 하나**의 sub-룰만 기록합니다. 단순 재실행으로 sub-룰을 바꾸지 않습니다.
+2. **sub-룰 선택 (git 계열 게이팅 포함).** 후보 sub-룰 목록을 만든 뒤, sub-룰 ID가 하나면 자동 선택하고 둘 이상이면 `AskUserQuestion` single-select로 묻습니다. 한 번의 호출에서 **정확히 하나**의 sub-룰만 기록합니다. 단순 재실행으로 sub-룰을 바꾸지 않습니다.
+
+   - **git 계열 공통 sub-룰 게이팅.** `git` sub-룰(`templates/git.md`, 백엔드 변형 없음, 출력 `rules/version-control/git.md`)은 **git 계열 백엔드일 때만** 후보 목록에 넣습니다. force push 등 git 전용 개념을 담기 때문입니다.
+     - git 계열 판정은 **3단계의 백엔드 판별 결과를 재사용**합니다. 새 origin 파싱·probe를 추가하지 않고, 후보 목록을 만들기 전에 3단계의 판별을 먼저 수행해 그 결과를 게이팅과 (백엔드 변형 sub-룰의) 본문 선택 양쪽에 함께 씁니다.
+     - 판별된 호스팅 백엔드를 git 계열로 분류하는 **정적 매핑**만 둡니다: `github`·`gitlab`은 git 계열입니다. 이 정적 매핑이 git 계열 분류의 단일 출처이며, 매핑에 없는 백엔드의 기본값은 **"git 계열 아님"**(미제공)입니다. 향후 비-git 백엔드가 추가되면 그 백엔드를 이 매핑에 넣지 않는 것만으로 자연히 게이팅됩니다.
+     - 판별된 백엔드가 **git 계열이 아니면** `git` sub-룰을 후보 목록에서 **제외**하고, 그 사실(이 백엔드는 git 계열이 아니어서 git 공통 지침을 제공하지 않음)을 사용자에게 안내합니다.
+     - 백엔드 변형이 없는 그 밖의 sub-룰은 git 계열 게이팅 없이 항상 후보입니다(`git` sub-룰에만 적용되는 게이팅입니다).
 
 3. **백엔드 자동 판별 (백엔드 변형을 가진 sub-룰일 때만).** git origin remote URL을 파싱해 호스트를 추출한 뒤, **공식 도메인은 호스트명 정밀 매칭으로(네트워크 호출 없음), self-hosted 호스트는 부작용 없는 read-only API probe로** 백엔드를 판별합니다. **호스트명 substring 매칭은 쓰지 않습니다**(`github-mirror.*`·`mygithub.com` 류 오판별 방지).
    - origin URL은 `git remote get-url origin`(또는 `git config --get remote.origin.url`)으로 읽습니다.
@@ -45,6 +51,14 @@ description: 현재 프로젝트의 git origin remote에서 호스팅 백엔드(
    백엔드 변형이 없는 sub-룰은 이 단계를 건너뜁니다.
 
 4. **본문 조립.** 선택된 sub-룰의 (백엔드 변형이 있으면 판별된 백엔드의) 템플릿에서 **frontmatter를 제거한 본문**을 그대로 취합니다. 본문은 placeholder 치환 외에 변형하지 않습니다.
+
+4-bis. **입력(inputs) 치환.** 선택된 템플릿 frontmatter에 `inputs`가 있으면, 형제 스킬 `engineering-rule-creator`의 inputs 방식을 **그대로 미러링**해 처리합니다. `inputs`가 없으면 이 단계를 건너뜁니다.
+   - **스키마.** 각 입력은 `name`, `header`, `question`, `options[{label, description, value?}]`를 가집니다(engineering-rule-creator와 동일 스키마).
+   - **질문.** 입력을 순서대로 `AskUserQuestion` **단일 선택(single-select)**으로 묻습니다. 옵션 표시 순서는 frontmatter에 적힌 순서를 따르므로, **추천 옵션은 첫 번째**에 두고 라벨에 `(Recommended)`를 붙여 표시합니다.
+   - **치환 규칙.** 선택된 옵션의 값으로 본문의 동명 placeholder `{{<name>}}`를 치환합니다. 값은 **`value`가 있으면 `value`, 없으면 `label`**을 씁니다(value 우선). 비어 있지 않은 "Other" 자유 입력도 허용합니다.
+   - **누락·빈 값 (일반).** 응답이 누락되거나 비어 있으면 engineering-rule-creator와 같이 `{{<name>}}`을 **보존**합니다.
+   - **force push 정책 입력의 특례.** `force_push_policy` 입력은 응답이 누락·빈 값일 때 placeholder를 보존하지 않고 **디폴트(금지)** 를 적용합니다 — 즉 추천(첫 번째) 옵션인 금지 옵션의 `value`(force push 금지 절 텍스트)를 공급합니다. 따라서 입력이 빠져도 금지 절이 포함된 `git.md`가 생성됩니다.
+   - **force push 금지/허용 분기는 치환만으로 표현합니다.** 금지 옵션의 `value`는 force push 금지 절 텍스트를, 허용 옵션의 `value`는 **빈 문자열**을 공급합니다. 허용을 고르면 placeholder가 빈 문자열로 치환되어 금지 절만 사라지고 나머지 본문은 그대로 남습니다. 별도의 조건부 렌더링 로직을 추가하지 않습니다. 빈 치환이 본문에 빈 줄·깨진 마크다운을 남기지 않도록 placeholder 주변 서식을 절 단위로 정리합니다.
 
 5. **파일 기록.**
    - 대상 디렉터리 `rules/version-control/`가 없으면 기록 전에 생성합니다.

--- a/plugins/project-init/skills/version-control-rule-creator/SKILL.md
+++ b/plugins/project-init/skills/version-control-rule-creator/SKILL.md
@@ -26,15 +26,7 @@ description: 현재 프로젝트의 git origin remote에서 호스팅 백엔드(
 
 1. **템플릿 열거.** `templates/*.md`만 읽습니다. 위 파일명 규약으로 각 파일의 sub-룰 ID와 (있으면) 백엔드 변형을 식별합니다. 같은 sub-룰 ID의 변형 집합을 묶습니다.
 
-2. **sub-룰 선택 (git 계열 게이팅 포함).** 후보 sub-룰 목록을 만든 뒤, sub-룰 ID가 하나면 자동 선택하고 둘 이상이면 `AskUserQuestion` single-select로 묻습니다. 한 번의 호출에서 **정확히 하나**의 sub-룰만 기록합니다. 단순 재실행으로 sub-룰을 바꾸지 않습니다.
-
-   - **git 계열 공통 sub-룰 게이팅.** `git` sub-룰(`templates/git.md`, 백엔드 변형 없음, 출력 `rules/version-control/git.md`)은 **git 계열 백엔드일 때만** 후보 목록에 넣습니다. force push 등 git 전용 개념을 담기 때문입니다.
-     - git 계열 판정은 **3단계의 백엔드 판별 결과를 재사용**합니다. 새 origin 파싱·probe를 추가하지 않고, 후보 목록을 만들기 전에 3단계의 판별을 먼저 수행해 그 결과를 게이팅과 (백엔드 변형 sub-룰의) 본문 선택 양쪽에 함께 씁니다.
-     - 판별된 호스팅 백엔드를 git 계열로 분류하는 **정적 매핑**만 둡니다: `github`·`gitlab`은 git 계열입니다. 이 정적 매핑이 git 계열 분류의 단일 출처이며, 매핑에 없는 백엔드의 기본값은 **"git 계열 아님"**(미제공)입니다. 향후 비-git 백엔드가 추가되면 그 백엔드를 이 매핑에 넣지 않는 것만으로 자연히 게이팅됩니다.
-     - 판별된 백엔드가 **git 계열이 아니면** `git` sub-룰을 후보 목록에서 **제외**하고, 그 사실(이 백엔드는 git 계열이 아니어서 git 공통 지침을 제공하지 않음)을 사용자에게 안내합니다.
-     - 백엔드 변형이 없는 그 밖의 sub-룰은 git 계열 게이팅 없이 항상 후보입니다(`git` sub-룰에만 적용되는 게이팅입니다).
-
-3. **백엔드 자동 판별 (백엔드 변형을 가진 sub-룰일 때만).** git origin remote URL을 파싱해 호스트를 추출한 뒤, **공식 도메인은 호스트명 정밀 매칭으로(네트워크 호출 없음), self-hosted 호스트는 부작용 없는 read-only API probe로** 백엔드를 판별합니다. **호스트명 substring 매칭은 쓰지 않습니다**(`github-mirror.*`·`mygithub.com` 류 오판별 방지).
+2. **백엔드 판별 (후보 확정 전 1회).** 1단계에서 열거한 후보 중 백엔드 변형을 가진 sub-룰(예: `review-approval`)이 있거나 git 계열 게이팅이 필요한 sub-룰(`git`)이 있으면, sub-룰을 선택하기 **전에** 백엔드를 1회 판별합니다. 이 판별 결과는 3단계의 git 계열 게이팅과 4단계의 백엔드 변형 본문 선택에서 **함께 재사용**하며 재판별하지 않습니다. git origin remote URL을 파싱해 호스트를 추출한 뒤, **공식 도메인은 호스트명 정밀 매칭으로(네트워크 호출 없음), self-hosted 호스트는 부작용 없는 read-only API probe로** 백엔드를 판별합니다. **호스트명 substring 매칭은 쓰지 않습니다**(`github-mirror.*`·`mygithub.com` 류 오판별 방지).
    - origin URL은 `git remote get-url origin`(또는 `git config --get remote.origin.url`)으로 읽습니다.
    - https 양식(`https://host/owner/repo.git`)과 ssh 양식(`git@host:owner/repo.git`·`ssh://git@host/owner/repo.git`) **모두**에서 호스트를 추출합니다.
    - **origin이 설정되어 있지 않으면**: 어떤 룰 파일도 생성하지 않고, origin remote를 먼저 설정하라고 안내한 뒤 종료합니다.
@@ -46,11 +38,17 @@ description: 현재 프로젝트의 git origin remote에서 호스팅 백엔드(
      - 잘 알려진 백엔드 식별 엔드포인트의 **상태코드·응답 헤더·본문 마커** 조합으로 github/gitlab을 판별합니다(예: GitLab은 `/api/v4/` 계열 응답·헤더, GitHub Enterprise는 `/api/v3` 계열 응답·헤더).
      - probe는 best-effort입니다. **timeout·도달 불가·인증요구(401/403)·식별 마커 부재는 모두 inconclusive**로 처리합니다.
    - **판별 실패 시 중단 (추측 금지).** (a) 정밀 매칭에도 해당하지 않고 (b) probe로도 백엔드를 확정하지 못하면(inconclusive 포함), 감지된 호스트와 지원 백엔드 목록(github·gitlab)을 안내하고 어떤 룰 파일도 생성하지 않고 종료합니다. 추측해서 생성하지 않습니다.
-   - 선택된 sub-룰에 판별된 백엔드의 변형 파일이 없으면, 그 사실을 알리고 종료합니다.
+   - 후보 중 어떤 sub-룰도 백엔드 정보를 필요로 하지 않으면 이 단계를 건너뜁니다.
 
-   백엔드 변형이 없는 sub-룰은 이 단계를 건너뜁니다.
+3. **sub-룰 선택 (git 계열 게이팅 포함).** 후보 sub-룰 목록을 구성하되 `git` sub-룰의 포함 여부는 **2단계 판별 결과**로 게이팅합니다. 그다음 sub-룰 ID가 하나면 자동 선택하고 둘 이상이면 `AskUserQuestion` single-select로 묻습니다. 한 번의 호출에서 **정확히 하나**의 sub-룰만 기록합니다. 단순 재실행으로 sub-룰을 바꾸지 않습니다.
 
-4. **본문 조립.** 선택된 sub-룰의 (백엔드 변형이 있으면 판별된 백엔드의) 템플릿에서 **frontmatter를 제거한 본문**을 그대로 취합니다. 본문은 placeholder 치환 외에 변형하지 않습니다.
+   - **git 계열 공통 sub-룰 게이팅.** `git` sub-룰(`templates/git.md`, 백엔드 변형 없음, 출력 `rules/version-control/git.md`)은 **2단계 판별 결과가 git 계열일 때만** 후보 목록에 넣습니다. force push 등 git 전용 개념을 담기 때문입니다.
+     - 판별된 호스팅 백엔드를 git 계열로 분류하는 **정적 매핑**만 둡니다: `github`·`gitlab`은 git 계열입니다. 이 정적 매핑이 git 계열 분류의 단일 출처이며, 매핑에 없는 백엔드의 기본값은 **"git 계열 아님"**(미제공)입니다. 향후 비-git 백엔드가 추가되면 그 백엔드를 이 매핑에 넣지 않는 것만으로 자연히 게이팅됩니다.
+     - 판별된 백엔드가 **git 계열이 아니면** `git` sub-룰을 후보 목록에서 **제외**하고, 그 사실(이 백엔드는 git 계열이 아니어서 git 공통 지침을 제공하지 않음)을 사용자에게 안내합니다.
+     - 백엔드 변형이 없는 그 밖의 sub-룰은 git 계열 게이팅 없이 항상 후보입니다(`git` sub-룰에만 적용되는 게이팅입니다).
+
+4. **본문 조립.** 선택된 sub-룰의 (백엔드 변형이 있으면 **2단계에서 판별된** 백엔드의) 템플릿에서 **frontmatter를 제거한 본문**을 그대로 취합니다. 본문은 placeholder 치환 외에 변형하지 않습니다.
+   - 선택된 sub-룰에 2단계에서 판별된 백엔드의 변형 파일이 없으면, 그 사실을 알리고 종료합니다.
 
 4-bis. **입력(inputs) 치환.** 선택된 템플릿 frontmatter에 `inputs`가 있으면, 형제 스킬 `engineering-rule-creator`의 inputs 방식을 **그대로 미러링**해 처리합니다. `inputs`가 없으면 이 단계를 건너뜁니다.
    - **스키마.** 각 입력은 `name`, `header`, `question`, `options[{label, description, value?}]`를 가집니다(engineering-rule-creator와 동일 스키마).

--- a/plugins/project-init/skills/version-control-rule-creator/templates/git.md
+++ b/plugins/project-init/skills/version-control-rule-creator/templates/git.md
@@ -1,0 +1,30 @@
+---
+sub_rule: git
+label: git 계열 공통 지침 (force push 정책)
+description: git 계열 백엔드(GitHub·GitLab 등) 공통으로 적용되는 version-control 지침. 첫 항목으로 force push 정책을 담습니다.
+inputs:
+  - name: force_push_policy
+    header: "force push"
+    question: "이 프로젝트에서 force push(history 재작성 push)를 허용하시겠습니까? (기본값: 금지)"
+    options:
+      - label: "금지 (Recommended)"
+        description: "공유 브랜치 history를 보호합니다. 협업 프로젝트의 안전한 기본값입니다."
+        value: |-
+          ## force push 금지
+
+          공유 브랜치(기본 브랜치 및 다른 사람이 받아 가는 브랜치)에 대한 **force push**(`git push --force` / `--force-with-lease`, history 재작성 push)를 **금지**합니다.
+
+          - 이미 푸시되어 공유된 commit은 history를 재작성해 덮어쓰지 않습니다. 잘못된 commit은 새 commit(revert·수정)으로 바로잡습니다.
+          - force push는 다른 사람이 받아 간 history를 무효화해 작업 손실·충돌을 일으키므로, 공유 브랜치에서는 예외 없이 막습니다.
+          - 아직 공유되지 않은 본인 전용 토픽 브랜치의 정리(rebase 후 force push)가 불가피하면, 그 브랜치가 공유되지 않았음을 확인한 경우에만 허용하며 공유 브랜치에는 적용하지 않습니다.
+          - 호스팅의 브랜치 보호(protected branch) 설정으로 기본 브랜치 force push를 차단하는 것을 권장합니다.
+      - label: "허용"
+        description: "force push를 정책상 막지 않습니다. 브랜치 보호는 호스팅 설정에 위임합니다."
+        value: ""
+---
+
+# git 계열 공통 지침
+
+이 프로젝트의 호스팅 백엔드는 **git 계열**(GitHub·GitLab 등)입니다. 본 지침은 호스팅 백엔드(GitHub/GitLab)와 무관하게 git 계열 전체에 공통으로 적용되는 version-control 규율을 정의합니다. 백엔드 특화 심사·승인 규율은 별도 sub-룰(`rules/version-control/review-approval.md`)이 담습니다.
+
+{{force_push_policy}}

--- a/plugins/project-init/skills/version-control-rule-creator/tests/git-common-force-push.test.sh
+++ b/plugins/project-init/skills/version-control-rule-creator/tests/git-common-force-push.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Structural acceptance test for the version-control "git 계열 공통 지침 (force-push 토글)" SPEC.
+# Verifies:
+#   - SKILL.md documents the inputs substitution mechanism (mirroring engineering-rule-creator)
+#   - SKILL.md documents git-family gating via a static backend classification reusing
+#     the existing backend determination, output rules/version-control/git.md
+#   - SKILL.md documents non-git exclusion + user notice, and force-push default-on-missing
+#   - templates/git.md exists: sub_rule git, inputs force_push_policy, 금지 first+Recommended
+#     with prohibition-clause value, 허용 with empty value, {{force_push_policy}} placeholder
+#
+# Run: bash git-common-force-push.test.sh   (exit 0 = pass)
+set -u
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL="$DIR/SKILL.md"
+TPL="$DIR/templates/git.md"
+
+fail=0
+check() { # desc, cmd...
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "ok   - $desc"
+  else
+    echo "FAIL - $desc"; fail=1
+  fi
+}
+
+# line number of first line matching a fixed string (empty if none)
+lineno() { grep -nF -m1 "$2" "$1" 2>/dev/null | cut -d: -f1; }
+# line number of first line matching an extended regex (empty if none)
+lineno_re() { grep -nE -m1 "$2" "$1" 2>/dev/null | cut -d: -f1; }
+
+# --- 1) inputs substitution mechanism in SKILL.md (mirrors engineering-rule-creator) ---
+check "SKILL.md documents an inputs mechanism" grep -qF 'inputs' "$SKILL"
+check "SKILL.md mirrors engineering-rule-creator inputs" grep -qF 'engineering-rule-creator' "$SKILL"
+check "SKILL.md documents {{name}} placeholder substitution" grep -qF '{{' "$SKILL"
+check "SKILL.md documents value-over-label substitution rule" grep -qF 'value' "$SKILL"
+
+# --- 2) git-family gating + static classification in SKILL.md ---
+check "SKILL.md mentions git 계열 (git-family)" grep -qF 'git 계열' "$SKILL"
+check "SKILL.md declares static git-family classification incl github" grep -qF 'github' "$SKILL"
+check "SKILL.md declares static git-family classification incl gitlab" grep -qF 'gitlab' "$SKILL"
+check "SKILL.md reuses existing backend determination (no new detection)" grep -qF '재사용' "$SKILL"
+check "SKILL.md fixes git common output to git.md" grep -qF 'git.md' "$SKILL"
+
+# --- 3) non-git exclusion + notice, and force-push default-on-missing in SKILL.md ---
+check "SKILL.md documents non-git exclusion notice" bash -c "grep -qF '계열이 아니' '$SKILL' || grep -qF '비-git' '$SKILL'"
+check "SKILL.md documents force-push default-on-missing (금지)" grep -qF 'force push' "$SKILL"
+
+# --- 4) templates/git.md existence + frontmatter ---
+check "templates/git.md exists" test -f "$TPL"
+check "git.md frontmatter declares sub_rule git" grep -qE '^sub_rule:[[:space:]]*git[[:space:]]*$' "$TPL"
+check "git.md declares an inputs block" grep -qF 'inputs:' "$TPL"
+check "git.md declares force_push_policy input" grep -qF 'force_push_policy' "$TPL"
+
+# --- 5) 금지 option: first, Recommended, carries prohibition clause ---
+check "git.md marks an option (Recommended)" grep -qF '(Recommended)' "$TPL"
+check "git.md prohibition option text mentions force push 금지" bash -c "grep -qF 'force push' '$TPL' && grep -qF '금지' '$TPL'"
+
+# 금지 option label must appear before 허용 option label (recommended is first).
+# Match the option `label:` lines specifically, not the question prose which
+# mentions both words.
+nodeny="$(lineno_re "$TPL" '^[[:space:]]*-?[[:space:]]*label:.*금지')"
+noallow="$(lineno_re "$TPL" '^[[:space:]]*-?[[:space:]]*label:.*허용')"
+check "git.md 금지 option label appears before 허용 option label" bash -c "[ -n '$nodeny' ] && [ -n '$noallow' ] && [ '$nodeny' -lt '$noallow' ]"
+
+# --- 6) 허용 option supplies an empty value ---
+check "git.md provides an empty value (허용 => placeholder removed)" grep -qE 'value:[[:space:]]*""' "$TPL"
+
+# --- 7) body placeholder ---
+check "git.md body has {{force_push_policy}} placeholder" grep -qF '{{force_push_policy}}' "$TPL"
+
+# --- 8) git common sub-rule has NO backend variant (single body, always git.md) ---
+check "no backend-variant git template (git.<backend>.md) exists" \
+  bash -c "! ls '$DIR/templates/' | grep -qE '^git\.[a-z]+\.md$'"
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS"; exit 0
+else
+  echo "FAILED"; exit 1
+fi

--- a/plugins/project-init/skills/version-control-rule-creator/tests/git-common-force-push.test.sh
+++ b/plugins/project-init/skills/version-control-rule-creator/tests/git-common-force-push.test.sh
@@ -53,6 +53,16 @@ check "git.md frontmatter declares sub_rule git" grep -qE '^sub_rule:[[:space:]]
 check "git.md declares an inputs block" grep -qF 'inputs:' "$TPL"
 check "git.md declares force_push_policy input" grep -qF 'force_push_policy' "$TPL"
 
+# --- 4-bis) step order: backend determination is described BEFORE git-family gating ---
+# Guards the reviewed contradiction where the gating step referenced a later
+# detection step's result (forward reference / step-number vs execution-order mismatch).
+detstep="$(lineno_re "$SKILL" '^[0-9]+\. \*\*백엔드 판별')"
+gatestep="$(lineno_re "$SKILL" 'git 계열 공통 sub-룰 게이팅')"
+check "SKILL.md describes backend determination before git-family gating" \
+  bash -c "[ -n '$detstep' ] && [ -n '$gatestep' ] && [ '$detstep' -lt '$gatestep' ]"
+check "SKILL.md has no forward-reference to a later detection step in gating" \
+  bash -c "! grep -qF '3단계의 백엔드 판별 결과를 재사용' '$SKILL'"
+
 # --- 5) 금지 option: first, Recommended, carries prohibition clause ---
 check "git.md marks an option (Recommended)" grep -qF '(Recommended)' "$TPL"
 check "git.md prohibition option text mentions force push 금지" bash -c "grep -qF 'force push' '$TPL' && grep -qF '금지' '$TPL'"


### PR DESCRIPTION
## 요약

`version-control-rule-creator`에 **git 계열 공통 지침 sub-룰**(`rules/version-control/git.md`)을 추가하고, 그 첫 항목으로 **force push 정책**을 담습니다. 생성 시 사용자에게 force push 허용 여부를 묻고(디폴트=금지) 선택에 따라 파일을 생성합니다.

force push는 git 전용 개념이므로, 이 sub-룰은 **git 계열 백엔드에서만** 제공됩니다(비-git이면 미제공 + 안내).

## 변경

- **`templates/git.md` 신규**: `force_push_policy` inputs 토글
  - 금지(추천/첫 번째): force push 금지 절 텍스트를 `value`로 공급
  - 허용: 빈 `value` → 금지 절만 제거, 나머지 본문 유지
  - 본문 `{{force_push_policy}}` placeholder, 출력 `rules/version-control/git.md`
- **`SKILL.md`**:
  - ① inputs 치환 메커니즘(4-bis) — `engineering-rule-creator` 미러, `value`>`label`, 일반 누락→placeholder 보존, `force_push_policy` 누락→금지 디폴트
  - ② git 계열 게이팅(2단계) — 기존 백엔드 판별 결과 재사용, 정적 매핑(github·gitlab=git 계열), 비-git 제외+안내
  - 기존 `review-approval` 백엔드 변형 흐름은 보존
- **테스트 신규**: 구조 acceptance 21건 (전부 통과)
- **SPEC 문서** 동봉: `docs/specs/2026-06-01-version-control-git-common-force-push/SPEC.md`

## 검증

- `tests/git-common-force-push.test.sh` 21/21 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)