### PR TITLE
fix(ci): Codex 리뷰 게시 보일러플레이트 한국어화

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -330,13 +330,13 @@ jobs:
             printf '\n\n'
             jq -r '
               if (.findings | length) == 0 then
-                "No findings."
+                "발견 사항 없음."
               else
-                "Findings:\n" + (
+                "발견 사항:\n" + (
                   [.findings[] |
                     "- [" + .severity + "/" + (.confidence_score|tostring) + "] " +
                     .title + " (" + .file + ":" + (if .line == null or .line == 0 then "N/A" else (.line|tostring) end) + ")\n  " +
-                    .body + "\n  Suggestion: " + .suggestion
+                    .body + "\n  제안: " + .suggestion
                   ] | join("\n")
                 )
               end
@@ -392,19 +392,19 @@ jobs:
                   `${index + 1}. [${finding.severity}/${finding.confidence_score}] ${finding.title}`,
                   `${finding.file}:${finding.line == null || finding.line === 0 ? 'N/A' : finding.line}`,
                   finding.body,
-                  `Suggestion: ${finding.suggestion}`,
+                  `제안: ${finding.suggestion}`,
                 ].join('\n')).join('\n\n');
             const body = [
               marker,
               '## Codex PR Review',
               '',
-              `Verdict: \`${result.verdict}\``,
+              `결과: \`${result.verdict}\``,
               '',
               approvalFailed
-                ? 'Codex review found no findings, but formal approval could not be submitted by this workflow token.'
-                : (result.summary || 'No findings. (summary unavailable)'),
+                ? 'Codex 리뷰에서 지적 사항을 찾지 못했으나, 이 워크플로 토큰 권한으로는 정식 승인을 제출하지 못했습니다.'
+                : (result.summary || '발견 사항 없음. (요약 없음)'),
               '',
-              approvalFailed ? 'No findings.' : findingText,
+              approvalFailed ? '발견 사항 없음.' : findingText,
             ].join('\n');
 
             const issue_number = Number(process.env.PR_NUMBER);


### PR DESCRIPTION
## 무엇을

Codex PR 자동 리뷰가 PR에 게시하는 보일러플레이트(요약/래퍼 텍스트)를 한국어로 표시합니다.

## 왜

`codex-review.yml`을 "Claude 동일 게시 구조"로 재작성할 때(`7848f48`) 영어 보일러플레이트 버전이 그대로 들어와, Claude 리뷰는 한국어 보일러플레이트를 쓰는데 Codex 리뷰만 영어 문구를 노출하는 불일치가 있었습니다. 지적 사항이 없는 흔한 approve 경우 PR에 영어 문구만 남아 "Codex 리뷰가 한국어를 쓰지 않는다"는 인상의 원인이었습니다.

## 변경 내용 (codex-review.yml 게시 단계, claude-review.yml 카피와 일치)

| 이전 (영어) | 변경 (한국어) |
|---|---|
| `No findings.` | `발견 사항 없음.` |
| `Findings:` | `발견 사항:` |
| `Suggestion:` | `제안:` |
| `Verdict:` | `결과:` |
| `... formal approval could not be submitted ...` | `... 정식 승인을 제출하지 못했습니다.` |
| `No findings. (summary unavailable)` | `발견 사항 없음. (요약 없음)` |

- 섹션 헤더 `## Codex PR Review`는 Claude 리뷰와 동일하게 영어 브랜드명 유지.
- 모델이 채우는 지적 사항 필드(summary·title·body·suggestion 본문)는 이미 한국어라 미변경.
- 숨김 HTML 마커·verdict/severity enum 값 미변경.

## 검증

- `tests/codex/test-codex-review-workflow.sh`: ALL CHECKS PASSED (25/25)
- 잔여 영어 보일러플레이트 없음(헤더 제외).

SPEC: `docs/specs/2026-06-02-codex-review-boilerplate-korean-parity/SPEC.md`

> 참고: 워크플로 변조방지 가드(`paths-ignore: .github/workflows/**`)로 이 PR은 codex 리뷰를 자기 트리거하지 않으며, 변경은 머지 후 효력이 발생합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)