### PR TITLE
refactor(ci): codex-review를 openai/codex-action + Claude 동일 게시 구조로 재작성

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -25,27 +25,18 @@ jobs:
           && github.event.issue.pull_request != null
           && contains(github.event.comment.body, '@codex')
           && github.event.comment.user.login != 'github-actions[bot]'
-          && github.event.comment.user.login != vars.REVIEW_APP_BOT_LOGIN
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
       || (github.event_name == 'pull_request_review_comment'
           && contains(github.event.comment.body, '@codex')
           && github.event.comment.user.login != 'github-actions[bot]'
-          && github.event.comment.user.login != vars.REVIEW_APP_BOT_LOGIN
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
       || (github.event_name == 'pull_request_review'
           && github.event.review.body != null
           && contains(github.event.review.body, '@codex')
           && github.event.review.user.login != 'github-actions[bot]'
-          && github.event.review.user.login != vars.REVIEW_APP_BOT_LOGIN
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      # Expose the App-id secret as env so the App-token step's `if:` can detect
-      # whether App-token issuance is configured — secrets cannot be referenced
-      # in a step `if:` directly. Empty when unset → the App-token step is skipped
-      # and the posting steps fall back to the default GITHUB_TOKEN (AC5).
-      REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}
     steps:
       - name: Resolve pull request context
         id: pr
@@ -75,27 +66,13 @@ jobs:
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('title', pr.title || '');
 
-      - name: Generate GitHub App installation token
-        id: app-token
-        # Short-lived installation token so the review can submit an official
-        # APPROVE that the default GITHUB_TOKEN cannot (github-actions[bot] hits
-        # the self-approve 403/422 on its own workflow's PRs). Skipped when the
-        # App secrets are not configured, and `continue-on-error` keeps a failed
-        # issuance from aborting the job — the posting steps then fall back to the
-        # default GITHUB_TOKEN (AC5). The token is consumed ONLY by the posting
-        # github-script steps below (as step outputs), never exported into the
-        # review CLI step, so the reviewer model never sees it.
-        if: ${{ env.REVIEW_APP_ID != '' }}
-        continue-on-error: true
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
-        with:
-          app-id: ${{ secrets.REVIEW_APP_ID }}
-          private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
-
-      - name: Check out pull request
+      - name: Check out trusted base
+        # Privileged job: check out the base ref so the helper script, prompt,
+        # and schema all come from trusted code. PR-controlled content is only
+        # consumed as untrusted data (diff/metadata) fetched via gh/git below.
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: refs/pull/${{ steps.pr.outputs.number }}/merge
+          ref: ${{ steps.pr.outputs.base_ref }}
           fetch-depth: 0
 
       - name: Fetch review base
@@ -112,12 +89,31 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install Codex CLI
-        run: npm install -g @openai/codex@0.132.0
-
-      - name: Run Codex review
+      - name: Bootstrap Codex auth.json
+        # ChatGPT account authentication: write the CODEX_AUTH_JSON secret into a
+        # dedicated codex-home directory as auth.json (chmod 600) and expose ONLY
+        # the directory path (CODEX_HOME_DIR) to the model step via the action's
+        # codex-home input. The secret value itself is never exported into the
+        # codex-action step's environment, and no API key input is supplied —
+        # codex authenticates from auth.json. Empty secret fails the job with a
+        # clear error so a misconfigured environment is caught immediately.
         env:
           CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          if [ -z "$CODEX_AUTH_JSON" ]; then
+            echo "CODEX_AUTH_JSON secret is required for Codex ChatGPT authentication." >&2
+            exit 1
+          fi
+          umask 077
+          codex_home="$RUNNER_TEMP/codex-home"
+          mkdir -p "$codex_home"
+          printf '%s' "$CODEX_AUTH_JSON" > "$codex_home/auth.json"
+          chmod 600 "$codex_home/auth.json"
+          echo "CODEX_HOME_DIR=$codex_home" >> "$GITHUB_ENV"
+
+      - name: Prepare Codex review input
+        id: prepare-codex-review
+        env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
@@ -127,23 +123,10 @@ jobs:
           PR_TITLE: ${{ steps.pr.outputs.title }}
           CODEX_REVIEW_LANG: ${{ vars.CODEX_REVIEW_LANG || 'Korean' }}
         run: |
-          if [ -z "$CODEX_AUTH_JSON" ]; then
-            echo "CODEX_AUTH_JSON secret is required for Codex CLI authentication." >&2
-            exit 1
-          fi
-
-          umask 077
-          mkdir -p "$HOME/.codex"
-          printf '%s' "$CODEX_AUTH_JSON" > "$HOME/.codex/auth.json"
-          unset CODEX_AUTH_JSON
-
           mkdir -p .codex-review
           REVIEW_BASE="$(git merge-base "origin/$PR_BASE_REF" "refs/remotes/pull/$PR_NUMBER/head")"
           REVIEW_PROMPT=".github/prompts/codex-pr-review.ko.md"
-          REVIEW_SCHEMA=".github/prompts/codex-pr-review.schema.json"
           initial_prompt=".codex-review/prompt.md"
-          second_prompt=".codex-review/prompt.follow-up.md"
-          result=".codex-review/result.json"
 
           REVIEW_OUTPUT_DIR=".review-context" \
           GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" \
@@ -185,17 +168,36 @@ jobs:
             printf '응답 객체의 모든 자연어 필드(summary, 각 finding의 title·body·suggestion)는 반드시 %s 로 작성합니다. 영어 등 다른 언어로 작성하면 안 됩니다. JSON 키·enum 값은 schema 정의 그대로 사용합니다.\n' "$CODEX_REVIEW_LANG"
           } >> "$initial_prompt"
 
+          # Drop the checkout credential before the model action runs so the
+          # review model cannot reach the authenticated git remote.
           git config --local --unset-all http.https://github.com/.extraheader || true
-          unset GH_TOKEN
 
-          codex exec \
-            --sandbox read-only \
-            --config model_reasoning_effort=\"medium\" \
-            --output-schema "$REVIEW_SCHEMA" \
-            --output-last-message "$result" \
-            < "$initial_prompt"
+      - name: Run Codex review
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1
+        with:
+          codex-version: '0.132.0'
+          codex-home: ${{ env.CODEX_HOME_DIR }}
+          sandbox: read-only
+          effort: medium
+          prompt-file: .codex-review/prompt.md
+          output-schema-file: .github/prompts/codex-pr-review.schema.json
+          output-file: .codex-review/result.json
 
-          jq empty "$result"
+      - name: Save Codex review result
+        run: |
+          set -euo pipefail
+          jq empty .codex-review/result.json
+
+      - name: Prepare Codex follow-up context
+        id: prepare-codex-follow-up
+        env:
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+
+          result=".codex-review/result.json"
+          initial_prompt=".codex-review/prompt.md"
+          second_prompt=".codex-review/prompt.follow-up.md"
 
           MAX_CONTEXT_REQUEST_FILES=5
           mkdir -p .review-extra-context
@@ -234,247 +236,191 @@ jobs:
                 awk 'NR <= 400 { print } NR == 401 { print "# ... (truncated at 400 lines)"; exit }' "$file"
               done
             } >> "$second_prompt"
-
-            codex exec \
-              --sandbox read-only \
-              --config model_reasoning_effort=\"medium\" \
-              --output-schema "$REVIEW_SCHEMA" \
-              --output-last-message "$result" \
-              < "$second_prompt"
-
-            jq empty "$result"
+            printf 'has_extra_context=true\n' >> "$GITHUB_OUTPUT"
+          else
+            printf 'has_extra_context=false\n' >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Run Codex follow-up review
+        if: steps.prepare-codex-follow-up.outputs.has_extra_context == 'true'
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1
+        with:
+          codex-version: '0.132.0'
+          codex-home: ${{ env.CODEX_HOME_DIR }}
+          sandbox: read-only
+          effort: medium
+          prompt-file: .codex-review/prompt.follow-up.md
+          output-schema-file: .github/prompts/codex-pr-review.schema.json
+          output-file: .codex-review/result.json
+
+      - name: Save Codex follow-up review result
+        if: steps.prepare-codex-follow-up.outputs.has_extra_context == 'true'
+        run: |
+          set -euo pipefail
+          jq empty .codex-review/result.json
+
       - name: Submit Codex review verdict
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+
+          result=".codex-review/result.json"
+          body=".codex-review/review-body.md"
+
+          verdict="$(jq -r '.verdict' "$result")"
+          may_approve="$(jq -r '.automation_safety.may_approve' "$result")"
+          may_request_changes="$(jq -r '.automation_safety.may_request_changes' "$result")"
+          eligibility="$(jq -r '.eligibility.status' "$result")"
+          diff_truncated="$(jq -r '.reviewed_context.diff_truncated' "$result")"
+          findings_count="$(jq '.findings | length' "$result")"
+          blocking_count="$(jq '[.findings[] | select(.severity == "blocking" and .confidence_score >= 80)] | length' "$result")"
+          approve_without_body=false
+
+          if [[ "$eligibility" != "reviewed" ]]; then
+            echo "No review output to post."
+            exit 0
+          fi
+
+          review_mode="comment"
+          if [[ "$findings_count" == "0" && "$verdict" == "approve" && "$may_approve" == "true" && "$diff_truncated" == "false" ]]; then
+            review_mode="approve"
+            approve_without_body=true
+          elif [[ "$findings_count" == "0" && ( "$verdict" == "comment" || "$verdict" == "needs_context" ) ]]; then
+            review_mode="comment"
+          elif [[ "$findings_count" == "0" ]]; then
+            review_mode="comment"
+          elif [[ "$diff_truncated" != "false" ]]; then
+            review_mode="comment"
+          elif [[ "$verdict" == "request_changes" && "$may_request_changes" == "true" && "$blocking_count" != "0" ]]; then
+            review_mode="request-changes"
+          fi
+
+          if [[ "$approve_without_body" == "true" ]]; then
+            if gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+              | jq -e --arg head "$PR_HEAD_SHA" 'any(.[]; .user.login == "github-actions[bot]" and .state == "APPROVED" and .commit_id == $head)' >/dev/null; then
+              echo "Formal Codex approval already exists for $PR_HEAD_SHA; skipping duplicate."
+              exit 0
+            fi
+            if ! gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve; then
+              echo "Formal Codex approval failed; continuing with managed PR comment."
+              touch .codex-review/approval-failed
+              exit 0
+            else
+              exit 0
+            fi
+          fi
+
+          {
+            printf '## Codex PR Review\n\n'
+            jq -r '.summary' "$result"
+            printf '\n\n'
+            jq -r '
+              if (.findings | length) == 0 then
+                "No findings."
+              else
+                "Findings:\n" + (
+                  [.findings[] |
+                    "- [" + .severity + "/" + (.confidence_score|tostring) + "] " +
+                    .title + " (" + .file + ":" + (if .line == null or .line == 0 then "N/A" else (.line|tostring) end) + ")\n  " +
+                    .body + "\n  Suggestion: " + .suggestion
+                  ] | join("\n")
+                )
+              end
+            ' "$result"
+          } > "$body"
+
+          marker="codex-formal-review head_sha=$PR_HEAD_SHA verdict=$verdict"
+          printf '\n\n<!-- %s -->\n' "$marker" >> "$body"
+
+          if gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+            | jq -e --arg marker "$marker" 'any(.[]; (.body // "") | contains($marker))' >/dev/null; then
+            echo "Formal Codex review already exists for $PR_HEAD_SHA / $verdict; skipping duplicate."
+            exit 0
+          fi
+
+          submit_review() {
+            if ! gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" "$@" --body-file "$body"; then
+              echo "Formal Codex review submission failed; continuing with managed PR comment."
+            fi
+          }
+
+          case "$review_mode" in
+            request-changes)
+              submit_review --request-changes
+              ;;
+            comment)
+              submit_review --comment
+              ;;
+            *)
+              echo "unknown review mode: $review_mode" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Post Codex review comment
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-          CODEX_FORMAL_PREFIX: codex-formal-review
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          CODEX_REVIEW_MARKER: '<!-- codex-api-pr-review -->'
         with:
-          # App installation token (if issued) so the official APPROVE is not
-          # blocked by the default token's self-approve restriction; falls back to
-          # the default GITHUB_TOKEN when App issuance was skipped/failed (AC1/AC5).
-          github-token: ${{ steps.app-token.outputs.token || github.token }}
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const result = JSON.parse(fs.readFileSync('.codex-review/result.json', 'utf8'));
-            const { owner, repo } = context.repo;
-            const pull_number = Number(process.env.PR_NUMBER);
-            const head_sha = process.env.PR_HEAD_SHA;
-            const prefix = process.env.CODEX_FORMAL_PREFIX;
-            // Bot login identity: when posting via the App installation token the
-            // author is `<app-slug>[bot]`; with the default token it is
-            // `github-actions[bot]`. Resolve dynamically so idempotency detection
-            // and self inline-thread identification track the actual posting
-            // identity rather than a hardcoded login (AC3).
-            const appSlug = process.env.APP_SLUG;
-            const botLogin = appSlug ? `${appSlug}[bot]` : 'github-actions[bot]';
-
-            // Deterministic finding fingerprint. Derived ONLY from the finding's
-            // stable attributes — file path, review perspective, and a normalized
-            // title — so the same finding keeps the same fingerprint across review
-            // runs even as the PR evolves and the line shifts (line/start_line are
-            // deliberately excluded). The workflow computes this; the model no
-            // longer supplies a free-form fingerprint. The same normalization is
-            // used in claude-review.yml so both workflows agree.
-            const crypto = require('crypto');
-            const normalizeTitle = (s) => String(s == null ? '' : s)
-              .normalize('NFKC')
-              .toLowerCase()
-              .replace(/[^\p{L}\p{N}]+/gu, ' ')
-              .trim();
-            const computeFingerprint = (f) => crypto
-              .createHash('sha256')
-              .update([f.file || '', f.review_perspective || '', normalizeTitle(f.title)].join(' '))
-              .digest('hex')
-              .slice(0, 16);
-
-            if (result.eligibility?.status !== 'reviewed') {
-              core.info('No review output to post.');
+            const marker = process.env.CODEX_REVIEW_MARKER;
+            const findings = result.findings || [];
+            const approvalFailed = fs.existsSync('.codex-review/approval-failed');
+            if (result.eligibility?.status !== 'reviewed' || (findings.length === 0 && !approvalFailed)) {
+              core.info('No managed Codex review comment to post.');
               return;
             }
+            const findingText = findings.map((finding, index) => [
+                  `${index + 1}. [${finding.severity}/${finding.confidence_score}] ${finding.title}`,
+                  `${finding.file}:${finding.line == null || finding.line === 0 ? 'N/A' : finding.line}`,
+                  finding.body,
+                  `Suggestion: ${finding.suggestion}`,
+                ].join('\n')).join('\n\n');
+            const body = [
+              marker,
+              '## Codex PR Review',
+              '',
+              `Verdict: \`${result.verdict}\``,
+              '',
+              approvalFailed
+                ? 'Codex review found no findings, but formal approval could not be submitted by this workflow token.'
+                : (result.summary || 'No findings. (summary unavailable)'),
+              '',
+              approvalFailed ? 'No findings.' : findingText,
+            ].join('\n');
 
-            const findings = result.findings || [];
-            // inline-only policy: every finding is posted as an inline comment.
-            // There is no issue-level finding channel. Findings that cannot anchor
-            // directly to a changed line are anchored by the model to the nearest
-            // changed hunk line (with the real location stated in the body), so we
-            // never route a finding into an issue comment.
-            const inlineFindings = findings;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              per_page: 100,
+            });
 
-            const verdict = result.verdict;
-            const mayApprove = !!result.automation_safety?.may_approve;
-            const diffTruncated = !!result.reviewed_context?.diff_truncated;
+            const previous = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' &&
+              comment.body?.includes(marker)
+            );
 
-            // Event decision — official review event is APPROVE or COMMENT only.
-            // The changes-requested review state is abolished: blocking findings
-            // surface as inline comments (inline-only policy), not as a review state.
-            let event;
-            if (findings.length === 0 && verdict === 'approve' && mayApprove && !diffTruncated) {
-              event = 'APPROVE';
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: previous.id,
+                body,
+              });
             } else {
-              event = 'COMMENT';
-            }
-
-            // Review body carries NO finding evaluations (inline-only policy):
-            // findings live as inline comments. The formal review body holds only
-            // the hidden idempotency marker, plus an approval line when the verdict
-            // is approve. Non-approve reviews still submit the event (to carry the
-            // inline comments) but with no issue-level summary text.
-            const marker = `<!-- ${prefix} head_sha=${head_sha} verdict=${verdict} -->`;
-            const body = (verdict === 'approve'
-              ? ['## Codex PR 리뷰', '',
-                 '_승인 — 지적 사항은 인라인 코멘트 참조._',
-                 '', marker]
-              : [marker]).join('\n');
-
-            // Inline review comments — path/line/body (start_line for multi-line range).
-            // The hidden marker lets us later identify self-owned threads so we can
-            // resolve them on a finding-unit (fingerprint) basis. We extend the
-            // existing self-identification marker by appending the finding's
-            // fingerprint — the base substring (inlineMarkerBase) is preserved so
-            // self-identification keeps working, and the fingerprint lets a later
-            // run map the model's resolved_threads judgments back to this thread.
-            const inlineMarkerBase = '<!-- codex-review-inline';
-            const inlineComments = inlineFindings.map((f) => {
-              // Anchor to f.line; fall back to f.start_line so a finding is never
-              // dropped (validation guarantees at least one is a positive int).
-              const anchor = (typeof f.line === 'number' && f.line > 0) ? f.line : f.start_line;
-              const fingerprintMarker = `${inlineMarkerBase} fingerprint=${computeFingerprint(f)} -->`;
-              const c = {
-                path: f.file,
-                body: `**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${fingerprintMarker}`,
-                side: 'RIGHT',
-                line: anchor,
-              };
-              if (typeof f.start_line === 'number'
-                  && f.start_line >= 1 && f.start_line < anchor) {
-                c.start_line = f.start_line;
-                c.start_side = 'RIGHT';
-              }
-              return c;
-            });
-
-            // Idempotency.
-            const existingReviews = await github.paginate(
-              github.rest.pulls.listReviews,
-              { owner, repo, pull_number, per_page: 100 });
-            // 중복 감지 시 즉시 return하지 않는다 — 제출(submit)만 건너뛰고
-            // self inline thread 의 finding 단위 resolve 후처리는 verdict 와 무관하게 계속 실행한다.
-            let skipSubmit = false;
-            if (existingReviews.some((r) =>
-                r.user?.login === botLogin && (r.body || '').includes(marker))) {
-              core.info(`Formal Codex review for ${head_sha} verdict=${verdict} already exists; skipping duplicate submission.`);
-              skipSubmit = true;
-            }
-            if (!skipSubmit && event === 'APPROVE' && existingReviews.some((r) =>
-                r.user?.login === botLogin && r.state === 'APPROVED' && r.commit_id === head_sha)) {
-              core.info(`Formal Codex approval already exists for ${head_sha}; skipping duplicate submission.`);
-              skipSubmit = true;
-            }
-
-            // Submit. Workflow token cannot self-approve — fall back to COMMENT if APPROVE 403/422s.
-            const submit = (ev) => github.rest.pulls.createReview({
-              owner, repo, pull_number,
-              commit_id: head_sha,
-              event: ev,
-              body,
-              comments: inlineComments,
-            });
-
-            let submitOk = false;
-            if (!skipSubmit) {
-              try {
-                await submit(event);
-                submitOk = true;
-                core.info(`Submitted ${event} review (${inlineComments.length} inline findings).`);
-              } catch (e) {
-                if (event === 'APPROVE') {
-                  core.warning(`APPROVE failed (${e.status || ''} ${e.message}); falling back to COMMENT.`);
-                  fs.writeFileSync('.codex-review/approval-failed', '');
-                  try { await submit('COMMENT'); submitOk = true; }
-                  catch (e2) { core.warning(`Fallback COMMENT also failed (${e2.status || ''} ${e2.message}); continuing.`); }
-                } else {
-                  core.warning(`Review submission failed (${e.status || ''} ${e.message}); continuing.`);
-                }
-              }
-            }
-
-            // inline-only policy: do NOT fall back to dumping findings into an
-            // issue comment — that would place finding evaluations in an
-            // issue-level comment (AC2). If createReview failed, the findings stay
-            // unposted and the failure is surfaced in the workflow log only.
-            if (!skipSubmit && !submitOk && inlineFindings.length > 0) {
-              core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) could not be posted. Not dumping to an issue comment (inline-only policy); see logs.`);
-            }
-
-            // Resolve self inline threads on a finding-unit (fingerprint) basis.
-            // This runs on every review execution regardless of verdict — it is
-            // NOT gated on approve. Two tiers:
-            //   (1) primary  — fingerprints the model listed in resolved_threads;
-            //   (2) fallback — self threads whose fingerprint is absent from this
-            //                   round's findings set (no longer reported).
-            // A self thread whose fingerprint is still in the findings set (and
-            // not in resolved_threads) is left untouched. Only self-owned threads
-            // are touched; threads whose marker has no extractable fingerprint are
-            // left untouched.
-            const resolvedFingerprints = new Set(
-              (result.resolved_threads || [])
-                .map((r) => r && r.fingerprint)
-                .filter((fp) => typeof fp === 'string' && fp.length > 0));
-            // Deterministic fingerprints for this round's findings (workflow-computed,
-            // not model-supplied) — the fallback tier resolves any self thread whose
-            // fingerprint is absent from this set.
-            const findingFingerprints = new Set(findings.map((f) => computeFingerprint(f)));
-            try {
-              const threadResp = await github.graphql(`
-                query($owner:String!, $repo:String!, $pr:Int!) {
-                  repository(owner: $owner, name: $repo) {
-                    pullRequest(number: $pr) {
-                      reviewThreads(first: 100) {
-                        nodes {
-                          id
-                          isResolved
-                          comments(first: 1) {
-                            nodes { author { login } body }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }`, { owner, repo, pr: pull_number });
-              const threads = threadResp.repository?.pullRequest?.reviewThreads?.nodes || [];
-              // GraphQL Actor.login omits the REST "[bot]" suffix (returns
-              // "github-actions"), so the REST botLogin never matches here —
-              // accept both forms.
-              const botLoginGql = botLogin.replace(/\[bot\]$/, '');
-              const fpRe = /<!-- codex-review-inline fingerprint=([^\s]+) -->/;
-              for (const t of threads) {
-                if (t.isResolved) continue;
-                const author = t.comments?.nodes?.[0]?.author?.login;
-                if (author !== botLogin && author !== botLoginGql) continue;
-                const cbody = t.comments?.nodes?.[0]?.body || '';
-                if (!cbody.includes(inlineMarkerBase)) continue;
-                const m = cbody.match(fpRe);
-                const fp = m && m[1];
-                if (!fp) continue; // legacy/markerless thread — leave untouched (AC7)
-                const byModel = resolvedFingerprints.has(fp);
-                const byFallback = !byModel && !findingFingerprints.has(fp);
-                if (!byModel && !byFallback) continue; // still reported — leave (AC5)
-                try {
-                  await github.graphql(`
-                    mutation($id:ID!) {
-                      resolveReviewThread(input: {threadId: $id}) {
-                        thread { id isResolved }
-                      }
-                    }`, { id: t.id });
-                  core.info(`Resolved self inline thread ${t.id} (fingerprint=${fp}, via=${byModel ? 'resolved_threads' : 'fallback'}).`);
-                } catch (e) {
-                  core.warning(`Failed to resolve thread ${t.id}: ${e.message}`);
-                }
-              }
-            } catch (e) {
-              core.warning(`Failed to fetch review threads for resolve: ${e.message}`);
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                body,
+              });
             }

--- a/docs/codex/pr-review-workflow.md
+++ b/docs/codex/pr-review-workflow.md
@@ -2,6 +2,8 @@
 
 이 문서는 `codex review` 자연어 출력 대신 직접 프롬프팅한 structured JSON을 사용해 PR 리뷰를 자동화하는 계획과 경계를 정의한다.
 
+모델 호출은 셸에서 `codex exec`를 직접 실행하지 않고 공식 GitHub Action `openai/codex-action`(SHA 고정, codex CLI 버전은 action의 `codex-version` 입력으로 고정)을 통해 이뤄진다. 인증은 ChatGPT 계정 `auth.json`을 codex-home 디렉터리로 부트스트랩하는 방식을 쓰며 API 키 입력은 사용하지 않는다. 리뷰 결과 게시는 자매 워크플로(Claude PR 리뷰, `claude-review.yml`)와 **동일한 구조**다 — 정식 리뷰 verdict 제출 + 마커 기반 관리형 PR 코멘트 1개. codex만의 독자 게시 경로(인라인 코멘트, fingerprint 기반 self thread 자동 resolve, GitHub App 토큰 정식 approve)는 사용하지 않는다.
+
 ## 목표
 
 - diff를 먼저 읽고 필요한 문맥만 확장한다.
@@ -12,51 +14,50 @@
 ## 현재 1차 워크플로
 
 1. PR context를 확인한다.
-2. base/head와 diff를 수집한다.
-3. `.github/prompts/codex-pr-review.ko.md`를 system prompt처럼 붙인다.
-4. `codex exec --output-schema .github/prompts/codex-pr-review.schema.json`을 stdin 기반으로 실행한다.
-5. JSON schema를 검증한다.
-6. `verdict`에 따라 GitHub review event를 `pulls.createReview`로 제출한다. **모든 finding은 inline 코멘트로만** 게시한다(inline-only 정책).
-   - `approve`: `APPROVE` (review body는 finding 평가 없이 승인 표현만)
-   - `request_changes`: `REQUEST_CHANGES` (body는 마커만, 평가 없음)
-   - `comment`, `needs_context`, `unavailable`: `COMMENT` (body는 마커만, 평가 없음)
-   - 변경 라인에 직접 anchor할 수 없는 finding도 issue 코멘트로 떨어뜨리지 않고, 가장 가까운 변경 hunk 라인에 inline으로 붙이고 본문에 실제 위치(파일·라인)를 명시한다.
-7. managed issue comment(marker 기반)는 **verdict=approve일 때만** 게시하며, 승인 표현만 담고 finding 평가 본문은 포함하지 않는다. approve가 아니면 게시하지 않고, 직전 approve 코멘트가 있으면 supersede 표시로 갱신한다.
+2. trusted base를 checkout하고 base/head와 diff를 공유 helper(`.github/scripts/pr-review-context.sh`)로 수집한다.
+3. `.github/prompts/codex-pr-review.ko.md`를 system prompt처럼 붙이고 untrusted PR context(metadata·comments·diff)와 출력 언어 지시를 더해 프롬프트 파일을 조립한다.
+4. 공식 action `openai/codex-action`을 호출한다. 공유 스키마(`.github/prompts/codex-pr-review.schema.json`)는 `output-schema-file` 입력으로, 조립한 프롬프트는 `prompt-file` 입력으로, 샌드박스는 `read-only`, reasoning effort는 `medium`, 결과 JSON은 `output-file` 입력으로 수신하고, auth.json 디렉터리는 `codex-home` 입력으로 전달한다.
+5. 결과 JSON을 저장 직후 `jq empty`로 유효성을 검증한다.
+6. 모델이 `needs_context`를 반환하면 요청 파일(최대 5개)을 PR head에서 수집해 2차 호출로 최종 verdict를 받는다(Claude 리뷰와 동일한 2-pass 흐름).
+7. 게시는 자매 Claude 워크플로와 **동일한 구조**다(`claude-review.yml`의 'Submit … review verdict' + 'Post … review comment' 스텝을 codex 라벨·마커로 치환).
+   - **정식 리뷰 verdict 제출**: `gh pr review`로 `--approve` / `--comment` / `--request-changes` 중 하나를 제출한다. 승인은 findings가 없고 `automation_safety.may_approve=true`이며 diff가 truncate되지 않았을 때만, request-changes는 confidence ≥ 80 blocking finding이 있을 때만. 본문 헤더는 `## Codex PR Review`이며 숨김 멱등 마커 `codex-formal-review head_sha=… verdict=…`를 담는다. 같은 (head_sha, verdict) 리뷰가 이미 있으면 중복 제출을 건너뛴다.
+   - **마커 관리형 PR 코멘트 1개**: findings를 담은 issue-level 코멘트를 마커(`<!-- codex-api-pr-review -->`) 기준으로 최대 1개만 생성하거나 갱신한다(clean approve일 때는 게시하지 않음). 기본 토큰 봇(`github-actions[bot]`)이 자기 소유 코멘트를 식별·갱신한다.
+
+   인라인 리뷰 코멘트, fingerprint 기반 self thread 자동 resolve, GitHub App 설치 토큰을 통한 정식 approve는 사용하지 않는다(Claude 리뷰와 동일한 한계: 워크플로 기본 토큰은 자기 PR을 정식 APPROVE하지 못해 COMMENT로 강등될 수 있다).
 
 ## 단계적 고도화 계획
 
 ### Phase 1: Structured Review MVP
 
-- `codex review` 대신 `codex exec`를 사용한다.
-- stdin으로 prompt를 전달해 shell `ARG_MAX` 한계를 피한다.
-- JSON schema로 최종 응답을 강제한다.
+- `codex review` 대신 structured `codex exec`(JSON schema 강제)를 사용한다. 단, codex는 셸에서 직접 실행하지 않고 공식 action `openai/codex-action`을 통해 호출한다(action 내부에서 `codex exec`가 실행됨).
+- 프롬프트는 `prompt-file` 입력으로 전달해 shell `ARG_MAX` 한계를 피한다.
+- JSON schema로 최종 응답을 강제하고 저장 직후 `jq empty`로 검증한다.
 - confidence score 80 미만 finding은 게시하지 않는다.
-- (구) 초기 MVP는 inline comment 없이 summary review body에 묶었으나, 현재는 모든 finding을 inline 코멘트로만 게시한다(inline-only 정책).
 
 완료 기준:
 - JSON schema 검증이 실패하면 approve하지 않는다.
 - `approve` verdict는 findings가 비어 있고 `automation_safety.may_approve=true`일 때만 제출된다.
 - `request_changes`는 confidence 80 이상의 blocking finding이 있을 때만 제출된다.
 
-### Phase 2: Inline Comment Adapter
+### Phase 2: Inline Comment Adapter (superseded)
 
-- 모든 finding을 GitHub inline review comment로 게시한다(inline-only 정책).
-- changed line에 직접 매핑되지 않는 finding도 issue comment로 떨어뜨리지 않고, 가장 가까운 변경 hunk 라인에 inline으로 붙이고 본문에 실제 위치를 명시한다.
-- comment marker에 `fingerprint`, `head_sha`, `severity`, `status`를 저장한다.
-- 같은 fingerprint가 이미 존재하면 중복 게시하지 않는다.
+> **Superseded.** 게시 구조를 자매 Claude 워크플로와 통일하면서 codex 독자 인라인 코멘트 경로는 제거되었다. findings는 인라인이 아니라 마커 관리형 PR 코멘트 1개에 담겨 게시된다("현재 1차 워크플로" 7번 참조). 아래는 과거 설계 기록이다.
 
-완료 기준:
-- diff line 매핑이 어려운 finding도 가장 가까운 변경 라인에 inline으로 남기며 issue-level로 degrade하지 않는다.
-- 기존 다른 reviewer가 같은 이슈를 남겼으면 `skipped_duplicates`로 기록하고 게시하지 않는다.
+- ~~모든 finding을 GitHub inline review comment로 게시한다(inline-only 정책).~~
+- ~~changed line에 직접 매핑되지 않는 finding도 issue comment로 떨어뜨리지 않고, 가장 가까운 변경 hunk 라인에 inline으로 붙이고 본문에 실제 위치를 명시한다.~~
+- ~~comment marker에 `fingerprint`, `head_sha`, `severity`, `status`를 저장한다.~~
+- ~~같은 fingerprint가 이미 존재하면 중복 게시하지 않는다.~~
 
-### Phase 3: Thread Lifecycle
+### Phase 3: Thread Lifecycle (superseded)
 
-- GraphQL `reviewThreads`를 읽어 `isResolved`, `isOutdated`, root comment body, marker를 수집한다.
-- Codex-owned active thread만 resolve/unresolve/reply 대상으로 삼는다.
-- 최신 push가 기존 finding을 고쳤으면 resolve한다.
-- 아직 고쳐지지 않았으면 같은 thread에 후속 피드백을 단다.
+> **Superseded.** Claude 동일 게시 구조에는 self thread lifecycle 관리가 없다. fingerprint 기반 self thread 자동 resolve 경로는 제거되었다. 아래는 과거 설계 기록이다.
 
-완료 기준:
+- ~~GraphQL `reviewThreads`를 읽어 `isResolved`, `isOutdated`, root comment body, marker를 수집한다.~~
+- ~~Codex-owned active thread만 resolve/unresolve/reply 대상으로 삼는다.~~
+- ~~최신 push가 기존 finding을 고쳤으면 resolve한다.~~
+- ~~아직 고쳐지지 않았으면 같은 thread에 후속 피드백을 단다.~~
+
+완료 기준(과거):
 - Codex가 만들지 않은 thread는 절대 resolve하지 않는다.
 - outdated thread는 fingerprint로 최신 diff에 남아 있는지 재확인한다.
 

--- a/docs/specs/2026-06-01-codex-review-via-codex-action/SPEC.md
+++ b/docs/specs/2026-06-01-codex-review-via-codex-action/SPEC.md
@@ -1,0 +1,60 @@
+---
+scope:
+  include:
+    - .github/workflows/codex-review.yml
+    - tests/codex/test-codex-review-workflow.sh
+    - docs/codex/pr-review-workflow.md
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+ears_language: ko
+---
+
+# codex-review 워크플로를 openai/codex-action 기반으로 재작성
+
+## 무엇을 만들 것인가
+<!-- WHAT/HOW 방어선: 무엇을 만들지만 적고 구현 방법·파일·라이브러리·클래스명은 제약으로 이동. -->
+Codex PR 리뷰 워크플로의 모델 호출을 codex CLI 직접 실행에서 공식 GitHub Action 호출로 바꾸고, 리뷰 결과 게시 구조를 자매 워크플로(Claude PR 리뷰)와 동일하게 통일한다. 인증은 ChatGPT 계정 auth.json 방식을 그대로 유지한다. codex만의 독자 게시 경로(인라인 코멘트, fingerprint 기반 thread 자동 resolve, GitHub App 토큰을 통한 정식 approve)는 제거하고, Claude 리뷰와 같은 게시 방식(정식 리뷰 verdict 제출 + 마커 기반 관리형 PR 코멘트 1개)으로 대체한다. 공유 자산(리뷰 context 수집 스크립트, codex 리뷰 프롬프트, 공유 출력 스키마)과 추가 context 요청 2-pass 흐름, @codex 멘션 트리거 게이트는 보존한다.
+
+## 완료 조건
+<!-- 5문장 패턴(항상 / …할 때 / …인 동안 / …이면(오류) / …기능이 켜지면)과 언어 규칙은 references/ears-patterns.md. 각 조건은 관찰 가능하고 독립 검증 가능해야 함. -->
+- PR 리뷰가 트리거되어 codex가 실행될 때, 모델 호출은 공식 GitHub Action(`openai/codex-action`)을 통해 이뤄지며, 워크플로에는 `npm install -g @openai/codex` 설치 스텝과 셸에서 직접 호출하는 `codex exec` 명령이 존재하지 않는다.
+- codex가 실행될 때, 인증은 ChatGPT 계정 auth.json 방식을 유지한다 — `CODEX_AUTH_JSON` 시크릿이 codex home 디렉터리의 `auth.json`으로 기록되고 그 디렉터리가 action에 전달되며, `OPENAI_API_KEY`(또는 동등 API 키 입력)는 요구되지 않는다.
+- `CODEX_AUTH_JSON` 시크릿이 비어 있으면, 워크플로는 인증 부재를 알리는 명확한 오류로 실패한다.
+- 리뷰가 실행되어 결과를 게시할 때, 게시 구조는 Claude PR 리뷰 워크플로와 동일하다 — verdict를 정식 리뷰(approve / comment / request-changes) body로 제출하고, findings를 담은 관리형 PR 코멘트를 마커 기준으로 최대 1개만 생성하거나 갱신한다.
+- 항상, 워크플로에는 인라인 리뷰 코멘트 게시 경로, fingerprint 기반 self thread 자동 resolve 경로, GitHub App 설치 토큰 발급·App 토큰을 통한 정식 approve 경로가 존재하지 않는다.
+- 리뷰가 실행될 때, 모델 출력은 공유 출력 스키마(`.github/prompts/codex-pr-review.schema.json`)로 강제되고, 결과 JSON이 파일로 저장되어 유효한 JSON임이 검증된다.
+- 모델이 추가 context(needs_context)를 요청하면, 요청 파일을 수집해 2차 호출로 최종 verdict를 받는 2-pass 흐름이 Claude 리뷰와 동일하게 동작한다.
+- @codex 멘션으로 트리거될 때, 작성자 association 제한(OWNER/MEMBER/COLLABORATOR)과 봇 self-trigger 차단 게이트가 유지된다.
+- 워크플로 contract 테스트가 새 구조를 검증하도록 갱신된다 — 공식 action 사용·auth.json codex-home 부트스트랩·Claude 동일 게시 구조의 존재를 단언하고, 인라인/fingerprint/App-approve 경로와 codex CLI 직접 호출의 부재를 단언하며, 전체 테스트가 통과한다.
+- 항상, codex 리뷰 워크플로 설계 문서(`docs/codex/pr-review-workflow.md`)는 codex CLI 직접 실행이 아니라 공식 action 기반 접근과 Claude 동일 게시 구조를 반영한다.
+
+## 범위
+포함:
+- `.github/workflows/codex-review.yml` 전면 재작성 — 모델 호출을 `openai/codex-action`으로, 게시 단계를 `claude-review.yml`과 동일 구조로 교체, auth.json codex-home 부트스트랩 스텝 추가.
+- `tests/codex/test-codex-review-workflow.sh` 갱신 — 새 구조 단언으로 전환(공식 action·auth.json codex-home·동일 게시 구조 존재; CLI 직접 호출·인라인·fingerprint·App approve 부재).
+- `docs/codex/pr-review-workflow.md` 갱신 — action 기반 접근·Claude 동일 게시 구조 반영.
+
+비-목표 / 제외:
+- `.github/prompts/codex-pr-review.ko.md`·`.github/prompts/codex-pr-review.schema.json` 내용 변경(모델 비종속 리뷰 코어·공유 스키마는 그대로).
+- `.github/scripts/pr-review-context.sh` 변경(두 워크플로 공유, 벤더 무관).
+- `claude-review.yml` 동작 변경.
+- 기존 열린 PR에 이미 남은 codex 인라인 코멘트·resolved thread의 사후 정리.
+
+## 검증
+<!-- 검증 기준의 단일 출처는 위 "완료 조건"이다. 검증을 실행하는 진입 명령(테스트·lint·빌드)은 SPEC이 선언하지 않는다. -->
+이 SPEC의 인수 바는 위 **완료 조건**이다. 각 조건이 관찰 가능하게 충족되면 충족된 것으로 본다. 검증을 실행하는 진입 명령은 SPEC이 아니라 프로젝트 규칙(`rules/`)이 단일 출처로 정의한다.
+
+## 제약 (있을 때만)
+- 공식 action 호출은 커밋 SHA로 핀하고(레포 컨벤션: 모든 GitHub Action을 SHA 핀), codex CLI 버전도 action의 버전 입력으로 핀한다.
+- action 입력 매핑: 공유 스키마를 스키마 파일 입력으로, 조립된 프롬프트를 프롬프트 파일 입력으로, 샌드박스는 read-only, reasoning effort는 medium(기존 동작 동치), 결과는 출력 파일 입력으로 수신, auth.json 디렉터리는 codex-home 입력으로 전달한다.
+- auth.json 부트스트랩은 `CODEX_AUTH_JSON`을 codex-home 디렉터리의 `auth.json`(권한 600)으로 기록하고, 그 시크릿 값을 모델 호출 스텝의 환경으로 노출하지 않는다.
+- 게시 단계는 `claude-review.yml`의 'Submit … review verdict' + 'Post … review comment' 스텝 구조를 codex 라벨·마커로 치환해 사용한다(예: 'Codex PR Review' 헤더, codex 전용 정식 리뷰 마커·관리형 코멘트 마커).
+- 자기 트리거 게이트는 @codex 멘션을 유지하되, App 봇 식별(`REVIEW_APP_BOT_LOGIN`) 분기는 제거한다(Claude 구조에 없음).
+- 워크플로 권한은 게시에 필요한 범위(contents:read, pull-requests:write, issues:write)로 두며, App/OIDC 전용 권한은 두지 않는다.
+
+## 위험 (있을 때만)
+- App 토큰 approve 제거로 `github-actions[bot]`이 자기 워크플로 PR에 정식 APPROVE를 못 해 COMMENT로 강등될 수 있다(Claude 리뷰와 동일한 한계). — 사용자 수용됨.
+- 기존 열린 PR에 남아 있던 codex 인라인 코멘트·자동 resolve된 thread는 새 구조에서 더 이상 관리·정리되지 않고 잔존한다(과도기). — 사용자 수용됨.
+- action의 출력 파일이 스키마 강제 JSON(마지막 메시지)을 그대로 담는지는 기존 `--output-last-message`와 동치이나, 저장 직후 JSON 유효성 가드(예: jq empty)로 계약 위반을 조기 검출한다.

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
-# Codex PR review workflow authentication contract.
+# Codex PR review workflow contract.
 #
 # Static checks only: do not call GitHub, npm, or Codex.
+#
+# This workflow calls the model through the official openai/codex-action and
+# publishes results with the SAME structure as the sibling Claude PR review
+# workflow (formal review verdict + a single marker-managed PR comment). The
+# legacy codex-only paths — direct `codex exec`/`codex review` CLI calls,
+# inline review comments, fingerprint-based self thread auto-resolve, and the
+# GitHub App installation token / App-token APPROVE — are gone. These checks
+# assert the new structure exists and the removed paths are absent.
 
 set -euo pipefail
 
@@ -13,123 +21,276 @@ SCHEMA="$REPO_ROOT/.github/prompts/codex-pr-review.schema.json"
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "OK: $*"; }
 
+count() { awk -v needle="$1" 'index($0, needle) { c++ } END { print c + 0 }' "$2"; }
+
 [[ -f "$WORKFLOW" ]] || fail "$WORKFLOW 부재"
 [[ -f "$PROMPT" ]] || fail "$PROMPT 부재"
 [[ -f "$SCHEMA" ]] || fail "$SCHEMA 부재"
 
-echo "=== check 1: auth.json secret is restored for Codex CLI ==="
-grep -q 'CODEX_AUTH_JSON:.*secrets\.CODEX_AUTH_JSON' "$WORKFLOW" \
-  || fail "CODEX_AUTH_JSON secret env 매핑 부재"
-grep -q 'mkdir -p "\$HOME/\.codex"' "$WORKFLOW" \
-  || fail "~/.codex 디렉토리 생성 부재"
-grep -q 'printf .*> "\$HOME/\.codex/auth\.json"' "$WORKFLOW" \
-  || fail "~/.codex/auth.json 복원 부재"
-grep -q 'unset CODEX_AUTH_JSON' "$WORKFLOW" \
-  || fail "auth.json 작성 후 CODEX_AUTH_JSON env 제거 부재"
-ok "check 1: CODEX_AUTH_JSON secret을 ~/.codex/auth.json 으로 복원"
+echo "=== check 1: 모델 호출은 공식 openai/codex-action 으로 이뤄진다 (AC1) ==="
+# 1차/2차(needs_context follow-up) 모두 동일한 SHA 고정 action 으로 실행.
+codex_action_count="$(grep -cE 'uses: openai/codex-action@[0-9a-f]{40}' "$WORKFLOW")"
+[[ "$codex_action_count" == "2" ]] \
+  || fail "openai/codex-action SHA 고정 호출이 1차/2차 2곳에 없음 (현재 $codex_action_count)"
+if grep -qE 'uses: openai/codex-action@v[0-9.]+' "$WORKFLOW"; then
+  fail "openai/codex-action 이 mutable version tag 로 참조됨 — SHA 고정 필요"
+fi
+ok "check 1: openai/codex-action SHA 고정 호출 2곳"
 
 echo ""
-echo "=== check 2: auth directory is created under restrictive umask ==="
-umask_line="$(grep -n 'umask 077' "$WORKFLOW" | head -1 | cut -d: -f1)"
-mkdir_line="$(grep -n 'mkdir -p "\$HOME/\.codex"' "$WORKFLOW" | head -1 | cut -d: -f1)"
-[[ -n "$umask_line" ]] || fail "umask 077 설정 부재"
-[[ -n "$mkdir_line" ]] || fail "~/.codex 디렉토리 생성 부재"
-(( umask_line < mkdir_line )) \
-  || fail "umask 077 이 ~/.codex mkdir 이후에 설정됨"
-ok "check 2: umask 077 이 ~/.codex 생성 전에 적용됨"
-
-echo ""
-echo "=== check 3: codex exec uses prompt stdin and JSON schema ==="
-grep -q 'REVIEW_BASE="$(git merge-base "origin/\$PR_BASE_REF" "refs/remotes/pull/\$PR_NUMBER/head")"' "$WORKFLOW" \
-  || fail "PR head 와 base branch 의 merge-base 계산 부재"
-grep -q 'REVIEW_PROMPT="\.github/prompts/codex-pr-review\.ko\.md"' "$WORKFLOW" \
-  || fail "structured review prompt 파일 참조 부재"
-grep -q 'REVIEW_SCHEMA="\.github/prompts/codex-pr-review\.schema\.json"' "$WORKFLOW" \
-  || fail "structured review schema 파일 참조 부재"
-grep -q 'codex exec' "$WORKFLOW" \
-  || fail "codex exec 사용 부재"
-grep -q -- '--sandbox read-only' "$WORKFLOW" \
-  || fail "codex exec sandbox 모드 지정 부재"
-reasoning_count="$(awk 'index($0, "--config model_reasoning_effort=\\\"medium\\\"") { count++ } END { print count + 0 }' "$WORKFLOW")"
-[[ "$reasoning_count" == "2" ]] \
-  || fail "codex review 1차/2차 exec 모두 medium reasoning effort 로 실행되지 않음"
-grep -q -- '--output-schema "\$REVIEW_SCHEMA"' "$WORKFLOW" \
-  || fail "codex exec output schema 지정 부재"
-result_output_count="$(awk 'index($0, "--output-last-message \"$result\"") { count++ } END { print count + 0 }' "$WORKFLOW")"
-[[ "$result_output_count" == "2" ]] \
-  || fail "codex 최종 JSON 출력 파일 지정이 1차/2차 exec 모두에 없음"
-grep -q '< "\$initial_prompt"' "$WORKFLOW" \
-  || fail "prompt 를 stdin 으로 전달하지 않음"
-grep -q 'unset GH_TOKEN' "$WORKFLOW" \
-  || fail "Codex 실행 전 GH_TOKEN env 제거 부재"
-if grep -q '"$(cat \.codex-review/full-prompt\.md)"' "$WORKFLOW"; then
-  fail "prompt 전체를 커맨드라인 인자로 전달하고 있음"
+echo "=== check 2: 셸 직접 codex CLI 호출·설치 스텝이 존재하지 않는다 (AC1) ==="
+if grep -q 'npm install -g @openai/codex' "$WORKFLOW"; then
+  fail "npm install -g @openai/codex 설치 스텝 잔존 — CLI 직접 호출 제거 필요 (AC1)"
+fi
+if grep -q 'codex exec' "$WORKFLOW"; then
+  fail "셸에서 직접 'codex exec' 호출 잔존 — action 을 통해야 함 (AC1)"
 fi
 if grep -q 'codex review' "$WORKFLOW"; then
-  fail "legacy codex review 호출이 남아 있음"
+  fail "legacy 'codex review' 호출 잔존 (AC1)"
 fi
-ok "check 3: codex exec + stdin + schema 로 structured review 실행"
+ok "check 2: codex CLI 직접 호출·설치 스텝 부재"
 
 echo ""
-echo "=== check 3b: codex workflow uses shared review context helper ==="
+echo "=== check 3: codex CLI 버전이 action 버전 입력으로 고정된다 (제약) ==="
+codex_version_count="$(count "codex-version: '0.132.0'" "$WORKFLOW")"
+[[ "$codex_version_count" == "2" ]] \
+  || fail "codex-version 입력이 1차/2차 action 호출 양쪽에 0.132.0 으로 고정되지 않음 (현재 $codex_version_count)"
+ok "check 3: codex-version 입력으로 codex CLI 0.132.0 고정"
+
+echo ""
+echo "=== check 4: ChatGPT auth.json codex-home 부트스트랩 (AC2/제약) ==="
+secret_count="$(count 'secrets.CODEX_AUTH_JSON' "$WORKFLOW")"
+[[ "$secret_count" == "1" ]] \
+  || fail "secrets.CODEX_AUTH_JSON 참조가 정확히 1곳(부트스트랩 env)이어야 함 — 모델 호출 스텝 노출 금지 (현재 $secret_count) (제약)"
+grep -q 'CODEX_AUTH_JSON:.*secrets\.CODEX_AUTH_JSON' "$WORKFLOW" \
+  || fail "CODEX_AUTH_JSON secret env 매핑 부재 (AC2)"
+grep -q 'printf .*> "\$codex_home/auth\.json"' "$WORKFLOW" \
+  || fail "codex-home 디렉터리의 auth.json 기록 부재 (AC2/제약)"
+grep -q 'chmod 600 "\$codex_home/auth\.json"' "$WORKFLOW" \
+  || fail "auth.json 권한 600 설정 부재 (제약)"
+grep -q 'codex-home: ${{ env\.CODEX_HOME_DIR }}' "$WORKFLOW" \
+  || fail "codex-home 디렉터리를 action 의 codex-home 입력으로 전달하지 않음 (AC2/제약)"
+codex_home_input_count="$(count 'codex-home: ${{ env.CODEX_HOME_DIR }}' "$WORKFLOW")"
+[[ "$codex_home_input_count" == "2" ]] \
+  || fail "codex-home 입력이 1차/2차 action 호출 양쪽에 전달되지 않음 (현재 $codex_home_input_count)"
+ok "check 4: CODEX_AUTH_JSON → codex-home/auth.json(600) → action codex-home 입력"
+
+echo ""
+echo "=== check 5: auth 디렉터리가 restrictive umask 아래 생성됨 (제약) ==="
+umask_line="$(grep -n 'umask 077' "$WORKFLOW" | head -1 | cut -d: -f1)"
+mkdir_line="$(grep -n 'mkdir -p "\$codex_home"' "$WORKFLOW" | head -1 | cut -d: -f1)"
+[[ -n "$umask_line" ]] || fail "umask 077 설정 부재"
+[[ -n "$mkdir_line" ]] || fail "codex-home 디렉터리 생성 부재"
+(( umask_line < mkdir_line )) \
+  || fail "umask 077 이 codex-home mkdir 이후에 설정됨"
+ok "check 5: umask 077 이 codex-home 생성 전에 적용됨"
+
+echo ""
+echo "=== check 6: CODEX_AUTH_JSON 비어 있으면 명확한 오류로 실패 (AC3) ==="
+grep -q 'if \[ -z "\$CODEX_AUTH_JSON" \]; then' "$WORKFLOW" \
+  || fail "CODEX_AUTH_JSON 비어있음 가드 부재 (AC3)"
+grep -qF 'CODEX_AUTH_JSON secret is required' "$WORKFLOW" \
+  || fail "인증 부재 오류 메시지 부재 (AC3)"
+ok "check 6: 빈 CODEX_AUTH_JSON → exit 1"
+
+echo ""
+echo "=== check 7: API 키 인증 경로가 없다 (AC2) ==="
+if grep -qi 'openai-api-key' "$WORKFLOW"; then
+  fail "openai-api-key 입력 잔존 — auth.json 방식만 허용 (AC2)"
+fi
+if grep -q 'OPENAI_API_KEY' "$WORKFLOW"; then
+  fail "OPENAI_API_KEY 환경 잔존 — auth.json 방식만 허용 (AC2)"
+fi
+if grep -q 'CODEX_ACCESS_TOKEN' "$WORKFLOW"; then
+  fail "CODEX_ACCESS_TOKEN 기반 인증 잔존"
+fi
+ok "check 7: API 키 인증 경로 부재"
+
+echo ""
+echo "=== check 8: action 입력 매핑 (schema 파일·프롬프트 파일·sandbox·effort·output 파일) (AC6/제약) ==="
+grep -q 'sandbox: read-only' "$WORKFLOW" \
+  || fail "sandbox read-only 입력 부재 (제약)"
+grep -q 'effort: medium' "$WORKFLOW" \
+  || fail "reasoning effort medium 입력 부재 (제약)"
+grep -q 'output-schema-file: \.github/prompts/codex-pr-review\.schema\.json' "$WORKFLOW" \
+  || fail "공유 schema 를 output-schema-file 입력으로 전달하지 않음 (AC6/제약)"
+grep -q 'output-file: \.codex-review/result\.json' "$WORKFLOW" \
+  || fail "결과 JSON 을 output-file 입력으로 수신하지 않음 (제약)"
+grep -q 'prompt-file: \.codex-review/prompt\.md' "$WORKFLOW" \
+  || fail "1차 프롬프트 파일을 prompt-file 입력으로 전달하지 않음 (제약)"
+grep -q 'prompt-file: \.codex-review/prompt\.follow-up\.md' "$WORKFLOW" \
+  || fail "2차(follow-up) 프롬프트 파일을 prompt-file 입력으로 전달하지 않음 (제약)"
+ok "check 8: schema-file·prompt-file·sandbox·effort·output-file 입력 매핑"
+
+echo ""
+echo "=== check 9: 결과 JSON 유효성 가드 (AC6/위험) ==="
+jq_empty_count="$(count 'jq empty .codex-review/result.json' "$WORKFLOW")"
+[[ "$jq_empty_count" == "2" ]] \
+  || fail "결과 JSON 유효성 가드(jq empty)가 1차/2차 저장 직후 양쪽에 없음 (현재 $jq_empty_count) (위험)"
+ok "check 9: 1차/2차 결과 저장 직후 jq empty 검증"
+
+echo ""
+echo "=== check 10: 공유 review context helper 사용 (보존) ==="
 grep -q '\.github/scripts/pr-review-context\.sh' "$WORKFLOW" \
   || fail "shared review context helper 호출 부재"
 grep -q 'source \.review-context/context-mode\.env' "$WORKFLOW" \
   || fail "review context mode env 로드 부재"
 grep -q 'REVIEW_CONTEXT_MODE' "$WORKFLOW" \
   || fail "prompt 에 review context mode 주입 부재"
-ok "check 3b: shared review context helper 사용"
+grep -q 'REVIEW_BASE="$(git merge-base "origin/\$PR_BASE_REF" "refs/remotes/pull/\$PR_NUMBER/head")"' "$WORKFLOW" \
+  || fail "PR head 와 base branch 의 merge-base 계산 부재"
+ok "check 10: 공유 context helper + merge-base 계산"
 
 echo ""
-echo "=== check 3c: codex workflow supports targeted context follow-up ==="
+echo "=== check 11: needs_context 2-pass follow-up 보존 (AC7) ==="
 grep -q 'context_requests' "$WORKFLOW" \
-  || fail "context_requests follow-up 처리 부재"
+  || fail "context_requests follow-up 처리 부재 (AC7)"
 grep -q 'review-extra-context' "$WORKFLOW" \
-  || fail "추가 context 디렉터리 부재"
+  || fail "추가 context 디렉터리 부재 (AC7)"
 grep -q 'MAX_CONTEXT_REQUEST_FILES=5' "$WORKFLOW" \
-  || fail "context request file limit 부재"
+  || fail "context request file limit 부재 (AC7)"
 grep -q 'truncated at 400 lines' "$WORKFLOW" \
-  || fail "추가 context 파일 절단 표시 부재"
-ok "check 3c: targeted context follow-up 처리 존재"
+  || fail "추가 context 파일 절단 표시 부재 (AC7)"
+grep -q 'has_extra_context' "$WORKFLOW" \
+  || fail "follow-up 게이트 출력(has_extra_context) 부재 (AC7)"
+grep -q "if: steps\.prepare-codex-follow-up\.outputs\.has_extra_context == 'true'" "$WORKFLOW" \
+  || fail "follow-up action 실행이 has_extra_context 로 게이트되지 않음 (AC7)"
+ok "check 11: needs_context 2-pass follow-up 보존"
 
 echo ""
-echo "=== check 4: @codex mention triggers require trusted author association ==="
+echo "=== check 12: @codex 멘션 트리거 + author association 게이트 보존, App 봇 분기 제거 (AC8/제약) ==="
 trusted_expr="contains(fromJSON('[\"OWNER\",\"MEMBER\",\"COLLABORATOR\"]')"
-trusted_count="$(awk -v needle="$trusted_expr" 'index($0, needle) { count++ } END { print count + 0 }' "$WORKFLOW")"
+trusted_count="$(count "$trusted_expr" "$WORKFLOW")"
 [[ "$trusted_count" == "3" ]] \
-  || fail "issue/review comment/review @codex 트리거의 trusted author 제한이 3곳 모두에 없음"
+  || fail "issue/review comment/review @codex 트리거의 trusted author 제한이 3곳 모두에 없음 (현재 $trusted_count) (AC8)"
+grep -q "contains(github.event.comment.body, '@codex')" "$WORKFLOW" \
+  || fail "@codex 멘션 트리거 부재 (AC8)"
 grep -q 'github.event.comment.author_association' "$WORKFLOW" \
-  || fail "comment 기반 @codex 트리거 author_association 제한 부재"
+  || fail "comment 기반 @codex 트리거 author_association 제한 부재 (AC8)"
 grep -q 'github.event.review.author_association' "$WORKFLOW" \
-  || fail "review 기반 @codex 트리거 author_association 제한 부재"
-ok "check 4: @codex mention 트리거가 OWNER/MEMBER/COLLABORATOR 로 제한됨"
-
-echo ""
-echo "=== check 5: PR body is not injected into the review prompt ==="
-if grep -q 'PR_BODY:' "$WORKFLOW" || grep -q 'echo "\$PR_BODY"' "$WORKFLOW"; then
-  fail "PR body 를 Codex review prompt 에 직접 주입하고 있음"
+  || fail "review 기반 @codex 트리거 author_association 제한 부재 (AC8)"
+grep -q "github.event.comment.user.login != 'github-actions\[bot\]'" "$WORKFLOW" \
+  || fail "봇 self-trigger 차단 게이트 부재 (AC8)"
+if grep -q 'REVIEW_APP_BOT_LOGIN' "$WORKFLOW"; then
+  fail "REVIEW_APP_BOT_LOGIN App 봇 식별 분기 잔존 — Claude 구조에 없음 (제약)"
 fi
-ok "check 5: PR body 직접 주입 제거됨"
+ok "check 12: @codex + author association + 봇 차단 게이트, App 봇 분기 제거됨"
 
 echo ""
-echo "=== check 6: checkout does not trigger submodule auth cleanup failure ==="
-if grep -q 'persist-credentials: false' "$WORKFLOW"; then
-  fail "actions/checkout persist-credentials:false 는 gitlink-only .claude/worktrees 에서 submodule cleanup 실패를 유발함"
+echo "=== check 13: Claude 동일 게시 구조 — verdict 정식 리뷰 제출 (AC4/제약) ==="
+grep -q 'name: Submit Codex review verdict' "$WORKFLOW" \
+  || fail "'Submit Codex review verdict' 스텝 부재 (Claude 'Submit … review verdict' 구조 치환) (제약)"
+# 정식 리뷰 verdict 는 gh pr review 로 제출 (Claude 와 동일). approve/comment/request-changes 3 경로.
+grep -q 'gh pr review .*--approve' "$WORKFLOW" \
+  || fail "approve 정식 리뷰 제출 경로 부재 (AC4)"
+grep -q 'submit_review --comment' "$WORKFLOW" \
+  || fail "comment 정식 리뷰 제출 경로 부재 (AC4)"
+grep -q 'submit_review --request-changes' "$WORKFLOW" \
+  || fail "request-changes 정식 리뷰 제출 경로 부재 (AC4 — Claude 동일)"
+grep -qF '## Codex PR Review' "$WORKFLOW" \
+  || fail "정식 리뷰 본문 헤더 '## Codex PR Review' 부재 (제약: codex 라벨 치환)"
+# 멱등 마커 (head_sha, verdict) 기준.
+grep -qF 'codex-formal-review head_sha=$PR_HEAD_SHA verdict=$verdict' "$WORKFLOW" \
+  || fail "formal review 멱등 마커(codex-formal-review head_sha=.. verdict=..) 부재 (제약)"
+grep -qF 'already exists for $PR_HEAD_SHA / $verdict; skipping duplicate' "$WORKFLOW" \
+  || fail "marker 기반 중복 review skip 부재 (AC4 멱등)"
+grep -qF 'pulls/$PR_NUMBER/reviews' "$WORKFLOW" \
+  || fail "기존 review 조회(REST) 부재 — 멱등성 판정 불가"
+grep -q 'touch .codex-review/approval-failed' "$WORKFLOW" \
+  || fail "APPROVE 실패 시 approval-failed marker 부재 (Claude 동일 fallback)"
+ok "check 13: verdict 정식 리뷰 제출 (approve/comment/request-changes) + 멱등"
+
+echo ""
+echo "=== check 14: Claude 동일 게시 구조 — 마커 관리형 PR 코멘트 1개 (AC4/제약) ==="
+grep -q 'name: Post Codex review comment' "$WORKFLOW" \
+  || fail "'Post Codex review comment' 스텝 부재 (Claude 'Post … review comment' 구조 치환) (제약)"
+grep -qF '<!-- codex-api-pr-review -->' "$WORKFLOW" \
+  || fail "codex 전용 관리형 코멘트 마커(<!-- codex-api-pr-review -->) 부재 (제약)"
+grep -qF 'github.rest.issues.listComments' "$WORKFLOW" \
+  || fail "기존 관리형 코멘트 조회(issues.listComments) 부재 — 1개 갱신 보장 불가 (AC4)"
+grep -qF 'github.rest.issues.updateComment' "$WORKFLOW" \
+  || fail "기존 관리형 코멘트 갱신(issues.updateComment) 경로 부재 (AC4: 최대 1개 갱신)"
+grep -qF 'github.rest.issues.createComment' "$WORKFLOW" \
+  || fail "관리형 코멘트 생성(issues.createComment) 경로 부재 (AC4)"
+grep -qF 'comment.body?.includes(marker)' "$WORKFLOW" \
+  || fail "마커 기준 기존 코멘트 식별 부재 (AC4: 마커 기준 최대 1개)"
+ok "check 14: 마커 기반 관리형 PR 코멘트 생성/갱신 (최대 1개)"
+
+echo ""
+echo "=== check 15: 인라인 리뷰 코멘트 게시 경로 부재 (AC5) ==="
+if grep -qF 'pulls.createReview' "$WORKFLOW"; then
+  fail "pulls.createReview 잔존 — 인라인 코멘트 게시 경로 제거되어야 함 (AC5)"
 fi
-ok "check 6: checkout 이 persist-credentials:false 를 사용하지 않음"
+if grep -qF 'inlineComments' "$WORKFLOW"; then
+  fail "inlineComments 잔존 — 인라인 코멘트 경로 제거되어야 함 (AC5)"
+fi
+if grep -qF 'inline-only' "$WORKFLOW"; then
+  fail "inline-only 정책 잔존 — 인라인 게시 경로 제거되어야 함 (AC5)"
+fi
+if grep -qF "side: 'RIGHT'" "$WORKFLOW"; then
+  fail "inline comment side='RIGHT' 잔존 (AC5)"
+fi
+ok "check 15: 인라인 리뷰 코멘트 게시 경로 부재"
 
 echo ""
-echo "=== check 6b: checkout credentials are cleared before codex exec ==="
-unset_extraheader_line="$(awk 'index($0, "git config --local --unset-all http.https://github.com/.extraheader") { print NR; exit }' "$WORKFLOW")"
-codex_exec_line="$(awk '/codex exec \\/ { print NR; exit }' "$WORKFLOW")"
-[[ -n "$unset_extraheader_line" ]] \
-  || fail "codex exec 전 checkout credential extraheader 제거 부재"
-(( unset_extraheader_line < codex_exec_line )) \
-  || fail "checkout credential extraheader 제거가 codex exec 이후에 위치함"
-ok "check 6b: codex exec 전 checkout credential extraheader 제거"
+echo "=== check 16: fingerprint 기반 self thread 자동 resolve 경로 부재 (AC5) ==="
+if grep -qF 'computeFingerprint' "$WORKFLOW"; then
+  fail "computeFingerprint 잔존 — fingerprint resolve 경로 제거되어야 함 (AC5)"
+fi
+if grep -qF 'resolveReviewThread' "$WORKFLOW"; then
+  fail "resolveReviewThread 잔존 — self thread 자동 resolve 제거되어야 함 (AC5)"
+fi
+if grep -qF 'reviewThreads' "$WORKFLOW"; then
+  fail "reviewThreads GraphQL 조회 잔존 (AC5)"
+fi
+if grep -qF 'resolved_threads' "$WORKFLOW"; then
+  fail "resolved_threads 소비 경로 잔존 (AC5)"
+fi
+if grep -qF 'codex-review-inline' "$WORKFLOW"; then
+  fail "codex-review-inline fingerprint 마커 잔존 (AC5)"
+fi
+if grep -qiF 'fingerprint' "$WORKFLOW"; then
+  fail "fingerprint 어휘 잔존 — fingerprint 기반 resolve 제거되어야 함 (AC5)"
+fi
+ok "check 16: fingerprint self thread 자동 resolve 경로 부재"
 
 echo ""
-echo "=== check 7: third-party actions and Codex CLI are pinned ==="
+echo "=== check 17: GitHub App 설치 토큰 발급·App 토큰 approve 경로 부재 (AC5/제약) ==="
+if grep -qF 'create-github-app-token' "$WORKFLOW"; then
+  fail "create-github-app-token 잔존 — App 설치 토큰 발급 경로 제거되어야 함 (AC5)"
+fi
+if grep -qF 'app-token' "$WORKFLOW"; then
+  fail "app-token 스텝/출력 잔존 (AC5)"
+fi
+if grep -qF 'app-slug' "$WORKFLOW"; then
+  fail "app-slug 동적 봇 식별 잔존 (AC5)"
+fi
+if grep -qF 'REVIEW_APP_ID' "$WORKFLOW"; then
+  fail "REVIEW_APP_ID App 게이트 잔존 (AC5)"
+fi
+if grep -qF 'dismissReview' "$WORKFLOW"; then
+  fail "dismissReview 잔존 (AC5)"
+fi
+# 자기 트리거/식별은 기본 토큰 봇(github-actions[bot])만 사용.
+grep -qF "'github-actions[bot]'" "$WORKFLOW" \
+  || fail "기본 토큰 봇 식별(github-actions[bot]) 부재"
+ok "check 17: App 토큰 발급·App approve 경로 부재"
+
+echo ""
+echo "=== check 18: 권한 범위 — 게시에 필요한 범위만, App/OIDC 전용 권한 없음 (제약) ==="
+grep -q 'contents: read' "$WORKFLOW" \
+  || fail "contents: read 권한 부재"
+grep -q 'pull-requests: write' "$WORKFLOW" \
+  || fail "pull-requests: write 권한 부재"
+grep -q 'issues: write' "$WORKFLOW" \
+  || fail "issues: write 권한 부재"
+if grep -q 'id-token: write' "$WORKFLOW"; then
+  fail "id-token: write 권한 잔존 — App/OIDC 전용 권한 두지 않음 (제약)"
+fi
+ok "check 18: 게시 권한 범위만, id-token 없음"
+
+echo ""
+echo "=== check 19: third-party actions SHA 고정 ==="
 if grep -qE 'uses: actions/[a-z-]+@v[0-9]+' "$WORKFLOW"; then
   fail "GitHub Actions가 mutable version tag 로 참조됨"
 fi
@@ -137,203 +298,30 @@ grep -qE 'uses: actions/github-script@[0-9a-f]{40}' "$WORKFLOW" \
   || fail "actions/github-script SHA 고정 부재"
 grep -qE 'uses: actions/checkout@[0-9a-f]{40}' "$WORKFLOW" \
   || fail "actions/checkout SHA 고정 부재"
-grep -qE 'uses: actions/setup-node@[0-9a-f]{40}' "$WORKFLOW" \
-  || fail "actions/setup-node SHA 고정 부재"
-grep -q 'npm install -g @openai/codex@0\.132\.0' "$WORKFLOW" \
-  || fail "@openai/codex 버전 고정 부재"
-ok "check 7: Actions SHA 및 Codex CLI 버전이 고정됨"
+ok "check 19: Actions SHA 고정"
 
 echo ""
-echo "=== check 8: legacy access-token auth is not used ==="
-if grep -q 'CODEX_ACCESS_TOKEN' "$WORKFLOW"; then
-  fail "CODEX_ACCESS_TOKEN 기반 인증이 남아 있음"
+echo "=== check 20: checkout 이 submodule auth cleanup 실패를 유발하지 않음 ==="
+if grep -q 'persist-credentials: false' "$WORKFLOW"; then
+  fail "actions/checkout persist-credentials:false 는 gitlink-only .claude/worktrees 에서 submodule cleanup 실패를 유발함"
 fi
-ok "check 8: CODEX_ACCESS_TOKEN 기반 인증 제거됨"
+ok "check 20: checkout 이 persist-credentials:false 를 사용하지 않음"
 
 echo ""
-echo "=== check 9: 관리형 issue-level 코멘트 채널이 제거됨 (AC1/AC2/AC3) ==="
-# 'Post Codex review comment' 스텝과 그 issues.create/updateComment 기반 관리형
-# 코멘트 게시·갱신 경로는 더 이상 존재하지 않아야 한다. 승인·지적은 정식 리뷰(①)와
-# inline 코멘트가 전달하므로 issue-level 관리형 채널을 완전히 없앤다.
-if grep -q 'Post Codex review comment' "$WORKFLOW"; then
-  fail "'Post Codex review comment' 스텝 잔존 — 관리형 issue-level 코멘트 채널 제거되어야 함 (AC3)"
-fi
-if grep -q '<!-- codex-cli-pr-review -->' "$WORKFLOW"; then
-  fail "관리형 코멘트 marker (codex-cli-pr-review) 잔존 — 채널 제거되어야 함 (AC3)"
-fi
-if grep -q 'issues\.createComment' "$WORKFLOW"; then
-  fail "issues.createComment 잔존 — 관리형 issue-level 코멘트 게시 경로 제거되어야 함 (AC1/AC3)"
-fi
-if grep -q 'issues\.updateComment' "$WORKFLOW"; then
-  fail "issues.updateComment 잔존 — 관리형 issue-level 코멘트 갱신/supersede 경로 제거되어야 함 (AC2/AC3)"
-fi
-ok "check 9: 관리형 issue-level 코멘트 채널 부재"
+echo "=== check 21: 모델 호출 전 checkout credential 제거 ==="
+grep -q 'git config --local --unset-all http.https://github.com/.extraheader' "$WORKFLOW" \
+  || fail "모델 호출 전 checkout credential extraheader 제거 부재"
+ok "check 21: checkout credential extraheader 제거"
 
 echo ""
-echo "=== check 10: verdict submission via Pulls REST API with inline comments (APPROVE/COMMENT only) ==="
-# Submit step is a github-script step that calls pulls.createReview directly
-# so it can post inline review comments. Official event is APPROVE or COMMENT
-# only — REQUEST_CHANGES is abolished (AC10/AC11).
-grep -qF 'github.rest.pulls.createReview' "$WORKFLOW" \
-  || fail "Pulls REST createReview 호출 부재 — inline comments 게시 불가 (gh pr review 로는 inline 미지원)"
-grep -qF 'comments: inlineComments' "$WORKFLOW" \
-  || fail "createReview 의 comments[] 배열에 inline findings 전달 부재"
-# inline-only 정책: 모든 finding 이 inline. issue 채널 분기/렌더가 없어야 한다.
-grep -qF 'inline-only' "$WORKFLOW" \
-  || fail "inline-only 정책 주석/마커 부재 (모든 finding 을 inline 으로 게시한다는 의도 명시 필요)"
-if grep -qF 'issueFindings' "$WORKFLOW"; then
-  fail "issueFindings 분기 잔존 — inline-only 정책에서 issue 채널 finding 라우팅 금지"
+echo "=== check 22: PR body 가 review prompt 에 직접 주입되지 않음 ==="
+if grep -q 'PR_BODY:' "$WORKFLOW" || grep -q 'echo "\$PR_BODY"' "$WORKFLOW"; then
+  fail "PR body 를 Codex review prompt 에 직접 주입하고 있음"
 fi
-if grep -qF 'Issue-level findings' "$WORKFLOW"; then
-  fail "'Issue-level findings' 렌더 잔존 — issue-level 코멘트에 finding 평가 본문 포함 금지 (AC2)"
-fi
-grep -qF "side: 'RIGHT'" "$WORKFLOW" \
-  || fail "inline comment 의 side='RIGHT' 지정 부재"
-grep -qF 'start_line' "$WORKFLOW" \
-  || fail "multi-line inline comment 의 start_line 처리 부재"
-grep -qF "event === 'APPROVE'" "$WORKFLOW" \
-  || fail "APPROVE event 분기 부재"
-# AC16(e): REQUEST_CHANGES review event 를 제출하는 분기가 존재하면 실패.
-if grep -qF 'REQUEST_CHANGES' "$WORKFLOW"; then
-  fail "REQUEST_CHANGES 잔존 — 공식 review event 는 APPROVE/COMMENT 만 (AC10/AC11)"
-fi
-grep -qF "fs.writeFileSync('.codex-review/approval-failed'" "$WORKFLOW" \
-  || fail "APPROVE 실패 시 approval-failed marker 부재"
-grep -qF "'github-actions[bot]'" "$WORKFLOW" \
-  || fail "self-review 식별 (github-actions[bot]) 부재"
-grep -qF 'automation_safety' "$WORKFLOW" \
-  || fail "automation_safety gate 부재"
-grep -qF 'confidence_score' "$WORKFLOW" \
-  || fail "confidence_score 부재"
-# inline-fallback 경로는 존재하면 안 된다 (createReview 실패 시 finding 을 issue 코멘트로 덤프 금지, AC2).
-if grep -qF 'inlineFallback' "$WORKFLOW"; then
-  fail "inlineFallback 경로 잔존 — createReview 실패 시 finding 을 issue 코멘트로 덤프하면 AC2 위반"
-fi
-if grep -qF 'inline-fallback-needed' "$WORKFLOW"; then
-  fail "inline-fallback-needed marker 잔존 — inline-only 정책에서 제거되어야 함"
-fi
-# 관리형 issue-level 코멘트 게이트(showFullBody)와 supersede 경로는 제거되어야 한다 (AC1/AC2/AC3).
-if grep -qF 'showFullBody' "$WORKFLOW"; then
-  fail "showFullBody 잔존 — 관리형 코멘트 verdict 게이트 제거되어야 함 (AC3)"
-fi
-if grep -qF 'Superseded stale managed comment' "$WORKFLOW"; then
-  fail "관리형 코멘트 supersede 경로 잔존 — issue-level 코멘트 채널 제거되어야 함 (AC2)"
-fi
-ok "check 10: createReview + inline comments + APPROVE/COMMENT only + 관리형 채널 부재"
+ok "check 22: PR body 직접 주입 없음"
 
 echo ""
-echo "=== check 10b: formal review idempotent per (head_sha, verdict) ==="
-grep -qF '<!-- ${prefix} head_sha=${head_sha} verdict=${verdict} -->' "$WORKFLOW" \
-  || fail "formal review 중복 방지 marker template 부재"
-grep -qF 'github.rest.pulls.listReviews' "$WORKFLOW" \
-  || fail "기존 review 조회 (pulls.listReviews) 부재"
-grep -qF "r.state === 'APPROVED' && r.commit_id === head_sha" "$WORKFLOW" \
-  || fail "동일 head_sha approve 중복 방지 부재"
-grep -qF 'already exists; skipping duplicate' "$WORKFLOW" \
-  || fail "marker 기반 중복 review skip 메시지 부재"
-ok "check 10b: marker + APPROVED state + head_sha 기준 멱등 (REST botLogin 식별 불변, AC14)"
-
-echo ""
-echo "=== check 10c: dismiss-on-approve(CHANGES_REQUESTED dismiss) 로직 제거됨 (AC13) ==="
-if grep -qF 'github.rest.pulls.dismissReview' "$WORKFLOW"; then
-  fail "dismissReview 잔존 — dismiss-on-approve 로직 제거 필요 (AC13)"
-fi
-if grep -qF 'CHANGES_REQUESTED' "$WORKFLOW"; then
-  fail "CHANGES_REQUESTED 잔존 — REQUEST_CHANGES 폐지로 거둘 대상 없음 (AC13)"
-fi
-if grep -qF 'verdictIsApprove' "$WORKFLOW"; then
-  fail "verdictIsApprove 게이트 잔존 — self thread resolve 는 verdict 무관이어야 함 (AC6)"
-fi
-ok "check 10c: dismiss-on-approve / CHANGES_REQUESTED 제거됨"
-
-echo ""
-echo "=== check 10e: finding-unit (fingerprint) self inline thread resolve, verdict 무관 (AC1~AC9) ==="
-# AC1/AC9: 게시 inline 마커가 기존 self-식별 substring 을 보존하면서 finding fingerprint 운반.
-grep -qF '<!-- codex-review-inline' "$WORKFLOW" \
-  || fail "inline self-식별 마커 substring(<!-- codex-review-inline) 부재 (AC9 기존 식별 보존)"
-# AC1: 게시 inline 마커는 워크플로가 결정론적으로 계산한 fingerprint 를 운반한다.
-grep -qF 'fingerprint=${computeFingerprint(f)}' "$WORKFLOW" \
-  || fail "게시 inline 마커가 결정론적 computeFingerprint(f) 를 운반하지 않음 (AC1)"
-if grep -qF 'fingerprint=${f.fingerprint}' "$WORKFLOW"; then
-  fail "게시 마커가 모델 자유 생성 f.fingerprint 를 운반 — 결정론 계산으로 전환되어야 함 (AC1)"
-fi
-# AC3: resolved_threads 소비 1차 경로.
-grep -qF 'resolved_threads' "$WORKFLOW" \
-  || fail "resolved_threads 소비 경로 부재 (AC3)"
-grep -qF 'resolvedFingerprints' "$WORKFLOW" \
-  || fail "resolved_threads fingerprint 집합(resolvedFingerprints) 부재 (AC3)"
-# AC4: fingerprint-부재 fallback 2차 경로.
-grep -qF 'findingFingerprints' "$WORKFLOW" \
-  || fail "이번 라운드 findings fingerprint 집합(findingFingerprints) 부재 (AC4 fallback)"
-# AC6: verdict 게이트 밖에서 매 실행 resolve (sentinel 마커).
-grep -qF 'regardless of verdict' "$WORKFLOW" \
-  || fail "resolve 가 verdict 무관 실행임을 명시하는 마커(regardless of verdict) 부재 (AC6)"
-grep -qF 'resolveReviewThread' "$WORKFLOW" \
-  || fail "GraphQL resolveReviewThread mutation 호출 부재 — self inline thread 자동 resolve 안 됨"
-grep -qF 'botLoginGql' "$WORKFLOW" \
-  || fail "GraphQL author login 형식 정규화(botLoginGql) 부재 (AC9)"
-grep -qF 'isResolved' "$WORKFLOW" \
-  || fail "isResolved 조건 검사 부재 (AC8 이미 resolved thread skip)"
-grep -qF 'reviewThreads(first: 100)' "$WORKFLOW" \
-  || fail "GraphQL reviewThreads 쿼리 부재"
-ok "check 10e: fingerprint 운반 + resolved_threads 1차 + fallback 2차 + verdict 무관 resolve"
-
-echo ""
-echo "=== check 10g: 결정론적 fingerprint 계산 — file+perspective+normalized title, 줄번호 비의존 (AC1/AC2/AC7) ==="
-# AC1/AC2: fingerprint 는 finding 의 안정 속성(파일 경로·리뷰 관점·정규화 제목)에서만
-# 결정론적으로 계산되며 line/start_line 에는 의존하지 않는다 — 줄 이동에도 동일 fp.
-grep -qF 'computeFingerprint' "$WORKFLOW" \
-  || fail "결정론적 fingerprint 계산 함수(computeFingerprint) 부재 (AC1)"
-grep -qF 'crypto' "$WORKFLOW" \
-  || fail "fingerprint 해시 계산(crypto) 부재 (AC1)"
-grep -qF "[f.file || '', f.review_perspective || '', normalizeTitle(f.title)]" "$WORKFLOW" \
-  || fail "fingerprint 입력이 file+review_perspective+normalized title 로 한정되지 않음 (AC1 제약)"
-# 정규화 방식은 두 워크플로에서 동일해야 한다(제약). 정확한 구현 라인을 잠근다.
-grep -qF "replace(/[^\\p{L}\\p{N}]+/gu, ' ')" "$WORKFLOW" \
-  || fail "제목 정규화(문장부호/공백 → 단일 공백) 구현 부재 또는 불일치 (제약: 두 워크플로 동일)"
-grep -qF "normalize('NFKC')" "$WORKFLOW" \
-  || fail "제목 정규화 NFKC 부재 또는 불일치 (제약: 두 워크플로 동일)"
-# 줄 비의존: findingFingerprints 가 모델 f.fingerprint 가 아니라 computeFingerprint 로 산정.
-grep -qF 'findings.map((f) => computeFingerprint(f))' "$WORKFLOW" \
-  || grep -qF 'findings.map(computeFingerprint)' "$WORKFLOW" \
-  || fail "findingFingerprints 가 결정론적 computeFingerprint 로 산정되지 않음 (AC4)"
-ok "check 10g: 결정론적 fingerprint(file+perspective+title), 줄번호 비의존"
-
-echo ""
-echo "=== check 10f: request_changes verdict 어휘 제거 (workflow) (AC12/AC16f) ==="
-# may_request_changes 필드(automation_safety)는 유지(non-goal). 그 외 request_changes 토큰 금지.
-if grep -oE '[a-z_]*request_changes' "$WORKFLOW" | grep -qvE '^may_request_changes$'; then
-  fail "request_changes verdict 어휘 잔존 (may_request_changes 외) — workflow 에서 제거 필요 (AC12)"
-fi
-ok "check 10f: workflow verdict 어휘에 request_changes 없음 (may_request_changes 만 잔존)"
-
-echo ""
-echo "=== check 10d: managed comment 은 finding 평가 본문을 렌더하지 않는다 (inline-only) ==="
-# inline-only 정책: finding 평가는 inline 코멘트 전용. managed(issue-level) comment 에
-# finding 상세를 렌더하던 inlineDetailText / renderIssue 경로는 제거되어야 한다 (AC2/AC4).
-if grep -qF 'inlineDetailText' "$WORKFLOW"; then
-  fail "inlineDetailText 잔존 — managed comment 에 inline finding 상세 렌더 금지 (AC2)"
-fi
-if grep -qF 'renderIssue' "$WORKFLOW"; then
-  fail "renderIssue 잔존 — issue-level 코멘트에 finding 평가 본문 렌더 금지 (AC2)"
-fi
-if grep -qF 'review submission failed; included here for visibility' "$WORKFLOW"; then
-  fail "inline-fallback 본문 헤더 잔존 — inline-only 정책에서 제거되어야 함"
-fi
-ok "check 10d: managed comment 에 finding 평가 렌더 경로 제거됨"
-
-echo ""
-echo "=== check 11b: 출력 언어 untrusted block 끝에 재강조 (영어 응답 예방) ==="
-grep -qF '## 마지막 재강조 (절대 위반 금지)' "$WORKFLOW" \
-  || fail "마지막 재강조 섹션 부재 — 모델이 untrusted PR diff 뒤에서 출력 언어 지시 흘릴 수 있음"
-grep -qF '영어 등 다른 언어로 작성하면 안 됩니다' "$WORKFLOW" \
-  || fail "출력 언어 명시적 강제 라인 부재"
-grep -qF '"$CODEX_REVIEW_LANG"' "$WORKFLOW" \
-  || fail "재강조 라인이 CODEX_REVIEW_LANG 변수를 사용하지 않음"
-ok "check 11b: untrusted block 끝에 출력 언어 재강조"
-
-echo ""
-echo "=== check 11: prompt captures token and confidence policies ==="
+echo "=== check 23: prompt 핵심 정책 보존 (비-목표: prompt 내용 불변) ==="
 grep -q '토큰 최적화 정책' "$PROMPT" \
   || fail "prompt 토큰 최적화 정책 부재"
 grep -q 'Confidence scoring' "$PROMPT" \
@@ -342,74 +330,10 @@ grep -q 'confidence_score < 80' "$PROMPT" \
   || fail "prompt confidence threshold 정책 부재"
 grep -q 'valid JSON' "$PROMPT" \
   || fail "prompt JSON-only 출력 규칙 부재"
-if grep -q '동일 head_sha에 대해 Codex 리뷰가 이미 완료' "$PROMPT"; then
-  fail "prompt 가 동일 head_sha 기존 Codex 리뷰만으로 리뷰를 skip 하도록 지시함"
-fi
-ok "check 11: prompt 핵심 정책 존재"
+ok "check 23: prompt 핵심 정책 존재"
 
 echo ""
-echo "=== check 11c: inline-only 코멘트 정책 (prompt + schema) ==="
-# 모든 finding 은 inline 코멘트로만. anchor 불가 finding 도 가장 가까운 변경 라인에 inline,
-# 본문에 실제 위치 명시. issue-level 코멘트로 finding 을 보고하지 않는다 (AC1/AC2/AC5).
-grep -q 'inline' "$PROMPT" \
-  || fail "prompt inline 코멘트 정책 부재"
-grep -q '가장 가까운 변경' "$PROMPT" \
-  || fail "prompt 에 anchor 불가 finding 을 가장 가까운 변경 라인에 inline 으로 붙이는 지침 부재 (AC5)"
-grep -q '실제 위치' "$PROMPT" \
-  || fail "prompt 에 inline 본문에 실제 문제 위치(파일·라인) 명시 지침 부재 (AC5)"
-if grep -q 'issue-level comment로 보고' "$PROMPT"; then
-  fail "prompt 가 finding 을 issue-level comment 로 보고하도록 지시함 — inline-only 정책 위반"
-fi
-grep -q 'inline comment로만 보고' "$PROMPT" \
-  || fail "prompt inline-only 보고 지침 부재 (모든 finding 은 inline)"
-# schema: comment_type enum 은 inline 전용
-grep -qF '"inline"' "$SCHEMA" \
-  || fail "schema comment_type 에 inline 값 부재"
-if grep -qF '"issue"' "$SCHEMA"; then
-  fail "schema comment_type enum 에 issue 잔존 — inline-only 정책에서 제거되어야 함"
-fi
-ok "check 11c: prompt·schema 가 inline-only + 강제 anchoring 정책을 반영"
-
-echo ""
-echo "=== check 11d: resolved_threads 채우기 지시 + request_changes 어휘 제거 (prompt·schema) ==="
-# AC2: 기존 self thread 마커 fingerprint 근거로 resolved_threads 를 채우라는 지시.
-grep -q 'resolved_threads' "$PROMPT" \
-  || fail "prompt 에 resolved_threads 기록 지시 부재 (AC2)"
-grep -q 'fingerprint' "$PROMPT" \
-  || fail "prompt 에 fingerprint 근거 지시 부재 (AC2)"
-# AC12/AC16(f): request_changes 어휘가 prompt·schema verdict enum 에서 제거.
-if grep -qF 'request_changes' "$PROMPT"; then
-  fail "prompt 에 request_changes 어휘 잔존 — 모델이 산출하지 않도록 제거 필요 (AC12)"
-fi
-if grep -oE '[a-z_]*request_changes' "$SCHEMA" | grep -qvE '^may_request_changes$'; then
-  fail "schema verdict enum 에 request_changes 잔존 (AC12)"
-fi
-grep -q 'may_request_changes' "$SCHEMA" \
-  || fail "may_request_changes 필드가 schema 에서 제거됨 — non-goal: 미사용으로 남기되 유지해야 함"
-ok "check 11d: resolved_threads 지시 + request_changes 어휘 제거 (may_request_changes 필드 유지)"
-
-echo ""
-echo "=== check 11e: 프롬프트 마커 형식이 실제 게시·매칭 마커와 일치 (AC5/AC7) ==="
-# AC5: 프롬프트가 모델에게 기존 self thread fingerprint 출처로 안내하는 마커 형식은,
-# 워크플로가 실제 게시(fingerprintMarker)하고 resolve 시 매칭(fpRe)하는 마커와 동일해야 한다.
-# 워크플로 실제 마커: <!-- codex-review-inline fingerprint=... -->
-grep -qF 'codex-review-inline fingerprint=' "$PROMPT" \
-  || fail "프롬프트가 실제 게시·매칭 마커 형식(codex-review-inline fingerprint=)을 가리키지 않음 (AC5)"
-# 어긋난 옛 JSON 마커 형식(<!-- codex-review: {json} -->)은 제거되어야 한다.
-if grep -qF '<!-- codex-review:' "$PROMPT"; then
-  fail "프롬프트에 옛 JSON 마커 형식(<!-- codex-review:) 잔존 — 실제 마커와 어긋남 (AC5)"
-fi
-# 프롬프트는 모델이 fingerprint 를 생성하지 않음을 반영해야 한다(줄 기반 생성 지시 제거).
-if grep -q 'changed line' "$PROMPT"; then
-  fail "프롬프트에 changed line 기반 fingerprint 생성 지시 잔존 — 결정론 계산은 워크플로 소관 (AC1)"
-fi
-# 워크플로의 게시 마커와 매칭 정규식이 동일 substring 을 공유하는지(자체 정합) 확인.
-grep -qF 'codex-review-inline fingerprint=' "$WORKFLOW" \
-  || fail "워크플로 마커 substring(codex-review-inline fingerprint=)이 프롬프트 안내와 불일치 (AC5)"
-ok "check 11e: 프롬프트 마커 == 실제 게시·매칭 마커"
-
-echo ""
-echo "=== check 12: schema requires automation safety and context fields ==="
+echo "=== check 24: 공유 schema 핵심 필드 존재 (비-목표: schema 불변) ==="
 grep -q '"automation_safety"' "$SCHEMA" \
   || fail "schema automation_safety 부재"
 grep -q '"reviewed_context"' "$SCHEMA" \
@@ -418,60 +342,17 @@ grep -q '"confidence_score"' "$SCHEMA" \
   || fail "schema confidence_score 부재"
 grep -q '"context_requests"' "$SCHEMA" \
   || fail "schema context_requests 부재"
-ok "check 12: schema 핵심 필드 존재"
+ok "check 24: schema 핵심 필드 존재"
 
 echo ""
-echo "=== check 13: PR 게시 보일러플레이트 한국어화 (SPEC 2026-05-31) ==="
-# AC1/AC6: 섹션 헤더 한국어. PR 코멘트 본문 헤더(## 접두)만 검사 — 워크플로 name 은 제외.
-grep -qF '## Codex PR 리뷰' "$WORKFLOW" \
-  || fail "한국어 섹션 헤더 '## Codex PR 리뷰' 부재"
-if grep -qF '## Codex PR Review' "$WORKFLOW"; then
-  fail "영어 섹션 헤더 '## Codex PR Review' 잔존"
-fi
-# AC1: approve 안내 문구 한국어.
-grep -qF '_승인 — 지적 사항은 인라인 코멘트 참조._' "$WORKFLOW" \
-  || fail "한국어 승인 안내 문구 부재"
-if grep -qF 'Approved by automated review' "$WORKFLOW"; then
-  fail "영어 승인 안내 문구 잔존"
-fi
-# NOTE: 관리형 issue-level 코멘트(②) 채널 제거(SPEC 2026-05-31-codex-review-approve-managed-comment)로
-# 그 스텝에만 있던 한국어 라벨('승인 — 차단 지적 없음', '승인 가능 — 단, 토큰 권한으로 정식 승인 미제출',
-# verdict 표시 줄 '결과: 승인')은 더 이상 존재하지 않는다. 해당 단언은 채널과 함께 제거됨.
-# 정식 리뷰(①) 본문의 한국어 보일러플레이트(위 섹션 헤더·승인 안내)는 유지·검증한다.
-# AC5 제약: 숨김 마커의 verdict enum 값(verdict=...) 은 변경 금지.
-grep -qF 'head_sha=${head_sha} verdict=${verdict}' "$WORKFLOW" \
-  || fail "숨김 멱등성 마커의 verdict enum 바인딩이 변경됨 (멱등성·승인 게이팅 위험)"
-ok "check 13: 보일러플레이트 한국어화 + 숨김 마커/enum 보존"
-
-echo ""
-echo "=== check 14: GitHub App 설치 토큰 발급 + identity 통일 + graceful fallback + self-trigger 게이트 (SPEC 2026-05-31 app-token-approve) ==="
-# AC1/제약(토큰 발급 방식): actions/create-github-app-token 으로 단명 설치 토큰 발급, SHA 고정.
-grep -qE 'uses: actions/create-github-app-token@[0-9a-f]{40}' "$WORKFLOW" \
-  || fail "actions/create-github-app-token SHA 고정 발급 스텝 부재 (단명 설치 토큰, 장기 PAT 금지)"
-grep -qF 'id: app-token' "$WORKFLOW" \
-  || fail "App 토큰 스텝 id(app-token) 부재 — outputs.token 참조 불가"
-# AC5/제약(graceful degradation): 시크릿 없으면 스텝 skip, 실패해도 job 중단 금지.
-grep -qF 'REVIEW_APP_ID' "$WORKFLOW" \
-  || fail "App 토큰 발급 게이트(REVIEW_APP_ID 시크릿 존재 판정) 부재 — 시크릿 미구성 환경 graceful skip 불가 (AC5)"
-grep -qF 'continue-on-error: true' "$WORKFLOW" \
-  || fail "App 토큰 발급 실패 시 job 중단 방지(continue-on-error) 부재 (AC5)"
-# AC1/AC2/제약(identity 통일): 게시 스텝 토큰이 App 토큰 우선·없으면 기본 토큰.
-# codex 는 managed comment 채널이 제거되어(PR #261) 게시 스텝이 verdict 제출 1곳뿐이다.
-fallback_count="$(grep -cF 'steps.app-token.outputs.token || github.token' "$WORKFLOW")"
-[[ "$fallback_count" -ge 1 ]] \
-  || fail "게시 스텝 github-token 이 App-토큰-or-기본 토큰 fallback 표현식을 쓰지 않음 (Submit 최소 1곳, 현재 $fallback_count) (AC2/AC5)"
-# AC3/제약(봇 로그인 동적 해석): App 봇 슬러그로 botLogin 해석, 기본 토큰 시 github-actions[bot].
-grep -qF 'app-slug' "$WORKFLOW" \
-  || fail "App 봇 로그인 동적 해석용 app-slug 출력 사용 부재 (AC3)"
-grep -qF 'process.env.APP_SLUG' "$WORKFLOW" \
-  || fail "게시/식별 스텝이 APP_SLUG env 로 봇 로그인 동적 해석 안 함 (AC3)"
-grep -qF "'github-actions[bot]'" "$WORKFLOW" \
-  || fail "기본 토큰 시 botLogin fallback(github-actions[bot]) 부재 (AC3 위험 분기)"
-# AC4/제약(self-trigger 차단): 게이트가 App 봇 identity 가 게시한 이벤트도 배제(3 이벤트 분기).
-appbot_gate_count="$(grep -cF 'vars.REVIEW_APP_BOT_LOGIN' "$WORKFLOW")"
-[[ "$appbot_gate_count" -ge 3 ]] \
-  || fail "self-trigger 게이트에 App 봇(vars.REVIEW_APP_BOT_LOGIN) 배제가 3개 이벤트 분기 모두에 없음 (현재 $appbot_gate_count) (AC4)"
-ok "check 14: App 설치 토큰 발급 + identity 통일 + 봇 로그인 동적 해석 + self-trigger 게이트"
+echo "=== check 25: 출력 언어 untrusted block 끝 재강조 보존 ==="
+grep -qF '## 마지막 재강조 (절대 위반 금지)' "$WORKFLOW" \
+  || fail "마지막 재강조 섹션 부재 — 모델이 untrusted PR diff 뒤에서 출력 언어 지시 흘릴 수 있음"
+grep -qF '영어 등 다른 언어로 작성하면 안 됩니다' "$WORKFLOW" \
+  || fail "출력 언어 명시적 강제 라인 부재"
+grep -qF '"$CODEX_REVIEW_LANG"' "$WORKFLOW" \
+  || fail "재강조 라인이 CODEX_REVIEW_LANG 변수를 사용하지 않음"
+ok "check 25: untrusted block 끝 출력 언어 재강조"
 
 echo ""
 echo "ALL CHECKS PASSED"


### PR DESCRIPTION
## 무엇을

Codex PR 리뷰 워크플로(`codex-review.yml`)의 모델 호출을 codex CLI 직접 실행(`npm install -g @openai/codex` + `codex exec`)에서 공식 GitHub Action **`openai/codex-action`**(SHA 핀)으로 전환하고, 하류 게시 구조를 자매 워크플로 `claude-review.yml`과 **완전 동일**하게 통일했습니다.

SPEC: `docs/specs/2026-06-01-codex-review-via-codex-action/SPEC.md`

## 핵심 변경

- **호출부**: `openai/codex-action` 사용 — `codex-version: 0.132.0`, `sandbox: read-only`, `effort: medium`, `prompt-file`, `output-schema-file`(공유 스키마), `output-file`. 2-pass(needs_context) 흐름 유지.
- **인증(auth.json 유지)**: `CODEX_AUTH_JSON` 시크릿을 `$RUNNER_TEMP/codex-home/auth.json`(chmod 600)으로 부트스트랩하고 디렉터리만 action의 `codex-home` 입력으로 전달. 시크릿 값은 모델 스텝에 미노출, 빈값이면 명확한 오류로 실패. **`OPENAI_API_KEY` 불필요** — ChatGPT 구독 인증 그대로.
- **게시 구조**: verdict를 정식 리뷰 body로 제출 + 마커 기반 관리형 PR 코멘트 1개(Claude 리뷰와 동일). **제거**: 인라인 코멘트 게시, fingerprint self-thread 자동 resolve, GitHub App 토큰 발급·App approve 경로.
- **권한**: 게시 범위(contents:read, pull-requests:write, issues:write)로 한정, id-token 없음.

## 보존(비-목표)

`codex-pr-review.ko.md`·`codex-pr-review.schema.json`·`pr-review-context.sh` 불변, `claude-review.yml` 동작 불변.

## 검증

- 워크플로 contract 테스트(`tests/codex/test-codex-review-workflow.sh`) check 1~25 **전부 통과**.
- 공유 context 테스트 통과, 워크플로 YAML 파싱 OK.

## 위험(수용됨)

- `github-actions[bot]`의 self-approve 한계로 정식 APPROVE가 COMMENT로 강등될 수 있음(Claude 리뷰와 동일).
- 기존 PR에 남은 codex 인라인 코멘트·resolved thread는 새 구조에서 정리되지 않고 잔존(과도기).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
