### PR TITLE
fix(review): approve일 때만 본문 코멘트(승인 사실만), 리뷰 요약 작성 폐지

### DIFF
--- a/.github/prompts/codex-pr-review.schema.json
+++ b/.github/prompts/codex-pr-review.schema.json
@@ -5,7 +5,6 @@
   "required": [
     "eligibility",
     "verdict",
-    "summary",
     "confidence",
     "reviewed_context",
     "automation_safety",
@@ -32,7 +31,6 @@
       "type": "string",
       "enum": ["approve", "comment", "needs_context", "unavailable"]
     },
-    "summary": { "type": "string" },
     "confidence": {
       "type": "string",
       "enum": ["high", "medium", "low"]

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -136,7 +136,7 @@ jobs:
           cat "$REVIEW_PROMPT" > .claude-review/prompt.md
           {
             printf '\n\n## 출력 언어\n'
-            printf '리뷰 산출물의 자연어 필드(summary, 각 finding의 title·body·suggestion)는 모두 %s로 작성합니다. JSON 키·구조와 verdict·severity 등 enum 값은 schema 정의를 그대로 따릅니다.\n' "$CLAUDE_REVIEW_LANG"
+            printf '리뷰 산출물의 자연어 필드(각 finding의 title·body·suggestion)는 모두 %s로 작성합니다. JSON 키·구조와 verdict·severity 등 enum 값은 schema 정의를 그대로 따릅니다.\n' "$CLAUDE_REVIEW_LANG"
           } >> .claude-review/prompt.md
           {
             printf '\n\n---\n\n'
@@ -159,7 +159,7 @@ jobs:
             printf '\n\nUnified diff:\n'
             cat .review-context/diff.patch
             printf '\n\n## 마지막 재강조 (절대 위반 금지)\n'
-            printf '응답 객체의 모든 자연어 필드(summary, 각 finding의 title·body·suggestion)는 반드시 %s 로 작성합니다. 영어 등 다른 언어로 작성하면 안 됩니다. JSON 키·enum 값은 schema 정의 그대로 사용합니다.\n' "$CLAUDE_REVIEW_LANG"
+            printf '응답 객체의 모든 자연어 필드(각 finding의 title·body·suggestion)는 반드시 %s 로 작성합니다. 영어 등 다른 언어로 작성하면 안 됩니다. JSON 키·enum 값은 schema 정의 그대로 사용합니다.\n' "$CLAUDE_REVIEW_LANG"
             printf '\n'
           } >> .claude-review/prompt.md
 
@@ -477,15 +477,14 @@ jobs:
               event = 'COMMENT';
             }
 
-            // Review body: header + summary (when present) + an approval line when
-            // the verdict is approve + the hidden idempotency marker. Finding
-            // evaluations live as inline comments only (inline-only policy).
+            // Review body: only on an actual APPROVE event does the body carry a
+            // single "승인되었습니다." line. Every non-approve review carries only the
+            // hidden idempotency marker, so findings live exclusively as inline
+            // comments (inline-only policy) and no review summary is ever written.
             const marker = `<!-- ${prefix} head_sha=${head_sha} verdict=${verdict} -->`;
-            const bodyLines = ['## Claude PR 리뷰', ''];
-            if (result.summary) bodyLines.push(String(result.summary), '');
-            if (verdict === 'approve') bodyLines.push('_승인 — 지적 사항은 인라인 코멘트 참조._', '');
-            bodyLines.push(marker);
-            const body = bodyLines.join('\n');
+            const body = event === 'APPROVE'
+              ? ['## Claude PR 리뷰', '', '승인되었습니다.', '', marker].join('\n')
+              : marker;
 
             // Inline review comments — path/line/body (start_line for multi-line range).
             // The hidden marker lets us later identify self-owned threads so we can

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -477,12 +477,14 @@ jobs:
               event = 'COMMENT';
             }
 
-            // Review body: only on an actual APPROVE event does the body carry a
-            // single "승인되었습니다." line. Every non-approve review carries only the
-            // hidden idempotency marker, so findings live exclusively as inline
-            // comments (inline-only policy) and no review summary is ever written.
+            // Review body — built from the ACTUAL submit event, not the intended
+            // one. Only an APPROVE submission carries the single "승인되었습니다." line;
+            // every other submission (including the APPROVE→COMMENT degradation when
+            // the default token cannot self-approve) carries only the hidden
+            // idempotency marker, so findings live exclusively as inline comments
+            // (inline-only policy) and no review summary is ever written.
             const marker = `<!-- ${prefix} head_sha=${head_sha} verdict=${verdict} -->`;
-            const body = event === 'APPROVE'
+            const buildBody = (ev) => ev === 'APPROVE'
               ? ['## Claude PR 리뷰', '', '승인되었습니다.', '', marker].join('\n')
               : marker;
 
@@ -545,7 +547,7 @@ jobs:
               owner, repo, pull_number,
               commit_id: head_sha,
               event: ev,
-              body,
+              body: buildBody(ev),
               comments: inlineComments,
             });
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -370,12 +370,14 @@ jobs:
               event = 'COMMENT';
             }
 
-            // Review body: only on an actual APPROVE event does the body carry a
-            // single "승인되었습니다." line. Every non-approve review carries only the
-            // hidden idempotency marker, so findings live exclusively as inline
-            // comments (inline-only policy) and no review summary is ever written.
+            // Review body — built from the ACTUAL submit event, not the intended
+            // one. Only an APPROVE submission carries the single "승인되었습니다." line;
+            // every other submission (including the APPROVE→COMMENT degradation when
+            // the default token cannot self-approve) carries only the hidden
+            // idempotency marker, so findings live exclusively as inline comments
+            // (inline-only policy) and no review summary is ever written.
             const marker = `<!-- ${prefix} head_sha=${head_sha} verdict=${verdict} -->`;
-            const body = event === 'APPROVE'
+            const buildBody = (ev) => ev === 'APPROVE'
               ? ['## Codex PR 리뷰', '', '승인되었습니다.', '', marker].join('\n')
               : marker;
 
@@ -438,7 +440,7 @@ jobs:
               owner, repo, pull_number,
               commit_id: head_sha,
               event: ev,
-              body,
+              body: buildBody(ev),
               comments: inlineComments,
             });
 

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -162,7 +162,7 @@ jobs:
           cat "$REVIEW_PROMPT" > "$initial_prompt"
           {
             printf '\n\n## 출력 언어\n'
-            printf '리뷰 산출물의 자연어 필드(summary, 각 finding의 title·body·suggestion)는 모두 %s로 작성합니다. JSON 키·구조와 verdict·severity 등 enum 값은 schema 정의를 그대로 따릅니다.\n' "$CODEX_REVIEW_LANG"
+            printf '리뷰 산출물의 자연어 필드(각 finding의 title·body·suggestion)는 모두 %s로 작성합니다. JSON 키·구조와 verdict·severity 등 enum 값은 schema 정의를 그대로 따릅니다.\n' "$CODEX_REVIEW_LANG"
           } >> "$initial_prompt"
           {
             printf '\n\n---\n\n'
@@ -185,7 +185,7 @@ jobs:
             printf '\n\nUnified diff:\n'
             cat .review-context/diff.patch
             printf '\n\n## 마지막 재강조 (절대 위반 금지)\n'
-            printf '응답 객체의 모든 자연어 필드(summary, 각 finding의 title·body·suggestion)는 반드시 %s 로 작성합니다. 영어 등 다른 언어로 작성하면 안 됩니다. JSON 키·enum 값은 schema 정의 그대로 사용합니다.\n' "$CODEX_REVIEW_LANG"
+            printf '응답 객체의 모든 자연어 필드(각 finding의 title·body·suggestion)는 반드시 %s 로 작성합니다. 영어 등 다른 언어로 작성하면 안 됩니다. JSON 키·enum 값은 schema 정의 그대로 사용합니다.\n' "$CODEX_REVIEW_LANG"
           } >> "$initial_prompt"
 
           # Drop the checkout credential before the model action runs so the
@@ -370,15 +370,14 @@ jobs:
               event = 'COMMENT';
             }
 
-            // Review body: header + summary (when present) + an approval line when
-            // the verdict is approve + the hidden idempotency marker. Finding
-            // evaluations live as inline comments only (inline-only policy).
+            // Review body: only on an actual APPROVE event does the body carry a
+            // single "승인되었습니다." line. Every non-approve review carries only the
+            // hidden idempotency marker, so findings live exclusively as inline
+            // comments (inline-only policy) and no review summary is ever written.
             const marker = `<!-- ${prefix} head_sha=${head_sha} verdict=${verdict} -->`;
-            const bodyLines = ['## Codex PR 리뷰', ''];
-            if (result.summary) bodyLines.push(String(result.summary), '');
-            if (verdict === 'approve') bodyLines.push('_승인 — 지적 사항은 인라인 코멘트 참조._', '');
-            bodyLines.push(marker);
-            const body = bodyLines.join('\n');
+            const body = event === 'APPROVE'
+              ? ['## Codex PR 리뷰', '', '승인되었습니다.', '', marker].join('\n')
+              : marker;
 
             // Inline review comments — path/line/body (start_line for multi-line range).
             // The hidden marker lets us later identify self-owned threads so we can

--- a/docs/claude/pr-review-workflow.md
+++ b/docs/claude/pr-review-workflow.md
@@ -7,7 +7,7 @@
 - Codex PR review workflow와 같은 review core schema를 공유한다.
 - diff를 먼저 읽고 필요한 문맥만 사용한다.
 - 명확하고 실행 가능한 correctness 이슈만 남긴다.
-- Claude 출력의 발견사항(findings)은 코드 라인에 anchor된 inline review thread로, 요약(summary)은 그 리뷰 본문으로 단일 리뷰에 담아 게시한다.
+- Claude 출력의 발견사항(findings)은 코드 라인에 anchor된 inline review thread로 단일 리뷰에 담아 게시한다. 리뷰 요약(summary)은 작성하지 않으며, 리뷰 본문은 approve일 때만 승인 사실 한 줄을 담는다.
 - GitHub 전용 publish 로직과 모델별 review prompt를 분리한다.
 
 ## 현재 1차 워크플로
@@ -18,7 +18,7 @@
 4. pinned `anthropics/claude-code-action`을 실행하면서 `.github/prompts/codex-pr-review.schema.json`을 `--json-schema`로 전달한다.
 5. action `structured_output`을 `.claude-review/result.json`으로 저장하고 JSON으로 검증한다.
 6. 발견사항을 inline review comment 배열로 만든다. 각 comment는 발견사항의 파일과 변경 라인에 anchor되고 `side: 'RIGHT'`이며(multi-line이면 `start_line`/`start_side` 추가), 본문 끝에 숨김 마커 `<!-- claude-review-inline fingerprint=<fp> -->`를 붙인다. `fingerprint`는 발견사항의 안정 속성(파일 경로 + 리뷰 관점 + 정규화한 제목)만으로 결정론적으로 계산되며 줄 번호에 의존하지 않는다(정규화·해시 규칙은 codex 워크플로와 byte-identical).
-7. `result.summary`(있으면)를 리뷰 본문에 담고, inline comment 배열과 함께 단일 `github.rest.pulls.createReview` 호출로 제출한다. review event는 발견사항 0 + `approve` verdict + `automation_safety.may_approve` + diff 미절단일 때 `APPROVE`, 그 외 `COMMENT`다. 워크플로 기본 토큰이 self-approve를 못 해 `APPROVE`가 실패하면 같은 inline 코멘트를 담은 `COMMENT` 리뷰로 강등 제출하고 `.claude-review/approval-failed`로 기록한다. 본문에는 `<!-- claude-formal-review head_sha=… verdict=… -->` 멱등 마커가 들어가, 같은 마커의 봇 리뷰가 이미 있으면 제출만 건너뛴다.
+7. inline comment 배열과 함께 단일 `github.rest.pulls.createReview` 호출로 제출한다. review event는 발견사항 0 + `approve` verdict + `automation_safety.may_approve` + diff 미절단일 때 `APPROVE`, 그 외 `COMMENT`다. **리뷰 본문은 실제 `APPROVE` 이벤트일 때만 `## Claude PR 리뷰` 헤더 + `승인되었습니다.` 한 줄을 담고, 그 외(비-approve)에는 숨김 멱등 마커만 담는다 — 리뷰 요약(summary)은 작성하지 않으며 발견사항은 inline 전용이다.** 워크플로 기본 토큰이 self-approve를 못 해 `APPROVE`가 실패하면 같은 inline 코멘트와 본문을 담은 `COMMENT` 리뷰로 강등 제출하고 `.claude-review/approval-failed`로 기록한다. 본문에는 `<!-- claude-formal-review head_sha=… verdict=… -->` 멱등 마커가 들어가, 같은 마커의 봇 리뷰가 이미 있으면 제출만 건너뛴다.
 8. 게시 후(중복으로 제출을 건너뛰었어도 verdict와 무관하게), GraphQL `reviewThreads`로 조회해 자기 소유 + fingerprint 추출 가능 + 미해결인 inline thread를 fingerprint 기준으로 자동 resolve한다 — 모델이 `resolved_threads`에 올린 fingerprint(1차)이거나 이번 회차 findings의 fingerprint 집합에서 사라진 thread(2차 fallback)를 `resolveReviewThread`로 닫는다. 다른 리뷰어 thread나 fingerprint를 추출할 수 없는 thread는 건드리지 않는다. 발견사항을 담는 별도의 마커 관리형 이슈 레벨 코멘트 게시 경로는 없다(발견사항은 inline 전용).
 
 ## 운영 원칙

--- a/docs/codex/pr-review-workflow.md
+++ b/docs/codex/pr-review-workflow.md
@@ -2,7 +2,7 @@
 
 이 문서는 `codex review` 자연어 출력 대신 직접 프롬프팅한 structured JSON을 사용해 PR 리뷰를 자동화하는 계획과 경계를 정의한다.
 
-모델 호출은 셸에서 `codex exec`를 직접 실행하지 않고 공식 GitHub Action `openai/codex-action`(SHA 고정, codex CLI 버전은 action의 `codex-version` 입력으로 고정)을 통해 이뤄진다. 인증은 ChatGPT 계정 `auth.json`을 codex-home 디렉터리로 부트스트랩하는 방식을 쓰며 API 키 입력은 사용하지 않는다. 리뷰 결과 게시는 자매 워크플로(Claude PR 리뷰, `claude-review.yml`)와 **동일한 구조**다 — 발견사항(findings)을 코드 라인에 anchor된 inline review thread로, 요약(summary)을 리뷰 본문으로 담은 **단일 inline 리뷰** 제출 + 모델이 해소로 판정한 자기 소유 thread의 **fingerprint 기준 자동 resolve**. 별도의 마커 관리형 이슈 레벨 코멘트 게시 경로는 없으며, 게시·resolve는 워크플로 기본 토큰만 사용한다(GitHub App 설치 토큰 발급·App 토큰 정식 approve 경로 없음).
+모델 호출은 셸에서 `codex exec`를 직접 실행하지 않고 공식 GitHub Action `openai/codex-action`(SHA 고정, codex CLI 버전은 action의 `codex-version` 입력으로 고정)을 통해 이뤄진다. 인증은 ChatGPT 계정 `auth.json`을 codex-home 디렉터리로 부트스트랩하는 방식을 쓰며 API 키 입력은 사용하지 않는다. 리뷰 결과 게시는 자매 워크플로(Claude PR 리뷰, `claude-review.yml`)와 **동일한 구조**다 — 발견사항(findings)을 코드 라인에 anchor된 inline review thread로 담은 **단일 inline 리뷰** 제출(리뷰 요약은 작성하지 않고, 본문은 approve일 때만 승인 사실 한 줄을 담는다) + 모델이 해소로 판정한 자기 소유 thread의 **fingerprint 기준 자동 resolve**. 별도의 마커 관리형 이슈 레벨 코멘트 게시 경로는 없으며, 게시·resolve는 워크플로 기본 토큰만 사용한다(GitHub App 설치 토큰 발급·App 토큰 정식 approve 경로 없음).
 
 ## 목표
 
@@ -22,10 +22,10 @@
 6. 모델이 `needs_context`를 반환하면 요청 파일(최대 5개)을 PR head에서 수집해 2차 호출로 최종 verdict를 받는다(Claude 리뷰와 동일한 2-pass 흐름).
 7. 게시는 자매 Claude 워크플로와 **동일한 구조**인 단일 `Submit … inline review` 스텝(codex 라벨·마커로 치환)에서 이뤄진다.
    - **inline comment 조립**: 발견사항마다 파일과 변경 라인에 anchor된 inline comment(`side: 'RIGHT'`, multi-line이면 `start_line`/`start_side` 추가)를 만들고 본문 끝에 숨김 마커 `<!-- codex-review-inline fingerprint=<fp> -->`를 붙인다. `fingerprint`는 발견사항의 안정 속성(파일 경로 + 리뷰 관점 + 정규화한 제목)만으로 결정론적으로 계산되며 줄 번호에 의존하지 않는다(정규화·해시 규칙은 Claude 워크플로와 byte-identical).
-   - **단일 리뷰 제출**: `result.summary`(있으면)를 리뷰 본문에 담고 inline comment 배열과 함께 단일 `github.rest.pulls.createReview` 호출로 제출한다. review event는 findings가 없고 `automation_safety.may_approve=true`이며 diff가 truncate되지 않은 `approve`일 때 `APPROVE`, 그 외 `COMMENT`다(REQUEST_CHANGES는 폐지). 본문 헤더는 `## Codex PR 리뷰`이며 숨김 멱등 마커 `codex-formal-review head_sha=… verdict=…`를 담는다. 같은 마커의 봇 리뷰가 이미 있으면 제출만 건너뛴다(resolve 후처리는 계속). 워크플로 기본 토큰은 자기 PR을 정식 APPROVE하지 못하므로 `APPROVE`가 실패하면 같은 inline 코멘트를 담은 `COMMENT` 리뷰로 강등 제출하고 `.codex-review/approval-failed`로 기록한다.
+   - **단일 리뷰 제출**: inline comment 배열과 함께 단일 `github.rest.pulls.createReview` 호출로 제출한다. review event는 findings가 없고 `automation_safety.may_approve=true`이며 diff가 truncate되지 않은 `approve`일 때 `APPROVE`, 그 외 `COMMENT`다(REQUEST_CHANGES는 폐지). **리뷰 본문은 실제 `APPROVE` 이벤트일 때만 `## Codex PR 리뷰` 헤더 + `승인되었습니다.` 한 줄을 담고, 그 외(비-approve)에는 숨김 멱등 마커만 담는다 — 리뷰 요약(summary)은 작성하지 않는다.** 숨김 멱등 마커는 `codex-formal-review head_sha=… verdict=…`이며, 같은 마커의 봇 리뷰가 이미 있으면 제출만 건너뛴다(resolve 후처리는 계속). 워크플로 기본 토큰은 자기 PR을 정식 APPROVE하지 못하므로 `APPROVE`가 실패하면 같은 inline 코멘트와 본문을 담은 `COMMENT` 리뷰로 강등 제출하고 `.codex-review/approval-failed`로 기록한다.
    - **fingerprint 기준 self thread resolve**: 제출(또는 중복 skip) 후 verdict와 무관하게, GraphQL `reviewThreads`로 조회해 자기 소유 + fingerprint 추출 가능 + 미해결인 inline thread를 자동 resolve한다 — 모델이 `resolved_threads`에 올린 fingerprint(1차)이거나 이번 회차 findings의 fingerprint 집합에서 사라진 thread(2차 fallback)를 `resolveReviewThread`로 닫는다. 다른 리뷰어 thread나 fingerprint를 추출할 수 없는 thread는 건드리지 않는다.
 
-   별도의 마커 관리형 이슈 레벨 코멘트 게시 경로는 없다(발견사항은 inline 전용; 요약은 리뷰 본문에만 실린다). createReview가 라인 매핑 등으로 실패하면 그 회차 inline은 게시되지 않고 로그로만 남으며, 발견사항을 이슈 코멘트로 덤프하지 않는다.
+   별도의 마커 관리형 이슈 레벨 코멘트 게시 경로는 없다(발견사항은 inline 전용; 리뷰 요약은 작성하지 않고, 본문은 approve일 때만 승인 사실 한 줄을 담는다). createReview가 라인 매핑 등으로 실패하면 그 회차 inline은 게시되지 않고 로그로만 남으며, 발견사항을 이슈 코멘트로 덤프하지 않는다.
 
 ## 단계적 고도화 계획
 

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -133,7 +133,7 @@ grep -qE 'uses: actions/setup-node@[0-9a-f]{40}' "$WORKFLOW" \
 ok "check 5: Actions SHA 고정됨"
 
 echo ""
-echo "=== check 6: 단일 inline 리뷰 제출 — verdict/event + body summary + 멱등 (AC1/AC7) ==="
+echo "=== check 6: 단일 inline 리뷰 제출 — verdict/event + 승인 본문 + 멱등 (AC1/AC7) ==="
 grep -q 'name: Submit Claude inline review' "$WORKFLOW" \
   || fail "'Submit Claude inline review' 스텝 부재 (단일 inline 리뷰 게시 스텝 치환) (제약)"
 grep -qF 'github.rest.pulls.createReview' "$WORKFLOW" \
@@ -150,8 +150,13 @@ if grep -oE '[a-z_]*request_changes' "$WORKFLOW" | grep -qvE '^may_request_chang
 fi
 grep -qF '## Claude PR 리뷰' "$WORKFLOW" \
   || fail "리뷰 본문 헤더 '## Claude PR 리뷰' 부재 (제약: claude 라벨)"
-grep -qF 'result.summary' "$WORKFLOW" \
-  || fail "리뷰 본문에 result.summary 포함 부재 (제약: summary 를 본문에 실음)"
+# 리뷰 요약(summary) 작성 폐지 — 본문에 result.summary 를 싣지 않는다.
+if grep -qF 'result.summary' "$WORKFLOW"; then
+  fail "result.summary 잔존 — 리뷰 요약 본문 게시 폐지 위반 (제약: summary 미작성)"
+fi
+# approve(event === 'APPROVE')일 때만 본문에 단순 승인 문구를 싣는다.
+grep -qF '승인되었습니다.' "$WORKFLOW" \
+  || fail "승인 본문 문구('승인되었습니다.') 부재 (제약: approve 시 승인 사실만)"
 grep -qF 'CLAUDE_FORMAL_PREFIX: claude-formal-review' "$WORKFLOW" \
   || fail "formal review 마커 prefix(CLAUDE_FORMAL_PREFIX: claude-formal-review) 부재 (제약)"
 grep -qF '${prefix} head_sha=${head_sha} verdict=${verdict}' "$WORKFLOW" \
@@ -166,7 +171,7 @@ grep -qF "submit('COMMENT')" "$WORKFLOW" \
   || fail "APPROVE 실패 시 같은 inline 코멘트로 COMMENT 강등 제출 부재 (AC7)"
 grep -qF 'may_approve' "$WORKFLOW" \
   || fail "approve safety gate(may_approve) 부재"
-ok "check 6: 단일 inline 리뷰 제출 (APPROVE/COMMENT) + body summary + 멱등 + APPROVE fallback"
+ok "check 6: 단일 inline 리뷰 제출 (APPROVE/COMMENT) + 승인 본문(요약 미작성) + 멱등 + APPROVE fallback"
 
 echo ""
 echo "=== check 7: 별도 마커 관리형 이슈 레벨 코멘트 게시 경로 부재 (AC6) ==="
@@ -283,7 +288,7 @@ grep -qF "CLAUDE_REVIEW_LANG: \${{ vars.CLAUDE_REVIEW_LANG || 'Korean' }}" "$WOR
 # 명시적 출력 언어 지시: untrusted 입력 앞, 프롬프트 본문 뒤 (AC1)
 grep -qF '## 출력 언어' "$WORKFLOW" \
   || fail "명시적 출력 언어 지시 섹션(## 출력 언어) 부재 (AC1)"
-grep -qF '리뷰 산출물의 자연어 필드(summary, 각 finding의 title·body·suggestion)' "$WORKFLOW" \
+grep -qF '리뷰 산출물의 자연어 필드(각 finding의 title·body·suggestion)' "$WORKFLOW" \
   || fail "자연어 필드 대상 명시 지시 부재 (AC1)"
 # untrusted PR 입력(metadata·comments·diff) 뒤 재강조 (AC2)
 grep -qF '## 마지막 재강조 (절대 위반 금지)' "$WORKFLOW" \

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -200,7 +200,7 @@ review_bot_type="$(count "github.event.review.user.type != 'Bot'" "$WORKFLOW")"
 ok "check 12: @codex + author association + 봇 차단 + 멘션 요구 + user.type!=Bot 로 App 봇 self-trigger 배제"
 
 echo ""
-echo "=== check 13: 단일 inline 리뷰 제출 — verdict/event + body summary + 멱등 (AC1/AC7) ==="
+echo "=== check 13: 단일 inline 리뷰 제출 — verdict/event + 승인 본문 + 멱등 (AC1/AC7) ==="
 grep -q 'name: Submit Codex inline review' "$WORKFLOW" \
   || fail "'Submit Codex inline review' 스텝 부재 (단일 inline 리뷰 게시 스텝 치환) (제약)"
 # 단일 createReview(comments[]) 로 inline + 본문을 한 번에 제출. event 는 APPROVE/COMMENT 만.
@@ -217,11 +217,16 @@ fi
 if grep -oE '[a-z_]*request_changes' "$WORKFLOW" | grep -qvE '^may_request_changes$'; then
   fail "request_changes verdict 어휘 잔존 (may_request_changes 외) — 제거 필요 (제약)"
 fi
-# 리뷰 본문(body): 헤더 + summary(있으면) — 한국어 헤더.
+# 리뷰 본문(body): approve 시에만 헤더 + 승인 문구, 그 외엔 마커만 — 요약 미작성.
 grep -qF '## Codex PR 리뷰' "$WORKFLOW" \
   || fail "리뷰 본문 헤더 '## Codex PR 리뷰' 부재 (제약: codex 라벨)"
-grep -qF 'result.summary' "$WORKFLOW" \
-  || fail "리뷰 본문에 result.summary 포함 부재 (제약: summary 를 본문에 실음)"
+# 리뷰 요약(summary) 작성 폐지 — 본문에 result.summary 를 싣지 않는다.
+if grep -qF 'result.summary' "$WORKFLOW"; then
+  fail "result.summary 잔존 — 리뷰 요약 본문 게시 폐지 위반 (제약: summary 미작성)"
+fi
+# approve(event === 'APPROVE')일 때만 본문에 단순 승인 문구를 싣는다.
+grep -qF '승인되었습니다.' "$WORKFLOW" \
+  || fail "승인 본문 문구('승인되었습니다.') 부재 (제약: approve 시 승인 사실만)"
 # 멱등 마커 (head_sha, verdict) 기준 + listReviews 조회 + 중복 skip.
 grep -qF 'CODEX_FORMAL_PREFIX: codex-formal-review' "$WORKFLOW" \
   || fail "formal review 마커 prefix(CODEX_FORMAL_PREFIX: codex-formal-review) 부재 (제약)"
@@ -236,7 +241,7 @@ grep -qF "fs.writeFileSync('.codex-review/approval-failed'" "$WORKFLOW" \
   || fail "APPROVE 실패 시 approval-failed marker 기록 부재 (AC7)"
 grep -qF "submit('COMMENT')" "$WORKFLOW" \
   || fail "APPROVE 실패 시 같은 inline 코멘트로 COMMENT 강등 제출 부재 (AC7)"
-ok "check 13: 단일 inline 리뷰 제출 (APPROVE/COMMENT) + body summary + 멱등 + APPROVE fallback"
+ok "check 13: 단일 inline 리뷰 제출 (APPROVE/COMMENT) + 승인 본문(요약 미작성) + 멱등 + APPROVE fallback"
 
 echo ""
 echo "=== check 14: 별도 마커 관리형 이슈 레벨 코멘트 게시 경로 부재 (AC6) ==="


### PR DESCRIPTION
## 목표
codex·claude PR 리뷰가 **approve일 때만** 리뷰 본문 코멘트를 달고, 그 내용은 단순히 `승인되었습니다.`만 담도록 한다. 리뷰 요약(summary)은 스키마·프롬프트에서 제거해 모델이 생성하지 않게 한다. 지적사항 있는 비-approve 리뷰는 inline 코멘트만 남기고 본문(이슈 레벨 요약)은 남기지 않는다.

## 변경
- **schema** (`.github/prompts/codex-pr-review.schema.json`): `summary`를 `required`·`properties`에서 제거 (`additionalProperties:false`라 모델이 더는 출력 못 함).
- **두 워크플로 본문**: `event === 'APPROVE'`일 때만 헤더 + `승인되었습니다.` + 숨김 마커, 그 외엔 숨김 마커만. `result.summary` 게시 제거. (`verdict`가 아닌 실제 `event` 기준 — `may_approve=false`/diff 절단으로 COMMENT 강등 시 승인 문구를 띄우지 않음.)
- **출력 언어 지시 문자열 4곳**: 자연어 필드 열거에서 `summary` 제거.
- **계약 테스트** (claude check6 / codex check13): `result.summary` 존재 단언 → 부재 단언, `승인되었습니다.` 단언 추가, 언어지시 문자열 단언 갱신.
- **docs** (`docs/{claude,codex}/pr-review-workflow.md`): 서술 갱신.

## 검증
- `bash tests/claude/test-claude-review-workflow.sh` → ALL CHECKS PASSED
- `bash tests/codex/test-codex-review-workflow.sh` → ALL CHECKS PASSED
- `jq empty` schema OK · `yq` 두 워크플로 YAML OK · `node --check` 본문 JS OK
- `grep -rn 'result.summary' .github/` → 0건, schema `"summary"` → 0건
- 본문 출력 확인: approve → `## … PR 리뷰\n\n승인되었습니다.\n\n<marker>`, 비-approve → `<marker>`만

> ⚠️ 워크플로 변경은 변조방지 가드로 **머지 후에야 효력**이 생긴다. 이 PR을 리뷰하는 봇은 기존 워크플로로 동작하므로 새 동작은 머지 이후 후속 PR에서 실증된다.

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
