### PR TITLE
fix(ci): claude-review PR 코멘트 보일러플레이트 한국어화

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -430,13 +430,13 @@ jobs:
             printf '\n\n'
             jq -r '
               if (.findings | length) == 0 then
-                "No findings."
+                "발견 사항 없음."
               else
-                "Findings:\n" + (
+                "발견 사항:\n" + (
                   [.findings[] |
                     "- [" + .severity + "/" + (.confidence_score|tostring) + "] " +
                     .title + " (" + .file + ":" + (if .line == null or .line == 0 then "N/A" else (.line|tostring) end) + ")\n  " +
-                    .body + "\n  Suggestion: " + .suggestion
+                    .body + "\n  제안: " + .suggestion
                   ] | join("\n")
                 )
               end
@@ -492,19 +492,19 @@ jobs:
                   `${index + 1}. [${finding.severity}/${finding.confidence_score}] ${finding.title}`,
                   `${finding.file}:${finding.line == null || finding.line === 0 ? 'N/A' : finding.line}`,
                   finding.body,
-                  `Suggestion: ${finding.suggestion}`,
+                  `제안: ${finding.suggestion}`,
                 ].join('\n')).join('\n\n');
             const body = [
               marker,
               '## Claude PR Review',
               '',
-              `Verdict: \`${result.verdict}\``,
+              `결과: \`${result.verdict}\``,
               '',
               approvalFailed
-                ? 'Claude review found no findings, but formal approval could not be submitted by this workflow token.'
-                : (result.summary || 'No findings. (summary unavailable)'),
+                ? 'Claude 리뷰에서 지적 사항을 찾지 못했으나, 이 워크플로 토큰 권한으로는 정식 승인을 제출하지 못했습니다.'
+                : (result.summary || '발견 사항 없음. (요약 없음)'),
               '',
-              approvalFailed ? 'No findings.' : findingText,
+              approvalFailed ? '발견 사항 없음.' : findingText,
             ].join('\n');
 
             const issue_number = Number(process.env.PR_NUMBER);


### PR DESCRIPTION
## 배경

`bf524f9` 가 `claude-review.yml` 을 claude-code-action 기반(`774bd67^`)으로 롤백하며 "감수한 손실"로 명시한 22개 하드닝 커밋에 **보일러플레이트 한국어화**(`04aefdd`/`692ce30`/`35c726f`)가 포함됐다. 이후 PR #272(`9b5d1eb`)는 prompt schema·결과 파싱만 안정화했을 뿐 한국어화는 복원하지 않아, claude-review가 PR에 게시하는 코멘트의 **제목·라벨·고정 문구가 영어**로 나오는 상태였다.

## 변경

게시 주체(`github-actions[bot]`)·인증·verdict 게이트·marker 로직은 **그대로** 두고, 워크플로가 직접 조립하는 영어 리터럴 8개만 한국어로 치환:

- **정식 리뷰 본문** (`Submit Claude review verdict`): `No findings.`→`발견 사항 없음.`, `Findings:`→`발견 사항:`, `Suggestion:`→`제안:`
- **managed 코멘트** (`Post Claude review comment`): `Verdict:`→`결과:`, approvalFailed 안내문, `No findings. (summary unavailable)`→`발견 사항 없음. (요약 없음)`, `Suggestion:`→`제안:`, `No findings.`→`발견 사항 없음.`

헤딩 `## Claude PR Review` 와 verdict enum 값은 브랜드·스키마 계약이라 영어 유지. codex-review.yml의 동일 문자열은 이번 범위 밖.

## 검증

- yq YAML 파싱 OK
- github-script와 동일한 async 래퍼에서 `node --check` 통과 (한국어 템플릿 리터럴 정상)
- `tests/claude/test-claude-review-workflow.sh` 14개 항목 전 통과
- origin/main 대비 diff = 의도한 8줄만

🤖 Generated with [Claude Code](https://claude.com/claude-code)