### PR TITLE
docs(loop): start 시그니처에서 loop.sh 인자·SKILL 차원 옵션 경계 명시

### DIFF
--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/conductor 4-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션, conductor로 spec→dispatch 자동화 파이프라인의 forge 호출 레이어(intake·start·review·merge·poll) 오케스트레이션.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -36,7 +36,9 @@ loop은 어떤 도구가 만든 스펙이든 **임의의 스펙 파일 경로**�
 
 ## Subcommands
 
-### start <spec-path> [--max-iterations N] [--wall-clock-minutes N] [--no-monitor] [--events-only]
+### start <spec-path> [--max-iterations N] [--wall-clock-minutes N]
+
+> 위 bracket의 플래그는 `loop.sh`가 받는 인자다. `--no-monitor`·`--events-only`는 SKILL 차원 모니터링 옵션이라 `loop.sh`에 전달하지 않는다(전달하면 `알 수 없는 옵션`으로 실패) — 의미·우선순위는 아래 [Monitor](#monitor) 절 참조.
 
 반드시 `Bash(bash $SKILL_DIR/references/loop.sh start <spec-path> [...flags], run_in_background: true)`로 실행한다. 동기 실행은 Monitor 가설을 막으므로 금지.
 


### PR DESCRIPTION
## 배경

`autopilot:loop` 스킬의 `start` 서브커맨드 시그니처가 `loop.sh`로 전달되는 인자(`--max-iterations`·`--wall-clock-minutes`)와 전달하면 안 되는 SKILL 차원 모니터링 옵션(`--no-monitor`·`--events-only`)을 한 bracket 묶음에 섞어 표기해, 명령 조립 시 SKILL 차원 옵션까지 `loop.sh`에 전달하게 만드는 affordance 결함이 있었다. `loop.sh` 파서는 그 외 옵션을 lock 획득 전에 `die "알 수 없는 옵션"`으로 즉시 실패시킨다. 경계 설명은 Monitor 절 산문에만 있어 시그니처를 읽는 시점에 보이지 않았다.

## 변경

- `start` 헤딩 bracket에는 `loop.sh`가 실제로 받는 인자만 남김
- 헤딩 바로 아래 인접 포인터로 `--no-monitor`·`--events-only`가 SKILL 차원이라 `loop.sh`에 전달하지 않음(전달 시 실패)을 명시하고 Monitor 절을 가리킴
- `loop.sh` 동작·Monitor 절 의미는 불변 (문서 표기만 수정)
- `plugins/` 워치 디렉토리 변경에 따른 PATCH 범프: `0.15.0` → `0.15.1`

## SPEC

`docs/specs/2026-06-02-loop-start-signature-flag-boundary/SPEC.md` (이미 main에 반영됨, 71e6244). 완료 조건 7개 모두 충족.

🤖 Generated with [Claude Code](https://claude.com/claude-code)