### PR TITLE
feat(version-control-rule-creator): git 공통 정책을 단일 multi-select 집계로 전환

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "project-init",
       "source": "./plugins/project-init",
       "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
-      "version": "0.8.0",
+      "version": "0.10.0",
       "category": "scaffold",
       "tags": ["scaffold", "init", "bootstrap"]
     },

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",

--- a/plugins/project-init/skills/version-control-rule-creator/SKILL.md
+++ b/plugins/project-init/skills/version-control-rule-creator/SKILL.md
@@ -19,7 +19,7 @@ allowed-tools:
 
 `templates/*.md` 중 하나를 `rules/version-control/<sub>.md`로 기록합니다. `<sub>`는 sub-룰 ID이며, 백엔드 변형을 가진 sub-룰은 git origin remote에서 자동 판별한 백엔드의 변형 본문을 씁니다.
 
-본 스킬은 **버전 관리(VCS) 카테고리의 sub-룰 디스패처**입니다. 형제 스킬(`engineering-rule-creator`)이 같은 카테고리 아래 여러 sub-룰을 호출마다 하나씩 디렉터리 구조로 누적하는 것과 같은 모양이되, **백엔드 변형을 가진 sub-룰은 사용자 메뉴 선택이 아니라 git origin remote URL 파싱으로 백엔드를 자동 판별**한다는 점이 다릅니다.
+본 스킬은 **버전 관리(VCS) 카테고리의 sub-룰 디스패처**입니다. 백엔드 변형을 가진 sub-룰(예: `review-approval`)은 사용자 메뉴 선택이 아니라 git origin remote URL 파싱으로 백엔드를 자동 판별해 그 변형 본문을 씁니다. 백엔드가 **git 계열**로 판별되면 git 계열 공통 지침(`git`)을 그 백엔드 룰셋의 **동반 출력**으로 함께 산출합니다 — git을 review-approval과 "둘 중 하나"로 고르게 하지 않습니다.
 
 이 카테고리의 첫 sub-룰은 변경 제안 심사·승인(`review-approval`)이며, 브랜치 전략·커밋 컨벤션 등 다른 git sub-룰로 확장할 수 있습니다. 새 백엔드나 새 sub-룰을 추가하려면 `templates/` 아래에 새 마크다운 파일을 두면 되고, **이 SKILL.md는 변경하지 않습니다**.
 
@@ -38,7 +38,7 @@ allowed-tools:
 
 1. **템플릿 열거.** `templates/*.md`만 읽습니다. 위 파일명 규약으로 각 파일의 sub-룰 ID와 (있으면) 백엔드 변형을 식별합니다. 같은 sub-룰 ID의 변형 집합을 묶습니다.
 
-2. **백엔드 판별 (후보 확정 전 1회).** 1단계에서 열거한 후보 중 백엔드 변형을 가진 sub-룰(예: `review-approval`)이 있거나 git 계열 게이팅이 필요한 sub-룰(`git`)이 있으면, sub-룰을 선택하기 **전에** 백엔드를 1회 판별합니다. 이 판별 결과는 3단계의 git 계열 게이팅과 4단계의 백엔드 변형 본문 선택에서 **함께 재사용**하며 재판별하지 않습니다. git origin remote URL을 파싱해 호스트를 추출한 뒤, **공식 도메인은 호스트명 정밀 매칭으로(네트워크 호출 없음), self-hosted 호스트는 부작용 없는 read-only API probe로** 백엔드를 판별합니다. **호스트명 substring 매칭은 쓰지 않습니다**(`github-mirror.*`·`mygithub.com` 류 오판별 방지).
+2. **백엔드 판별 (후보 확정 전 1회).** 1단계에서 열거한 후보 중 백엔드 변형을 가진 sub-룰(예: `review-approval`)이 있거나 git 계열 여부에 따라 동반 산출되는 sub-룰(`git`)이 있으면, sub-룰을 선택하기 **전에** 백엔드를 1회 판별합니다. 이 판별 결과는 3단계의 git 계열 동반 산출 판정과 4단계의 백엔드 변형 본문 선택에서 **함께 재사용**하며 재판별하지 않습니다. git origin remote URL을 파싱해 호스트를 추출한 뒤, **공식 도메인은 호스트명 정밀 매칭으로(네트워크 호출 없음), self-hosted 호스트는 부작용 없는 read-only API probe로** 백엔드를 판별합니다. **호스트명 substring 매칭은 쓰지 않습니다**(`github-mirror.*`·`mygithub.com` 류 오판별 방지).
    - origin URL은 `git remote get-url origin`(또는 `git config --get remote.origin.url`)으로 읽습니다.
    - https 양식(`https://host/owner/repo.git`)과 ssh 양식(`git@host:owner/repo.git`·`ssh://git@host/owner/repo.git`) **모두**에서 호스트를 추출합니다.
    - **origin이 설정되어 있지 않으면**: 어떤 룰 파일도 생성하지 않고, origin remote를 먼저 설정하라고 안내한 뒤 종료합니다.
@@ -52,25 +52,26 @@ allowed-tools:
    - **판별 실패 시 중단 (추측 금지).** (a) 정밀 매칭에도 해당하지 않고 (b) probe로도 백엔드를 확정하지 못하면(inconclusive 포함), 감지된 호스트와 지원 백엔드 목록(github·gitlab)을 안내하고 어떤 룰 파일도 생성하지 않고 종료합니다. 추측해서 생성하지 않습니다.
    - 후보 중 어떤 sub-룰도 백엔드 정보를 필요로 하지 않으면 이 단계를 건너뜁니다.
 
-3. **sub-룰 선택 (git 계열 게이팅 포함).** 후보 sub-룰 목록을 구성하되 `git` sub-룰의 포함 여부는 **2단계 판별 결과**로 게이팅합니다. 그다음 sub-룰 ID가 하나면 자동 선택하고 둘 이상이면 `AskUserQuestion` single-select로 묻습니다. 한 번의 호출에서 **정확히 하나**의 sub-룰만 기록합니다. 단순 재실행으로 sub-룰을 바꾸지 않습니다.
+3. **sub-룰 선택과 git 공통 동반 산출.** 후보 sub-룰을 두 부류로 나눠 처리합니다.
 
-   - **git 계열 공통 sub-룰 게이팅.** `git` sub-룰(`templates/git.md`, 백엔드 변형 없음, 출력 `rules/version-control/git.md`)은 **2단계 판별 결과가 git 계열일 때만** 후보 목록에 넣습니다. force push 등 git 전용 개념을 담기 때문입니다.
-     - 판별된 호스팅 백엔드를 git 계열로 분류하는 **정적 매핑**만 둡니다: `github`·`gitlab`은 git 계열입니다. 이 정적 매핑이 git 계열 분류의 단일 출처이며, 매핑에 없는 백엔드의 기본값은 **"git 계열 아님"**(미제공)입니다. 향후 비-git 백엔드가 추가되면 그 백엔드를 이 매핑에 넣지 않는 것만으로 자연히 게이팅됩니다.
-     - 판별된 백엔드가 **git 계열이 아니면** `git` sub-룰을 후보 목록에서 **제외**하고, 그 사실(이 백엔드는 git 계열이 아니어서 git 공통 지침을 제공하지 않음)을 사용자에게 안내합니다.
-     - 백엔드 변형이 없는 그 밖의 sub-룰은 git 계열 게이팅 없이 항상 후보입니다(`git` sub-룰에만 적용되는 게이팅입니다).
+   - **백엔드 변형 sub-룰과 그 밖의 sub-룰(`review-approval` 등).** sub-룰 ID가 하나면 자동 선택하고 둘 이상이면 `AskUserQuestion` single-select로 고릅니다. 이렇게 고른 sub-룰을 기록합니다. 단순 재실행으로 이 선택을 바꾸지 않습니다.
+   - **git 계열 공통 sub-룰(`git`)은 사용자 선택지가 아닙니다.** `templates/git.md`(백엔드 변형 없음, 출력 `rules/version-control/git.md`)는 **2단계 판별이 git 계열일 때 자동으로 함께 산출되는 동반 출력**입니다. review-approval과 "둘 중 하나"로 고르게 하는 메뉴 항목으로 노출하지 않습니다.
+     - 판별된 백엔드를 git 계열로 분류하는 **정적 매핑**만 둡니다: `github`·`gitlab`은 git 계열입니다. 이 정적 매핑이 git 계열 분류의 단일 출처이며, 매핑에 없는 백엔드의 기본값은 **"git 계열 아님"**입니다. 향후 비-git 백엔드는 이 매핑에 넣지 않는 것만으로 동반 산출에서 자연히 빠집니다.
+     - 2단계 판별이 **git 계열이면**: 위에서 고른 백엔드 변형 sub-룰(review-approval)과 git 공통 지침(`rules/version-control/git.md`)을 **함께 산출**합니다.
+     - **git 계열이 아니면**: git 공통 지침을 산출하지 않습니다. 사용자에게는 산출 대상이 무엇인지만 안내하고, git이 왜 공통으로 분리됐는지·분류 기준 같은 내부 사정은 노출하지 않습니다.
 
-4. **본문 조립.** 선택된 sub-룰의 (백엔드 변형이 있으면 **2단계에서 판별된** 백엔드의) 템플릿에서 **frontmatter를 제거한 본문**을 그대로 취합니다. 본문은 placeholder 치환 외에 변형하지 않습니다.
-   - 선택된 sub-룰에 2단계에서 판별된 백엔드의 변형 파일이 없으면, 그 사실을 알리고 종료합니다.
+4. **본문 조립.** 산출 대상인 각 sub-룰(백엔드 변형 sub-룰, 그리고 git 계열이면 동반 `git`)의 (백엔드 변형이 있으면 **2단계에서 판별된** 백엔드의) 템플릿에서 **frontmatter를 제거한 본문**을 그대로 취합니다. 본문은 placeholder 치환 외에 변형하지 않습니다.
+   - 선택된 백엔드 변형 sub-룰에 2단계에서 판별된 백엔드의 변형 파일이 없으면, 그 사실을 알리고 종료합니다.
 
-4-bis. **입력(inputs) 치환.** 선택된 템플릿 frontmatter에 `inputs`가 있으면, 형제 스킬 `engineering-rule-creator`의 inputs 방식을 **그대로 미러링**해 처리합니다. `inputs`가 없으면 이 단계를 건너뜁니다.
-   - **스키마.** 각 입력은 `name`, `header`, `question`, `options[{label, description, value?}]`를 가집니다(engineering-rule-creator와 동일 스키마).
-   - **질문.** 입력을 순서대로 `AskUserQuestion` **단일 선택(single-select)**으로 묻습니다. 옵션 표시 순서는 frontmatter에 적힌 순서를 따르므로, **추천 옵션은 첫 번째**에 두고 라벨에 `(Recommended)`를 붙여 표시합니다.
-   - **치환 규칙.** 선택된 옵션의 값으로 본문의 동명 placeholder `{{<name>}}`를 치환합니다. 값은 **`value`가 있으면 `value`, 없으면 `label`**을 씁니다(value 우선). 비어 있지 않은 "Other" 자유 입력도 허용합니다.
-   - **누락·빈 값 (일반).** 응답이 누락되거나 비어 있으면 engineering-rule-creator와 같이 `{{<name>}}`을 **보존**합니다.
-   - **force push 정책 입력의 특례.** `force_push_policy` 입력은 응답이 누락·빈 값일 때 placeholder를 보존하지 않고 **디폴트(금지)** 를 적용합니다 — 즉 추천(첫 번째) 옵션인 금지 옵션의 `value`(force push 금지 절 텍스트)를 공급합니다. 따라서 입력이 빠져도 금지 절이 포함된 `git.md`가 생성됩니다.
-   - **force push 금지/허용 분기는 치환만으로 표현합니다.** 금지 옵션의 `value`는 force push 금지 절 텍스트를, 허용 옵션의 `value`는 **빈 문자열**을 공급합니다. 허용을 고르면 placeholder가 빈 문자열로 치환되어 금지 절만 사라지고 나머지 본문은 그대로 남습니다. 별도의 조건부 렌더링 로직을 추가하지 않습니다. 빈 치환이 본문에 빈 줄·깨진 마크다운을 남기지 않도록 placeholder 주변 서식을 절 단위로 정리합니다.
+4-bis. **입력(inputs) 치환 — 정적 multi-select 집계.** 산출 대상 템플릿 frontmatter에 `inputs`가 있으면 처리하고, 없으면 이 단계를 건너뜁니다. (현재 `git` 템플릿이 이 메커니즘을 씁니다.)
+   - **스키마.** 각 입력은 `name`, `header`, `question`, `multi_select`, `options[{label, description, value?, default?}]`를 가집니다. `multi_select: true`는 **한 질문에서 여러 정책을 다중 선택**함을 뜻합니다.
+   - **질문.** 입력을 `AskUserQuestion` **다중 선택(multi-select)**으로 **한 번** 묻습니다. 옵션 표시 순서는 frontmatter 순서를 따릅니다. `default: true`인 옵션은 **기본 선택(체크)** 상태로 제시합니다(추천·기본 옵션을 첫 번째에 둡니다). 사용자에게는 정책 선택지만 노출하고, 정책이 공통으로 분리된 내부 사정·분류 기준은 노출하지 않습니다.
+   - **집계 치환.** 본문의 **단일 집계 placeholder** `{{<name>}}`를, **선택된 옵션들의 값을 표시 순서대로 연결**한 텍스트로 치환합니다. 값은 `value`가 있으면 `value`, 없으면 `label`을 씁니다(value 우선). 비어 있지 않은 "Other" 자유 입력도 연결 대상에 포함합니다. 절과 절 사이는 빈 줄 하나로 구분해 마크다운 서식을 유지합니다. **정책별 개별 placeholder는 두지 않습니다.**
+   - **빈 선택.** 아무 옵션도 선택되지 않으면 집계 결과는 빈 문자열이고, placeholder가 놓인 줄을 절 단위로 정리·제거해 빈 줄·깨진 마크다운을 남기지 않습니다. 도입부(헤더 + git 계열 분류)는 그대로 남습니다.
+   - **누락 응답 (디폴트 경로).** 응답이 누락되면 `default: true`인 옵션들이 선택된 것으로 간주합니다. 따라서 force push 금지(기본 체크)가 적용되어 금지 절이 포함된 `git.md`가 생성됩니다(force push 미체크 = 허용).
+   - **확장.** 새 git 공통 정책은 frontmatter `options`에 **옵션 항목만 추가**하면 됩니다 — 이 SKILL.md 로직, 본문 집계 placeholder, 질문 수는 바뀌지 않습니다.
 
-5. **파일 기록.**
+5. **파일 기록.** 산출 대상인 각 sub-룰(백엔드 변형 sub-룰, 그리고 git 계열이면 동반 `git`)을 아래 규칙으로 각각 기록합니다.
    - 대상 디렉터리 `rules/version-control/`가 없으면 기록 전에 생성합니다.
    - 본문을 `rules/version-control/<sub>.md`로 기록합니다. 출력 파일명에 백엔드 식별자를 남기지 않습니다.
    - 대상 파일이 이미 있으면 덮어쓰지 않고 **diff를 보여** 사용자에게 묻습니다. `덮어쓴다 (교체)` / `보존한다 (취소)` 중 **명시적 교체 선택일 때만** 덮어씁니다. 자유 텍스트나 침묵은 동의가 아닙니다.
@@ -79,8 +80,8 @@ allowed-tools:
 
 ## 규칙
 
-- 본 스킬은 `rules/version-control/<sub>.md` **단일 파일만** 생성·갱신합니다. 같은 실행에서 다른 sub-룰이나 카테고리 밖 파일을 만지지 않습니다. 다른 카테고리의 기존 지침(범용 리뷰 원칙 `rules/review.md`·릴리스 버전 지침 `rules/engineering/versioning.md` 포함)을 변경하지 않습니다.
-- 한 번의 호출 = 한 sub-룰. 두 템플릿을 합치거나 한 번에 여러 sub-룰을 기록하지 않습니다.
+- 본 스킬은 `rules/version-control/` 아래 sub-룰 파일만 생성·갱신합니다. 한 실행에서 기록하는 백엔드 변형 sub-룰은 하나이며, 백엔드가 git 계열이면 git 공통 지침(`git.md`)을 그 **동반 출력**으로 함께 기록합니다. 카테고리 밖 파일이나 다른 카테고리의 기존 지침(범용 리뷰 원칙 `rules/review.md`·릴리스 버전 지침 `rules/engineering/versioning.md` 포함)은 변경하지 않습니다.
+- 백엔드 변형 sub-룰은 한 번의 호출에서 하나만 고릅니다. git 계열일 때 동반 산출되는 git 공통 지침은 그 예외로, 백엔드 변형 sub-룰과 `git.md`가 함께 기록됩니다. 템플릿 본문을 서로 합치지는 않습니다.
 - 템플릿 본문은 그대로 복사합니다. SKILL.md에 본문별 로직을 추가하지 않습니다. 새 백엔드·새 sub-룰은 `templates/` 파일 추가만으로 확장하며 이 SKILL.md를 수정하지 않습니다.
 - 백엔드 판별은 **공식 도메인 호스트명 정밀 매칭(네트워크 없음) + self-hosted read-only API probe**로 수행합니다. 호스트명 substring 매칭은 쓰지 않으며, 정밀 매칭에도 probe에도 걸리지 않으면(inconclusive 포함) 추측 없이 중단하고 안내합니다.
 - 기존 sub-룰 파일은 사용자 명시 동의 없이는 절대 덮어쓰지 않습니다. 단순 재실행으로 sub-룰·백엔드를 바꾸지 않습니다.

--- a/plugins/project-init/skills/version-control-rule-creator/templates/git.md
+++ b/plugins/project-init/skills/version-control-rule-creator/templates/git.md
@@ -1,14 +1,16 @@
 ---
 sub_rule: git
-label: git 계열 공통 지침 (force push 정책)
-description: git 계열 백엔드(GitHub·GitLab 등) 공통으로 적용되는 version-control 지침. 첫 항목으로 force push 정책을 담습니다.
+label: git 계열 공통 지침
+description: git 계열 백엔드(GitHub·GitLab 등)에 공통으로 적용되는 version-control 정책. 한 번의 multi-select로 적용할 정책을 고릅니다.
 inputs:
-  - name: force_push_policy
-    header: "force push"
-    question: "이 프로젝트에서 force push(history 재작성 push)를 허용하시겠습니까? (기본값: 금지)"
+  - name: git_policies
+    multi_select: true
+    header: "git 정책"
+    question: "이 프로젝트에 적용할 git 공통 정책을 고르세요. 체크한 정책만 본문에 들어갑니다(해제하면 빠집니다)."
     options:
-      - label: "금지 (Recommended)"
-        description: "공유 브랜치 history를 보호합니다. 협업 프로젝트의 안전한 기본값입니다."
+      - label: "force push 금지"
+        default: true
+        description: "공유 브랜치 history를 보호합니다. 협업 프로젝트의 안전한 기본값입니다. 해제하면 force push를 정책상 막지 않습니다."
         value: |-
           ## force push 금지
 
@@ -18,13 +20,10 @@ inputs:
           - force push는 다른 사람이 받아 간 history를 무효화해 작업 손실·충돌을 일으키므로, 공유 브랜치에서는 예외 없이 막습니다.
           - 아직 공유되지 않은 본인 전용 토픽 브랜치의 정리(rebase 후 force push)가 불가피하면, 그 브랜치가 공유되지 않았음을 확인한 경우에만 허용하며 공유 브랜치에는 적용하지 않습니다.
           - 호스팅의 브랜치 보호(protected branch) 설정으로 기본 브랜치 force push를 차단하는 것을 권장합니다.
-      - label: "허용"
-        description: "force push를 정책상 막지 않습니다. 브랜치 보호는 호스팅 설정에 위임합니다."
-        value: ""
 ---
 
 # git 계열 공통 지침
 
-이 프로젝트의 호스팅 백엔드는 **git 계열**(GitHub·GitLab 등)입니다. 본 지침은 호스팅 백엔드(GitHub/GitLab)와 무관하게 git 계열 전체에 공통으로 적용되는 version-control 규율을 정의합니다. 백엔드 특화 심사·승인 규율은 별도 sub-룰(`rules/version-control/review-approval.md`)이 담습니다.
+이 프로젝트의 호스팅 백엔드는 **git 계열**(GitHub·GitLab 등)입니다. 본 지침은 git 계열 백엔드에 공통으로 적용되는 version-control 정책을 정의합니다.
 
-{{force_push_policy}}
+{{git_policies}}

--- a/plugins/project-init/skills/version-control-rule-creator/tests/git-common-force-push.test.sh
+++ b/plugins/project-init/skills/version-control-rule-creator/tests/git-common-force-push.test.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
-# Structural acceptance test for the version-control "git 계열 공통 지침 (force-push 토글)" SPEC.
-# Verifies:
-#   - SKILL.md documents the inputs substitution mechanism (mirroring engineering-rule-creator)
-#   - SKILL.md documents git-family gating via a static backend classification reusing
-#     the existing backend determination, output rules/version-control/git.md
-#   - SKILL.md documents non-git exclusion + user notice, and force-push default-on-missing
-#   - templates/git.md exists: sub_rule git, inputs force_push_policy, 금지 first+Recommended
-#     with prohibition-clause value, 허용 with empty value, {{force_push_policy}} placeholder
+# Structural acceptance test for the version-control "git 공통 정책 multi-select 집계" SPEC.
+# Verifies the NEW model:
+#   - templates/git.md declares git common policy input as ONE multi-select question
+#     (multi_select: true), not per-policy single-select questions.
+#   - force push 금지 is the FIRST option and is default-checked (default: true).
+#   - body has a SINGLE aggregate placeholder ({{git_policies}}); no per-policy
+#     placeholder like {{force_push_policy}}.
+#   - 허용 is expressed by leaving force push 금지 unchecked (no separate 허용 option /
+#     no value:"" empty-value option needed).
+#   - always-create: intro (header + git-family classification) stands without any policy.
+#   - SKILL.md documents the static multi-select aggregate mechanism (multi_select,
+#     집계 placeholder, default-checked, default-on-missing) and git-family
+#     co-production (review-approval + git together), NOT a git-vs-review-approval
+#     single-select menu.
 #
 # Run: bash git-common-force-push.test.sh   (exit 0 = pass)
 set -u
@@ -30,59 +36,105 @@ lineno() { grep -nF -m1 "$2" "$1" 2>/dev/null | cut -d: -f1; }
 # line number of first line matching an extended regex (empty if none)
 lineno_re() { grep -nE -m1 "$2" "$1" 2>/dev/null | cut -d: -f1; }
 
-# --- 1) inputs substitution mechanism in SKILL.md (mirrors engineering-rule-creator) ---
-check "SKILL.md documents an inputs mechanism" grep -qF 'inputs' "$SKILL"
-check "SKILL.md mirrors engineering-rule-creator inputs" grep -qF 'engineering-rule-creator' "$SKILL"
+# ===========================================================================
+# 1) templates/git.md: single multi-select question
+# ===========================================================================
+check "templates/git.md exists" test -f "$TPL"
+check "git.md frontmatter declares sub_rule git" grep -qE '^sub_rule:[[:space:]]*git[[:space:]]*$' "$TPL"
+check "git.md declares an inputs block" grep -qF 'inputs:' "$TPL"
+check "git.md declares multi-select (multi_select: true)" grep -qE 'multi_select:[[:space:]]*true' "$TPL"
+
+# exactly ONE input under inputs: => exactly one `- name:` entry
+ninputs="$(grep -cE '^[[:space:]]*-[[:space:]]*name:' "$TPL")"
+check "git.md declares exactly ONE input (one aggregate question)" \
+  bash -c "[ '$ninputs' -eq 1 ]"
+
+# the single input is named git_policies (aggregate over policies, not per-policy)
+check "git.md single input is named git_policies" grep -qE '^[[:space:]]*-[[:space:]]*name:[[:space:]]*git_policies[[:space:]]*$' "$TPL"
+
+# ===========================================================================
+# 2) force push 금지 = first option + default-checked
+# ===========================================================================
+check "git.md has a force push 금지 option clause" bash -c "grep -qF 'force push' '$TPL' && grep -qF '금지' '$TPL'"
+
+# first option label must mention force push 금지
+firstlabel="$(lineno_re "$TPL" '^[[:space:]]*-[[:space:]]*label:')"
+firstdeny="$(lineno_re "$TPL" '^[[:space:]]*-[[:space:]]*label:.*(force push|금지)')"
+check "git.md FIRST option label is force push 금지" \
+  bash -c "[ -n '$firstlabel' ] && [ -n '$firstdeny' ] && [ '$firstlabel' -eq '$firstdeny' ]"
+
+# default-checked marker present
+check "git.md marks force push option default-checked (default: true)" grep -qE 'default:[[:space:]]*true' "$TPL"
+
+# default: true must belong to the FIRST option (before any 2nd option label, if any)
+deflineno="$(lineno_re "$TPL" 'default:[[:space:]]*true')"
+secondlabel="$(grep -nE '^[[:space:]]*-[[:space:]]*label:' "$TPL" | sed -n '2p' | cut -d: -f1)"
+check "git.md default-checked belongs to the first option" \
+  bash -c "[ -n '$deflineno' ] && [ '$deflineno' -gt '$firstlabel' ] && { [ -z '$secondlabel' ] || [ '$deflineno' -lt '$secondlabel' ]; }"
+
+# ===========================================================================
+# 3) single aggregate placeholder; NO per-policy placeholder
+# ===========================================================================
+# body (after frontmatter) — frontmatter is delimited by the first two `---`
+fmend="$(grep -nE '^---[[:space:]]*$' "$TPL" | sed -n '2p' | cut -d: -f1)"
+check "git.md has a closed frontmatter block" bash -c "[ -n '$fmend' ]"
+
+# exactly one distinct {{...}} placeholder in the file, and it is {{git_policies}}
+distinct_ph="$(grep -oE '\{\{[a-zA-Z_]+\}\}' "$TPL" | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+check "git.md body uses the single aggregate placeholder {{git_policies}}" \
+  bash -c "[ '$distinct_ph' = '{{git_policies}}' ]"
+check "git.md has NO per-policy {{force_push_policy}} placeholder" \
+  bash -c "! grep -qF '{{force_push_policy}}' '$TPL'"
+
+# ===========================================================================
+# 4) 허용 = unchecked (no separate empty-value 허용 option)
+# ===========================================================================
+check "git.md does NOT carry a separate empty-value option (value:\"\")" \
+  bash -c "! grep -qE 'value:[[:space:]]*\"\"[[:space:]]*$' '$TPL'"
+
+# ===========================================================================
+# 5) always-create intro: header + git-family classification anchor
+# ===========================================================================
+check "git.md body has the H1 header" grep -qE '^#[[:space:]].*git' "$TPL"
+check "git.md intro states git-family classification" grep -qF 'git 계열' "$TPL"
+
+# ===========================================================================
+# 6) no backend-variant git template (single body, always git.md)
+# ===========================================================================
+check "no backend-variant git template (git.<backend>.md) exists" \
+  bash -c "! ls '$DIR/templates/' | grep -qE '^git\.[a-z]+\.md$'"
+
+# ===========================================================================
+# 7) SKILL.md: multi-select aggregate mechanism
+# ===========================================================================
+check "SKILL.md documents a multi-select input (multi_select)" grep -qF 'multi_select' "$SKILL"
+check "SKILL.md documents aggregate placeholder substitution (집계)" grep -qF '집계' "$SKILL"
 check "SKILL.md documents {{name}} placeholder substitution" grep -qF '{{' "$SKILL"
 check "SKILL.md documents value-over-label substitution rule" grep -qF 'value' "$SKILL"
+check "SKILL.md documents default-checked default-on-missing" grep -qF 'default' "$SKILL"
+check "SKILL.md still mentions force push default-on-missing (금지)" grep -qF 'force push' "$SKILL"
 
-# --- 2) git-family gating + static classification in SKILL.md ---
+# ===========================================================================
+# 8) SKILL.md: git-family co-production, NOT git-vs-review-approval menu
+# ===========================================================================
 check "SKILL.md mentions git 계열 (git-family)" grep -qF 'git 계열' "$SKILL"
 check "SKILL.md declares static git-family classification incl github" grep -qF 'github' "$SKILL"
 check "SKILL.md declares static git-family classification incl gitlab" grep -qF 'gitlab' "$SKILL"
 check "SKILL.md reuses existing backend determination (no new detection)" grep -qF '재사용' "$SKILL"
 check "SKILL.md fixes git common output to git.md" grep -qF 'git.md' "$SKILL"
+check "SKILL.md documents review-approval + git co-production (함께 산출)" grep -qF '함께 산출' "$SKILL"
+check "SKILL.md describes git common as a companion output (동반)" grep -qF '동반' "$SKILL"
 
-# --- 3) non-git exclusion + notice, and force-push default-on-missing in SKILL.md ---
-check "SKILL.md documents non-git exclusion notice" bash -c "grep -qF '계열이 아니' '$SKILL' || grep -qF '비-git' '$SKILL'"
-check "SKILL.md documents force-push default-on-missing (금지)" grep -qF 'force push' "$SKILL"
+# git must NOT be offered as a single-select choice competing with review-approval.
+# Guard the specific old phrasing that gated git into the single-select sub-rule menu.
+check "SKILL.md does not gate git into the single-select sub-rule menu (old phrasing gone)" \
+  bash -c "! grep -qF 'git 계열 공통 sub-룰 게이팅' '$SKILL'"
 
-# --- 4) templates/git.md existence + frontmatter ---
-check "templates/git.md exists" test -f "$TPL"
-check "git.md frontmatter declares sub_rule git" grep -qE '^sub_rule:[[:space:]]*git[[:space:]]*$' "$TPL"
-check "git.md declares an inputs block" grep -qF 'inputs:' "$TPL"
-check "git.md declares force_push_policy input" grep -qF 'force_push_policy' "$TPL"
-
-# --- 4-bis) step order: backend determination is described BEFORE git-family gating ---
-# Guards the reviewed contradiction where the gating step referenced a later
-# detection step's result (forward reference / step-number vs execution-order mismatch).
+# ===========================================================================
+# 9) backend determination still precedes git-family handling
+# ===========================================================================
 detstep="$(lineno_re "$SKILL" '^[0-9]+\. \*\*백엔드 판별')"
-gatestep="$(lineno_re "$SKILL" 'git 계열 공통 sub-룰 게이팅')"
-check "SKILL.md describes backend determination before git-family gating" \
-  bash -c "[ -n '$detstep' ] && [ -n '$gatestep' ] && [ '$detstep' -lt '$gatestep' ]"
-check "SKILL.md has no forward-reference to a later detection step in gating" \
-  bash -c "! grep -qF '3단계의 백엔드 판별 결과를 재사용' '$SKILL'"
-
-# --- 5) 금지 option: first, Recommended, carries prohibition clause ---
-check "git.md marks an option (Recommended)" grep -qF '(Recommended)' "$TPL"
-check "git.md prohibition option text mentions force push 금지" bash -c "grep -qF 'force push' '$TPL' && grep -qF '금지' '$TPL'"
-
-# 금지 option label must appear before 허용 option label (recommended is first).
-# Match the option `label:` lines specifically, not the question prose which
-# mentions both words.
-nodeny="$(lineno_re "$TPL" '^[[:space:]]*-?[[:space:]]*label:.*금지')"
-noallow="$(lineno_re "$TPL" '^[[:space:]]*-?[[:space:]]*label:.*허용')"
-check "git.md 금지 option label appears before 허용 option label" bash -c "[ -n '$nodeny' ] && [ -n '$noallow' ] && [ '$nodeny' -lt '$noallow' ]"
-
-# --- 6) 허용 option supplies an empty value ---
-check "git.md provides an empty value (허용 => placeholder removed)" grep -qE 'value:[[:space:]]*""' "$TPL"
-
-# --- 7) body placeholder ---
-check "git.md body has {{force_push_policy}} placeholder" grep -qF '{{force_push_policy}}' "$TPL"
-
-# --- 8) git common sub-rule has NO backend variant (single body, always git.md) ---
-check "no backend-variant git template (git.<backend>.md) exists" \
-  bash -c "! ls '$DIR/templates/' | grep -qE '^git\.[a-z]+\.md$'"
+check "SKILL.md still describes backend determination step" bash -c "[ -n '$detstep' ]"
 
 if [ "$fail" -eq 0 ]; then
   echo "PASS"; exit 0


### PR DESCRIPTION
## 요약

`version-control-rule-creator` 스킬에서 git 계열 공통 지침(`git.md`)의 노출·입력 방식을 바꿉니다. SPEC: `docs/specs/2026-06-02-version-control-rule-creator-git-policy-multi-select/SPEC.md` (이미 main 반영).

- **git을 review-approval과 경쟁하는 single-select 메뉴 항목에서 제거** → git 계열 백엔드로 판별되면 review-approval(백엔드 변형)과 `git.md`를 **동반 산출**.
- **git 정책 입력을 단일 multi-select 질문으로 전환** (`git_policies`, `multi_select: true`). force push 금지 = 첫 항목 + 기본 체크(`default: true`). 미체크 = 허용(별도 허용 옵션 제거).
- **본문은 단일 집계 placeholder `{{git_policies}}`** — 선택 항목 절을 표시 순서대로 연결. 정책별 개별 placeholder 없음.
- **향후 정책은 frontmatter `options`에 항목만 추가**하면 끝 — SKILL.md 로직·본문·질문 수 불변.
- git이 공통으로 분리된 이유·게이팅 근거는 **사용자 대면 비노출**.
- `git.md`는 git 계열이면 **항상 생성**, 빈 선택은 정책 절만 비움 / 입력 누락은 force push 금지 디폴트 적용.

## 검증

- 구조 검증 테스트(`tests/git-common-force-push.test.sh`)를 신 모델로 갱신, fresh 실행 **exit 0 (32개 PASS)**.
- `plugins/project-init/.claude-plugin/plugin.json`·`.claude-plugin/marketplace.json` project-init 버전 **0.10.0**으로 동반 범프·일치.

🤖 Generated with [Claude Code](https://claude.com/claude-code)