### PR TITLE
chore(project-init): v0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "project-init",
       "source": "./plugins/project-init",
       "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "category": "scaffold",
       "tags": ["scaffold", "init", "bootstrap"]
     },

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",


### PR DESCRIPTION
## 요약

project-init 플러그인 버전을 `0.6.0` → `0.7.0` 으로 범프합니다.

## 근거 (versioning 룰)

- SemVer · SoT는 `plugin.json` · `plugins/`는 워치 디렉토리
- 0.6.0 이후 변경: `feat(bootstrap): 선택적 두 섹션을 단일 multiSelect 질문으로 통합` (#270, 134cb62)
- 호환되는 새 기능 → **MINOR** 범프

## 변경

- `plugins/project-init/.claude-plugin/plugin.json`: 0.6.0 → 0.7.0 (SoT)
- `.claude-plugin/marketplace.json`: project-init 항목 0.6.0 → 0.7.0 (파생 동기화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)