### PR TITLE
fix(ci): codex-action auth.json 호출에 server-info 시드 추가 (#269 후속)

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -109,6 +109,17 @@ jobs:
           mkdir -p "$codex_home"
           printf '%s' "$CODEX_AUTH_JSON" > "$codex_home/auth.json"
           chmod 600 "$codex_home/auth.json"
+          # Seed a placeholder Responses API proxy "server info" file so the
+          # action's "Read server info" step succeeds. That step is gated on a
+          # prompt being supplied (always true here), but the steps that START
+          # the proxy and WRITE this file are gated on an OpenAI API key input
+          # being set — which we deliberately do not supply, since we auth via
+          # auth.json. Without this seed the read step loops on the missing file
+          # and the job fails with "Failed to read server info". The proxy config
+          # step is also api-key-gated, so it is skipped: the placeholder port is
+          # never dialed and codex talks to OpenAI directly using auth.json.
+          # File name must match action.yml: "$codex_home/<github.run_id>.json".
+          printf '{"port":1}' > "$codex_home/${GITHUB_RUN_ID}.json"
           echo "CODEX_HOME_DIR=$codex_home" >> "$GITHUB_ENV"
 
       - name: Prepare Codex review input

--- a/docs/codex/pr-review-workflow.md
+++ b/docs/codex/pr-review-workflow.md
@@ -17,6 +17,7 @@
 2. trusted base를 checkout하고 base/head와 diff를 공유 helper(`.github/scripts/pr-review-context.sh`)로 수집한다.
 3. `.github/prompts/codex-pr-review.ko.md`를 system prompt처럼 붙이고 untrusted PR context(metadata·comments·diff)와 출력 언어 지시를 더해 프롬프트 파일을 조립한다.
 4. 공식 action `openai/codex-action`을 호출한다. 공유 스키마(`.github/prompts/codex-pr-review.schema.json`)는 `output-schema-file` 입력으로, 조립한 프롬프트는 `prompt-file` 입력으로, 샌드박스는 `read-only`, reasoning effort는 `medium`, 결과 JSON은 `output-file` 입력으로 수신하고, auth.json 디렉터리는 `codex-home` 입력으로 전달한다.
+   - **server-info 시드(중요)**: action은 API 키가 있을 때만 Responses API 프록시를 띄워 `<codex-home>/<run_id>.json`(server-info)을 쓰지만, 그 파일을 읽는 "Read server info" 스텝은 프롬프트만 있으면 무조건 실행된다. API 키 없이 auth.json만 쓰면 읽을 파일이 없어 `Failed to read server info`로 죽는다. 그래서 부트스트랩 단계에서 codex-home에 `auth.json`과 함께 더미 server-info(`{"port":1}`)를 같은 `<run_id>.json` 이름으로 미리 심는다. 프록시 설정 스텝도 API 키 게이트라 건너뛰므로 더미 port는 실제로 연결되지 않고 codex는 auth.json으로 OpenAI에 직접 인증한다. (이 시드는 고정한 action SHA의 step 게이트 동작에 결합되어 있다 — action 갱신 시 재검증 필요.)
 5. 결과 JSON을 저장 직후 `jq empty`로 유효성을 검증한다.
 6. 모델이 `needs_context`를 반환하면 요청 파일(최대 5개)을 PR head에서 수집해 2차 호출로 최종 verdict를 받는다(Claude 리뷰와 동일한 2-pass 흐름).
 7. 게시는 자매 Claude 워크플로와 **동일한 구조**다(`claude-review.yml`의 'Submit … review verdict' + 'Post … review comment' 스텝을 codex 라벨·마커로 치환).

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -73,7 +73,14 @@ grep -q 'codex-home: ${{ env\.CODEX_HOME_DIR }}' "$WORKFLOW" \
 codex_home_input_count="$(count 'codex-home: ${{ env.CODEX_HOME_DIR }}' "$WORKFLOW")"
 [[ "$codex_home_input_count" == "2" ]] \
   || fail "codex-home 입력이 1차/2차 action 호출 양쪽에 전달되지 않음 (현재 $codex_home_input_count)"
-ok "check 4: CODEX_AUTH_JSON → codex-home/auth.json(600) → action codex-home 입력"
+# Placeholder server-info seed: the action's "Read server info" step fires on
+# prompt presence but the proxy that writes that file only runs with an API
+# key. Without the seed the job dies on "Failed to read server info". The seed
+# file name must be "<codex_home>/<github.run_id>.json" per action.yml.
+grep -q 'port' "$WORKFLOW" \
+  && grep -Eq '"\$codex_home/\$\{GITHUB_RUN_ID\}\.json"|\$codex_home/\$GITHUB_RUN_ID\.json' "$WORKFLOW" \
+  || fail "codex-home 에 더미 server-info(<run_id>.json, port) 시드 부재 — auth.json 단독 호출 시 'Read server info' 실패 회귀 (AC2)"
+ok "check 4: CODEX_AUTH_JSON → codex-home/auth.json(600) + server-info 시드 → action codex-home 입력"
 
 echo ""
 echo "=== check 5: auth 디렉터리가 restrictive umask 아래 생성됨 (제약) ==="

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -76,10 +76,13 @@ codex_home_input_count="$(count 'codex-home: ${{ env.CODEX_HOME_DIR }}' "$WORKFL
 # Placeholder server-info seed: the action's "Read server info" step fires on
 # prompt presence but the proxy that writes that file only runs with an API
 # key. Without the seed the job dies on "Failed to read server info". The seed
-# file name must be "<codex_home>/<github.run_id>.json" per action.yml.
-grep -q 'port' "$WORKFLOW" \
-  && grep -Eq '"\$codex_home/\$\{GITHUB_RUN_ID\}\.json"|\$codex_home/\$GITHUB_RUN_ID\.json' "$WORKFLOW" \
-  || fail "codex-home 에 더미 server-info(<run_id>.json, port) 시드 부재 — auth.json 단독 호출 시 'Read server info' 실패 회귀 (AC2)"
+# file name must be "<codex_home>/<github.run_id>.json" per action.yml, and the
+# JSON must carry a numeric "port" (read-server-info skips a non-numeric port).
+# Assert port + run_id filename on the SAME line so a seed that drops the port
+# (e.g. printf '{}' > ".../<run_id>.json") fails — a separate `grep port` would
+# pass on unrelated tokens like "export" elsewhere in the workflow.
+grep -Eq "printf '\{\"port\":[0-9]+\}' > \"\\\$codex_home/\\\$\{GITHUB_RUN_ID\}\.json\"" "$WORKFLOW" \
+  || fail "codex-home 에 더미 server-info 시드(<run_id>.json, numeric port) 부재 — auth.json 단독 호출 시 'Read server info' 실패 회귀 (AC2)"
 ok "check 4: CODEX_AUTH_JSON → codex-home/auth.json(600) + server-info 시드 → action codex-home 입력"
 
 echo ""


### PR DESCRIPTION
## 배경

#269가 머지된 직후, 그 버전의 `codex-review.yml`은 PR에서 **Codex PR Review 체크가 실패**합니다:

```
Error: Failed to read server info from /home/runner/work/_temp/codex-home/<run_id>.json
```

`openai/codex-action`은 기본적으로 Responses API 프록시를 통해 codex를 실행합니다. 프록시를 띄우고 server-info(`<codex-home>/<run_id>.json`)를 쓰는 스텝들은 `openai-api-key`가 있을 때만 동작하지만, 그 파일을 **읽는** "Read server info" 스텝은 prompt만 있으면 무조건 실행됩니다. 우리는 API 키 없이 `auth.json`(ChatGPT 구독)으로 인증하므로 — 읽을 파일이 없어 잡이 죽습니다.

(#269 자체는 `7848f48` 상태로 머지되어, 이 수정이 그 위에 누락되었습니다.)

## 변경

부트스트랩 단계에서 codex-home에 `auth.json`과 함께 **더미 server-info**(`{"port":1}`)를 같은 `<run_id>.json` 이름으로 미리 심습니다.

- `read-server-info`는 JSON에서 numeric `port`만 추출하고 프록시 생존을 검증하지 않으므로 통과합니다.
- 프록시 설정(`write-proxy-config`) 스텝도 api-key 게이트라 건너뛰므로 더미 port는 연결되지 않고, codex는 `auth.json`으로 OpenAI에 직접 인증합니다(구 직접 호출과 동치).

계약 테스트에 시드 단언 추가, 설계 문서 갱신.

## 검증

- `tests/codex/test-codex-review-workflow.sh` check 1~25 전부 통과.
- 소스 검증(pinned SHA `e0fdf01`): action.yml step 게이트, `readServerInfo`(numeric port만), `resolveCodexHome`(override 그대로 반환), `writeProxyConfig`(api-key 게이트).

## 주의

이 시드는 고정한 action SHA의 step 게이트 동작에 결합되어 있습니다 — action 버전 갱신 시 재검증이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
