### PR TITLE
feat(ci): PR 리뷰를 inline review thread + fingerprint resolve 로 전환 (codex·claude)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -370,168 +370,224 @@ jobs:
           PY
           jq empty .claude-review/result.json
 
-      - name: Submit Claude review verdict
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-
-          result=".claude-review/result.json"
-          body=".claude-review/review-body.md"
-
-          verdict="$(jq -r '.verdict' "$result")"
-          may_approve="$(jq -r '.automation_safety.may_approve' "$result")"
-          may_request_changes="$(jq -r '.automation_safety.may_request_changes' "$result")"
-          eligibility="$(jq -r '.eligibility.status' "$result")"
-          diff_truncated="$(jq -r '.reviewed_context.diff_truncated' "$result")"
-          findings_count="$(jq '.findings | length' "$result")"
-          blocking_count="$(jq '[.findings[] | select(.severity == "blocking" and .confidence_score >= 80)] | length' "$result")"
-          approve_without_body=false
-
-          if [[ "$eligibility" != "reviewed" ]]; then
-            echo "No review output to post."
-            exit 0
-          fi
-
-          review_mode="comment"
-          if [[ "$findings_count" == "0" && "$verdict" == "approve" && "$may_approve" == "true" && "$diff_truncated" == "false" ]]; then
-            review_mode="approve"
-            approve_without_body=true
-          elif [[ "$findings_count" == "0" && ( "$verdict" == "comment" || "$verdict" == "needs_context" ) ]]; then
-            review_mode="comment"
-          elif [[ "$findings_count" == "0" ]]; then
-            review_mode="comment"
-          elif [[ "$diff_truncated" != "false" ]]; then
-            review_mode="comment"
-          elif [[ "$verdict" == "request_changes" && "$may_request_changes" == "true" && "$blocking_count" != "0" ]]; then
-            review_mode="request-changes"
-          fi
-
-          if [[ "$approve_without_body" == "true" ]]; then
-            if gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-              | jq -e --arg head "$PR_HEAD_SHA" 'any(.[]; .user.login == "github-actions[bot]" and .state == "APPROVED" and .commit_id == $head)' >/dev/null; then
-              echo "Formal Claude approval already exists for $PR_HEAD_SHA; skipping duplicate."
-              exit 0
-            fi
-            if ! gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve; then
-              echo "Formal Claude approval failed; continuing with managed PR comment."
-              touch .claude-review/approval-failed
-              exit 0
-            else
-              exit 0
-            fi
-          fi
-
-          {
-            printf '## Claude PR Review\n\n'
-            jq -r '.summary' "$result"
-            printf '\n\n'
-            jq -r '
-              if (.findings | length) == 0 then
-                "발견 사항 없음."
-              else
-                "발견 사항:\n" + (
-                  [.findings[] |
-                    "- [" + .severity + "/" + (.confidence_score|tostring) + "] " +
-                    .title + " (" + .file + ":" + (if .line == null or .line == 0 then "N/A" else (.line|tostring) end) + ")\n  " +
-                    .body + "\n  제안: " + .suggestion
-                  ] | join("\n")
-                )
-              end
-            ' "$result"
-          } > "$body"
-
-          marker="claude-formal-review head_sha=$PR_HEAD_SHA verdict=$verdict"
-          printf '\n\n<!-- %s -->\n' "$marker" >> "$body"
-
-          if gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            | jq -e --arg marker "$marker" 'any(.[]; (.body // "") | contains($marker))' >/dev/null; then
-            echo "Formal Claude review already exists for $PR_HEAD_SHA / $verdict; skipping duplicate."
-            exit 0
-          fi
-
-          submit_review() {
-            if ! gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" "$@" --body-file "$body"; then
-              echo "Formal Claude review submission failed; continuing with managed PR comment."
-            fi
-          }
-
-          case "$review_mode" in
-            request-changes)
-              submit_review --request-changes
-              ;;
-            comment)
-              submit_review --comment
-              ;;
-            *)
-              echo "unknown review mode: $review_mode" >&2
-              exit 1
-              ;;
-          esac
-
-      - name: Post Claude review comment
+      - name: Submit Claude inline review
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          CLAUDE_REVIEW_MARKER: '<!-- claude-api-pr-review -->'
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          CLAUDE_FORMAL_PREFIX: claude-formal-review
         with:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const result = JSON.parse(fs.readFileSync('.claude-review/result.json', 'utf8'));
-            const marker = process.env.CLAUDE_REVIEW_MARKER;
-            const findings = result.findings || [];
-            const approvalFailed = fs.existsSync('.claude-review/approval-failed');
-            if (result.eligibility?.status !== 'reviewed' || (findings.length === 0 && !approvalFailed)) {
-              core.info('No managed Claude review comment to post.');
+            const { owner, repo } = context.repo;
+            const pull_number = Number(process.env.PR_NUMBER);
+            const head_sha = process.env.PR_HEAD_SHA;
+            const prefix = process.env.CLAUDE_FORMAL_PREFIX;
+            // Posting identity is always the default-token bot — there is no
+            // GitHub App installation token path. Idempotency detection and self
+            // inline-thread identification track this fixed login.
+            const botLogin = 'github-actions[bot]';
+
+            // Deterministic finding fingerprint. Derived ONLY from the finding's
+            // stable attributes — file path, review perspective, and a normalized
+            // title — so the same finding keeps the same fingerprint across review
+            // runs even as the PR evolves and the line shifts (line/start_line are
+            // deliberately excluded). The same normalization is used in
+            // codex-review.yml so both workflows agree byte-identically.
+            const crypto = require('crypto');
+            const normalizeTitle = (s) => String(s == null ? '' : s)
+              .normalize('NFKC')
+              .toLowerCase()
+              .replace(/[^\p{L}\p{N}]+/gu, ' ')
+              .trim();
+            const computeFingerprint = (f) => crypto
+              .createHash('sha256')
+              .update([f.file || '', f.review_perspective || '', normalizeTitle(f.title)].join(' '))
+              .digest('hex')
+              .slice(0, 16);
+
+            if (result.eligibility?.status !== 'reviewed') {
+              core.info('No review output to post.');
               return;
             }
-            const findingText = findings.map((finding, index) => [
-                  `${index + 1}. [${finding.severity}/${finding.confidence_score}] ${finding.title}`,
-                  `${finding.file}:${finding.line == null || finding.line === 0 ? 'N/A' : finding.line}`,
-                  finding.body,
-                  `제안: ${finding.suggestion}`,
-                ].join('\n')).join('\n\n');
-            const body = [
-              marker,
-              '## Claude PR Review',
-              '',
-              `결과: \`${result.verdict}\``,
-              '',
-              approvalFailed
-                ? 'Claude 리뷰에서 지적 사항을 찾지 못했으나, 이 워크플로 토큰 권한으로는 정식 승인을 제출하지 못했습니다.'
-                : (result.summary || '발견 사항 없음. (요약 없음)'),
-              '',
-              approvalFailed ? '발견 사항 없음.' : findingText,
-            ].join('\n');
 
-            const issue_number = Number(process.env.PR_NUMBER);
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number,
-              per_page: 100,
+            const findings = result.findings || [];
+            // inline-only policy: every finding is posted as an inline comment.
+            // There is no issue-level finding channel — findings never get routed
+            // into an issue comment.
+            const inlineFindings = findings;
+
+            const verdict = result.verdict;
+            const mayApprove = !!result.automation_safety?.may_approve;
+            const diffTruncated = !!result.reviewed_context?.diff_truncated;
+
+            // Event decision — official review event is APPROVE or COMMENT only.
+            // The changes-requested review state is abolished: blocking findings
+            // surface as inline comments (inline-only policy), not a review state.
+            let event;
+            if (findings.length === 0 && verdict === 'approve' && mayApprove && !diffTruncated) {
+              event = 'APPROVE';
+            } else {
+              event = 'COMMENT';
+            }
+
+            // Review body: header + summary (when present) + an approval line when
+            // the verdict is approve + the hidden idempotency marker. Finding
+            // evaluations live as inline comments only (inline-only policy).
+            const marker = `<!-- ${prefix} head_sha=${head_sha} verdict=${verdict} -->`;
+            const bodyLines = ['## Claude PR 리뷰', ''];
+            if (result.summary) bodyLines.push(String(result.summary), '');
+            if (verdict === 'approve') bodyLines.push('_승인 — 지적 사항은 인라인 코멘트 참조._', '');
+            bodyLines.push(marker);
+            const body = bodyLines.join('\n');
+
+            // Inline review comments — path/line/body (start_line for multi-line range).
+            // The hidden marker lets us later identify self-owned threads so we can
+            // resolve them on a finding-unit (fingerprint) basis. The base substring
+            // (inlineMarkerBase) is preserved for self-identification, and the
+            // appended fingerprint lets a later run map the model's resolved_threads
+            // judgments back to this thread.
+            const inlineMarkerBase = '<!-- claude-review-inline';
+            const inlineComments = inlineFindings.map((f) => {
+              // Anchor to f.line; fall back to f.start_line so a finding is never
+              // dropped (validation guarantees at least one is a positive int).
+              const anchor = (typeof f.line === 'number' && f.line > 0) ? f.line : f.start_line;
+              const fingerprintMarker = `${inlineMarkerBase} fingerprint=${computeFingerprint(f)} -->`;
+              const c = {
+                path: f.file,
+                body: `**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${fingerprintMarker}`,
+                side: 'RIGHT',
+                line: anchor,
+              };
+              if (typeof f.start_line === 'number'
+                  && f.start_line >= 1 && f.start_line < anchor) {
+                c.start_line = f.start_line;
+                c.start_side = 'RIGHT';
+              }
+              return c;
             });
 
-            const previous = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' &&
-              comment.body?.includes(marker)
-            );
+            // Idempotency.
+            const existingReviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              { owner, repo, pull_number, per_page: 100 });
+            // 중복 감지 시 즉시 return 하지 않는다 — 제출(submit)만 건너뛰고
+            // self inline thread 의 finding 단위 resolve 후처리는 verdict 와 무관하게 계속 실행한다.
+            let skipSubmit = false;
+            if (existingReviews.some((r) =>
+                r.user?.login === botLogin && (r.body || '').includes(marker))) {
+              core.info(`Formal Claude review for ${head_sha} verdict=${verdict} already exists; skipping duplicate submission.`);
+              skipSubmit = true;
+            }
+            if (!skipSubmit && event === 'APPROVE' && existingReviews.some((r) =>
+                r.user?.login === botLogin && r.state === 'APPROVED' && r.commit_id === head_sha)) {
+              core.info(`Formal Claude approval already exists for ${head_sha}; skipping duplicate submission.`);
+              skipSubmit = true;
+            }
 
-            if (previous) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: previous.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number,
-                body,
-              });
+            // Submit. Workflow token cannot self-approve — fall back to COMMENT if APPROVE 403/422s.
+            const submit = (ev) => github.rest.pulls.createReview({
+              owner, repo, pull_number,
+              commit_id: head_sha,
+              event: ev,
+              body,
+              comments: inlineComments,
+            });
+
+            let submitOk = false;
+            if (!skipSubmit) {
+              try {
+                await submit(event);
+                submitOk = true;
+                core.info(`Submitted ${event} review (${inlineComments.length} inline findings).`);
+              } catch (e) {
+                if (event === 'APPROVE') {
+                  core.warning(`APPROVE failed (${e.status || ''} ${e.message}); falling back to COMMENT.`);
+                  fs.writeFileSync('.claude-review/approval-failed', '');
+                  try { await submit('COMMENT'); submitOk = true; }
+                  catch (e2) { core.warning(`Fallback COMMENT also failed (${e2.status || ''} ${e2.message}); continuing.`); }
+                } else {
+                  core.warning(`Review submission failed (${e.status || ''} ${e.message}); continuing.`);
+                }
+              }
+            }
+
+            // inline-only policy: do NOT fall back to dumping findings into an
+            // issue comment — that would place finding evaluations in an issue-level
+            // comment (AC6). If createReview failed, the findings stay unposted and
+            // the failure is surfaced in the workflow log only.
+            if (!skipSubmit && !submitOk && inlineFindings.length > 0) {
+              core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) could not be posted. Not dumping to an issue comment (inline-only policy); see logs.`);
+            }
+
+            // Resolve self inline threads on a finding-unit (fingerprint) basis.
+            // This runs on every review execution regardless of verdict — it is
+            // NOT gated on approve, and runs even when submission was skipped as a
+            // duplicate. Two tiers:
+            //   (1) primary  — fingerprints the model listed in resolved_threads;
+            //   (2) fallback — self threads whose fingerprint is absent from this
+            //                   round's findings set (no longer reported).
+            // A self thread whose fingerprint is still in the findings set (and not
+            // in resolved_threads) is left untouched. Only self-owned threads are
+            // touched; threads whose marker has no extractable fingerprint are left
+            // untouched.
+            const resolvedFingerprints = new Set(
+              (result.resolved_threads || [])
+                .map((r) => r && r.fingerprint)
+                .filter((fp) => typeof fp === 'string' && fp.length > 0));
+            // Deterministic fingerprints for this round's findings (workflow-computed,
+            // not model-supplied) — the fallback tier resolves any self thread whose
+            // fingerprint is absent from this set.
+            const findingFingerprints = new Set(findings.map((f) => computeFingerprint(f)));
+            try {
+              const threadResp = await github.graphql(`
+                query($owner:String!, $repo:String!, $pr:Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $pr) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          id
+                          isResolved
+                          comments(first: 1) {
+                            nodes { author { login } body }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`, { owner, repo, pr: pull_number });
+              const threads = threadResp.repository?.pullRequest?.reviewThreads?.nodes || [];
+              // GraphQL Actor.login omits the REST "[bot]" suffix (returns
+              // "github-actions"), so the REST botLogin never matches here —
+              // accept both forms.
+              const botLoginGql = botLogin.replace(/\[bot\]$/, '');
+              const fpRe = /<!-- claude-review-inline fingerprint=([^\s]+) -->/;
+              for (const t of threads) {
+                if (t.isResolved) continue;
+                const author = t.comments?.nodes?.[0]?.author?.login;
+                if (author !== botLogin && author !== botLoginGql) continue;
+                const cbody = t.comments?.nodes?.[0]?.body || '';
+                if (!cbody.includes(inlineMarkerBase)) continue;
+                const m = cbody.match(fpRe);
+                const fp = m && m[1];
+                if (!fp) continue; // legacy/markerless thread — leave untouched
+                const byModel = resolvedFingerprints.has(fp);
+                const byFallback = !byModel && !findingFingerprints.has(fp);
+                if (!byModel && !byFallback) continue; // still reported — leave
+                try {
+                  await github.graphql(`
+                    mutation($id:ID!) {
+                      resolveReviewThread(input: {threadId: $id}) {
+                        thread { id isResolved }
+                      }
+                    }`, { id: t.id });
+                  core.info(`Resolved self inline thread ${t.id} (fingerprint=${fp}, via=${byModel ? 'resolved_threads' : 'fallback'}).`);
+                } catch (e) {
+                  core.warning(`Failed to resolve thread ${t.id}: ${e.message}`);
+                }
+              }
+            } catch (e) {
+              core.warning(`Failed to fetch review threads for resolve: ${e.message}`);
             }

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -270,168 +270,224 @@ jobs:
           set -euo pipefail
           jq empty .codex-review/result.json
 
-      - name: Submit Codex review verdict
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-
-          result=".codex-review/result.json"
-          body=".codex-review/review-body.md"
-
-          verdict="$(jq -r '.verdict' "$result")"
-          may_approve="$(jq -r '.automation_safety.may_approve' "$result")"
-          may_request_changes="$(jq -r '.automation_safety.may_request_changes' "$result")"
-          eligibility="$(jq -r '.eligibility.status' "$result")"
-          diff_truncated="$(jq -r '.reviewed_context.diff_truncated' "$result")"
-          findings_count="$(jq '.findings | length' "$result")"
-          blocking_count="$(jq '[.findings[] | select(.severity == "blocking" and .confidence_score >= 80)] | length' "$result")"
-          approve_without_body=false
-
-          if [[ "$eligibility" != "reviewed" ]]; then
-            echo "No review output to post."
-            exit 0
-          fi
-
-          review_mode="comment"
-          if [[ "$findings_count" == "0" && "$verdict" == "approve" && "$may_approve" == "true" && "$diff_truncated" == "false" ]]; then
-            review_mode="approve"
-            approve_without_body=true
-          elif [[ "$findings_count" == "0" && ( "$verdict" == "comment" || "$verdict" == "needs_context" ) ]]; then
-            review_mode="comment"
-          elif [[ "$findings_count" == "0" ]]; then
-            review_mode="comment"
-          elif [[ "$diff_truncated" != "false" ]]; then
-            review_mode="comment"
-          elif [[ "$verdict" == "request_changes" && "$may_request_changes" == "true" && "$blocking_count" != "0" ]]; then
-            review_mode="request-changes"
-          fi
-
-          if [[ "$approve_without_body" == "true" ]]; then
-            if gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-              | jq -e --arg head "$PR_HEAD_SHA" 'any(.[]; .user.login == "github-actions[bot]" and .state == "APPROVED" and .commit_id == $head)' >/dev/null; then
-              echo "Formal Codex approval already exists for $PR_HEAD_SHA; skipping duplicate."
-              exit 0
-            fi
-            if ! gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --approve; then
-              echo "Formal Codex approval failed; continuing with managed PR comment."
-              touch .codex-review/approval-failed
-              exit 0
-            else
-              exit 0
-            fi
-          fi
-
-          {
-            printf '## Codex PR Review\n\n'
-            jq -r '.summary' "$result"
-            printf '\n\n'
-            jq -r '
-              if (.findings | length) == 0 then
-                "발견 사항 없음."
-              else
-                "발견 사항:\n" + (
-                  [.findings[] |
-                    "- [" + .severity + "/" + (.confidence_score|tostring) + "] " +
-                    .title + " (" + .file + ":" + (if .line == null or .line == 0 then "N/A" else (.line|tostring) end) + ")\n  " +
-                    .body + "\n  제안: " + .suggestion
-                  ] | join("\n")
-                )
-              end
-            ' "$result"
-          } > "$body"
-
-          marker="codex-formal-review head_sha=$PR_HEAD_SHA verdict=$verdict"
-          printf '\n\n<!-- %s -->\n' "$marker" >> "$body"
-
-          if gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-            | jq -e --arg marker "$marker" 'any(.[]; (.body // "") | contains($marker))' >/dev/null; then
-            echo "Formal Codex review already exists for $PR_HEAD_SHA / $verdict; skipping duplicate."
-            exit 0
-          fi
-
-          submit_review() {
-            if ! gh pr review "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" "$@" --body-file "$body"; then
-              echo "Formal Codex review submission failed; continuing with managed PR comment."
-            fi
-          }
-
-          case "$review_mode" in
-            request-changes)
-              submit_review --request-changes
-              ;;
-            comment)
-              submit_review --comment
-              ;;
-            *)
-              echo "unknown review mode: $review_mode" >&2
-              exit 1
-              ;;
-          esac
-
-      - name: Post Codex review comment
+      - name: Submit Codex inline review
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
-          CODEX_REVIEW_MARKER: '<!-- codex-api-pr-review -->'
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          CODEX_FORMAL_PREFIX: codex-formal-review
         with:
           github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const result = JSON.parse(fs.readFileSync('.codex-review/result.json', 'utf8'));
-            const marker = process.env.CODEX_REVIEW_MARKER;
-            const findings = result.findings || [];
-            const approvalFailed = fs.existsSync('.codex-review/approval-failed');
-            if (result.eligibility?.status !== 'reviewed' || (findings.length === 0 && !approvalFailed)) {
-              core.info('No managed Codex review comment to post.');
+            const { owner, repo } = context.repo;
+            const pull_number = Number(process.env.PR_NUMBER);
+            const head_sha = process.env.PR_HEAD_SHA;
+            const prefix = process.env.CODEX_FORMAL_PREFIX;
+            // Posting identity is always the default-token bot — there is no
+            // GitHub App installation token path. Idempotency detection and self
+            // inline-thread identification track this fixed login.
+            const botLogin = 'github-actions[bot]';
+
+            // Deterministic finding fingerprint. Derived ONLY from the finding's
+            // stable attributes — file path, review perspective, and a normalized
+            // title — so the same finding keeps the same fingerprint across review
+            // runs even as the PR evolves and the line shifts (line/start_line are
+            // deliberately excluded). The same normalization is used in
+            // claude-review.yml so both workflows agree byte-identically.
+            const crypto = require('crypto');
+            const normalizeTitle = (s) => String(s == null ? '' : s)
+              .normalize('NFKC')
+              .toLowerCase()
+              .replace(/[^\p{L}\p{N}]+/gu, ' ')
+              .trim();
+            const computeFingerprint = (f) => crypto
+              .createHash('sha256')
+              .update([f.file || '', f.review_perspective || '', normalizeTitle(f.title)].join(' '))
+              .digest('hex')
+              .slice(0, 16);
+
+            if (result.eligibility?.status !== 'reviewed') {
+              core.info('No review output to post.');
               return;
             }
-            const findingText = findings.map((finding, index) => [
-                  `${index + 1}. [${finding.severity}/${finding.confidence_score}] ${finding.title}`,
-                  `${finding.file}:${finding.line == null || finding.line === 0 ? 'N/A' : finding.line}`,
-                  finding.body,
-                  `제안: ${finding.suggestion}`,
-                ].join('\n')).join('\n\n');
-            const body = [
-              marker,
-              '## Codex PR Review',
-              '',
-              `결과: \`${result.verdict}\``,
-              '',
-              approvalFailed
-                ? 'Codex 리뷰에서 지적 사항을 찾지 못했으나, 이 워크플로 토큰 권한으로는 정식 승인을 제출하지 못했습니다.'
-                : (result.summary || '발견 사항 없음. (요약 없음)'),
-              '',
-              approvalFailed ? '발견 사항 없음.' : findingText,
-            ].join('\n');
 
-            const issue_number = Number(process.env.PR_NUMBER);
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number,
-              per_page: 100,
+            const findings = result.findings || [];
+            // inline-only policy: every finding is posted as an inline comment.
+            // There is no issue-level finding channel — findings never get routed
+            // into an issue comment.
+            const inlineFindings = findings;
+
+            const verdict = result.verdict;
+            const mayApprove = !!result.automation_safety?.may_approve;
+            const diffTruncated = !!result.reviewed_context?.diff_truncated;
+
+            // Event decision — official review event is APPROVE or COMMENT only.
+            // The changes-requested review state is abolished: blocking findings
+            // surface as inline comments (inline-only policy), not a review state.
+            let event;
+            if (findings.length === 0 && verdict === 'approve' && mayApprove && !diffTruncated) {
+              event = 'APPROVE';
+            } else {
+              event = 'COMMENT';
+            }
+
+            // Review body: header + summary (when present) + an approval line when
+            // the verdict is approve + the hidden idempotency marker. Finding
+            // evaluations live as inline comments only (inline-only policy).
+            const marker = `<!-- ${prefix} head_sha=${head_sha} verdict=${verdict} -->`;
+            const bodyLines = ['## Codex PR 리뷰', ''];
+            if (result.summary) bodyLines.push(String(result.summary), '');
+            if (verdict === 'approve') bodyLines.push('_승인 — 지적 사항은 인라인 코멘트 참조._', '');
+            bodyLines.push(marker);
+            const body = bodyLines.join('\n');
+
+            // Inline review comments — path/line/body (start_line for multi-line range).
+            // The hidden marker lets us later identify self-owned threads so we can
+            // resolve them on a finding-unit (fingerprint) basis. The base substring
+            // (inlineMarkerBase) is preserved for self-identification, and the
+            // appended fingerprint lets a later run map the model's resolved_threads
+            // judgments back to this thread.
+            const inlineMarkerBase = '<!-- codex-review-inline';
+            const inlineComments = inlineFindings.map((f) => {
+              // Anchor to f.line; fall back to f.start_line so a finding is never
+              // dropped (validation guarantees at least one is a positive int).
+              const anchor = (typeof f.line === 'number' && f.line > 0) ? f.line : f.start_line;
+              const fingerprintMarker = `${inlineMarkerBase} fingerprint=${computeFingerprint(f)} -->`;
+              const c = {
+                path: f.file,
+                body: `**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${fingerprintMarker}`,
+                side: 'RIGHT',
+                line: anchor,
+              };
+              if (typeof f.start_line === 'number'
+                  && f.start_line >= 1 && f.start_line < anchor) {
+                c.start_line = f.start_line;
+                c.start_side = 'RIGHT';
+              }
+              return c;
             });
 
-            const previous = comments.find((comment) =>
-              comment.user?.login === 'github-actions[bot]' &&
-              comment.body?.includes(marker)
-            );
+            // Idempotency.
+            const existingReviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              { owner, repo, pull_number, per_page: 100 });
+            // 중복 감지 시 즉시 return 하지 않는다 — 제출(submit)만 건너뛰고
+            // self inline thread 의 finding 단위 resolve 후처리는 verdict 와 무관하게 계속 실행한다.
+            let skipSubmit = false;
+            if (existingReviews.some((r) =>
+                r.user?.login === botLogin && (r.body || '').includes(marker))) {
+              core.info(`Formal Codex review for ${head_sha} verdict=${verdict} already exists; skipping duplicate submission.`);
+              skipSubmit = true;
+            }
+            if (!skipSubmit && event === 'APPROVE' && existingReviews.some((r) =>
+                r.user?.login === botLogin && r.state === 'APPROVED' && r.commit_id === head_sha)) {
+              core.info(`Formal Codex approval already exists for ${head_sha}; skipping duplicate submission.`);
+              skipSubmit = true;
+            }
 
-            if (previous) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: previous.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number,
-                body,
-              });
+            // Submit. Workflow token cannot self-approve — fall back to COMMENT if APPROVE 403/422s.
+            const submit = (ev) => github.rest.pulls.createReview({
+              owner, repo, pull_number,
+              commit_id: head_sha,
+              event: ev,
+              body,
+              comments: inlineComments,
+            });
+
+            let submitOk = false;
+            if (!skipSubmit) {
+              try {
+                await submit(event);
+                submitOk = true;
+                core.info(`Submitted ${event} review (${inlineComments.length} inline findings).`);
+              } catch (e) {
+                if (event === 'APPROVE') {
+                  core.warning(`APPROVE failed (${e.status || ''} ${e.message}); falling back to COMMENT.`);
+                  fs.writeFileSync('.codex-review/approval-failed', '');
+                  try { await submit('COMMENT'); submitOk = true; }
+                  catch (e2) { core.warning(`Fallback COMMENT also failed (${e2.status || ''} ${e2.message}); continuing.`); }
+                } else {
+                  core.warning(`Review submission failed (${e.status || ''} ${e.message}); continuing.`);
+                }
+              }
+            }
+
+            // inline-only policy: do NOT fall back to dumping findings into an
+            // issue comment — that would place finding evaluations in an issue-level
+            // comment (AC6). If createReview failed, the findings stay unposted and
+            // the failure is surfaced in the workflow log only.
+            if (!skipSubmit && !submitOk && inlineFindings.length > 0) {
+              core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) could not be posted. Not dumping to an issue comment (inline-only policy); see logs.`);
+            }
+
+            // Resolve self inline threads on a finding-unit (fingerprint) basis.
+            // This runs on every review execution regardless of verdict — it is
+            // NOT gated on approve, and runs even when submission was skipped as a
+            // duplicate. Two tiers:
+            //   (1) primary  — fingerprints the model listed in resolved_threads;
+            //   (2) fallback — self threads whose fingerprint is absent from this
+            //                   round's findings set (no longer reported).
+            // A self thread whose fingerprint is still in the findings set (and not
+            // in resolved_threads) is left untouched. Only self-owned threads are
+            // touched; threads whose marker has no extractable fingerprint are left
+            // untouched.
+            const resolvedFingerprints = new Set(
+              (result.resolved_threads || [])
+                .map((r) => r && r.fingerprint)
+                .filter((fp) => typeof fp === 'string' && fp.length > 0));
+            // Deterministic fingerprints for this round's findings (workflow-computed,
+            // not model-supplied) — the fallback tier resolves any self thread whose
+            // fingerprint is absent from this set.
+            const findingFingerprints = new Set(findings.map((f) => computeFingerprint(f)));
+            try {
+              const threadResp = await github.graphql(`
+                query($owner:String!, $repo:String!, $pr:Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $pr) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          id
+                          isResolved
+                          comments(first: 1) {
+                            nodes { author { login } body }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`, { owner, repo, pr: pull_number });
+              const threads = threadResp.repository?.pullRequest?.reviewThreads?.nodes || [];
+              // GraphQL Actor.login omits the REST "[bot]" suffix (returns
+              // "github-actions"), so the REST botLogin never matches here —
+              // accept both forms.
+              const botLoginGql = botLogin.replace(/\[bot\]$/, '');
+              const fpRe = /<!-- codex-review-inline fingerprint=([^\s]+) -->/;
+              for (const t of threads) {
+                if (t.isResolved) continue;
+                const author = t.comments?.nodes?.[0]?.author?.login;
+                if (author !== botLogin && author !== botLoginGql) continue;
+                const cbody = t.comments?.nodes?.[0]?.body || '';
+                if (!cbody.includes(inlineMarkerBase)) continue;
+                const m = cbody.match(fpRe);
+                const fp = m && m[1];
+                if (!fp) continue; // legacy/markerless thread — leave untouched
+                const byModel = resolvedFingerprints.has(fp);
+                const byFallback = !byModel && !findingFingerprints.has(fp);
+                if (!byModel && !byFallback) continue; // still reported — leave
+                try {
+                  await github.graphql(`
+                    mutation($id:ID!) {
+                      resolveReviewThread(input: {threadId: $id}) {
+                        thread { id isResolved }
+                      }
+                    }`, { id: t.id });
+                  core.info(`Resolved self inline thread ${t.id} (fingerprint=${fp}, via=${byModel ? 'resolved_threads' : 'fallback'}).`);
+                } catch (e) {
+                  core.warning(`Failed to resolve thread ${t.id}: ${e.message}`);
+                }
+              }
+            } catch (e) {
+              core.warning(`Failed to fetch review threads for resolve: ${e.message}`);
             }

--- a/docs/claude/pr-review-workflow.md
+++ b/docs/claude/pr-review-workflow.md
@@ -7,7 +7,7 @@
 - Codex PR review workflow와 같은 review core schema를 공유한다.
 - diff를 먼저 읽고 필요한 문맥만 사용한다.
 - 명확하고 실행 가능한 correctness 이슈만 남긴다.
-- Claude 출력은 action `structured_output`으로 받아 GitHub review 동작으로 매핑한다.
+- Claude 출력의 발견사항(findings)은 코드 라인에 anchor된 inline review thread로, 요약(summary)은 그 리뷰 본문으로 단일 리뷰에 담아 게시한다.
 - GitHub 전용 publish 로직과 모델별 review prompt를 분리한다.
 
 ## 현재 1차 워크플로
@@ -17,11 +17,9 @@
 3. `.github/prompts/claude-pr-review.ko.md`를 system prompt처럼 붙인다.
 4. pinned `anthropics/claude-code-action`을 실행하면서 `.github/prompts/codex-pr-review.schema.json`을 `--json-schema`로 전달한다.
 5. action `structured_output`을 `.claude-review/result.json`으로 저장하고 JSON으로 검증한다.
-6. `verdict`에 따라 GitHub review를 제출한다.
-   - `approve`: `gh pr review --approve`
-   - `request_changes`: `gh pr review --request-changes`
-   - `comment`, `needs_context`, `unavailable`: `gh pr review --comment`
-7. managed issue comment를 marker 기반으로 create/update한다.
+6. 발견사항을 inline review comment 배열로 만든다. 각 comment는 발견사항의 파일과 변경 라인에 anchor되고 `side: 'RIGHT'`이며(multi-line이면 `start_line`/`start_side` 추가), 본문 끝에 숨김 마커 `<!-- claude-review-inline fingerprint=<fp> -->`를 붙인다. `fingerprint`는 발견사항의 안정 속성(파일 경로 + 리뷰 관점 + 정규화한 제목)만으로 결정론적으로 계산되며 줄 번호에 의존하지 않는다(정규화·해시 규칙은 codex 워크플로와 byte-identical).
+7. `result.summary`(있으면)를 리뷰 본문에 담고, inline comment 배열과 함께 단일 `github.rest.pulls.createReview` 호출로 제출한다. review event는 발견사항 0 + `approve` verdict + `automation_safety.may_approve` + diff 미절단일 때 `APPROVE`, 그 외 `COMMENT`다. 워크플로 기본 토큰이 self-approve를 못 해 `APPROVE`가 실패하면 같은 inline 코멘트를 담은 `COMMENT` 리뷰로 강등 제출하고 `.claude-review/approval-failed`로 기록한다. 본문에는 `<!-- claude-formal-review head_sha=… verdict=… -->` 멱등 마커가 들어가, 같은 마커의 봇 리뷰가 이미 있으면 제출만 건너뛴다.
+8. 게시 후(중복으로 제출을 건너뛰었어도 verdict와 무관하게), GraphQL `reviewThreads`로 조회해 자기 소유 + fingerprint 추출 가능 + 미해결인 inline thread를 fingerprint 기준으로 자동 resolve한다 — 모델이 `resolved_threads`에 올린 fingerprint(1차)이거나 이번 회차 findings의 fingerprint 집합에서 사라진 thread(2차 fallback)를 `resolveReviewThread`로 닫는다. 다른 리뷰어 thread나 fingerprint를 추출할 수 없는 thread는 건드리지 않는다. 발견사항을 담는 별도의 마커 관리형 이슈 레벨 코멘트 게시 경로는 없다(발견사항은 inline 전용).
 
 ## 운영 원칙
 

--- a/docs/codex/pr-review-workflow.md
+++ b/docs/codex/pr-review-workflow.md
@@ -2,7 +2,7 @@
 
 이 문서는 `codex review` 자연어 출력 대신 직접 프롬프팅한 structured JSON을 사용해 PR 리뷰를 자동화하는 계획과 경계를 정의한다.
 
-모델 호출은 셸에서 `codex exec`를 직접 실행하지 않고 공식 GitHub Action `openai/codex-action`(SHA 고정, codex CLI 버전은 action의 `codex-version` 입력으로 고정)을 통해 이뤄진다. 인증은 ChatGPT 계정 `auth.json`을 codex-home 디렉터리로 부트스트랩하는 방식을 쓰며 API 키 입력은 사용하지 않는다. 리뷰 결과 게시는 자매 워크플로(Claude PR 리뷰, `claude-review.yml`)와 **동일한 구조**다 — 정식 리뷰 verdict 제출 + 마커 기반 관리형 PR 코멘트 1개. codex만의 독자 게시 경로(인라인 코멘트, fingerprint 기반 self thread 자동 resolve, GitHub App 토큰 정식 approve)는 사용하지 않는다.
+모델 호출은 셸에서 `codex exec`를 직접 실행하지 않고 공식 GitHub Action `openai/codex-action`(SHA 고정, codex CLI 버전은 action의 `codex-version` 입력으로 고정)을 통해 이뤄진다. 인증은 ChatGPT 계정 `auth.json`을 codex-home 디렉터리로 부트스트랩하는 방식을 쓰며 API 키 입력은 사용하지 않는다. 리뷰 결과 게시는 자매 워크플로(Claude PR 리뷰, `claude-review.yml`)와 **동일한 구조**다 — 발견사항(findings)을 코드 라인에 anchor된 inline review thread로, 요약(summary)을 리뷰 본문으로 담은 **단일 inline 리뷰** 제출 + 모델이 해소로 판정한 자기 소유 thread의 **fingerprint 기준 자동 resolve**. 별도의 마커 관리형 이슈 레벨 코멘트 게시 경로는 없으며, 게시·resolve는 워크플로 기본 토큰만 사용한다(GitHub App 설치 토큰 발급·App 토큰 정식 approve 경로 없음).
 
 ## 목표
 
@@ -20,11 +20,12 @@
    - **server-info 시드(중요)**: action은 API 키가 있을 때만 Responses API 프록시를 띄워 `<codex-home>/<run_id>.json`(server-info)을 쓰지만, 그 파일을 읽는 "Read server info" 스텝은 프롬프트만 있으면 무조건 실행된다. API 키 없이 auth.json만 쓰면 읽을 파일이 없어 `Failed to read server info`로 죽는다. 그래서 부트스트랩 단계에서 codex-home에 `auth.json`과 함께 더미 server-info(`{"port":1}`)를 같은 `<run_id>.json` 이름으로 미리 심는다. 프록시 설정 스텝도 API 키 게이트라 건너뛰므로 더미 port는 실제로 연결되지 않고 codex는 auth.json으로 OpenAI에 직접 인증한다. (이 시드는 고정한 action SHA의 step 게이트 동작에 결합되어 있다 — action 갱신 시 재검증 필요.)
 5. 결과 JSON을 저장 직후 `jq empty`로 유효성을 검증한다.
 6. 모델이 `needs_context`를 반환하면 요청 파일(최대 5개)을 PR head에서 수집해 2차 호출로 최종 verdict를 받는다(Claude 리뷰와 동일한 2-pass 흐름).
-7. 게시는 자매 Claude 워크플로와 **동일한 구조**다(`claude-review.yml`의 'Submit … review verdict' + 'Post … review comment' 스텝을 codex 라벨·마커로 치환).
-   - **정식 리뷰 verdict 제출**: `gh pr review`로 `--approve` / `--comment` / `--request-changes` 중 하나를 제출한다. 승인은 findings가 없고 `automation_safety.may_approve=true`이며 diff가 truncate되지 않았을 때만, request-changes는 confidence ≥ 80 blocking finding이 있을 때만. 본문 헤더는 `## Codex PR Review`이며 숨김 멱등 마커 `codex-formal-review head_sha=… verdict=…`를 담는다. 같은 (head_sha, verdict) 리뷰가 이미 있으면 중복 제출을 건너뛴다.
-   - **마커 관리형 PR 코멘트 1개**: findings를 담은 issue-level 코멘트를 마커(`<!-- codex-api-pr-review -->`) 기준으로 최대 1개만 생성하거나 갱신한다(clean approve일 때는 게시하지 않음). 기본 토큰 봇(`github-actions[bot]`)이 자기 소유 코멘트를 식별·갱신한다.
+7. 게시는 자매 Claude 워크플로와 **동일한 구조**인 단일 `Submit … inline review` 스텝(codex 라벨·마커로 치환)에서 이뤄진다.
+   - **inline comment 조립**: 발견사항마다 파일과 변경 라인에 anchor된 inline comment(`side: 'RIGHT'`, multi-line이면 `start_line`/`start_side` 추가)를 만들고 본문 끝에 숨김 마커 `<!-- codex-review-inline fingerprint=<fp> -->`를 붙인다. `fingerprint`는 발견사항의 안정 속성(파일 경로 + 리뷰 관점 + 정규화한 제목)만으로 결정론적으로 계산되며 줄 번호에 의존하지 않는다(정규화·해시 규칙은 Claude 워크플로와 byte-identical).
+   - **단일 리뷰 제출**: `result.summary`(있으면)를 리뷰 본문에 담고 inline comment 배열과 함께 단일 `github.rest.pulls.createReview` 호출로 제출한다. review event는 findings가 없고 `automation_safety.may_approve=true`이며 diff가 truncate되지 않은 `approve`일 때 `APPROVE`, 그 외 `COMMENT`다(REQUEST_CHANGES는 폐지). 본문 헤더는 `## Codex PR 리뷰`이며 숨김 멱등 마커 `codex-formal-review head_sha=… verdict=…`를 담는다. 같은 마커의 봇 리뷰가 이미 있으면 제출만 건너뛴다(resolve 후처리는 계속). 워크플로 기본 토큰은 자기 PR을 정식 APPROVE하지 못하므로 `APPROVE`가 실패하면 같은 inline 코멘트를 담은 `COMMENT` 리뷰로 강등 제출하고 `.codex-review/approval-failed`로 기록한다.
+   - **fingerprint 기준 self thread resolve**: 제출(또는 중복 skip) 후 verdict와 무관하게, GraphQL `reviewThreads`로 조회해 자기 소유 + fingerprint 추출 가능 + 미해결인 inline thread를 자동 resolve한다 — 모델이 `resolved_threads`에 올린 fingerprint(1차)이거나 이번 회차 findings의 fingerprint 집합에서 사라진 thread(2차 fallback)를 `resolveReviewThread`로 닫는다. 다른 리뷰어 thread나 fingerprint를 추출할 수 없는 thread는 건드리지 않는다.
 
-   인라인 리뷰 코멘트, fingerprint 기반 self thread 자동 resolve, GitHub App 설치 토큰을 통한 정식 approve는 사용하지 않는다(Claude 리뷰와 동일한 한계: 워크플로 기본 토큰은 자기 PR을 정식 APPROVE하지 못해 COMMENT로 강등될 수 있다).
+   별도의 마커 관리형 이슈 레벨 코멘트 게시 경로는 없다(발견사항은 inline 전용; 요약은 리뷰 본문에만 실린다). createReview가 라인 매핑 등으로 실패하면 그 회차 inline은 게시되지 않고 로그로만 남으며, 발견사항을 이슈 코멘트로 덤프하지 않는다.
 
 ## 단계적 고도화 계획
 
@@ -38,29 +39,30 @@
 완료 기준:
 - JSON schema 검증이 실패하면 approve하지 않는다.
 - `approve` verdict는 findings가 비어 있고 `automation_safety.may_approve=true`일 때만 제출된다.
-- `request_changes`는 confidence 80 이상의 blocking finding이 있을 때만 제출된다.
+- `request_changes` verdict는 별도의 REQUEST_CHANGES 리뷰 이벤트로 제출되지 않는다(폐지). blocking finding은 inline comment로 게시되고 리뷰 이벤트는 `COMMENT`로 남는다.
 
-### Phase 2: Inline Comment Adapter (superseded)
+### Phase 2: Inline Comment Adapter
 
-> **Superseded.** 게시 구조를 자매 Claude 워크플로와 통일하면서 codex 독자 인라인 코멘트 경로는 제거되었다. findings는 인라인이 아니라 마커 관리형 PR 코멘트 1개에 담겨 게시된다("현재 1차 워크플로" 7번 참조). 아래는 과거 설계 기록이다.
+게시는 모든 finding을 코드 라인에 anchor된 GitHub inline review comment로 올린다("현재 1차 워크플로" 7번 참조).
 
-- ~~모든 finding을 GitHub inline review comment로 게시한다(inline-only 정책).~~
-- ~~changed line에 직접 매핑되지 않는 finding도 issue comment로 떨어뜨리지 않고, 가장 가까운 변경 hunk 라인에 inline으로 붙이고 본문에 실제 위치를 명시한다.~~
-- ~~comment marker에 `fingerprint`, `head_sha`, `severity`, `status`를 저장한다.~~
-- ~~같은 fingerprint가 이미 존재하면 중복 게시하지 않는다.~~
+- 모든 finding을 GitHub inline review comment로 게시한다(inline-only 정책).
+- changed line에 직접 매핑되지 않는 finding도 issue comment로 떨어뜨리지 않고, 가장 가까운 변경 hunk 라인에 inline으로 붙이고 본문에 실제 위치를 명시한다.
+- inline comment 본문 끝 숨김 마커에 결정론적 `fingerprint`를 저장한다(마커 base substring을 보존해 self-식별을 유지).
+- `fingerprint`는 파일 경로 + 리뷰 관점 + 정규화한 제목만으로 계산되어 줄 이동에도 실행 간 동일하다.
 
-### Phase 3: Thread Lifecycle (superseded)
+### Phase 3: Thread Lifecycle
 
-> **Superseded.** Claude 동일 게시 구조에는 self thread lifecycle 관리가 없다. fingerprint 기반 self thread 자동 resolve 경로는 제거되었다. 아래는 과거 설계 기록이다.
+자기 소유 inline thread는 fingerprint 단위로 자동 resolve한다("현재 1차 워크플로" 7번 참조).
 
-- ~~GraphQL `reviewThreads`를 읽어 `isResolved`, `isOutdated`, root comment body, marker를 수집한다.~~
-- ~~Codex-owned active thread만 resolve/unresolve/reply 대상으로 삼는다.~~
-- ~~최신 push가 기존 finding을 고쳤으면 resolve한다.~~
-- ~~아직 고쳐지지 않았으면 같은 thread에 후속 피드백을 단다.~~
+- GraphQL `reviewThreads`를 읽어 `isResolved`, root comment author, marker(fingerprint)를 수집한다.
+- 자기 소유(`github-actions[bot]`, GraphQL은 `[bot]` 접미사 생략형도 허용) + fingerprint 추출 가능 + 미해결 thread만 resolve 대상으로 삼는다.
+- 모델이 `resolved_threads`에 올린 fingerprint(1차)이거나 이번 회차 findings의 fingerprint 집합에서 사라진 thread(2차 fallback)를 `resolveReviewThread`로 닫는다.
+- 아직 보고되는(findings에 남은) fingerprint의 thread는 건드리지 않는다.
 
-완료 기준(과거):
-- Codex가 만들지 않은 thread는 절대 resolve하지 않는다.
-- outdated thread는 fingerprint로 최신 diff에 남아 있는지 재확인한다.
+완료 기준:
+- 봇이 만들지 않은 thread는 절대 resolve하지 않는다.
+- fingerprint를 추출할 수 없는 thread는 건드리지 않는다.
+- resolve는 verdict와 무관하게, 중복으로 제출을 건너뛴 경우에도 실행된다.
 
 ### Phase 4: Token Optimized Review
 

--- a/docs/specs/2026-06-02-pr-review-inline-thread-fingerprint-resolve/SPEC.md
+++ b/docs/specs/2026-06-02-pr-review-inline-thread-fingerprint-resolve/SPEC.md
@@ -1,0 +1,99 @@
+---
+scope:
+  include:
+    - .github/workflows/codex-review.yml
+    - .github/workflows/claude-review.yml
+    - tests/codex/test-codex-review-workflow.sh
+    - tests/claude/test-claude-review-workflow.sh
+    - docs/codex/pr-review-workflow.md
+    - docs/claude/pr-review-workflow.md
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+# ears_language: ko
+---
+
+# PR Review Inline Thread 게시 + fingerprint resolve 복원
+
+## 무엇을 만들 것인가
+<!-- WHAT/HOW 방어선: 무엇을 만들지만 적고 구현 방법·파일·라이브러리·클래스명은 제약으로 이동. -->
+
+두 PR 리뷰 GitHub Actions 워크플로(Codex·Claude)가 리뷰 발견사항(findings)을 **코드 라인에 anchor된 inline review thread**로 게시하고, 모델이 해소되었다고 판정한 자기 소유 thread를 **fingerprint 기준으로 자동 resolve**하도록 게시 동작을 전환한다.
+
+현재 두 워크플로의 프롬프트와 공유 스키마는 이미 "inline 전용 게시 + fingerprint 기반 thread 라이프사이클"을 완전히 기술하지만, 실제 게시 단계는 그 데이터를 버리고 정식 verdict 리뷰 + 마커 관리형 이슈 코멘트 1개를 평문으로 올린다. 이 어긋남을 해소해, 게시를 **단일 inline 리뷰**로 통합한다 — findings는 inline comment로, 리뷰 요약(summary)은 그 리뷰 본문으로, 한 번의 리뷰 제출에 담는다. 별도 마커 관리형 이슈 코멘트 게시 경로는 제거한다.
+
+이 inline+resolve 게시 동작은 과거에 존재했다가 제거된 것으로, 검증된 구현이 git 이력에 온전히 남아 있다. 백지에서 다시 설계하지 않고 그 구현을 현재(앱 토큰이 제거된) 구조에 맞춰 복원·적응한다.
+
+## 완료 조건
+<!-- 5문장 패턴(항상 / …할 때 / …인 동안 / …이면(오류) / …기능이 켜지면). 각 조건은 관찰 가능하고 독립 검증 가능. -->
+
+1. **항상**, 두 워크플로(Codex·Claude)의 리뷰 게시 단계는 발견사항을 inline comment 배열과 함께 단일 리뷰 생성 호출(`github.rest.pulls.createReview`의 `comments[]`)로 게시해야 한다. 각 inline comment는 발견사항의 파일과 변경 라인에 anchor되고 `side: 'RIGHT'`를 갖는다.
+
+2. **모델이 발견사항을 반환할 때**, 시스템은 각 inline comment 본문 끝에 그 발견사항의 fingerprint를 담은 숨김 마커(`<!-- codex-review-inline fingerprint=… -->` 또는 `<!-- claude-review-inline fingerprint=… -->`)를 자동으로 덧붙여야 한다.
+
+3. **항상**, fingerprint는 발견사항의 안정 속성(파일 경로 + 리뷰 관점 + 정규화한 제목)만으로 계산되고 줄 번호에 의존하지 않아야 하며, 두 워크플로가 byte-identical한 정규화·해시 규칙으로 같은 값을 산출해야 한다(같은 발견사항은 PR 진화로 줄 위치가 바뀌어도 실행 간 동일 fingerprint).
+
+4. **모델이 어떤 self thread를 해소로 판정(resolved_threads)했거나, 이전 회차 self thread의 발견사항이 이번 회차 발견사항 집합에서 사라졌을 때**, 시스템은 그 자기 소유 미해결 inline thread를 자동으로 resolve해야 한다(리뷰 thread 조회 → 자기 소유 + fingerprint 추출 가능 + 미해결인 thread만 대상; 다른 리뷰어 thread는 건드리지 않음). 이 후처리는 verdict와 무관하게, 그리고 중복 제출로 게시를 건너뛴 경우에도 실행되어야 한다.
+
+5. **항상**, 게시·resolve는 워크플로 기본 토큰만 사용해야 하며 GitHub App 설치 토큰 발급·App 토큰 정식 승인 경로를 두지 않아야 한다.
+
+6. **항상**, 발견사항을 담는 별도의 마커 관리형 이슈 레벨 코멘트 게시 경로가 없어야 한다(발견사항은 inline 전용; 요약은 리뷰 본문에만 실린다).
+
+7. **정식 승인(APPROVE) 제출이 토큰 권한으로 실패하면**, 시스템은 같은 inline 코멘트를 담은 COMMENT 리뷰로 강등 제출하고 승인 실패를 기록해야 한다(발견사항을 미게시로 흘리지 않음).
+
+8. **항상**, 두 계약 테스트(`tests/codex/test-codex-review-workflow.sh`, `tests/claude/test-claude-review-workflow.sh`)가 inline 게시·fingerprint resolve 동작의 존재를 단언하고 모두 통과(ALL CHECKS PASSED)해야 한다.
+
+## 범위
+포함:
+- `.github/workflows/codex-review.yml`: 게시 두 스텝(`Submit Codex review verdict` + `Post Codex review comment`)을 단일 inline 리뷰 게시 스텝으로 대체.
+- `.github/workflows/claude-review.yml`: 동일하게 `Submit Claude review verdict` + `Post Claude review comment`를 단일 inline 리뷰 게시 스텝으로 대체.
+- `tests/codex/test-codex-review-workflow.sh`: inline 부재를 강제하던 검사를 inline 존재 강제로 반전, verdict/이슈 코멘트 검사를 inline 구조로 갱신.
+- `tests/claude/test-claude-review-workflow.sh`: 동일한 inline 존재 + fingerprint resolve 회귀 가드 추가(패리티), 기존 verdict/comment 검사 갱신.
+- `docs/codex/pr-review-workflow.md`: Phase 2/3 "superseded" 표기 해제 → 현행 동작 기술.
+- `docs/claude/pr-review-workflow.md`: 게시 구조 기술을 inline 단일 리뷰 + fingerprint resolve로 갱신.
+
+비-목표 / 제외:
+- 공유 스키마(`.github/prompts/codex-pr-review.schema.json`) 수정 — 이미 inline·fingerprint thread 필드 보유.
+- 두 리뷰 프롬프트(`.github/prompts/*-pr-review.ko.md`) 수정 — 이미 inline 전용 정책·마커 라이프사이클 기술.
+- 공유 컨텍스트 헬퍼(`.github/scripts/pr-review-context.sh`) 수정 — 기존 thread는 게시 스텝이 GraphQL로 직접 조회.
+- createReview all-or-nothing 422를 회피하는 diff 라인 사전검증 하드닝 — 별도 후속(범위 외).
+- 모델 호출·인증·2-pass needs_context 흐름 등 게시 외 단계 변경.
+
+## 검증
+<!-- 검증 기준의 단일 출처는 위 "완료 조건"이다. 검증을 실행하는 진입 명령(테스트·lint·빌드)은 SPEC이 선언하지 않는다. -->
+이 SPEC의 인수 바는 위 **완료 조건**이다. 각 조건이 관찰 가능하게 충족되면 충족된 것으로 본다. 검증을 실행하는 진입 명령은 SPEC이 아니라 프로젝트 규칙(`rules/`)이 단일 출처로 정의한다.
+
+## 제약 (있을 때만)
+
+**복원 기준 구현 (백지 작성 금지).** 검증된 구현이 커밋 `3199ff1`에 온전히 존재한다. 이를 참조해 복원·적응한다:
+- 참조: `git show 3199ff1:.github/workflows/codex-review.yml` — 게시 스텝은 단일 `actions/github-script` 블록(원본 L248-480). 동일 시점의 `claude-review.yml`도 같은 구조.
+- 신규 게시 스텝은 `actions/github-script`(현재 SHA 고정 핀 유지) 한 개로, 다음을 수행한다:
+  - **결정론적 fingerprint**: `sha256(file + ' ' + review_perspective + ' ' + normalizeTitle(title))`의 hex 앞 16자. `normalizeTitle` = NFKC 정규화 → 소문자 → `[^\p{L}\p{N}]+`를 단일 공백으로 → trim. 정규화·해시 규칙은 두 워크플로 byte-identical.
+  - **inline comments 배열**: 발견사항마다 `{ path: f.file, line: (f.line>0 ? f.line : f.start_line), side: 'RIGHT', body }`. multi-line이면 `start_line < anchor`일 때만 `start_line`/`start_side:'RIGHT'` 추가. `body`는 `**[severity/confidence] title**` + 본문 + `**Suggestion:**` + 끝에 `<!-- {codex,claude}-review-inline fingerprint=<fp> -->` 마커.
+  - **단일 리뷰 제출**: `github.rest.pulls.createReview({ owner, repo, pull_number, commit_id: head_sha, event, body, comments })`. `event`는 발견사항 0 + verdict `approve` + `automation_safety.may_approve` + `reviewed_context.diff_truncated`가 false일 때 `APPROVE`, 그 외 `COMMENT`.
+  - **리뷰 본문(body)**: 헤더(`## Codex PR 리뷰` / `## Claude PR 리뷰`) + `result.summary`(있으면) + 숨김 멱등 마커 `<!-- {prefix}-formal-review head_sha=… verdict=… -->`. approve일 때는 `_승인 — 지적 사항은 인라인 코멘트 참조._` 줄 추가. 자연어 문자열은 한국어 유지.
+  - **멱등성**: `github.rest.pulls.listReviews`에서 `botLogin`이 올린 리뷰 중 본문에 같은 멱등 마커가 있으면 제출만 건너뛴다(resolve 후처리는 계속). APPROVE 중복(같은 head_sha의 기존 APPROVED)도 건너뛴다.
+  - **APPROVE 실패 fallback**: APPROVE 제출이 throw하면 `.{codex,claude}-review/approval-failed`를 쓰고 COMMENT로 재시도한다.
+  - **self-thread resolve**: GraphQL `reviewThreads(first:100)`로 조회 → `isResolved=false` + 첫 코멘트 author가 `botLogin`(또는 `[bot]` suffix 제거형 `botLoginGql`) + 본문에 inline 마커 base 포함 + `fingerprint=…` 추출 가능한 thread에 대해, (1차) `resolved_threads`에 fingerprint가 있거나 (2차/fallback) 이번 회차 findings의 fingerprint 집합에 없으면 `resolveReviewThread` mutation 실행. fingerprint를 추출할 수 없는 thread는 건드리지 않는다.
+
+**현재 구조에 맞춘 적응 (원본과의 차이).**
+- App 토큰 의존 제거: 원본의 `app-token`/`app-slug`/`APP_SLUG` 입력·분기를 두지 않는다. `github-token: ${{ github.token }}`, `botLogin = 'github-actions[bot]'` 고정.
+- summary를 리뷰 본문에 포함(원본은 inline-only로 summary를 본문에서 생략했음 — 본 SPEC은 사용자 결정에 따라 summary를 본문에 싣는다).
+- `claude-review.yml`의 기존 `id-token: write` 권한은 `claude-code-action` OIDC용이므로 유지한다. `codex-review.yml`에는 `id-token` 권한을 추가하지 않는다.
+
+**테스트 갱신.**
+- `tests/codex/test-codex-review-workflow.sh`: inline 부재를 강제하던 검사(현 check 15: `pulls.createReview`/`inlineComments`/`side: 'RIGHT'` 부재 단언, check 16: `computeFingerprint`/`resolveReviewThread`/`reviewThreads`/`resolved_threads`/`codex-review-inline`/`fingerprint` 부재 단언)를 **존재 강제로 반전**한다. verdict·이슈 코멘트 구조 검사(현 check 13/14)는 inline 단일 리뷰 구조로 갱신하되 `issues.createComment` 등 이슈 코멘트 게시 단언은 제거한다. App 토큰 부재 검사(현 check 17)·권한 검사(현 check 18, `id-token` 없음 포함)·기타 보안/핀 검사는 유지한다. 줄 비의존 fingerprint(줄 번호 미포함)·마커 형식 일치 회귀 가드는 `3199ff1`이 추가했던 것을 참조해 복원한다.
+- `tests/claude/test-claude-review-workflow.sh`: 현재 inline 단언이 없으므로 codex와 동등한 inline 존재 + fingerprint resolve 회귀 가드를 추가하고, 기존 verdict/comment 단언을 inline 구조로 갱신한다.
+
+**문서 갱신.**
+- `docs/codex/pr-review-workflow.md`: Phase 2(Inline Comment Adapter)·Phase 3(Thread Lifecycle)의 "superseded" 표기를 해제하고 현행 동작으로 기술한다. "현재 1차 워크플로" 게시 단락과 인라인 미사용을 명시한 단락을 inline 단일 리뷰 + fingerprint resolve로 갱신한다.
+- `docs/claude/pr-review-workflow.md`: 게시 구조 기술(현재 이슈 코멘트 + verdict)을 inline 단일 리뷰 + fingerprint resolve로 갱신한다.
+
+**일관성.** 두 워크플로의 게시 스텝은 라벨/마커 prefix/헤더 문자열만 다르고(codex ↔ claude) 로직은 동일해야 한다.
+
+## 위험 (있을 때만)
+
+- **createReview all-or-nothing 422**: 한 발견사항의 line이 diff에 포함되지 않으면 `pulls.createReview`가 통째로 422가 되어 그 회차 inline이 전부 미게시되고 로그로만 남는다. 프롬프트가 "변경된 diff 라인의 양수 정수에 anchor"를 강하게 강제하므로 원본 동작을 그대로 수용한다. diff 라인 사전검증 후 미anchor 발견사항을 본문으로 강등하는 하드닝은 범위 외 후속.
+- **self-approve 제약**: 워크플로 기본 토큰은 자기 PR을 정식 APPROVE하지 못해 COMMENT로 강등될 수 있다(완료 조건 7로 처리).
+- **워크플로 자기 변경 가드**: 두 워크플로 모두 `paths-ignore: .github/workflows/**` 트리거를 가져, 이 SPEC 변경을 담은 PR에서는 변경된 워크플로가 머지 후에야 효력을 갖는다. 따라서 신규 inline 동작은 이 PR의 self-review로 직접 검증할 수 없고 머지 후 후속 PR에서 확인한다. 계약 테스트·정적 검증이 머지 전 1차 판정 근거다.

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -133,57 +133,111 @@ grep -qE 'uses: actions/setup-node@[0-9a-f]{40}' "$WORKFLOW" \
 ok "check 5: Actions SHA 고정됨"
 
 echo ""
-echo "=== check 6: review output is posted idempotently ==="
-grep -q '<!-- claude-api-pr-review -->' "$WORKFLOW" \
-  || fail "중복 방지 marker 부재"
-grep -q 'issues.updateComment' "$WORKFLOW" \
-  || fail "기존 리뷰 코멘트 update 경로 부재"
-grep -q 'issues.createComment' "$WORKFLOW" \
-  || fail "신규 리뷰 코멘트 create 경로 부재"
-ok "check 6: marker 기반 update/create 코멘트 경로 존재"
-
-echo ""
-echo "=== check 7: verdict submission with graceful degradation ==="
-grep -q 'findings_count=' "$WORKFLOW" \
-  || fail "findings count 계산 부재"
-grep -q 'No review output to post' "$WORKFLOW" \
-  || fail "eligibility != reviewed 시 skip 경로 부재"
-grep -q 'approve_without_body=' "$WORKFLOW" \
-  || fail "finding 없는 approve 의 무본문 처리 부재"
-grep -q 'state == "APPROVED"' "$WORKFLOW" \
-  || fail "동일 head approve 중복 방지 부재"
-grep -Fq 'user.login == "github-actions[bot]"' "$WORKFLOW" \
-  || fail "approve 중복 체크가 봇 자신 리뷰로 제한되지 않음"
-grep -q 'touch \.claude-review/approval-failed' "$WORKFLOW" \
-  || fail "approve 실패 시 managed comment fallback marker 부재"
-grep -A3 'touch \.claude-review/approval-failed' "$WORKFLOW" | grep -q 'exit 0' \
-  || fail "approve 실패 후 정상 종료(다음 step 진행) 부재"
-if grep -q 'submit_review --approve' "$WORKFLOW"; then
-  fail "finding 없는 approve 는 body 없는 전용 경로만 사용해야 함"
+echo "=== check 6: 단일 inline 리뷰 제출 — verdict/event + body summary + 멱등 (AC1/AC7) ==="
+grep -q 'name: Submit Claude inline review' "$WORKFLOW" \
+  || fail "'Submit Claude inline review' 스텝 부재 (단일 inline 리뷰 게시 스텝 치환) (제약)"
+grep -qF 'github.rest.pulls.createReview' "$WORKFLOW" \
+  || fail "Pulls REST createReview 호출 부재 — inline 단일 리뷰 제출 불가 (AC1)"
+grep -qF "event === 'APPROVE'" "$WORKFLOW" \
+  || fail "APPROVE event 분기 부재 (AC1)"
+grep -qF "event = 'COMMENT'" "$WORKFLOW" \
+  || fail "COMMENT event 분기 부재 (AC1)"
+if grep -qF 'REQUEST_CHANGES' "$WORKFLOW"; then
+  fail "REQUEST_CHANGES 잔존 — 공식 review event 는 APPROVE/COMMENT 만 (제약)"
 fi
-grep -q 'submit_review --request-changes' "$WORKFLOW" \
-  || fail "request changes review 제출 경로 부재"
-grep -q 'submit_review --comment' "$WORKFLOW" \
-  || fail "comment review 제출 경로 부재"
-grep -q 'gh pr review "\$PR_NUMBER".*--body-file "\$body"' "$WORKFLOW" \
-  || fail "submit_review 의 gh pr review 호출 부재 (graceful degradation)"
-grep -q 'No managed Claude review comment to post' "$WORKFLOW" \
-  || fail "managed comment 게이트(미reviewed/무findings 생략) 부재"
-grep -q 'automation_safety\.may_approve' "$WORKFLOW" \
-  || fail "approve safety gate 부재"
-grep -q 'confidence_score >= 80' "$WORKFLOW" \
-  || fail "confidence threshold gate 부재"
-ok "check 7: verdict 제출 + graceful degradation + managed comment 게이트"
+if grep -oE '[a-z_]*request_changes' "$WORKFLOW" | grep -qvE '^may_request_changes$'; then
+  fail "request_changes verdict 어휘 잔존 (may_request_changes 외) — 제거 필요 (제약)"
+fi
+grep -qF '## Claude PR 리뷰' "$WORKFLOW" \
+  || fail "리뷰 본문 헤더 '## Claude PR 리뷰' 부재 (제약: claude 라벨)"
+grep -qF 'result.summary' "$WORKFLOW" \
+  || fail "리뷰 본문에 result.summary 포함 부재 (제약: summary 를 본문에 실음)"
+grep -qF 'CLAUDE_FORMAL_PREFIX: claude-formal-review' "$WORKFLOW" \
+  || fail "formal review 마커 prefix(CLAUDE_FORMAL_PREFIX: claude-formal-review) 부재 (제약)"
+grep -qF '${prefix} head_sha=${head_sha} verdict=${verdict}' "$WORKFLOW" \
+  || fail "formal review 멱등 마커 템플릿(<!-- {prefix} head_sha=.. verdict=.. -->) 부재 (제약)"
+grep -qF 'github.rest.pulls.listReviews' "$WORKFLOW" \
+  || fail "기존 review 조회(listReviews) 부재 — 멱등성 판정 불가 (AC1)"
+grep -qF 'skipping duplicate submission' "$WORKFLOW" \
+  || fail "marker 기반 중복 review 제출 skip 부재 (멱등)"
+grep -qF "fs.writeFileSync('.claude-review/approval-failed'" "$WORKFLOW" \
+  || fail "APPROVE 실패 시 approval-failed marker 기록 부재 (AC7)"
+grep -qF "submit('COMMENT')" "$WORKFLOW" \
+  || fail "APPROVE 실패 시 같은 inline 코멘트로 COMMENT 강등 제출 부재 (AC7)"
+grep -qF 'may_approve' "$WORKFLOW" \
+  || fail "approve safety gate(may_approve) 부재"
+ok "check 6: 단일 inline 리뷰 제출 (APPROVE/COMMENT) + body summary + 멱등 + APPROVE fallback"
 
 echo ""
-echo "=== check 7b: formal review submission is idempotent per (head_sha, verdict) ==="
-grep -q 'marker="claude-formal-review head_sha=\$PR_HEAD_SHA verdict=\$verdict"' "$WORKFLOW" \
-  || fail "formal review 중복 방지 marker 부재"
-grep -q 'gh api "repos/\$GITHUB_REPOSITORY/pulls/\$PR_NUMBER/reviews"' "$WORKFLOW" \
-  || fail "기존 review marker 조회 부재"
-grep -q 'skipping duplicate' "$WORKFLOW" \
-  || fail "중복 review 제출 skip 경로 부재"
-ok "check 7b: formal review 제출이 (head_sha, verdict) 기준 멱등"
+echo "=== check 7: 별도 마커 관리형 이슈 레벨 코멘트 게시 경로 부재 (AC6) ==="
+grep -q 'name: Post Claude review comment' "$WORKFLOW" \
+  && fail "'Post Claude review comment' 스텝 잔존 — 이슈 코멘트 게시 경로 제거 필요 (AC6)"
+if grep -qF '<!-- claude-api-pr-review -->' "$WORKFLOW"; then
+  fail "관리형 이슈 코멘트 마커(<!-- claude-api-pr-review -->) 잔존 (AC6)"
+fi
+if grep -qF 'issues.createComment' "$WORKFLOW"; then
+  fail "issues.createComment 잔존 — 발견사항 이슈 코멘트 게시 금지 (AC6)"
+fi
+if grep -qF 'issues.updateComment' "$WORKFLOW"; then
+  fail "issues.updateComment 잔존 — 관리형 이슈 코멘트 갱신 경로 금지 (AC6)"
+fi
+ok "check 7: 마커 관리형 이슈 레벨 코멘트 게시 경로 부재"
+
+echo ""
+echo "=== check 7b: 인라인 리뷰 코멘트 게시 경로 존재 (AC1/AC2) ==="
+grep -qF 'comments: inlineComments' "$WORKFLOW" \
+  || fail "createReview 의 comments[] 배열에 inline findings(inlineComments) 전달 부재 (AC1)"
+grep -qF 'inline-only' "$WORKFLOW" \
+  || fail "inline-only 정책 주석/마커 부재 (모든 finding 을 inline 으로 게시) (AC6)"
+grep -qF "side: 'RIGHT'" "$WORKFLOW" \
+  || fail "inline comment side='RIGHT' 지정 부재 (AC1)"
+grep -qF 'start_line' "$WORKFLOW" \
+  || fail "multi-line inline comment 의 start_line 처리 부재 (AC1)"
+if grep -qF 'inlineFallback' "$WORKFLOW"; then
+  fail "inlineFallback 경로 잔존 — createReview 실패 시 이슈 코멘트 덤프 금지 (AC6)"
+fi
+ok "check 7b: 인라인 리뷰 코멘트 게시 경로 존재 (createReview comments[] + RIGHT + start_line)"
+
+echo ""
+echo "=== check 7c: fingerprint 기반 self thread 자동 resolve 경로 존재 (AC3/AC4) ==="
+grep -qF 'computeFingerprint' "$WORKFLOW" \
+  || fail "결정론적 fingerprint 계산(computeFingerprint) 부재 (AC3)"
+grep -qF 'resolveReviewThread' "$WORKFLOW" \
+  || fail "GraphQL resolveReviewThread mutation 부재 — self thread 자동 resolve 안 됨 (AC4)"
+grep -qF 'reviewThreads(first: 100)' "$WORKFLOW" \
+  || fail "GraphQL reviewThreads 조회 부재 (AC4)"
+grep -qF 'resolved_threads' "$WORKFLOW" \
+  || fail "resolved_threads 소비(1차) 경로 부재 (AC4)"
+grep -qF 'findingFingerprints' "$WORKFLOW" \
+  || fail "이번 라운드 findings fingerprint 집합(findingFingerprints) 부재 (AC4 fallback)"
+grep -qF '<!-- claude-review-inline' "$WORKFLOW" \
+  || fail "inline self-식별 마커 substring(<!-- claude-review-inline) 부재 (AC2)"
+grep -qF 'fingerprint=${computeFingerprint(f)}' "$WORKFLOW" \
+  || fail "게시 inline 마커가 결정론적 computeFingerprint(f) 를 운반하지 않음 (AC2/AC3)"
+grep -qF 'botLoginGql' "$WORKFLOW" \
+  || fail "GraphQL author login 형식 정규화(botLoginGql) 부재 (AC4)"
+grep -qF 'isResolved' "$WORKFLOW" \
+  || fail "isResolved 조건 검사 부재 (이미 resolved thread skip)"
+grep -qF 'regardless of verdict' "$WORKFLOW" \
+  || fail "resolve 가 verdict 무관 실행임을 명시하는 마커(regardless of verdict) 부재 (AC4)"
+if grep -qF 'fingerprint=${f.fingerprint}' "$WORKFLOW"; then
+  fail "게시 마커가 모델 자유 생성 f.fingerprint 운반 — 결정론 계산으로 전환되어야 함 (AC3)"
+fi
+ok "check 7c: fingerprint self thread 자동 resolve 경로 존재 (resolved_threads 1차 + fallback)"
+
+echo ""
+echo "=== check 7d: 결정론적 fingerprint — file+perspective+normalized title, 줄번호 비의존 (AC3) ==="
+grep -qF 'crypto' "$WORKFLOW" \
+  || fail "fingerprint 해시 계산(crypto) 부재 (AC3)"
+grep -qF "[f.file || '', f.review_perspective || '', normalizeTitle(f.title)]" "$WORKFLOW" \
+  || fail "fingerprint 입력이 file+review_perspective+normalized title 로 한정되지 않음 (AC3)"
+grep -qF "normalize('NFKC')" "$WORKFLOW" \
+  || fail "제목 정규화 NFKC 부재 또는 불일치 (제약: 두 워크플로 byte-identical)"
+grep -qF "replace(/[^\\p{L}\\p{N}]+/gu, ' ')" "$WORKFLOW" \
+  || fail "제목 정규화(문장부호/공백 → 단일 공백) 구현 부재 또는 불일치 (제약: 두 워크플로 동일)"
+grep -qF 'findings.map((f) => computeFingerprint(f))' "$WORKFLOW" \
+  || fail "findingFingerprints 가 결정론적 computeFingerprint 로 산정되지 않음 (AC3)"
+ok "check 7d: 결정론적 fingerprint(file+perspective+title), 줄번호 비의존"
 
 echo ""
 echo "=== check 8: prompt captures token and confidence policies ==="

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -4,12 +4,15 @@
 # Static checks only: do not call GitHub, npm, or Codex.
 #
 # This workflow calls the model through the official openai/codex-action and
-# publishes results with the SAME structure as the sibling Claude PR review
-# workflow (formal review verdict + a single marker-managed PR comment). The
-# legacy codex-only paths — direct `codex exec`/`codex review` CLI calls,
-# inline review comments, fingerprint-based self thread auto-resolve, and the
-# GitHub App installation token / App-token APPROVE — are gone. These checks
-# assert the new structure exists and the removed paths are absent.
+# publishes results as a SINGLE inline review: findings become inline review
+# comments anchored to changed lines, the review summary rides in the review
+# body, and self-owned inline threads auto-resolve on a deterministic
+# fingerprint basis. The legacy codex-only paths — direct `codex exec`/`codex
+# review` CLI calls and the GitHub App installation token / App-token APPROVE —
+# are gone, as is the separate marker-managed issue-level finding comment.
+# These checks assert the inline+resolve structure exists and removed paths are
+# absent. The posting logic mirrors claude-review.yml byte-identically except
+# for label/marker/prefix strings.
 
 set -euo pipefail
 
@@ -187,82 +190,116 @@ fi
 ok "check 12: @codex + author association + 봇 차단 게이트, App 봇 분기 제거됨"
 
 echo ""
-echo "=== check 13: Claude 동일 게시 구조 — verdict 정식 리뷰 제출 (AC4/제약) ==="
-grep -q 'name: Submit Codex review verdict' "$WORKFLOW" \
-  || fail "'Submit Codex review verdict' 스텝 부재 (Claude 'Submit … review verdict' 구조 치환) (제약)"
-# 정식 리뷰 verdict 는 gh pr review 로 제출 (Claude 와 동일). approve/comment/request-changes 3 경로.
-grep -q 'gh pr review .*--approve' "$WORKFLOW" \
-  || fail "approve 정식 리뷰 제출 경로 부재 (AC4)"
-grep -q 'submit_review --comment' "$WORKFLOW" \
-  || fail "comment 정식 리뷰 제출 경로 부재 (AC4)"
-grep -q 'submit_review --request-changes' "$WORKFLOW" \
-  || fail "request-changes 정식 리뷰 제출 경로 부재 (AC4 — Claude 동일)"
-grep -qF '## Codex PR Review' "$WORKFLOW" \
-  || fail "정식 리뷰 본문 헤더 '## Codex PR Review' 부재 (제약: codex 라벨 치환)"
-# 멱등 마커 (head_sha, verdict) 기준.
-grep -qF 'codex-formal-review head_sha=$PR_HEAD_SHA verdict=$verdict' "$WORKFLOW" \
-  || fail "formal review 멱등 마커(codex-formal-review head_sha=.. verdict=..) 부재 (제약)"
-grep -qF 'already exists for $PR_HEAD_SHA / $verdict; skipping duplicate' "$WORKFLOW" \
-  || fail "marker 기반 중복 review skip 부재 (AC4 멱등)"
-grep -qF 'pulls/$PR_NUMBER/reviews' "$WORKFLOW" \
-  || fail "기존 review 조회(REST) 부재 — 멱등성 판정 불가"
-grep -q 'touch .codex-review/approval-failed' "$WORKFLOW" \
-  || fail "APPROVE 실패 시 approval-failed marker 부재 (Claude 동일 fallback)"
-ok "check 13: verdict 정식 리뷰 제출 (approve/comment/request-changes) + 멱등"
+echo "=== check 13: 단일 inline 리뷰 제출 — verdict/event + body summary + 멱등 (AC1/AC7) ==="
+grep -q 'name: Submit Codex inline review' "$WORKFLOW" \
+  || fail "'Submit Codex inline review' 스텝 부재 (단일 inline 리뷰 게시 스텝 치환) (제약)"
+# 단일 createReview(comments[]) 로 inline + 본문을 한 번에 제출. event 는 APPROVE/COMMENT 만.
+grep -qF 'github.rest.pulls.createReview' "$WORKFLOW" \
+  || fail "Pulls REST createReview 호출 부재 — inline 단일 리뷰 제출 불가 (AC1)"
+grep -qF "event === 'APPROVE'" "$WORKFLOW" \
+  || fail "APPROVE event 분기 부재 (AC1)"
+grep -qF "event = 'COMMENT'" "$WORKFLOW" \
+  || fail "COMMENT event 분기 부재 (AC1)"
+# REQUEST_CHANGES review event 는 폐지. may_request_changes(automation_safety) 외 request_changes 토큰 금지.
+if grep -qF 'REQUEST_CHANGES' "$WORKFLOW"; then
+  fail "REQUEST_CHANGES 잔존 — 공식 review event 는 APPROVE/COMMENT 만 (제약)"
+fi
+if grep -oE '[a-z_]*request_changes' "$WORKFLOW" | grep -qvE '^may_request_changes$'; then
+  fail "request_changes verdict 어휘 잔존 (may_request_changes 외) — 제거 필요 (제약)"
+fi
+# 리뷰 본문(body): 헤더 + summary(있으면) — 한국어 헤더.
+grep -qF '## Codex PR 리뷰' "$WORKFLOW" \
+  || fail "리뷰 본문 헤더 '## Codex PR 리뷰' 부재 (제약: codex 라벨)"
+grep -qF 'result.summary' "$WORKFLOW" \
+  || fail "리뷰 본문에 result.summary 포함 부재 (제약: summary 를 본문에 실음)"
+# 멱등 마커 (head_sha, verdict) 기준 + listReviews 조회 + 중복 skip.
+grep -qF 'CODEX_FORMAL_PREFIX: codex-formal-review' "$WORKFLOW" \
+  || fail "formal review 마커 prefix(CODEX_FORMAL_PREFIX: codex-formal-review) 부재 (제약)"
+grep -qF '${prefix} head_sha=${head_sha} verdict=${verdict}' "$WORKFLOW" \
+  || fail "formal review 멱등 마커 템플릿(<!-- {prefix} head_sha=.. verdict=.. -->) 부재 (제약)"
+grep -qF 'github.rest.pulls.listReviews' "$WORKFLOW" \
+  || fail "기존 review 조회(listReviews) 부재 — 멱등성 판정 불가 (AC1)"
+grep -qF 'skipping duplicate submission' "$WORKFLOW" \
+  || fail "marker 기반 중복 review 제출 skip 부재 (멱등)"
+# APPROVE 실패 → COMMENT 강등 + approval-failed 기록 (AC7).
+grep -qF "fs.writeFileSync('.codex-review/approval-failed'" "$WORKFLOW" \
+  || fail "APPROVE 실패 시 approval-failed marker 기록 부재 (AC7)"
+grep -qF "submit('COMMENT')" "$WORKFLOW" \
+  || fail "APPROVE 실패 시 같은 inline 코멘트로 COMMENT 강등 제출 부재 (AC7)"
+ok "check 13: 단일 inline 리뷰 제출 (APPROVE/COMMENT) + body summary + 멱등 + APPROVE fallback"
 
 echo ""
-echo "=== check 14: Claude 동일 게시 구조 — 마커 관리형 PR 코멘트 1개 (AC4/제약) ==="
+echo "=== check 14: 별도 마커 관리형 이슈 레벨 코멘트 게시 경로 부재 (AC6) ==="
 grep -q 'name: Post Codex review comment' "$WORKFLOW" \
-  || fail "'Post Codex review comment' 스텝 부재 (Claude 'Post … review comment' 구조 치환) (제약)"
-grep -qF '<!-- codex-api-pr-review -->' "$WORKFLOW" \
-  || fail "codex 전용 관리형 코멘트 마커(<!-- codex-api-pr-review -->) 부재 (제약)"
-grep -qF 'github.rest.issues.listComments' "$WORKFLOW" \
-  || fail "기존 관리형 코멘트 조회(issues.listComments) 부재 — 1개 갱신 보장 불가 (AC4)"
-grep -qF 'github.rest.issues.updateComment' "$WORKFLOW" \
-  || fail "기존 관리형 코멘트 갱신(issues.updateComment) 경로 부재 (AC4: 최대 1개 갱신)"
-grep -qF 'github.rest.issues.createComment' "$WORKFLOW" \
-  || fail "관리형 코멘트 생성(issues.createComment) 경로 부재 (AC4)"
-grep -qF 'comment.body?.includes(marker)' "$WORKFLOW" \
-  || fail "마커 기준 기존 코멘트 식별 부재 (AC4: 마커 기준 최대 1개)"
-ok "check 14: 마커 기반 관리형 PR 코멘트 생성/갱신 (최대 1개)"
+  && fail "'Post Codex review comment' 스텝 잔존 — 이슈 코멘트 게시 경로 제거 필요 (AC6)"
+if grep -qF '<!-- codex-api-pr-review -->' "$WORKFLOW"; then
+  fail "관리형 이슈 코멘트 마커(<!-- codex-api-pr-review -->) 잔존 (AC6)"
+fi
+if grep -qF 'github.rest.issues.createComment' "$WORKFLOW"; then
+  fail "issues.createComment 잔존 — 발견사항 이슈 코멘트 게시 금지 (AC6)"
+fi
+if grep -qF 'github.rest.issues.updateComment' "$WORKFLOW"; then
+  fail "issues.updateComment 잔존 — 관리형 이슈 코멘트 갱신 경로 금지 (AC6)"
+fi
+ok "check 14: 마커 관리형 이슈 레벨 코멘트 게시 경로 부재"
 
 echo ""
-echo "=== check 15: 인라인 리뷰 코멘트 게시 경로 부재 (AC5) ==="
-if grep -qF 'pulls.createReview' "$WORKFLOW"; then
-  fail "pulls.createReview 잔존 — 인라인 코멘트 게시 경로 제거되어야 함 (AC5)"
+echo "=== check 15: 인라인 리뷰 코멘트 게시 경로 존재 (AC1/AC2) ==="
+grep -qF 'comments: inlineComments' "$WORKFLOW" \
+  || fail "createReview 의 comments[] 배열에 inline findings(inlineComments) 전달 부재 (AC1)"
+grep -qF 'inline-only' "$WORKFLOW" \
+  || fail "inline-only 정책 주석/마커 부재 (모든 finding 을 inline 으로 게시) (AC6)"
+grep -qF "side: 'RIGHT'" "$WORKFLOW" \
+  || fail "inline comment side='RIGHT' 지정 부재 (AC1)"
+grep -qF 'start_line' "$WORKFLOW" \
+  || fail "multi-line inline comment 의 start_line 처리 부재 (AC1)"
+# createReview 실패 시 finding 을 이슈 코멘트로 덤프하지 않는다 (inline-only).
+if grep -qF 'inlineFallback' "$WORKFLOW"; then
+  fail "inlineFallback 경로 잔존 — createReview 실패 시 이슈 코멘트 덤프 금지 (AC6)"
 fi
-if grep -qF 'inlineComments' "$WORKFLOW"; then
-  fail "inlineComments 잔존 — 인라인 코멘트 경로 제거되어야 함 (AC5)"
-fi
-if grep -qF 'inline-only' "$WORKFLOW"; then
-  fail "inline-only 정책 잔존 — 인라인 게시 경로 제거되어야 함 (AC5)"
-fi
-if grep -qF "side: 'RIGHT'" "$WORKFLOW"; then
-  fail "inline comment side='RIGHT' 잔존 (AC5)"
-fi
-ok "check 15: 인라인 리뷰 코멘트 게시 경로 부재"
+ok "check 15: 인라인 리뷰 코멘트 게시 경로 존재 (createReview comments[] + RIGHT + start_line)"
 
 echo ""
-echo "=== check 16: fingerprint 기반 self thread 자동 resolve 경로 부재 (AC5) ==="
-if grep -qF 'computeFingerprint' "$WORKFLOW"; then
-  fail "computeFingerprint 잔존 — fingerprint resolve 경로 제거되어야 함 (AC5)"
+echo "=== check 16: fingerprint 기반 self thread 자동 resolve 경로 존재 (AC3/AC4) ==="
+grep -qF 'computeFingerprint' "$WORKFLOW" \
+  || fail "결정론적 fingerprint 계산(computeFingerprint) 부재 (AC3)"
+grep -qF 'resolveReviewThread' "$WORKFLOW" \
+  || fail "GraphQL resolveReviewThread mutation 부재 — self thread 자동 resolve 안 됨 (AC4)"
+grep -qF 'reviewThreads(first: 100)' "$WORKFLOW" \
+  || fail "GraphQL reviewThreads 조회 부재 (AC4)"
+grep -qF 'resolved_threads' "$WORKFLOW" \
+  || fail "resolved_threads 소비(1차) 경로 부재 (AC4)"
+grep -qF 'findingFingerprints' "$WORKFLOW" \
+  || fail "이번 라운드 findings fingerprint 집합(findingFingerprints) 부재 (AC4 fallback)"
+grep -qF '<!-- codex-review-inline' "$WORKFLOW" \
+  || fail "inline self-식별 마커 substring(<!-- codex-review-inline) 부재 (AC2)"
+grep -qF 'fingerprint=${computeFingerprint(f)}' "$WORKFLOW" \
+  || fail "게시 inline 마커가 결정론적 computeFingerprint(f) 를 운반하지 않음 (AC2/AC3)"
+grep -qF 'botLoginGql' "$WORKFLOW" \
+  || fail "GraphQL author login 형식 정규화(botLoginGql) 부재 (AC4)"
+grep -qF 'isResolved' "$WORKFLOW" \
+  || fail "isResolved 조건 검사 부재 (이미 resolved thread skip)"
+# verdict 무관 실행 + 모델 자유 fingerprint 미사용.
+grep -qF 'regardless of verdict' "$WORKFLOW" \
+  || fail "resolve 가 verdict 무관 실행임을 명시하는 마커(regardless of verdict) 부재 (AC4)"
+if grep -qF 'fingerprint=${f.fingerprint}' "$WORKFLOW"; then
+  fail "게시 마커가 모델 자유 생성 f.fingerprint 운반 — 결정론 계산으로 전환되어야 함 (AC3)"
 fi
-if grep -qF 'resolveReviewThread' "$WORKFLOW"; then
-  fail "resolveReviewThread 잔존 — self thread 자동 resolve 제거되어야 함 (AC5)"
-fi
-if grep -qF 'reviewThreads' "$WORKFLOW"; then
-  fail "reviewThreads GraphQL 조회 잔존 (AC5)"
-fi
-if grep -qF 'resolved_threads' "$WORKFLOW"; then
-  fail "resolved_threads 소비 경로 잔존 (AC5)"
-fi
-if grep -qF 'codex-review-inline' "$WORKFLOW"; then
-  fail "codex-review-inline fingerprint 마커 잔존 (AC5)"
-fi
-if grep -qiF 'fingerprint' "$WORKFLOW"; then
-  fail "fingerprint 어휘 잔존 — fingerprint 기반 resolve 제거되어야 함 (AC5)"
-fi
-ok "check 16: fingerprint self thread 자동 resolve 경로 부재"
+ok "check 16: fingerprint self thread 자동 resolve 경로 존재 (resolved_threads 1차 + fallback)"
+
+echo ""
+echo "=== check 16b: 결정론적 fingerprint — file+perspective+normalized title, 줄번호 비의존 (AC3) ==="
+grep -qF 'crypto' "$WORKFLOW" \
+  || fail "fingerprint 해시 계산(crypto) 부재 (AC3)"
+grep -qF "[f.file || '', f.review_perspective || '', normalizeTitle(f.title)]" "$WORKFLOW" \
+  || fail "fingerprint 입력이 file+review_perspective+normalized title 로 한정되지 않음 (AC3)"
+grep -qF "normalize('NFKC')" "$WORKFLOW" \
+  || fail "제목 정규화 NFKC 부재 또는 불일치 (제약: 두 워크플로 byte-identical)"
+grep -qF "replace(/[^\\p{L}\\p{N}]+/gu, ' ')" "$WORKFLOW" \
+  || fail "제목 정규화(문장부호/공백 → 단일 공백) 구현 부재 또는 불일치 (제약: 두 워크플로 동일)"
+grep -qF 'findings.map((f) => computeFingerprint(f))' "$WORKFLOW" \
+  || fail "findingFingerprints 가 결정론적 computeFingerprint 로 산정되지 않음 (AC3)"
+ok "check 16b: 결정론적 fingerprint(file+perspective+title), 줄번호 비의존"
 
 echo ""
 echo "=== check 17: GitHub App 설치 토큰 발급·App 토큰 approve 경로 부재 (AC5/제약) ==="


### PR DESCRIPTION
## 무엇을 / 왜

두 PR 리뷰 워크플로(Codex·Claude)의 프롬프트·공유 스키마는 이미 **inline 전용 게시 + fingerprint 기반 thread resolve 라이프사이클**을 기술하지만, 게시 단계는 그 데이터를 버리고 정식 verdict 리뷰 + 마커 관리형 이슈 코멘트 1개를 평문으로 올려 어긋나 있었다(inline 경로는 `7848f48`에서 제거됨). 이 PR은 게시를 **단일 inline 리뷰**로 통합해 프롬프트·스키마와 정합시킨다.

검증된 옛 구현(`3199ff1`)을 **App 토큰 제거·summary 본문 포함** 형태로 복원·적응했다(백지 작성 아님).

## 변경

- **`.github/workflows/{codex,claude}-review.yml`**: 게시 두 스텝(`Submit … review verdict` + `Post … review comment`)을 단일 `Submit … inline review`(`actions/github-script`)로 교체.
  - findings → `github.rest.pulls.createReview`의 inline `comments[]`(path/line/`side:'RIGHT'`, multi-line `start_line`), body에 `summary`.
  - finding마다 `<!-- {codex,claude}-review-inline fingerprint=… -->` 마커. fingerprint = `sha256(file + perspective + 정규화 title)` 앞 16자, **줄 번호 비의존·두 워크플로 byte-identical**.
  - GraphQL `reviewThreads` 조회 → `resolveReviewThread`로 self-thread 자동 resolve(1차 `resolved_threads` + 2차 findings에서 사라진 thread fallback).
  - `event` APPROVE/COMMENT, 멱등(`listReviews` + 마커), APPROVE 실패 시 COMMENT fallback + `approval-failed`.
  - App 설치 토큰 경로 제거(`github.token`/`github-actions[bot]`). codex `id-token` 없음, claude `id-token: write` 유지(claude-code-action OIDC).
- **`tests/{codex,claude}/test-*-review-workflow.sh`**: inline-부재 강제 단언을 inline-존재 강제로 반전, verdict/이슈 코멘트 단언을 inline 구조로 갱신, 줄-비의존 fingerprint·마커 일치 회귀 가드 추가.
- **`docs/{codex,claude}/pr-review-workflow.md`**: Phase 2/3 "superseded" 해제 → 현행 inline+resolve 동작 기술.
- **`docs/specs/2026-06-02-pr-review-inline-thread-fingerprint-resolve/SPEC.md`**: 설계 SPEC.

비변경(확인): 공유 스키마·두 프롬프트·컨텍스트 헬퍼(이미 inline·fingerprint 지원).

## 검증

- `tests/codex/...`·`tests/claude/...` 계약 테스트 **ALL CHECKS PASSED**.
- 두 워크플로 YAML 파싱 OK, 추출 github-script `node --check` OK, 두 게시 스텝 라벨 정규화 후 로직 IDENTICAL.

## 한계

- `paths-ignore: .github/workflows/**` 때문에 이 PR의 워크플로 변경은 **머지 후** 효력 — 신규 inline 동작은 self-review로 직접 검증 불가, 머지 후 후속 PR에서 확인.
- `createReview`는 한 finding의 line이 diff 밖이면 그 회차 inline 전부 422(로그만) — 옛 동작 그대로 수용. diff 라인 사전검증 하드닝은 범위 외 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
