### PR TITLE
fix: PR 리뷰 self inline thread resolve를 결정론적 fingerprint로 안정화

### DIFF
--- a/.github/prompts/claude-pr-review.ko.md
+++ b/.github/prompts/claude-pr-review.ko.md
@@ -73,26 +73,14 @@
 - 다른 리뷰어가 만든 thread/comment는 resolve하거나 수정하지 않습니다.
 - Claude가 만든 thread/comment만 관리합니다.
 
-중복 방지:
-모든 Claude comment에는 아래 hidden marker를 포함해야 합니다.
+self thread 식별 마커:
+워크플로는 게시하는 각 Claude inline comment 본문 끝에 아래 형식의 hidden marker를 자동으로 덧붙입니다. 이 마커는 워크플로가 실제로 게시하고 resolve 시 매칭하는 형식입니다.
 
-<!-- claude-review:
-{
-  "owner": "claude",
-  "fingerprint": "<stable-fingerprint>",
-  "kind": "inline",
-  "severity": "blocking|non_blocking|question",
-  "status": "active|resolved",
-  "head_sha": "<head-sha>"
-}
--->
+<!-- claude-review-inline fingerprint=<deterministic-fingerprint> -->
 
-fingerprint는 아래 값을 정규화하여 안정적으로 생성합니다.
-- issue category
-- file path
-- changed line 또는 nearest changed hunk
-- normalized title
-- normalized root cause
+fingerprint 값은 워크플로가 finding의 안정 속성(파일 경로 + 리뷰 관점 `review_perspective` + 정규화한 제목)으로부터 결정론적으로 계산합니다. 줄 번호에는 의존하지 않으므로, 같은 finding은 PR 진화로 줄 위치가 바뀌어도 실행 간 동일한 fingerprint를 갖습니다. 모델은 이 fingerprint를 직접 생성하지 않습니다 — 마커는 워크플로가 부여합니다.
+
+기존 Claude(자신) self inline thread를 resolve로 판단할 때는, 그 thread 첫 코멘트의 위 마커에서 `fingerprint=` 뒤의 값을 그대로 읽어 그 값과 reason을 resolved_threads에 기록합니다. 아직 해결되지 않은 thread는 같은 방식으로 읽은 fingerprint를 unresolved_threads에 기록합니다.
 
 심각도:
 - blocking: merge 전에 반드시 수정해야 하는 문제입니다. correctness, security, data loss, clear regression, broken CI/release behavior에 사용합니다.

--- a/.github/prompts/codex-pr-review.ko.md
+++ b/.github/prompts/codex-pr-review.ko.md
@@ -84,26 +84,14 @@
 - 다른 리뷰어가 만든 thread/comment는 resolve하거나 수정하지 않습니다.
 - Codex가 만든 thread/comment만 관리합니다.
 
-중복 방지:
-모든 Codex comment에는 아래 hidden marker를 포함해야 합니다.
+self thread 식별 마커:
+워크플로는 게시하는 각 Codex inline comment 본문 끝에 아래 형식의 hidden marker를 자동으로 덧붙입니다. 이 마커는 워크플로가 실제로 게시하고 resolve 시 매칭하는 형식입니다.
 
-<!-- codex-review:
-{
-  "owner": "codex",
-  "fingerprint": "<stable-fingerprint>",
-  "kind": "inline",
-  "severity": "blocking|non_blocking|question",
-  "status": "active|resolved",
-  "head_sha": "<head-sha>"
-}
--->
+<!-- codex-review-inline fingerprint=<deterministic-fingerprint> -->
 
-fingerprint는 아래 값을 정규화하여 안정적으로 생성합니다.
-- issue category
-- file path
-- changed line 또는 nearest changed hunk
-- normalized title
-- normalized root cause
+fingerprint 값은 워크플로가 finding의 안정 속성(파일 경로 + 리뷰 관점 `review_perspective` + 정규화한 제목)으로부터 결정론적으로 계산합니다. 줄 번호에는 의존하지 않으므로, 같은 finding은 PR 진화로 줄 위치가 바뀌어도 실행 간 동일한 fingerprint를 갖습니다. 모델은 이 fingerprint를 직접 생성하지 않습니다 — 마커는 워크플로가 부여합니다.
+
+기존 Codex(자신) self inline thread를 resolve로 판단할 때는, 그 thread 첫 코멘트의 위 마커에서 `fingerprint=` 뒤의 값을 그대로 읽어 그 값과 reason을 resolved_threads에 기록합니다. 아직 해결되지 않은 thread는 같은 방식으로 읽은 fingerprint를 unresolved_threads에 기록합니다.
 
 심각도:
 - blocking: merge 전에 반드시 수정해야 하는 문제입니다. correctness, security, data loss, clear regression, broken CI/release behavior에 사용합니다.

--- a/.github/prompts/codex-pr-review.schema.json
+++ b/.github/prompts/codex-pr-review.schema.json
@@ -93,7 +93,6 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
-          "fingerprint",
           "severity",
           "confidence_score",
           "review_perspective",
@@ -107,7 +106,6 @@
           "duplicate_of"
         ],
         "properties": {
-          "fingerprint": { "type": "string" },
           "severity": {
             "type": "string",
             "enum": ["blocking", "non_blocking", "question"]

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -346,7 +346,6 @@ jobs:
               and ([.findings[]? |
                     (.severity | IN("blocking","non_blocking","question"))
                     and (.confidence_score | type == "number")
-                    and (.fingerprint | type == "string")
                     and (.review_perspective | IN("guideline","bug","history","previous_pr","code_comment","cross_file"))
                     and (.comment_type | IN("inline"))
                     and (.file | type == "string")
@@ -440,6 +439,25 @@ jobs:
             const appSlug = process.env.APP_SLUG;
             const botLogin = appSlug ? `${appSlug}[bot]` : 'github-actions[bot]';
 
+            // Deterministic finding fingerprint. Derived ONLY from the finding's
+            // stable attributes — file path, review perspective, and a normalized
+            // title — so the same finding keeps the same fingerprint across review
+            // runs even as the PR evolves and the line shifts (line/start_line are
+            // deliberately excluded). The workflow computes this; the model no
+            // longer supplies a free-form fingerprint. The same normalization is
+            // used in codex-review.yml so both workflows agree.
+            const crypto = require('crypto');
+            const normalizeTitle = (s) => String(s == null ? '' : s)
+              .normalize('NFKC')
+              .toLowerCase()
+              .replace(/[^\p{L}\p{N}]+/gu, ' ')
+              .trim();
+            const computeFingerprint = (f) => crypto
+              .createHash('sha256')
+              .update([f.file || '', f.review_perspective || '', normalizeTitle(f.title)].join(' '))
+              .digest('hex')
+              .slice(0, 16);
+
             if (result.eligibility?.status !== 'reviewed') {
               core.info('No review output to post.');
               return;
@@ -491,7 +509,7 @@ jobs:
               // Anchor to f.line; fall back to f.start_line so a finding is never
               // dropped (validation guarantees at least one is a positive int).
               const anchor = (typeof f.line === 'number' && f.line > 0) ? f.line : f.start_line;
-              const fingerprintMarker = `${inlineMarkerBase} fingerprint=${f.fingerprint} -->`;
+              const fingerprintMarker = `${inlineMarkerBase} fingerprint=${computeFingerprint(f)} -->`;
               const c = {
                 path: f.file,
                 body: `**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${fingerprintMarker}`,
@@ -573,10 +591,10 @@ jobs:
               (result.resolved_threads || [])
                 .map((r) => r && r.fingerprint)
                 .filter((fp) => typeof fp === 'string' && fp.length > 0));
-            const findingFingerprints = new Set(
-              findings
-                .map((f) => f && f.fingerprint)
-                .filter((fp) => typeof fp === 'string' && fp.length > 0));
+            // Deterministic fingerprints for this round's findings (workflow-computed,
+            // not model-supplied) — the fallback tier resolves any self thread whose
+            // fingerprint is absent from this set.
+            const findingFingerprints = new Set(findings.map((f) => computeFingerprint(f)));
             try {
               const threadResp = await github.graphql(`
                 query($owner:String!, $repo:String!, $pr:Int!) {

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -272,6 +272,25 @@ jobs:
             const appSlug = process.env.APP_SLUG;
             const botLogin = appSlug ? `${appSlug}[bot]` : 'github-actions[bot]';
 
+            // Deterministic finding fingerprint. Derived ONLY from the finding's
+            // stable attributes — file path, review perspective, and a normalized
+            // title — so the same finding keeps the same fingerprint across review
+            // runs even as the PR evolves and the line shifts (line/start_line are
+            // deliberately excluded). The workflow computes this; the model no
+            // longer supplies a free-form fingerprint. The same normalization is
+            // used in claude-review.yml so both workflows agree.
+            const crypto = require('crypto');
+            const normalizeTitle = (s) => String(s == null ? '' : s)
+              .normalize('NFKC')
+              .toLowerCase()
+              .replace(/[^\p{L}\p{N}]+/gu, ' ')
+              .trim();
+            const computeFingerprint = (f) => crypto
+              .createHash('sha256')
+              .update([f.file || '', f.review_perspective || '', normalizeTitle(f.title)].join(' '))
+              .digest('hex')
+              .slice(0, 16);
+
             if (result.eligibility?.status !== 'reviewed') {
               core.info('No review output to post.');
               return;
@@ -323,7 +342,7 @@ jobs:
               // Anchor to f.line; fall back to f.start_line so a finding is never
               // dropped (validation guarantees at least one is a positive int).
               const anchor = (typeof f.line === 'number' && f.line > 0) ? f.line : f.start_line;
-              const fingerprintMarker = `${inlineMarkerBase} fingerprint=${f.fingerprint} -->`;
+              const fingerprintMarker = `${inlineMarkerBase} fingerprint=${computeFingerprint(f)} -->`;
               const c = {
                 path: f.file,
                 body: `**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${fingerprintMarker}`,
@@ -405,10 +424,10 @@ jobs:
               (result.resolved_threads || [])
                 .map((r) => r && r.fingerprint)
                 .filter((fp) => typeof fp === 'string' && fp.length > 0));
-            const findingFingerprints = new Set(
-              findings
-                .map((f) => f && f.fingerprint)
-                .filter((fp) => typeof fp === 'string' && fp.length > 0));
+            // Deterministic fingerprints for this round's findings (workflow-computed,
+            // not model-supplied) — the fallback tier resolves any self thread whose
+            // fingerprint is absent from this set.
+            const findingFingerprints = new Set(findings.map((f) => computeFingerprint(f)));
             try {
               const threadResp = await github.graphql(`
                 query($owner:String!, $repo:String!, $pr:Int!) {

--- a/docs/specs/2026-06-01-pr-review-inline-thread-resolve-deterministic-fingerprint/SPEC.md
+++ b/docs/specs/2026-06-01-pr-review-inline-thread-resolve-deterministic-fingerprint/SPEC.md
@@ -1,0 +1,69 @@
+---
+scope:
+  include:
+    - .github/workflows/codex-review.yml
+    - .github/workflows/claude-review.yml
+    - .github/prompts/codex-pr-review.ko.md
+    - .github/prompts/claude-pr-review.ko.md
+    - .github/prompts/codex-pr-review.schema.json
+    - tests/codex/test-codex-review-workflow.sh
+    - tests/claude/test-claude-review-workflow.sh
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+ears_language: ko
+---
+
+# PR 리뷰 inline thread resolve 결정론적 fingerprint 안정화
+
+## 무엇을 만들 것인가
+<!-- WHAT/HOW 방어선: 무엇을 만들지만 적고 구현 방법·파일·라이브러리·클래스명은 제약으로 이동. -->
+Claude·Codex 두 PR 리뷰 워크플로의 self inline thread 자동 resolve가 신뢰성 없이 깨지는 두 원인을 제거한다.
+
+(1) **fingerprint 결정론화.** 현재 finding의 fingerprint는 모델이 매 리뷰 실행마다 자유 문자열로 새로 생성한다. resolve는 이 fingerprint의 교차-실행 문자열 일치에 의존하는데, 모델이 같은 finding에 매번 동일한 문자열을 재현한다는 보장이 없어, 아직 해결되지 않은 thread가 오-resolve되거나 중복 thread가 생기거나 해결된 thread가 남는다. 이를 워크플로가 finding의 **안정 속성**(파일 경로 + 리뷰 관점 + 정규화한 제목)으로부터 fingerprint를 **결정론적으로 계산**하도록 바꿔, 같은 finding이 PR 진화(줄 이동 포함) 중에도 실행 간 동일 fingerprint를 갖게 한다. 모델의 자유 fingerprint 생성 의존을 제거한다.
+
+(2) **마커 형식 일치.** 프롬프트는 모델에게 "기존 self thread의 마커에 fingerprint가 들어 있으니 그것을 근거로 resolved_threads를 채우라"고 안내하면서, resolve 코드가 실제 게시·매칭하는 마커 형식과 **다른 형식**의 마커를 가리킨다. 이 어긋남 때문에 모델이 기존 thread의 fingerprint를 정확히 읽어 resolved_threads에 기록하는 1차 경로가 동작하지 못한다. 프롬프트가 가리키는 self-식별 마커 형식을, 워크플로가 실제 게시하고 resolve 시 매칭하는 마커 형식과 일치시킨다.
+
+resolve의 기존 2단 구조 — 1차(모델이 resolved_threads로 지목한 self thread) + 2차(이번 라운드 findings의 fingerprint 집합에 더 이상 없는 self thread를 fallback) — 는 그대로 유지하되, 두 경로 모두 이 결정론적 fingerprint를 기준으로 동작한다. 두 워크플로에 동일하게 적용하고 회귀 가드를 둔다.
+
+## 완료 조건
+<!-- 5문장 패턴(항상 / …할 때 / …인 동안 / …이면(오류) / …기능이 켜지면)과 언어 규칙은 references/ears-patterns.md. 각 조건은 관찰 가능하고 독립 검증 가능해야 함. -->
+1. 항상, 시스템은 self inline thread의 fingerprint를 finding의 파일 경로·리뷰 관점·정규화한 제목으로부터 결정론적으로 계산해야 하며, 줄 번호에는 의존하지 않아야 한다.
+2. 동일한 미해결 finding이 PR 진화로 줄 위치가 바뀐 채 다시 보고될 때, 시스템은 그 finding에 직전 실행과 동일한 fingerprint를 부여해야 한다.
+3. 모델이 기존 self thread 마커의 fingerprint를 resolved_threads에 기록할 때, 시스템은 그 fingerprint를 가진 미해결 self thread를 resolved 상태로 전환해야 한다.
+4. self thread의 fingerprint가 이번 실행 findings의 fingerprint 집합에 더 이상 없을 때, 시스템은 그 thread를 resolved 상태로 전환해야 하고, 여전히 findings에 있는 fingerprint의 thread는 그대로 두어야 한다.
+5. 항상, 프롬프트가 모델에게 기존 self thread fingerprint의 출처로 안내하는 마커 형식은, 워크플로가 실제 게시하고 resolve 시 매칭하는 마커 형식과 동일해야 한다.
+6. 시스템은 Claude·Codex 두 리뷰 워크플로에서 동일한 결정론적 fingerprint 계산과 self inline thread resolve 동작을 제공해야 한다.
+7. 시스템은 두 워크플로 테스트 스위트에, fingerprint 계산이 줄 번호에 의존하지 않음과 프롬프트 안내 마커 형식이 실제 매칭 마커와 일치함을 강제하는 회귀 가드를 포함해야 한다.
+
+## 범위
+포함:
+- 두 워크플로의 fingerprint 산정 — 모델 자유 생성에서 워크플로 결정론 계산(파일+리뷰 관점+정규화 제목)으로 전환
+- 게시 inline 코멘트 self-식별 마커가 이 결정론적 fingerprint를 운반하도록 유지
+- 두 프롬프트(`codex-pr-review.ko.md`·`claude-pr-review.ko.md`)의 마커 안내를 실제 게시·매칭 마커 형식과 일치시키는 수정
+- 리뷰 출력 스키마에서 fingerprint 산정 주체 전환에 따라 필요한 조정(공유 `codex-pr-review.schema.json`)
+- 1차(resolved_threads) + 2차(fallback) resolve 경로를 결정론적 fingerprint 기준으로 동작시키기
+- 두 워크플로 테스트의 fingerprint·마커 일치 회귀 가드
+
+비-목표 / 제외:
+- approve/토큰 관련 변경 (별도 SPEC `pr-review-approve-via-github-app-token` 소관)
+- `resolveReviewThread` 외 thread lifecycle(재-open 등) 추가
+- 봇 작성자 식별·이미 resolved skip·다른 리뷰어 thread 미접촉·verdict 무관 매 실행 resolve 같은 기존 resolve 동작의 변경
+- 모델이 finding을 생성·표면화하는 기준(confidence_score 게이트 등)의 변경
+- 레거시(결정론적 fingerprint 이전에 게시된) 마커 thread를 소급 재계산해 강제 resolve
+
+## 검증
+<!-- 검증 기준의 단일 출처는 위 "완료 조건"이다. 검증을 실행하는 진입 명령(테스트·lint·빌드)은 SPEC이 선언하지 않는다. -->
+이 SPEC의 인수 바는 위 **완료 조건**이다. 각 조건이 관찰 가능하게 충족되면 충족된 것으로 본다. 검증을 실행하는 진입 명령은 SPEC이 아니라 프로젝트 규칙(`rules/`)이 단일 출처로 정의한다.
+
+## 제약 (있을 때만)
+- fingerprint 입력은 파일 경로 + 리뷰 관점(`review_perspective`) + 정규화한 제목으로 한정하고, 줄 번호·시작줄은 포함하지 않는다.
+- 제목 정규화 방식(대소문자·공백·문장부호 처리)은 두 워크플로에서 동일해야 한다.
+- 게시 inline 코멘트의 기존 self-식별 마커 substring(자기 식별 보존)은 유지하고, 그 마커가 결정론적 fingerprint를 운반한다. 워크플로별 마커 prefix(claude-review-inline·codex-review-inline)는 각자 유지한다.
+- resolve의 봇 작성자 식별·이미 resolved thread skip·다른 리뷰어 thread 미접촉 동작과, verdict 무관 매 실행 resolve(approve 게이트 부재)는 변경하지 않는다.
+- 두 워크플로(`claude-review.yml`·`codex-review.yml`)에 동일하게 적용한다.
+
+## 위험 (있을 때만)
+- 파일+리뷰 관점+제목이 같은 서로 다른 finding이 동일 fingerprint를 받을 가능성 — 제목이 finding을 충분히 구별하므로 낮으며, 충돌 시 한 thread 단위로만 resolve가 추적되는 정도의 영향에 그친다.
+- 결정론적 fingerprint 도입 이전에 게시된 thread는 새 계산식과 매칭되지 않아 레거시로 남을 수 있다 — 2차 fallback이 "현재 findings에 없음"으로 결국 resolve하거나 미접촉으로 남으며(수용), 소급 강제 resolve는 비-목표다.

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -126,8 +126,11 @@ grep -qF 'IN("inline")' "$WORKFLOW" \
 if grep -qF 'IN("inline","issue")' "$WORKFLOW"; then
   fail "comment_type 에 issue 가 잔존 — inline-only 정책에서 finding 은 issue 채널로 가지 않음"
 fi
-grep -qF '.fingerprint | type == "string"' "$WORKFLOW" \
-  || fail "findings[].fingerprint 검증 부재 (schema required, dedup 에 사용)"
+# findings[].fingerprint 는 모델이 생성하지 않으므로(워크플로가 결정론적으로 계산)
+# schema·검증에서 제거되었다 — 모델 출력에 fingerprint 가 있으면 안 된다.
+if grep -qF '.fingerprint | type == "string"' "$WORKFLOW"; then
+  fail "findings[].fingerprint 검증 잔존 — 결정론 계산 전환으로 모델 fingerprint 의존 제거되어야 함 (AC1)"
+fi
 grep -qF '.duplicate_of | (type == "string" or . == null)' "$WORKFLOW" \
   || fail "findings[].duplicate_of nullable 검증 부재"
 grep -qF 'and ((.line | type == "number") or (.start_line | type == "number"))' "$WORKFLOW" \
@@ -302,8 +305,12 @@ echo "=== check 7e: finding-unit (fingerprint) self inline thread resolve, verdi
 # AC1/AC9: 게시 inline 마커가 기존 self-식별 substring 을 보존하면서 finding fingerprint 운반.
 grep -qF '<!-- claude-review-inline' "$WORKFLOW" \
   || fail "inline self-식별 마커 substring(<!-- claude-review-inline) 부재 (AC9 기존 식별 보존)"
-grep -qF 'fingerprint=${f.fingerprint}' "$WORKFLOW" \
-  || fail "게시 inline 마커에 finding fingerprint 미운반 (AC1) — fingerprint=\${f.fingerprint} 필요"
+# AC1: 게시 inline 마커는 워크플로가 결정론적으로 계산한 fingerprint 를 운반한다.
+grep -qF 'fingerprint=${computeFingerprint(f)}' "$WORKFLOW" \
+  || fail "게시 inline 마커가 결정론적 computeFingerprint(f) 를 운반하지 않음 (AC1)"
+if grep -qF 'fingerprint=${f.fingerprint}' "$WORKFLOW"; then
+  fail "게시 마커가 모델 자유 생성 f.fingerprint 를 운반 — 결정론 계산으로 전환되어야 함 (AC1)"
+fi
 # AC3: resolved_threads 소비 1차 경로.
 grep -qF 'resolved_threads' "$WORKFLOW" \
   || fail "resolved_threads 소비 경로 부재 (AC3) — 모델 판단을 thread resolve 로 매핑 못함"
@@ -324,6 +331,27 @@ grep -qF 'isResolved' "$WORKFLOW" \
 grep -qF 'reviewThreads(first: 100)' "$WORKFLOW" \
   || fail "GraphQL reviewThreads 쿼리 부재"
 ok "check 7e: fingerprint 운반 + resolved_threads 1차 + fallback 2차 + verdict 무관 resolve"
+
+echo ""
+echo "=== check 7g: 결정론적 fingerprint 계산 — file+perspective+normalized title, 줄번호 비의존 (AC1/AC2/AC7) ==="
+# AC1/AC2: fingerprint 는 finding 의 안정 속성(파일 경로·리뷰 관점·정규화 제목)에서만
+# 결정론적으로 계산되며 line/start_line 에는 의존하지 않는다 — 줄 이동에도 동일 fp.
+grep -qF 'computeFingerprint' "$WORKFLOW" \
+  || fail "결정론적 fingerprint 계산 함수(computeFingerprint) 부재 (AC1)"
+grep -qF 'crypto' "$WORKFLOW" \
+  || fail "fingerprint 해시 계산(crypto) 부재 (AC1)"
+grep -qF "[f.file || '', f.review_perspective || '', normalizeTitle(f.title)]" "$WORKFLOW" \
+  || fail "fingerprint 입력이 file+review_perspective+normalized title 로 한정되지 않음 (AC1 제약)"
+# 정규화 방식은 두 워크플로에서 동일해야 한다(제약). 정확한 구현 라인을 잠근다.
+grep -qF "replace(/[^\\p{L}\\p{N}]+/gu, ' ')" "$WORKFLOW" \
+  || fail "제목 정규화(문장부호/공백 → 단일 공백) 구현 부재 또는 불일치 (제약: 두 워크플로 동일)"
+grep -qF "normalize('NFKC')" "$WORKFLOW" \
+  || fail "제목 정규화 NFKC 부재 또는 불일치 (제약: 두 워크플로 동일)"
+# 줄 비의존: findingFingerprints 가 모델 f.fingerprint 가 아니라 computeFingerprint 로 산정.
+grep -qF 'findings.map((f) => computeFingerprint(f))' "$WORKFLOW" \
+  || grep -qF 'findings.map(computeFingerprint)' "$WORKFLOW" \
+  || fail "findingFingerprints 가 결정론적 computeFingerprint 로 산정되지 않음 (AC4)"
+ok "check 7g: 결정론적 fingerprint(file+perspective+title), 줄번호 비의존"
 
 echo ""
 echo "=== check 7f: request_changes verdict 어휘 제거 (workflow 검증) (AC12/AC16f) ==="
@@ -383,11 +411,8 @@ grep -q '실제 위치' "$PROMPT" \
 if grep -q 'issue-level comment로 보고' "$PROMPT"; then
   fail "prompt 가 finding 을 issue-level comment 로 보고하도록 지시함 — inline-only 정책 위반"
 fi
-grep -qF '"kind": "inline"' "$PROMPT" \
-  || fail "prompt hidden marker 의 kind 가 inline 전용이 아님"
-if grep -qF 'inline|issue' "$PROMPT"; then
-  fail "prompt 에 inline|issue 잔존 — inline-only 정책에서 kind 는 inline 만"
-fi
+grep -q 'inline comment로만 보고' "$PROMPT" \
+  || fail "prompt inline-only 보고 지침 부재 (모든 finding 은 inline)"
 # schema: comment_type enum 은 inline 전용
 grep -qF '"inline"' "$SCHEMA" \
   || fail "schema comment_type 에 inline 값 부재"
@@ -413,6 +438,26 @@ fi
 grep -q 'may_request_changes' "$SCHEMA" \
   || fail "may_request_changes 필드가 schema 에서 제거됨 — non-goal: 미사용으로 남기되 유지해야 함"
 ok "check 8c: resolved_threads 지시 + request_changes 어휘 제거 (may_request_changes 필드 유지)"
+
+echo ""
+echo "=== check 8e: 프롬프트 마커 형식이 실제 게시·매칭 마커와 일치 (AC5/AC7) ==="
+# AC5: 프롬프트가 모델에게 기존 self thread fingerprint 출처로 안내하는 마커 형식은,
+# 워크플로가 실제 게시(fingerprintMarker)하고 resolve 시 매칭(fpRe)하는 마커와 동일해야 한다.
+# 워크플로 실제 마커: <!-- claude-review-inline fingerprint=... -->
+grep -qF 'claude-review-inline fingerprint=' "$PROMPT" \
+  || fail "프롬프트가 실제 게시·매칭 마커 형식(claude-review-inline fingerprint=)을 가리키지 않음 (AC5)"
+# 어긋난 옛 JSON 마커 형식(<!-- claude-review: {json} -->)은 제거되어야 한다.
+if grep -qF '<!-- claude-review:' "$PROMPT"; then
+  fail "프롬프트에 옛 JSON 마커 형식(<!-- claude-review:) 잔존 — 실제 마커와 어긋남 (AC5)"
+fi
+# 프롬프트는 모델이 fingerprint 를 생성하지 않음을 반영해야 한다(줄 기반 생성 지시 제거).
+if grep -q 'changed line' "$PROMPT"; then
+  fail "프롬프트에 changed line 기반 fingerprint 생성 지시 잔존 — 결정론 계산은 워크플로 소관 (AC1)"
+fi
+# 워크플로의 게시 마커와 매칭 정규식이 동일 substring 을 공유하는지(자체 정합) 확인.
+grep -qF 'claude-review-inline fingerprint=' "$WORKFLOW" \
+  || fail "워크플로 마커 substring(claude-review-inline fingerprint=)이 프롬프트 안내와 불일치 (AC5)"
+ok "check 8e: 프롬프트 마커 == 실제 게시·매칭 마커"
 
 echo ""
 echo "=== check 9: privileged job checks out trusted base, not PR-controlled code ==="

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -251,8 +251,12 @@ echo "=== check 10e: finding-unit (fingerprint) self inline thread resolve, verd
 # AC1/AC9: 게시 inline 마커가 기존 self-식별 substring 을 보존하면서 finding fingerprint 운반.
 grep -qF '<!-- codex-review-inline' "$WORKFLOW" \
   || fail "inline self-식별 마커 substring(<!-- codex-review-inline) 부재 (AC9 기존 식별 보존)"
-grep -qF 'fingerprint=${f.fingerprint}' "$WORKFLOW" \
-  || fail "게시 inline 마커에 finding fingerprint 미운반 (AC1) — fingerprint=\${f.fingerprint} 필요"
+# AC1: 게시 inline 마커는 워크플로가 결정론적으로 계산한 fingerprint 를 운반한다.
+grep -qF 'fingerprint=${computeFingerprint(f)}' "$WORKFLOW" \
+  || fail "게시 inline 마커가 결정론적 computeFingerprint(f) 를 운반하지 않음 (AC1)"
+if grep -qF 'fingerprint=${f.fingerprint}' "$WORKFLOW"; then
+  fail "게시 마커가 모델 자유 생성 f.fingerprint 를 운반 — 결정론 계산으로 전환되어야 함 (AC1)"
+fi
 # AC3: resolved_threads 소비 1차 경로.
 grep -qF 'resolved_threads' "$WORKFLOW" \
   || fail "resolved_threads 소비 경로 부재 (AC3)"
@@ -273,6 +277,27 @@ grep -qF 'isResolved' "$WORKFLOW" \
 grep -qF 'reviewThreads(first: 100)' "$WORKFLOW" \
   || fail "GraphQL reviewThreads 쿼리 부재"
 ok "check 10e: fingerprint 운반 + resolved_threads 1차 + fallback 2차 + verdict 무관 resolve"
+
+echo ""
+echo "=== check 10g: 결정론적 fingerprint 계산 — file+perspective+normalized title, 줄번호 비의존 (AC1/AC2/AC7) ==="
+# AC1/AC2: fingerprint 는 finding 의 안정 속성(파일 경로·리뷰 관점·정규화 제목)에서만
+# 결정론적으로 계산되며 line/start_line 에는 의존하지 않는다 — 줄 이동에도 동일 fp.
+grep -qF 'computeFingerprint' "$WORKFLOW" \
+  || fail "결정론적 fingerprint 계산 함수(computeFingerprint) 부재 (AC1)"
+grep -qF 'crypto' "$WORKFLOW" \
+  || fail "fingerprint 해시 계산(crypto) 부재 (AC1)"
+grep -qF "[f.file || '', f.review_perspective || '', normalizeTitle(f.title)]" "$WORKFLOW" \
+  || fail "fingerprint 입력이 file+review_perspective+normalized title 로 한정되지 않음 (AC1 제약)"
+# 정규화 방식은 두 워크플로에서 동일해야 한다(제약). 정확한 구현 라인을 잠근다.
+grep -qF "replace(/[^\\p{L}\\p{N}]+/gu, ' ')" "$WORKFLOW" \
+  || fail "제목 정규화(문장부호/공백 → 단일 공백) 구현 부재 또는 불일치 (제약: 두 워크플로 동일)"
+grep -qF "normalize('NFKC')" "$WORKFLOW" \
+  || fail "제목 정규화 NFKC 부재 또는 불일치 (제약: 두 워크플로 동일)"
+# 줄 비의존: findingFingerprints 가 모델 f.fingerprint 가 아니라 computeFingerprint 로 산정.
+grep -qF 'findings.map((f) => computeFingerprint(f))' "$WORKFLOW" \
+  || grep -qF 'findings.map(computeFingerprint)' "$WORKFLOW" \
+  || fail "findingFingerprints 가 결정론적 computeFingerprint 로 산정되지 않음 (AC4)"
+ok "check 10g: 결정론적 fingerprint(file+perspective+title), 줄번호 비의존"
 
 echo ""
 echo "=== check 10f: request_changes verdict 어휘 제거 (workflow) (AC12/AC16f) ==="
@@ -335,11 +360,8 @@ grep -q '실제 위치' "$PROMPT" \
 if grep -q 'issue-level comment로 보고' "$PROMPT"; then
   fail "prompt 가 finding 을 issue-level comment 로 보고하도록 지시함 — inline-only 정책 위반"
 fi
-grep -qF '"kind": "inline"' "$PROMPT" \
-  || fail "prompt hidden marker 의 kind 가 inline 전용이 아님"
-if grep -qF 'inline|issue' "$PROMPT"; then
-  fail "prompt 에 inline|issue 잔존 — inline-only 정책에서 kind 는 inline 만"
-fi
+grep -q 'inline comment로만 보고' "$PROMPT" \
+  || fail "prompt inline-only 보고 지침 부재 (모든 finding 은 inline)"
 # schema: comment_type enum 은 inline 전용
 grep -qF '"inline"' "$SCHEMA" \
   || fail "schema comment_type 에 inline 값 부재"
@@ -365,6 +387,26 @@ fi
 grep -q 'may_request_changes' "$SCHEMA" \
   || fail "may_request_changes 필드가 schema 에서 제거됨 — non-goal: 미사용으로 남기되 유지해야 함"
 ok "check 11d: resolved_threads 지시 + request_changes 어휘 제거 (may_request_changes 필드 유지)"
+
+echo ""
+echo "=== check 11e: 프롬프트 마커 형식이 실제 게시·매칭 마커와 일치 (AC5/AC7) ==="
+# AC5: 프롬프트가 모델에게 기존 self thread fingerprint 출처로 안내하는 마커 형식은,
+# 워크플로가 실제 게시(fingerprintMarker)하고 resolve 시 매칭(fpRe)하는 마커와 동일해야 한다.
+# 워크플로 실제 마커: <!-- codex-review-inline fingerprint=... -->
+grep -qF 'codex-review-inline fingerprint=' "$PROMPT" \
+  || fail "프롬프트가 실제 게시·매칭 마커 형식(codex-review-inline fingerprint=)을 가리키지 않음 (AC5)"
+# 어긋난 옛 JSON 마커 형식(<!-- codex-review: {json} -->)은 제거되어야 한다.
+if grep -qF '<!-- codex-review:' "$PROMPT"; then
+  fail "프롬프트에 옛 JSON 마커 형식(<!-- codex-review:) 잔존 — 실제 마커와 어긋남 (AC5)"
+fi
+# 프롬프트는 모델이 fingerprint 를 생성하지 않음을 반영해야 한다(줄 기반 생성 지시 제거).
+if grep -q 'changed line' "$PROMPT"; then
+  fail "프롬프트에 changed line 기반 fingerprint 생성 지시 잔존 — 결정론 계산은 워크플로 소관 (AC1)"
+fi
+# 워크플로의 게시 마커와 매칭 정규식이 동일 substring 을 공유하는지(자체 정합) 확인.
+grep -qF 'codex-review-inline fingerprint=' "$WORKFLOW" \
+  || fail "워크플로 마커 substring(codex-review-inline fingerprint=)이 프롬프트 안내와 불일치 (AC5)"
+ok "check 11e: 프롬프트 마커 == 실제 게시·매칭 마커"
 
 echo ""
 echo "=== check 12: schema requires automation safety and context fields ==="


### PR DESCRIPTION
## 무엇을

두 PR 리뷰 워크플로(`claude-review.yml`·`codex-review.yml`)의 self inline thread 자동 resolve가 신뢰성 없이 깨지던 두 원인을 제거한다.

### 원인
1. **모델 생성 비결정 fingerprint** — finding fingerprint를 모델이 매 실행 자유 문자열로 생성해, resolve의 교차-실행 문자열 일치가 보장되지 않았다(미해결 thread 오-resolve / 중복 thread / 미해소).
2. **마커 형식 불일치** — 프롬프트가 모델에게 가리키는 self-식별 마커 형식(`<!-- codex-review: {json} -->`)이 resolve 코드가 실제 게시·매칭하는 마커(`<!-- codex-review-inline fingerprint=X -->`)와 어긋나, 모델의 resolved_threads 1차 경로가 동작하지 못했다.

### 수정
- fingerprint를 워크플로가 **파일 경로 + 리뷰 관점(`review_perspective`) + 정규화한 제목**에서 `sha256`으로 **결정론적 계산**(줄 번호 배제 → PR 진화에도 동일 finding은 동일 fingerprint). 모델 자유 생성 의존 제거.
- 프롬프트가 가리키는 마커 형식을 실제 게시·매칭 마커와 일치시킴 → 모델 resolved_threads 1차 경로 복구.
- resolve 2단(1차 resolved_threads + 2차 fallback) 유지, 두 경로 모두 결정론적 fingerprint 기준.

## 검증
- 두 워크플로 테스트 스위트 **ALL CHECKS PASSED** (신규 가드: 마커 일치 codex `check 11e`·claude `check 8e`).

## 범위 메모
- 동반 조사하던 **approve(정식 APPROVE)** 는 별개로 PR #264(GitHub App 설치 토큰)로 **이미 origin/main에 병합**돼 있어 본 PR 범위가 아니다. 본 PR은 resolve 안정화에만 집중한다.

SPEC: `docs/specs/2026-06-01-pr-review-inline-thread-resolve-deterministic-fingerprint/SPEC.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)