### PR TITLE
fix(ci): claude-review 구조화 출력을 prompt schema + 결과 텍스트 파싱으로 안정화

### DIFF
--- a/.github/prompts/claude-pr-review.ko.md
+++ b/.github/prompts/claude-pr-review.ko.md
@@ -9,8 +9,8 @@
 - 이 프롬프트는 특정 병렬 실행 방식을 가정하지 않습니다.
 - 입력으로 제공된 diff/context 범위 안에서 판단합니다.
 - context가 부족하면 추측하지 말고 `needs_context` 또는 `unavailable` verdict를 반환합니다.
-- 최종 응답은 반드시 제공된 JSON schema를 만족하는 구조화 출력(structured output) 하나로만 제출합니다.
-- 구조화 출력은 schema의 모든 required 필드를 채우고 enum·타입을 그대로 따릅니다. 별도 custom tool 이름(예: submit_pr_review)을 가정하지 말고, `--json-schema`가 제공하는 structured-output 메커니즘으로만 제출합니다.
+- 최종 응답은 프롬프트 본문에 포함된 JSON Schema 를 만족하는 JSON 객체 하나로만 출력합니다.
+- JSON 객체는 schema의 모든 required 필드를 채우고 enum·타입을 그대로 따릅니다. 코드펜스(```)나 산문, 추가 설명, 별도 도구 호출 없이 JSON 객체 텍스트만 출력합니다.
 
 입력:
 - Pull Request metadata
@@ -129,5 +129,5 @@ Evidence requirement:
 - 수정하지 않은 라인의 pre-existing issue
 
 출력 규칙:
-마크다운 설명, 코드블록, 추가 문장은 출력하지 않습니다.
-반드시 제공된 JSON schema를 만족하는 구조화 출력(structured output)으로만 결과를 제출합니다.
+마크다운 설명, 코드펜스(```), 추가 문장은 출력하지 않습니다.
+프롬프트 본문에 포함된 JSON Schema 를 만족하는 JSON 객체 하나만, 선행·후행 산문 없이 그대로 출력합니다.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -147,22 +147,30 @@ jobs:
             printf '\n'
           } >> .claude-review/prompt.md
 
+          # Embed the shared review schema into the prompt body and instruct the
+          # model to emit a single JSON object. We no longer rely on the forced
+          # structured output channel; the complex shared schema made the model
+          # frequently answer in plain text without calling that tool, which
+          # aborted the step. Instead the workflow extracts JSON from the
+          # model's result text.
           {
-            printf 'schema<<EOF\n'
-            jq -c . "$REVIEW_SCHEMA"
-            printf '\nEOF\n'
-          } >> "$GITHUB_OUTPUT"
+            printf '\n\n---\n\n'
+            printf '출력 형식 지시:\n'
+            printf '위 리뷰 정책에 따라, 아래 JSON Schema 를 만족하는 JSON 객체 하나만 출력하세요.\n'
+            printf '코드펜스(```)나 산문, 추가 설명을 붙이지 말고 JSON 객체만 출력합니다.\n\n'
+            printf 'JSON Schema:\n'
+            cat "$REVIEW_SCHEMA"
+            printf '\n'
+          } >> .claude-review/prompt.md
 
           # Inline the full review prompt as a step output so the model receives it
           # directly (mirroring the Codex workflow's stdin injection) instead of
-          # reading a file agentically. The read-then-respond agentic flow caused
-          # claude-code-action to finish with "Result subtype: success" but no
-          # structured_output, failing the --json-schema contract.
+          # reading a file agentically.
           prompt_delim="CLAUDE_PROMPT_EOF_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}"
           {
             printf 'prompt<<%s\n' "$prompt_delim"
             cat .claude-review/prompt.md
-            printf '\n\nReturn only the structured review object required by the JSON schema.\n'
+            printf '\n\n스키마에 맞는 JSON 객체 하나만 출력하세요. 코드펜스나 산문은 붙이지 마세요.\n'
             printf '%s\n' "$prompt_delim"
           } >> "$GITHUB_OUTPUT"
 
@@ -178,14 +186,62 @@ jobs:
           prompt: ${{ steps.prepare-claude-review.outputs.prompt }}
           claude_args: |
             --model ${{ vars.CLAUDE_REVIEW_MODEL || 'claude-sonnet-4-5-20250929' }}
-            --json-schema '${{ steps.prepare-claude-review.outputs.schema }}'
 
       - name: Save Claude review result
         env:
-          CLAUDE_STRUCTURED_OUTPUT: ${{ steps.claude-review.outputs.structured_output }}
+          CLAUDE_EXECUTION_FILE: ${{ steps.claude-review.outputs.execution_file }}
         run: |
           set -euo pipefail
-          printf '%s\n' "$CLAUDE_STRUCTURED_OUTPUT" > .claude-review/result.json
+          # Extract the JSON review object from the model's final result text in
+          # the action execution log (no forced structured-output channel).
+          python3 - "$CLAUDE_EXECUTION_FILE" .claude-review/result.json <<'PY'
+          import json, re, sys
+
+          exec_file, out_path = sys.argv[1], sys.argv[2]
+
+          with open(exec_file) as fh:
+              raw = fh.read()
+
+          messages = []
+          try:
+              data = json.loads(raw)
+              messages = data if isinstance(data, list) else [data]
+          except json.JSONDecodeError:
+              for line in raw.splitlines():
+                  line = line.strip()
+                  if not line:
+                      continue
+                  try:
+                      messages.append(json.loads(line))
+                  except json.JSONDecodeError:
+                      continue
+
+          text = ""
+          for msg in messages:
+              if isinstance(msg, dict) and msg.get("type") == "result" and msg.get("result"):
+                  text = msg["result"]
+
+          if not text:
+              sys.exit("Claude 실행 로그(execution_file)에서 최종 결과 메시지를 찾지 못했습니다.")
+
+          # Strip any code fences / surrounding prose: keep first '{' .. last '}'.
+          match = re.search(r"\{.*\}", text, re.DOTALL)
+          if not match:
+              sys.exit("Claude 결과 텍스트에서 JSON 객체를 추출하지 못했습니다.")
+
+          try:
+              obj = json.loads(match.group(0))
+          except json.JSONDecodeError as exc:
+              sys.exit("추출한 JSON 이 유효하지 않습니다: %s" % exc)
+
+          required = ["verdict", "eligibility", "findings", "automation_safety", "reviewed_context"]
+          missing = [key for key in required if key not in obj]
+          if missing:
+              sys.exit("결과 JSON 에 필수 필드가 없습니다: %s" % ", ".join(missing))
+
+          with open(out_path, "w") as fh:
+              json.dump(obj, fh)
+          PY
           jq empty .claude-review/result.json
 
       - name: Prepare Claude follow-up context
@@ -256,15 +312,62 @@ jobs:
           prompt: ${{ steps.prepare-claude-follow-up.outputs.prompt }}
           claude_args: |
             --model ${{ vars.CLAUDE_REVIEW_MODEL || 'claude-sonnet-4-5-20250929' }}
-            --json-schema '${{ steps.prepare-claude-review.outputs.schema }}'
 
       - name: Save Claude follow-up review result
         if: steps.prepare-claude-follow-up.outputs.has_extra_context == 'true'
         env:
-          CLAUDE_STRUCTURED_OUTPUT: ${{ steps.claude-follow-up-review.outputs.structured_output }}
+          CLAUDE_EXECUTION_FILE: ${{ steps.claude-follow-up-review.outputs.execution_file }}
         run: |
           set -euo pipefail
-          printf '%s\n' "$CLAUDE_STRUCTURED_OUTPUT" > .claude-review/result.json
+          # Same extraction as the first pass: JSON object from the model's final
+          # result text in the action execution log.
+          python3 - "$CLAUDE_EXECUTION_FILE" .claude-review/result.json <<'PY'
+          import json, re, sys
+
+          exec_file, out_path = sys.argv[1], sys.argv[2]
+
+          with open(exec_file) as fh:
+              raw = fh.read()
+
+          messages = []
+          try:
+              data = json.loads(raw)
+              messages = data if isinstance(data, list) else [data]
+          except json.JSONDecodeError:
+              for line in raw.splitlines():
+                  line = line.strip()
+                  if not line:
+                      continue
+                  try:
+                      messages.append(json.loads(line))
+                  except json.JSONDecodeError:
+                      continue
+
+          text = ""
+          for msg in messages:
+              if isinstance(msg, dict) and msg.get("type") == "result" and msg.get("result"):
+                  text = msg["result"]
+
+          if not text:
+              sys.exit("Claude 실행 로그(execution_file)에서 최종 결과 메시지를 찾지 못했습니다.")
+
+          match = re.search(r"\{.*\}", text, re.DOTALL)
+          if not match:
+              sys.exit("Claude 결과 텍스트에서 JSON 객체를 추출하지 못했습니다.")
+
+          try:
+              obj = json.loads(match.group(0))
+          except json.JSONDecodeError as exc:
+              sys.exit("추출한 JSON 이 유효하지 않습니다: %s" % exc)
+
+          required = ["verdict", "eligibility", "findings", "automation_safety", "reviewed_context"]
+          missing = [key for key in required if key not in obj]
+          if missing:
+              sys.exit("결과 JSON 에 필수 필드가 없습니다: %s" % ", ".join(missing))
+
+          with open(out_path, "w") as fh:
+              json.dump(obj, fh)
+          PY
           jq empty .claude-review/result.json
 
       - name: Submit Claude review verdict

--- a/docs/specs/2026-06-01-claude-review-structured-output-prompt-schema/SPEC.md
+++ b/docs/specs/2026-06-01-claude-review-structured-output-prompt-schema/SPEC.md
@@ -1,0 +1,57 @@
+---
+scope:
+  include:
+    - .github/workflows/claude-review.yml
+    - tests/claude/test-claude-review-workflow.sh
+    - .github/prompts/claude-pr-review.ko.md
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+ears_language: ko
+---
+
+# claude-review structured output을 prompt schema + 결과 텍스트 파싱으로 안정화
+
+## 무엇을 만들 것인가
+<!-- WHAT/HOW 방어선: 무엇을 만들지만 적고 구현 방법·파일·라이브러리·클래스명은 제약으로 이동. -->
+Claude PR 리뷰 워크플로가 모든 PR에서 구조화 결과를 신뢰성 있게 얻도록 결과 획득 방식을 바꾼다. 현재는 모델 호출 액션의 강제 구조화 출력 채널(`--json-schema` → `structured_output`)에 의존하는데, 공유 리뷰 스키마가 복잡해 모델이 구조화 출력 도구를 호출하지 않고 텍스트로 한 번에 응답을 끝내는 경우가 잦고, 그러면 액션이 "구조화 출력이 없다"며 스텝을 오류 종료시켜 이후 게시 단계가 전부 막힌다. 대신 공유 스키마를 프롬프트 본문으로 모델에 전달해 스키마에 맞는 JSON만 출력하도록 지시하고, 워크플로가 모델의 결과 텍스트에서 JSON을 추출해 결과 파일로 저장한 뒤 유효성과 핵심 필드 존재를 확인하는 방식으로 전환한다. 1차 리뷰와 추가 컨텍스트 2차 리뷰 모두 동일 방식을 쓴다. 결과 파일을 소비하는 후속 게시 단계(정식 리뷰 verdict 제출·관리형 PR 코멘트)와 그 동작, 그리고 Codex 리뷰 워크플로·공유 자산은 그대로 둔다.
+
+## 완료 조건
+<!-- 5문장 패턴(항상 / …할 때 / …인 동안 / …이면(오류) / …기능이 켜지면)과 언어 규칙은 references/ears-patterns.md. 각 조건은 관찰 가능하고 독립 검증 가능해야 함. -->
+- PR 리뷰가 트리거되어 Claude 리뷰가 실행될 때, 모델은 공유 리뷰 스키마를 프롬프트로 전달받아 그 스키마에 맞는 JSON 객체를 산출하며, 워크플로는 모델 호출 액션의 강제 구조화 출력 채널(`--json-schema`/`structured_output`)에 의존하지 않는다.
+- Claude 리뷰가 실행되어 모델이 응답을 반환하면, 워크플로는 모델의 결과 텍스트에서 JSON을 추출하고(코드펜스 등 비-JSON 래핑 제거) 결과 파일로 저장한다.
+- 결과 파일을 저장한 뒤, 워크플로는 그 파일이 유효한 JSON이고 후속 게시 단계가 사용하는 핵심 필드(verdict·eligibility·findings 및 automation_safety·reviewed_context)를 포함함을 확인한다.
+- 모델 응답에서 유효한 JSON을 추출하지 못하거나 핵심 필드가 없으면, 워크플로는 그 사실을 알리는 명확한 오류로 실패한다.
+- 모델이 구조화 출력 도구를 호출하지 않고 텍스트로만 응답하더라도, 워크플로는 더 이상 "구조화 출력이 반환되지 않았다"는 사유로 모델 호출 스텝을 오류 종료시키지 않고 결과를 정상 처리한다.
+- 모델이 추가 컨텍스트(needs_context)를 요청하는 2차 리뷰 흐름에서도, 스키마를 프롬프트로 전달하고 결과 텍스트에서 JSON을 추출하는 동일 방식이 적용된다.
+- 항상, 결과 파일을 소비하는 후속 게시 단계(정식 리뷰 verdict 제출, 관리형 PR 코멘트 생성·갱신)의 동작은 변경되지 않는다.
+- 항상, Codex 리뷰 워크플로(`.github/workflows/codex-review.yml`)와 공유 리뷰 컨텍스트 수집 스크립트, 공유 리뷰 스키마는 변경되지 않는다.
+- 워크플로 contract 테스트가 새 방식을 검증하도록 갱신된다 — 스키마를 프롬프트로 전달함·결과 텍스트에서 JSON 추출·핵심 필드 확인의 존재를 단언하고, `--json-schema`/`structured_output` 의존의 부재를 단언하며, 전체 테스트가 통과한다.
+
+## 범위
+포함:
+- `.github/workflows/claude-review.yml` 수정 — 모델 호출에서 강제 구조화 출력 채널 의존을 제거하고, 프롬프트에 공유 스키마를 실어 JSON-only 출력을 지시하며, 결과 텍스트에서 JSON을 추출·저장·검증(유효성 + 핵심 필드)하도록 1차/2차 리뷰 단계를 전환.
+- `tests/claude/test-claude-review-workflow.sh` 갱신 — 새 방식 단언으로 전환(프롬프트 스키마 전달·텍스트 JSON 추출·핵심 필드 확인 존재; `--json-schema`/`structured_output` 의존 부재).
+- `.github/prompts/claude-pr-review.ko.md` — 필요한 경우 JSON-only 출력 지시·스키마 준수 문구 보강(Claude 전용 프롬프트).
+
+비-목표 / 제외:
+- 후속 게시 단계(verdict 제출·관리형 코멘트)의 게이팅·문구·동작 변경.
+- `.github/workflows/codex-review.yml` 변경.
+- `.github/scripts/pr-review-context.sh`·`.github/prompts/codex-pr-review.schema.json`(공유 스키마)·`.github/prompts/codex-pr-review.ko.md` 변경.
+- 공유 스키마 자체의 단순화(공유 자산이므로 손대지 않는다).
+
+## 검증
+<!-- 검증 기준의 단일 출처는 위 "완료 조건"이다. 검증을 실행하는 진입 명령(테스트·lint·빌드)은 SPEC이 선언하지 않는다. -->
+이 SPEC의 인수 바는 위 **완료 조건**이다. 각 조건이 관찰 가능하게 충족되면 충족된 것으로 본다. 검증을 실행하는 진입 명령은 SPEC이 아니라 프로젝트 규칙(`rules/`)이 단일 출처로 정의한다.
+
+## 제약 (있을 때만)
+- 모델 결과 텍스트는 모델 호출 액션이 남기는 실행 로그(execution_file)의 최종 결과 메시지에서 얻는다 — 강제 구조화 출력(`structured_output`) 채널에 의존하지 않는다.
+- 프롬프트에는 공유 스키마(`.github/prompts/codex-pr-review.schema.json`) 내용을 실어 전달하고, "스키마에 맞는 JSON 객체만 출력하고 코드펜스·산문을 붙이지 말 것"을 명시한다. JSON 추출 시 혹시 모를 코드펜스/선행·후행 산문을 제거한다.
+- 핵심 필드 확인은 jq 유효성 + 후속 게시 스텝이 실제로 읽는 필드(verdict·eligibility·findings·automation_safety·reviewed_context)의 존재 확인 수준으로 한다(전체 JSON Schema 강제 검증은 하지 않는다 — 미세한 스키마 어긋남으로 매번 실패하는 위험 회피).
+- 기존 보안 불변식(체크아웃 자격증명 제거, PR 본문 미주입, untrusted 컨텍스트 표시, 액션 SHA 고정)은 유지한다.
+
+## 위험 (있을 때만)
+- 강제 구조화 출력을 떼면 모델이 드물게 비-JSON 산문이나 코드펜스로 감싼 출력을 낼 수 있다. — 코드펜스 제거 + jq 유효성/핵심 필드 확인으로 방어하고, 실패 시 명확한 오류로 떨어뜨린다.
+- 전체 스키마 강제 검증을 하지 않으므로 스키마의 비핵심 필드 누락은 통과할 수 있다. — 후속 게시 스텝이 읽는 핵심 필드만 보장하면 게시 동작은 깨지지 않으므로 수용한다(사용자 선택: jq 유효성 + 핵심 필드 확인).
+- 결과 텍스트 추출이 액션의 실행 로그(execution_file) 형식에 의존한다. — 고정한 액션 SHA 기준으로 형식을 확인하고, 액션 버전 갱신 시 재검증한다.

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -49,12 +49,16 @@ grep -qE 'uses: anthropics/claude-code-action@[0-9a-f]{40}' "$WORKFLOW" \
   || fail "anthropics/claude-code-action SHA 고정 부재"
 grep -q 'claude_code_oauth_token:.*secrets\.CLAUDE_CODE_OAUTH_TOKEN' "$WORKFLOW" \
   || fail "claude_code_oauth_token input 매핑 부재"
-grep -q -- '--json-schema' "$WORKFLOW" \
-  || fail "Claude action json schema 지정 부재"
-grep -q 'steps\.prepare-claude-review\.outputs\.schema' "$WORKFLOW" \
-  || fail "Claude action schema output 연결 부재"
-grep -q 'steps\.claude-review\.outputs\.structured_output' "$WORKFLOW" \
-  || fail "Claude structured_output 저장 부재"
+if grep -q -- '--json-schema' "$WORKFLOW"; then
+  fail "--json-schema 강제 구조화 출력 채널 의존이 남아 있음 (prompt schema 방식으로 전환해야 함)"
+fi
+if grep -q 'structured_output' "$WORKFLOW"; then
+  fail "structured_output 강제 채널 의존이 남아 있음 (execution_file 결과 텍스트 파싱으로 전환해야 함)"
+fi
+grep -qF 'cat "$REVIEW_SCHEMA"' "$WORKFLOW" \
+  || fail "공유 스키마(REVIEW_SCHEMA)를 프롬프트 본문에 싣지 않음 (cat \"\$REVIEW_SCHEMA\" 부재)"
+grep -q 'steps\.claude-review\.outputs\.execution_file' "$WORKFLOW" \
+  || fail "1차 리뷰 결과를 claude-code-action execution_file 에서 가져오지 않음"
 if grep -q -- '--bare' "$WORKFLOW"; then
   fail "--bare 는 OAuth token 대신 API key 를 요구하므로 사용하면 안 됨"
 fi
@@ -65,7 +69,21 @@ grep -q '\.claude-review/result\.json' "$WORKFLOW" \
   || fail "Claude 최종 JSON 출력 파일 지정 부재"
 grep -q 'jq empty \.claude-review/result\.json' "$WORKFLOW" \
   || fail "Claude 최종 JSON jq 검증 부재"
-ok "check 2: pinned claude-code-action + schema + shared context 로 structured review 실행"
+ok "check 2: pinned claude-code-action + prompt schema + shared context 로 review 실행 (강제 구조화 출력 채널 미사용)"
+
+echo ""
+echo "=== check 2c: model result text is parsed into JSON with core-field validation ==="
+grep -q 'JSON 객체를 추출' "$WORKFLOW" \
+  || fail "모델 결과 텍스트에서 JSON 추출 실패 시 명확한 오류 부재"
+grep -q '필수 필드' "$WORKFLOW" \
+  || fail "추출 JSON 핵심 필드 확인(필수 필드) 부재"
+for field in verdict eligibility findings automation_safety reviewed_context; do
+  grep -q "\"$field\"" "$WORKFLOW" \
+    || fail "핵심 필드 확인 목록에 \"$field\" 부재"
+done
+grep -q 'steps\.claude-follow-up-review\.outputs\.execution_file' "$WORKFLOW" \
+  || fail "2차(follow-up) 리뷰도 execution_file 결과 텍스트 파싱을 쓰지 않음"
+ok "check 2c: 결과 텍스트 JSON 추출 + 핵심 필드 검증 (1차/2차 동일)"
 
 echo ""
 echo "=== check 2b: claude workflow supports targeted context follow-up ==="
@@ -175,9 +193,14 @@ grep -q 'Confidence scoring' "$PROMPT" \
   || fail "prompt confidence scoring 정책 부재"
 grep -q 'confidence_score < 80' "$PROMPT" \
   || fail "prompt confidence threshold 정책 부재"
-grep -q 'submit_pr_review' "$PROMPT" \
-  || fail "prompt structured tool output 규칙 부재"
-ok "check 8: prompt 핵심 정책 존재"
+grep -q 'JSON 객체' "$PROMPT" \
+  || fail "prompt JSON-only 출력 지시 부재"
+grep -q '코드펜스' "$PROMPT" \
+  || fail "prompt 코드펜스 금지 지시 부재"
+if grep -qE 'submit_pr_review|--json-schema|structured_output' "$PROMPT"; then
+  fail "prompt 가 강제 구조화 출력 채널/도구를 지시하고 있음 (JSON-only 출력으로 전환해야 함)"
+fi
+ok "check 8: prompt 핵심 정책 + JSON-only 출력 지시 존재"
 
 echo ""
 echo "=== check 9: privileged job checks out trusted base, not PR-controlled code ==="


### PR DESCRIPTION
## 배경

모든 PR에서 **Claude PR Review 체크가 실패**합니다:

```
--json-schema was provided but Claude did not return structured_output. Result subtype: success
```

`claude-code-action`의 `--json-schema`는 에이전트 SDK의 **StructuredOutput 툴 호출**에 의존하는데, 공유 리뷰 스키마(`codex-pr-review.schema.json`: findings 배열·중첩 객체 다수)가 복잡해 모델이 그 툴을 호출하지 않고 텍스트로 1턴 종료(`num_turns:1, is_error:false, subtype:success`)하는 경우가 잦습니다. 그러면 structured_output이 비고, 액션이 계약 위반으로 스텝을 **에러 종료**시켜 이후 게시 단계가 전부 막힙니다(claude-agent-sdk #277과 동일 증상). codex는 `codex exec --output-schema`로 JSON을 강제 디코딩하므로 동일 스키마로도 성공합니다.

SPEC: `docs/specs/2026-06-01-claude-review-structured-output-prompt-schema/SPEC.md`

## 변경

강제 구조화 출력 채널 의존을 제거하고, **공유 스키마를 프롬프트로 실어** JSON-only 출력을 지시한 뒤 **결과 텍스트에서 JSON을 파싱**한다.

- **prepare 스텝**: 공유 스키마(`REVIEW_SCHEMA`)를 프롬프트 본문에 싣고 "스키마에 맞는 JSON 객체만, 코드펜스·산문 없이 출력" 지시. `schema` step output 제거.
- **run 스텝(1·2차)**: `claude_args`에서 `--json-schema` 제거.
- **save 스텝(1·2차)**: `execution_file`의 최종 result 메시지에서 JSON 추출(첫 `{`~마지막 `}`로 코드펜스/산문 제거) → `json.loads` 유효성 + 핵심 필드(verdict·eligibility·findings·automation_safety·reviewed_context) 존재 확인 → 실패 시 명확한 오류 → `jq empty`.
- **프롬프트**: 구조화 출력/`submit_pr_review` 문구를 JSON-only 출력 지시로 전환.
- **테스트**: 새 방식 단언 + `--json-schema`/`structured_output` 부재 단언으로 갱신.

게시 단계·`codex-review.yml`·공유 컨텍스트 스크립트·공유 스키마는 불변. 보안 불변식(자격증명 제거, PR 본문 미주입, untrusted 표시, SHA 고정) 유지.

## 검증

- `tests/claude/test-claude-review-workflow.sh` 전체 통과.
- 자율 구현(autopilot:spec→dispatch)으로 작성, 메인이 검증.

## 주의

결과 텍스트 추출이 액션의 `execution_file` 형식에 의존합니다 — 고정 SHA 기준, action 버전 갱신 시 재검증 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
