### PR TITLE
fix(review): idempotency 두 번째 검사를 자기 marker prefix로 스코프 — 공유 봇 신원 레이스로 인한 리뷰 누락 수정

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -525,8 +525,16 @@ jobs:
               core.info(`Formal Claude review for ${head_sha} verdict=${verdict} already exists; skipping duplicate submission.`);
               skipSubmit = true;
             }
+            // Scope this fallback to THIS reviewer's own marker prefix. Claude and
+            // Codex both submit as the same App bot (courtesy-bot[bot]) once the
+            // App-token path is active, so a bare login+APPROVED+commit_id match
+            // would treat the other reviewer's approval as our own and skip — the
+            // late-finishing reviewer's approval would silently vanish. Every review
+            // body always carries `<!-- ${prefix} … -->`, so the prefix substring
+            // distinguishes our approvals from the peer reviewer's.
             if (!skipSubmit && event === 'APPROVE' && existingReviews.some((r) =>
-                r.user?.login === botLogin && r.state === 'APPROVED' && r.commit_id === head_sha)) {
+                r.user?.login === botLogin && r.state === 'APPROVED' && r.commit_id === head_sha
+                && (r.body || '').includes(`<!-- ${prefix}`))) {
               core.info(`Formal Claude approval already exists for ${head_sha}; skipping duplicate submission.`);
               skipSubmit = true;
             }

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -418,8 +418,16 @@ jobs:
               core.info(`Formal Codex review for ${head_sha} verdict=${verdict} already exists; skipping duplicate submission.`);
               skipSubmit = true;
             }
+            // Scope this fallback to THIS reviewer's own marker prefix. Claude and
+            // Codex both submit as the same App bot (courtesy-bot[bot]) once the
+            // App-token path is active, so a bare login+APPROVED+commit_id match
+            // would treat the other reviewer's approval as our own and skip — the
+            // late-finishing reviewer's approval would silently vanish. Every review
+            // body always carries `<!-- ${prefix} … -->`, so the prefix substring
+            // distinguishes our approvals from the peer reviewer's.
             if (!skipSubmit && event === 'APPROVE' && existingReviews.some((r) =>
-                r.user?.login === botLogin && r.state === 'APPROVED' && r.commit_id === head_sha)) {
+                r.user?.login === botLogin && r.state === 'APPROVED' && r.commit_id === head_sha
+                && (r.body || '').includes(`<!-- ${prefix}`))) {
               core.info(`Formal Codex approval already exists for ${head_sha}; skipping duplicate submission.`);
               skipSubmit = true;
             }


### PR DESCRIPTION
## 문제

PR #299에서 Codex 리뷰(approve)는 남았으나 **Claude 리뷰가 누락**됐다. 워크플로는 성공(1m58s)했고, 제출 스텝 로그에 원인이 있다:

> `Formal Claude approval already exists for f9ac1b8…; skipping duplicate submission.`

## 근본 원인 (회귀)

App-토큰 경로 복원(PR #296, commit e7cfe0e) 이후 Claude·Codex 리뷰가 **동일 App 봇 `courtesy-bot[bot]`** 으로 게시된다. 그런데 두 번째 idempotency 검사(`claude-review.yml:528`, `codex-review.yml:421`)는 마커 prefix를 보지 않고 `botLogin + APPROVED + commit_id` 만 본다:

```js
r.user?.login === botLogin && r.state === 'APPROVED' && r.commit_id === head_sha
```

→ 같은 봇으로 **먼저 approve한 리뷰어의 결과를 자기 것으로 오인**하고 제출을 스킵한다. PR #299에서는 Codex(52s)가 먼저 06:00:51에 approve → Claude 제출 스텝(06:01:59)이 그 approval을 보고 스킵 → Claude 리뷰가 사라졌다. 늦게 끝나는 리뷰어가 항상 묻히는 레이스다.

복원 전에는 Claude가 `github.token`(`github-actions[bot]`)을 써서 login이 달라 충돌하지 않았다.

## 수정

리뷰 본문은 항상 `<!-- <prefix> head_sha=… verdict=… -->` 마커를 포함하므로, 두 번째 검사를 **자기 marker prefix로 스코프**한다:

```js
… && (r.body || '').includes(`<!-- ${prefix}`)
```

claude/codex 양쪽 대칭 수정. 첫 번째 검사는 이미 prefix 포함 marker로 매칭하므로 변경 없음.

## 검증

- 로직 테스트(node): 기존 = Codex approval에 Claude 스킵(`true`, 버그 재현) → 수정 후 = 스킵 안 함(`false`, Claude 정상 게시), 진짜 직전 Claude approval에는 여전히 스킵(`true`, 멱등 유지).
- ⚠️ 워크플로 수정 PR은 변조방지 가드로 **자기 PR에서 검증 불가** — 효력은 머지 후 다음 PR부터. 머지 후 후속 PR에서 양쪽 리뷰가 모두 게시되는지 최종 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)