### PR TITLE
fix(review): App 설치 토큰으로 inline thread resolve·PR approve 복원

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,18 +26,27 @@ jobs:
           && github.event.issue.pull_request != null
           && contains(github.event.comment.body, '@claude')
           && github.event.comment.user.login != 'github-actions[bot]'
+          && github.event.comment.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
       || (github.event_name == 'pull_request_review_comment'
           && contains(github.event.comment.body, '@claude')
           && github.event.comment.user.login != 'github-actions[bot]'
+          && github.event.comment.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
       || (github.event_name == 'pull_request_review'
           && github.event.review.body != null
           && contains(github.event.review.body, '@claude')
           && github.event.review.user.login != 'github-actions[bot]'
+          && github.event.review.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Expose the App ID secret as an env var so the App-token step can gate on
+    # its presence (secrets cannot be referenced directly in a step `if:`).
+    # Empty in forks / unconfigured repos → App-token step is skipped and the
+    # workflow degrades to the default github.token (graceful degradation).
+    env:
+      REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}
     steps:
       - name: Resolve pull request context
         id: pr
@@ -377,14 +386,39 @@ jobs:
           PY
           jq empty .claude-review/result.json
 
+      # Issue a short-lived GitHub App installation token so the review is
+      # posted, identified, resolved, and approved under a single App bot
+      # identity that — unlike the default workflow token — can resolve self
+      # inline review threads (GraphQL) and submit an official APPROVE review.
+      # Gated on REVIEW_APP_ID presence: when the App secrets are absent
+      # (forks / unconfigured repos) the step is skipped and posting falls back
+      # to the default github.token (graceful degradation, AC5).
+      - name: Generate GitHub App token
+        id: app-token
+        if: ${{ env.REVIEW_APP_ID != '' }}
+        # Token issuance must never abort the review: on failure the step is
+        # marked failed but the job continues, its `token` output stays empty,
+        # and posting falls back to the default github.token (graceful, AC5).
+        continue-on-error: true
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
+        with:
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
+
       - name: Submit Claude inline review
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           CLAUDE_FORMAL_PREFIX: claude-formal-review
+          # App bot slug (empty when the App-token step was skipped) → drives
+          # dynamic bot-login resolution below.
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         with:
-          github-token: ${{ github.token }}
+          # App token when available (can resolve threads + self-approve);
+          # otherwise the default token. Posting, identification, resolve, and
+          # approve all share this single token / identity (AC3).
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             const fs = require('fs');
             const result = JSON.parse(fs.readFileSync('.claude-review/result.json', 'utf8'));
@@ -392,10 +426,13 @@ jobs:
             const pull_number = Number(process.env.PR_NUMBER);
             const head_sha = process.env.PR_HEAD_SHA;
             const prefix = process.env.CLAUDE_FORMAL_PREFIX;
-            // Posting identity is always the default-token bot — there is no
-            // GitHub App installation token path. Idempotency detection and self
-            // inline-thread identification track this fixed login.
-            const botLogin = 'github-actions[bot]';
+            // Posting identity is dynamically resolved. When an App installation
+            // token was issued the bot login is `<app-slug>[bot]`; with the
+            // default token it is the fixed `github-actions[bot]`. Idempotency
+            // detection and self inline-thread identification track whichever
+            // login actually posted (AC3) — never a hardcoded App login.
+            const appSlug = process.env.APP_SLUG;
+            const botLogin = appSlug ? `${appSlug}[bot]` : 'github-actions[bot]';
 
             // Deterministic finding fingerprint. Derived ONLY from the finding's
             // stable attributes — file path, review perspective, and a normalized
@@ -494,7 +531,9 @@ jobs:
               skipSubmit = true;
             }
 
-            // Submit. Workflow token cannot self-approve — fall back to COMMENT if APPROVE 403/422s.
+            // Submit. The App token can self-approve; the default workflow token
+            // cannot — so APPROVE may still 403/422 when degraded to the default
+            // token. Fall back to COMMENT in that case (AC5).
             const submit = (ev) => github.rest.pulls.createReview({
               owner, repo, pull_number,
               commit_id: head_sha,

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -25,18 +25,27 @@ jobs:
           && github.event.issue.pull_request != null
           && contains(github.event.comment.body, '@codex')
           && github.event.comment.user.login != 'github-actions[bot]'
+          && github.event.comment.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
       || (github.event_name == 'pull_request_review_comment'
           && contains(github.event.comment.body, '@codex')
           && github.event.comment.user.login != 'github-actions[bot]'
+          && github.event.comment.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
       || (github.event_name == 'pull_request_review'
           && github.event.review.body != null
           && contains(github.event.review.body, '@codex')
           && github.event.review.user.login != 'github-actions[bot]'
+          && github.event.review.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Expose the App ID secret as an env var so the App-token step can gate on
+    # its presence (secrets cannot be referenced directly in a step `if:`).
+    # Empty in forks / unconfigured repos → App-token step is skipped and the
+    # workflow degrades to the default github.token (graceful degradation).
+    env:
+      REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}
     steps:
       - name: Resolve pull request context
         id: pr
@@ -270,14 +279,39 @@ jobs:
           set -euo pipefail
           jq empty .codex-review/result.json
 
+      # Issue a short-lived GitHub App installation token so the review is
+      # posted, identified, resolved, and approved under a single App bot
+      # identity that — unlike the default workflow token — can resolve self
+      # inline review threads (GraphQL) and submit an official APPROVE review.
+      # Gated on REVIEW_APP_ID presence: when the App secrets are absent
+      # (forks / unconfigured repos) the step is skipped and posting falls back
+      # to the default github.token (graceful degradation, AC5).
+      - name: Generate GitHub App token
+        id: app-token
+        if: ${{ env.REVIEW_APP_ID != '' }}
+        # Token issuance must never abort the review: on failure the step is
+        # marked failed but the job continues, its `token` output stays empty,
+        # and posting falls back to the default github.token (graceful, AC5).
+        continue-on-error: true
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
+        with:
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
+
       - name: Submit Codex inline review
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           CODEX_FORMAL_PREFIX: codex-formal-review
+          # App bot slug (empty when the App-token step was skipped) → drives
+          # dynamic bot-login resolution below.
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         with:
-          github-token: ${{ github.token }}
+          # App token when available (can resolve threads + self-approve);
+          # otherwise the default token. Posting, identification, resolve, and
+          # approve all share this single token / identity (AC3).
+          github-token: ${{ steps.app-token.outputs.token || github.token }}
           script: |
             const fs = require('fs');
             const result = JSON.parse(fs.readFileSync('.codex-review/result.json', 'utf8'));
@@ -285,10 +319,13 @@ jobs:
             const pull_number = Number(process.env.PR_NUMBER);
             const head_sha = process.env.PR_HEAD_SHA;
             const prefix = process.env.CODEX_FORMAL_PREFIX;
-            // Posting identity is always the default-token bot — there is no
-            // GitHub App installation token path. Idempotency detection and self
-            // inline-thread identification track this fixed login.
-            const botLogin = 'github-actions[bot]';
+            // Posting identity is dynamically resolved. When an App installation
+            // token was issued the bot login is `<app-slug>[bot]`; with the
+            // default token it is the fixed `github-actions[bot]`. Idempotency
+            // detection and self inline-thread identification track whichever
+            // login actually posted (AC3) — never a hardcoded App login.
+            const appSlug = process.env.APP_SLUG;
+            const botLogin = appSlug ? `${appSlug}[bot]` : 'github-actions[bot]';
 
             // Deterministic finding fingerprint. Derived ONLY from the finding's
             // stable attributes — file path, review perspective, and a normalized
@@ -387,7 +424,9 @@ jobs:
               skipSubmit = true;
             }
 
-            // Submit. Workflow token cannot self-approve — fall back to COMMENT if APPROVE 403/422s.
+            // Submit. The App token can self-approve; the default workflow token
+            // cannot — so APPROVE may still 403/422 when degraded to the default
+            // token. Fall back to COMMENT in that case (AC5).
             const submit = (ev) => github.rest.pulls.createReview({
               owner, repo, pull_number,
               commit_id: head_sha,

--- a/docs/specs/2026-06-03-review-workflow-app-token-resolve-approve/SPEC.md
+++ b/docs/specs/2026-06-03-review-workflow-app-token-resolve-approve/SPEC.md
@@ -1,0 +1,75 @@
+---
+scope:
+  include:
+    - .github/workflows/claude-review.yml
+    - .github/workflows/codex-review.yml
+    - tests/claude/test-claude-review-workflow.sh
+    - tests/codex/test-codex-review-workflow.sh
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+ears_language: ko
+---
+
+# 리뷰 워크플로 App 설치 토큰으로 inline thread resolve·PR approve 복원
+
+## 무엇을 만들 것인가
+<!-- WHAT/HOW 방어선: 무엇을 만들지만 적고 구현 방법·파일·라이브러리·클래스명은 제약으로 이동. -->
+
+두 PR 리뷰 워크플로(Claude·Codex)가 **GitHub App 설치 토큰**으로 리뷰를 게시·식별·resolve·approve 하도록 복원한다. 그래서 고쳐진 finding의 self inline review thread가 **실제로 resolved 상태가 되고**, 승인 안전조건을 만족할 때 PR이 **실제로 APPROVE** 된다.
+
+해결하려는 문제: 현재 두 워크플로는 워크플로 기본 토큰만 쓴다. 이 토큰은 리뷰 thread를 resolve 하려는 GraphQL 호출과 PR을 공식 APPROVE 하려는 호출을 모두 권한 부족으로 거부당한다(라이브 증거: PR #293에서 모델이 해결된 thread의 fingerprint를 올바르게 보고했는데도 resolve가 "Resource not accessible by integration"으로 실패). 즉 fingerprint 기반 self thread 자동 resolve 기능이 코드에는 있으나 토큰 권한 때문에 한 번도 실제로 동작하지 못한 채 출하돼 있었고, 그 실패는 비치명적 경고로 삼켜져 워크플로는 green 으로 끝나 드러나지 않았다.
+
+이력 맥락(중요): App 설치 토큰 경로는 과거에 도입됐다가 이후 일부러 제거됐고, 직전 결정(self inline thread fingerprint resolve 복원 SPEC)은 "게시·resolve는 워크플로 기본 토큰만 사용하고 App 설치 토큰 경로를 두지 않는다"를 확정하며 계약 테스트에 App 토큰 재도입을 금지하는 검사를 박았다. 그 결정은 self-approve 불가(APPROVE→COMMENT 강등)만 수용 위험으로 보았고, **같은 권한 부족이 thread resolve까지 깨뜨린다는 점은 인지하지 못했다**. 본 SPEC은 그 직전 결정의 "App 토큰 금지" 수용 기준을 **명시적으로 역전(supersede)** 하고, App 설치 토큰 경로를 두 워크플로에 다시 도입한다. App 토큰을 쓸 수 없는 환경(App 시크릿 미구성, 발급 실패, 포크 PR 등)에서는 기존처럼 기본 토큰으로 계속 동작해 워크플로가 깨지지 않는다.
+
+이 변경에는 그 금지 검사를 박은 계약 테스트의 **갱신**이 포함된다 — App 토큰 경로를 금지하던 검사를 App 토큰 경로를 요구·허용하도록 바꾸고, 그 외 기존 보안·핀 검사는 보존한다. (이전 구현 시도는 이 테스트가 변경 범위 밖이라 금지 검사를 고치지 못해 막혔다 — 본 SPEC은 두 계약 테스트를 범위에 포함해 그 교착을 해소한다.)
+
+## 완료 조건
+<!-- 5문장 패턴(항상 / …할 때 / …인 동안 / …이면(오류) / …기능이 켜지면)과 언어 규칙은 references/ears-patterns.md. 각 조건은 관찰 가능하고 독립 검증 가능해야 함. -->
+
+1. App 토큰 발급 시크릿이 구성된 환경에서, 이전 리뷰가 남긴 self inline thread의 finding이 현재 변경에서 해결됐다고 판정되면, 워크플로는 App 설치 토큰으로 그 thread를 **실제 resolved 상태로 전환**하며 기본 토큰의 권한 거부("Resource not accessible by integration")에 걸리지 않는다.
+
+2. App 토큰 발급 시크릿이 구성된 환경에서 리뷰 판정이 approve이고 승인 안전조건(지적 0건·승인 허용 플래그 참·diff 미절단)이 충족되면, 워크플로는 App 설치 토큰으로 해당 PR에 공식 **APPROVE** 리뷰를 제출하며 기본 토큰의 self-approve 제약(403/422)에 걸리지 않는다.
+
+3. 워크플로가 App 토큰으로 동작하는 동안, 공식 리뷰 제출·inline 코멘트·관리 코멘트·self inline thread resolve는 모두 **동일한 App 봇 identity**로 이뤄지고(게시 주체가 둘로 갈라지지 않는다), 중복 리뷰 감지와 self thread 식별에 쓰는 봇 로그인은 하드코딩 값이 아니라 **인증된 App 봇 로그인으로 동적 해석**되어 정확히 동작한다.
+
+4. App 봇 identity로 게시된 리뷰·코멘트 이벤트는 이 리뷰 워크플로를 **다시 트리거하지 않는다**(self-trigger 루프가 생기지 않는다).
+
+5. App 토큰 발급 시크릿이 없거나 토큰 발급에 실패하면(또는 포크 PR 등 사용할 수 없는 맥락이면), 워크플로는 기본 토큰으로 동작을 이어가 리뷰를 계속 게시하고(APPROVE 시도가 막히면 COMMENT로 fallback) 실패로 중단하지 않는다.
+
+6. 두 워크플로의 계약 테스트가 실행될 때, 테스트는 App 설치 토큰 발급·App 봇 동적 식별·승인 경로의 **존재를 요구(또는 허용)** 하며 더 이상 그 존재를 이유로 실패하지 않고, 동시에 기존 보안 검사(third-party action SHA 고정, 신뢰 base checkout, 모델 action 전 자격증명 제거 등)는 그대로 통과를 요구한다.
+
+7. 위 1~6의 동작은 `claude-review.yml`과 `codex-review.yml` 양쪽에서 동일하게 성립한다.
+
+## 범위
+포함:
+- `.github/workflows/claude-review.yml` — App 설치 토큰 발급 단계 추가, 게시·resolve·approve 스텝 토큰을 App 토큰(없으면 기본 토큰)으로 전환, 봇 로그인 동적 해석, self-trigger 가드에 App 봇 포함.
+- `.github/workflows/codex-review.yml` — 위와 동일 패턴 적용.
+- `tests/codex/test-codex-review-workflow.sh` — App 토큰 경로를 금지하던 검사를 요구·허용으로 갱신(다른 보안·핀 검사는 보존).
+- `tests/claude/test-claude-review-workflow.sh` — App 토큰 경로 도입에 맞춰 검사 갱신·추가(Claude가 OAuth 토큰 교환에 필요로 하는 기존 `id-token: write` 요구는 보존).
+
+비-목표 / 제외:
+- 리뷰 판정 로직(verdict·findings·승인 허용 플래그 산정)·프롬프트·결과 스키마 변경.
+- inline-only 정책, fingerprint 산정 방식, idempotency·managed comment supersede 등 기존 게시 규약 변경.
+- GitHub App 자체의 생성·설치, App ID·private key 시크릿 값의 등록(레포 설정·운영 작업이며 워크플로 코드 변경 범위 밖 — 시크릿은 이미 구성돼 있다고 전제).
+- `rules/`·`milestones/`·`CLAUDE.md` 등 워크플로·테스트 외 문서.
+
+## 검증
+<!-- 검증 기준의 단일 출처는 위 "완료 조건"이다. 검증을 실행하는 진입 명령(테스트·lint·빌드)은 SPEC이 선언하지 않는다. -->
+이 SPEC의 인수 바는 위 **완료 조건**이다. 각 조건이 관찰 가능하게 충족되면 충족된 것으로 본다. 검증을 실행하는 진입 명령은 SPEC이 아니라 프로젝트 규칙(`rules/`)이 단일 출처로 정의한다.
+
+## 제약 (있을 때만)
+- **직전 결정의 명시적 역전**: 본 SPEC은 직전 "App 토큰 금지(기본 토큰만 사용)" 수용 기준을 의도적으로 역전한다. 구현·테스트는 그 금지 기준을 되살리지 않는다.
+- **토큰 발급 방식**: GitHub 공식 액션 `actions/create-github-app-token`을 SHA 고정으로 사용해, App ID·private key 시크릿(`REVIEW_APP_ID`·`REVIEW_APP_PRIVATE_KEY`)으로 매 실행 단명(short-lived) 설치 토큰을 발급한다. 장기 PAT를 단일 시크릿에 저장하는 방식은 쓰지 않는다.
+- **시크릿 부재 시 graceful degradation**: 토큰 발급 스텝은 시크릿이 없으면 건너뛰고, 후속 게시 스텝은 App 토큰이 있으면 그것을, 없으면 기본 토큰을 쓴다(예: `${{ steps.<id>.outputs.token || github.token }}`). 시크릿을 워크플로 레벨 `if`에서 직접 참조할 수 없으면 env 로 노출해 판정한다.
+- **identity 통일**: 리뷰를 게시·식별·resolve·approve 하는 모든 스텝은 동일 토큰(App 토큰 우선, 없으면 기본 토큰)을 쓴다. 봇 로그인은 인증 주체(`getAuthenticated`류) 또는 App slug 로 동적 해석하고, 기본 토큰 사용 시 기존 `github-actions[bot]`을 유지한다.
+- **self-trigger 차단 보존**: 상단 `if:` 게이트가 자동 게시 이벤트를 무시하던 동작을 App 봇 identity 게시 이벤트도 무시하도록 확장한다(또는 기존 `@claude` 멘션 요구가 App 자동 게시를 이미 배제함을 보장한다).
+- **OIDC 권한 구분**: `actions/create-github-app-token`은 OIDC(`id-token`)를 필요로 하지 않는다. Claude 워크플로의 기존 `id-token: write`는 claude-code-action 의 OAuth 토큰 교환을 위한 것이므로 보존하고, App 토큰 도입을 이유로 새로 추가하지 않는다.
+- **third-party action 핀**: App 토큰 액션을 포함한 모든 third-party action 은 mutable 태그가 아니라 커밋 SHA 로 고정한다.
+- **기존 동작 보존**: idempotency·inline thread fingerprint resolve 로직·managed comment supersede·신뢰 base checkout·모델 action 전 자격증명 제거 등 기존 보장은 토큰·identity 교체로 깨지지 않아야 한다.
+
+## 위험 (있을 때만)
+- 워크플로 파일을 수정하는 PR은 변조 방지 가드로 인해 그 PR 안에서 변경된 워크플로가 자기 자신을 실행·검증하지 못할 수 있다(머지 후 다음 리뷰 실행부터 효력). 따라서 resolve·approve 가 실제로 동작하는지는 머지 후 후속 PR에서 관찰해 확인하며, PR 단계 검증은 계약 테스트(정적)에 의존한다.
+- App 봇 identity 도입이 self-trigger 가드를 우회하면 무한 리뷰 루프가 생길 수 있다(완료 조건 4 로 방어).
+- App 설치 토큰 발급 실패를 치명적으로 처리하면 리뷰가 전면 중단될 수 있다(완료 조건 5 의 graceful degradation 으로 방어).

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -303,4 +303,51 @@ grep -qF '"$CLAUDE_REVIEW_LANG"' "$WORKFLOW" \
 ok "check 11: 출력 언어 지시 + untrusted block 끝 재강조 + 구성 변수(기본 Korean)"
 
 echo ""
+echo "=== check 12: GitHub App 설치 토큰 발급 + 동적 봇 식별 + graceful degradation (AC1/AC2/AC3/AC5/제약) ==="
+# App 설치 토큰 발급 스텝이 SHA 고정 actions/create-github-app-token 으로 존재.
+grep -qE 'uses: actions/create-github-app-token@[0-9a-f]{40}' "$WORKFLOW" \
+  || fail "actions/create-github-app-token SHA 고정 발급 스텝 부재 (AC1/제약)"
+if grep -qE 'uses: actions/create-github-app-token@v[0-9.]+' "$WORKFLOW"; then
+  fail "create-github-app-token 이 mutable version tag — SHA 고정 필요 (제약)"
+fi
+# App ID / private key 시크릿으로 단명 토큰 발급 (장기 PAT 단일 시크릿 금지).
+grep -qF 'app-id: ${{ secrets.REVIEW_APP_ID }}' "$WORKFLOW" \
+  || fail "create-github-app-token 에 app-id=secrets.REVIEW_APP_ID 입력 부재 (제약)"
+grep -qF 'private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}' "$WORKFLOW" \
+  || fail "create-github-app-token 에 private-key=secrets.REVIEW_APP_PRIVATE_KEY 입력 부재 (제약)"
+# 시크릿 부재 시 발급 스텝 skip — graceful degradation (AC5).
+grep -qF "if: \${{ env.REVIEW_APP_ID != '' }}" "$WORKFLOW" \
+  || fail "App 토큰 발급 스텝이 REVIEW_APP_ID 부재 시 skip 되도록 게이트되지 않음 (AC5)"
+grep -qF 'REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}' "$WORKFLOW" \
+  || fail "REVIEW_APP_ID 시크릿을 env 로 노출(게이트 판정용)하지 않음 (AC5/제약)"
+# 발급 실패가 리뷰를 중단시키지 않도록 continue-on-error (AC5: 발급 실패 graceful).
+grep -qF 'continue-on-error: true' "$WORKFLOW" \
+  || fail "App 토큰 발급 스텝 continue-on-error 부재 — 발급 실패 시 리뷰 전면 중단 (AC5)"
+# 게시 토큰: App 토큰 우선, 없으면 기본 토큰 (AC5 graceful).
+grep -qF 'steps.app-token.outputs.token || github.token' "$WORKFLOW" \
+  || fail "게시 토큰이 App 토큰 우선·기본 토큰 폴백(steps.app-token.outputs.token || github.token)으로 해석되지 않음 (AC5/제약)"
+# 봇 로그인 동적 해석: app-slug → <slug>[bot], 없으면 github-actions[bot] (AC3).
+grep -qF 'steps.app-token.outputs.app-slug' "$WORKFLOW" \
+  || fail "App 봇 로그인 동적 해석(app-slug 출력) 부재 (AC3)"
+grep -qF 'const botLogin = appSlug' "$WORKFLOW" \
+  || fail "botLogin 이 app-slug 기반 동적 해석으로 산정되지 않음 (AC3/AC5)"
+grep -qF "'github-actions[bot]'" "$WORKFLOW" \
+  || fail "기본 토큰 봇 식별(github-actions[bot]) 폴백 부재 (AC5)"
+# Claude 의 기존 id-token: write(OAuth 토큰 교환용)는 App 토큰 도입 후에도 보존.
+grep -qE '^[[:space:]]*id-token:[[:space:]]*write' "$WORKFLOW" \
+  || fail "claude-code-action OAuth 용 id-token: write 권한이 App 토큰 도입으로 사라짐 (제약)"
+# App 자동 게시 self-trigger 배제(AC4): @claude 멘션 요구가 멘션 없는 App 자동게시를 배제.
+mention_count="$(awk -v n="contains(github.event.comment.body, '@claude')" 'index($0,n){c++} END{print c+0}' "$WORKFLOW")"
+review_mention_count="$(awk -v n="contains(github.event.review.body, '@claude')" 'index($0,n){c++} END{print c+0}' "$WORKFLOW")"
+(( mention_count + review_mention_count >= 3 )) \
+  || fail "@claude 멘션 요구가 comment/review 트리거 3개 분기에 모두 있지 않음 — App 자동게시 self-trigger 배제 불가 (AC4)"
+# App 봇 identity(<slug>[bot])는 'github-actions[bot]' 리터럴 배제로는 걸러지지 않으므로,
+# 모든 봇 작성 comment/review 이벤트를 user.type 로 배제해 App 봇 self-trigger 루프를 막는다 (AC4).
+cbt="$(awk -v n="github.event.comment.user.type != 'Bot'" 'index($0,n){c++} END{print c+0}' "$WORKFLOW")"
+rbt="$(awk -v n="github.event.review.user.type != 'Bot'" 'index($0,n){c++} END{print c+0}' "$WORKFLOW")"
+(( cbt >= 2 && rbt >= 1 )) \
+  || fail "App 봇 포함 봇 작성 이벤트 배제(user.type != 'Bot')가 comment 2개·review 1개 분기에 없음 (AC4)"
+ok "check 12: App 토큰 발급(SHA 고정) + 동적 봇 식별 + graceful degradation + id-token 보존 + self-trigger 배제"
+
+echo ""
 echo "ALL CHECKS PASSED"

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -184,10 +184,20 @@ grep -q 'github.event.review.author_association' "$WORKFLOW" \
   || fail "review 기반 @codex 트리거 author_association 제한 부재 (AC8)"
 grep -q "github.event.comment.user.login != 'github-actions\[bot\]'" "$WORKFLOW" \
   || fail "봇 self-trigger 차단 게이트 부재 (AC8)"
-if grep -q 'REVIEW_APP_BOT_LOGIN' "$WORKFLOW"; then
-  fail "REVIEW_APP_BOT_LOGIN App 봇 식별 분기 잔존 — Claude 구조에 없음 (제약)"
-fi
-ok "check 12: @codex + author association + 봇 차단 게이트, App 봇 분기 제거됨"
+# App 봇 자동 게시 self-trigger 차단(AC4): @codex 멘션 요구가 멘션 없는 App
+# 자동 게시(리뷰/인라인)를 이미 배제한다. comment/review 트리거 분기 모두
+# @codex 멘션을 요구하므로 App 봇 identity 게시 이벤트는 재트리거하지 않는다.
+mention_count="$(count "contains(github.event.comment.body, '@codex')" "$WORKFLOW")"
+review_mention_count="$(count "contains(github.event.review.body, '@codex')" "$WORKFLOW")"
+(( mention_count + review_mention_count >= 3 )) \
+  || fail "@codex 멘션 요구가 comment/review 트리거 3개 분기에 모두 있지 않음 — App 자동게시 self-trigger 배제 불가 (AC4)"
+# App 봇 identity(<slug>[bot])는 'github-actions[bot]' 리터럴 배제로는 걸러지지 않으므로,
+# 모든 봇 작성 comment/review 이벤트를 user.type 로 배제해 App 봇 self-trigger 루프를 막는다 (AC4).
+comment_bot_type="$(count "github.event.comment.user.type != 'Bot'" "$WORKFLOW")"
+review_bot_type="$(count "github.event.review.user.type != 'Bot'" "$WORKFLOW")"
+(( comment_bot_type >= 2 && review_bot_type >= 1 )) \
+  || fail "App 봇 포함 봇 작성 이벤트 배제(user.type != 'Bot')가 comment 2개·review 1개 분기에 없음 (AC4)"
+ok "check 12: @codex + author association + 봇 차단 + 멘션 요구 + user.type!=Bot 로 App 봇 self-trigger 배제"
 
 echo ""
 echo "=== check 13: 단일 inline 리뷰 제출 — verdict/event + body summary + 멱등 (AC1/AC7) ==="
@@ -302,26 +312,38 @@ grep -qF 'findings.map((f) => computeFingerprint(f))' "$WORKFLOW" \
 ok "check 16b: 결정론적 fingerprint(file+perspective+title), 줄번호 비의존"
 
 echo ""
-echo "=== check 17: GitHub App 설치 토큰 발급·App 토큰 approve 경로 부재 (AC5/제약) ==="
-if grep -qF 'create-github-app-token' "$WORKFLOW"; then
-  fail "create-github-app-token 잔존 — App 설치 토큰 발급 경로 제거되어야 함 (AC5)"
+echo "=== check 17: GitHub App 설치 토큰 발급 + 동적 봇 식별 + graceful degradation (AC1/AC2/AC3/AC5/제약) ==="
+# App 설치 토큰 발급 스텝이 SHA 고정 actions/create-github-app-token 으로 존재.
+grep -qE 'uses: actions/create-github-app-token@[0-9a-f]{40}' "$WORKFLOW" \
+  || fail "actions/create-github-app-token SHA 고정 발급 스텝 부재 (AC1/제약)"
+if grep -qE 'uses: actions/create-github-app-token@v[0-9.]+' "$WORKFLOW"; then
+  fail "create-github-app-token 이 mutable version tag — SHA 고정 필요 (제약)"
 fi
-if grep -qF 'app-token' "$WORKFLOW"; then
-  fail "app-token 스텝/출력 잔존 (AC5)"
-fi
-if grep -qF 'app-slug' "$WORKFLOW"; then
-  fail "app-slug 동적 봇 식별 잔존 (AC5)"
-fi
-if grep -qF 'REVIEW_APP_ID' "$WORKFLOW"; then
-  fail "REVIEW_APP_ID App 게이트 잔존 (AC5)"
-fi
-if grep -qF 'dismissReview' "$WORKFLOW"; then
-  fail "dismissReview 잔존 (AC5)"
-fi
-# 자기 트리거/식별은 기본 토큰 봇(github-actions[bot])만 사용.
+# App ID / private key 시크릿으로 단명 토큰 발급 (장기 PAT 단일 시크릿 금지).
+grep -qF 'app-id: ${{ secrets.REVIEW_APP_ID }}' "$WORKFLOW" \
+  || fail "create-github-app-token 에 app-id=secrets.REVIEW_APP_ID 입력 부재 (제약)"
+grep -qF 'private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}' "$WORKFLOW" \
+  || fail "create-github-app-token 에 private-key=secrets.REVIEW_APP_PRIVATE_KEY 입력 부재 (제약)"
+# 시크릿 부재 시 발급 스텝 skip — graceful degradation (AC5).
+grep -qF "if: \${{ env.REVIEW_APP_ID != '' }}" "$WORKFLOW" \
+  || fail "App 토큰 발급 스텝이 REVIEW_APP_ID 부재 시 skip 되도록 게이트되지 않음 (AC5)"
+grep -qF 'REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}' "$WORKFLOW" \
+  || fail "REVIEW_APP_ID 시크릿을 env 로 노출(게이트 판정용)하지 않음 (AC5/제약)"
+# 발급 실패가 리뷰를 중단시키지 않도록 continue-on-error (AC5: 발급 실패 graceful).
+grep -qF 'continue-on-error: true' "$WORKFLOW" \
+  || fail "App 토큰 발급 스텝 continue-on-error 부재 — 발급 실패 시 리뷰 전면 중단 (AC5)"
+# 게시 토큰: App 토큰 우선, 없으면 기본 토큰 (AC5 graceful).
+grep -qF 'steps.app-token.outputs.token || github.token' "$WORKFLOW" \
+  || fail "게시 토큰이 App 토큰 우선·기본 토큰 폴백(steps.app-token.outputs.token || github.token)으로 해석되지 않음 (AC5/제약)"
+# 봇 로그인 동적 해석: app-slug → <slug>[bot], 없으면 github-actions[bot] (AC3).
+grep -qF 'steps.app-token.outputs.app-slug' "$WORKFLOW" \
+  || fail "App 봇 로그인 동적 해석(app-slug 출력) 부재 (AC3)"
+grep -qF 'const botLogin = appSlug' "$WORKFLOW" \
+  || fail "botLogin 이 app-slug 기반 동적 해석으로 산정되지 않음 (AC3/AC5)"
+# 기본 토큰 사용 시 봇 식별은 기존 github-actions[bot] 유지.
 grep -qF "'github-actions[bot]'" "$WORKFLOW" \
-  || fail "기본 토큰 봇 식별(github-actions[bot]) 부재"
-ok "check 17: App 토큰 발급·App approve 경로 부재"
+  || fail "기본 토큰 봇 식별(github-actions[bot]) 폴백 부재 (AC5)"
+ok "check 17: App 토큰 발급(SHA 고정) + 동적 봇 식별 + graceful degradation"
 
 echo ""
 echo "=== check 18: 권한 범위 — 게시에 필요한 범위만, App/OIDC 전용 권한 없음 (제약) ==="


### PR DESCRIPTION
## 문제

inline review thread의 fingerprint 기반 자동 resolve 기능이 **토큰 권한 때문에 한 번도 실제로 동작하지 못한 채 출하**돼 있었다. 라이브 증거(PR #293): 모델이 `resolved_threads`에 올바른 fingerprint를 넣었는데도 `resolveReviewThread` GraphQL 호출이 `Resource not accessible by integration`으로 거부됨. 같은 권한 부족으로 PR 공식 APPROVE도 거부(`GitHub Actions is not permitted to approve pull requests`)된다. 두 실패 모두 비치명적 경고로 삼켜져 워크플로는 green으로 끝나 드러나지 않았다.

## 이력 맥락 (이 PR이 역전하는 결정)

App 설치 토큰 경로는 2026-05-31에 도입됐다가 06-01~06-02에 일부러 제거됐고, 2026-06-02 SPEC의 AC5가 "게시·resolve는 기본 토큰만 사용"을 확정하며 codex 계약 테스트(check 17/18)에 App 토큰 재도입 **금지** 어서션을 박았다. 그 결정은 self-approve 불가만 수용 위험으로 봤고, **같은 권한 부족이 thread resolve까지 깨뜨린다는 점은 인지하지 못했다**. 이 PR은 그 결정을 **명시적으로 역전**한다(사용자 결정).

## 변경 (두 워크플로 동일)

- job env `REVIEW_APP_ID` 게이트(step `if`에서 시크릿 직접참조 불가 회피).
- `actions/create-github-app-token`(SHA 고정 `d72941d…`) 발급 스텝: `if` 게이트 + `continue-on-error`(발급 실패해도 리뷰 중단 안 함).
- Submit 토큰 = `steps.app-token.outputs.token || github.token` (graceful degradation).
- `botLogin` = `app-slug` 동적 해석(`<slug>[bot]`), 없으면 `github-actions[bot]` — 게시·식별·resolve·approve 단일 identity.
- self-trigger 가드(AC4): comment/review 트리거 3분기에 `user.type != 'Bot'` 추가 → App 봇 자동 게시가 재트리거 안 됨.
- Claude `id-token: write`(claude-code-action OAuth용) 보존, Codex는 OIDC 불필요로 미추가.
- 계약 테스트 2종 갱신: App 토큰 금지 → 발급·동적식별·graceful 요구로 역전. 기존 보안·SHA핀·trusted base·자격증명 제거 검사는 보존.

## 검증

`bash tests/codex/...` · `bash tests/claude/...` → 둘 다 `ALL CHECKS PASSED`. SPEC AC1~7 충족.

## Caveat (머지 후 관찰)

워크플로 자기 자신을 수정하므로 실제 resolve/APPROVE 동작은 변조방지 가드로 이 PR 내에서 자기검증 불가 — **머지 후** 후속 PR에서 관찰 확인. 전제: `REVIEW_APP_ID`/`REVIEW_APP_PRIVATE_KEY` 시크릿 이미 구성됨(확인 완료).

## 관련

영어 코멘트 수정은 별도 #295. SPEC: `docs/specs/2026-06-03-review-workflow-app-token-resolve-approve/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
