### PR TITLE
fix(review): diff-only anchor 검증 + false-green 가드 (PR #306 codex 리뷰 미게시 수정)

### DIFF
--- a/.github/scripts/diff-anchor-filter.js
+++ b/.github/scripts/diff-anchor-filter.js
@@ -1,0 +1,166 @@
+'use strict';
+
+// Shared diff-only anchor filter for the codex / claude PR review workflows.
+//
+// Both workflows post model findings as inline review comments. GitHub's
+// createReview rejects (422 "Path could not be resolved") any inline comment
+// anchored to a file/line that is not part of the PR diff's RIGHT side, and
+// that rejection takes down the WHOLE review batch — valid findings included.
+// This module is the single shared validation unit: it derives the set of
+// anchorable RIGHT-side lines (added `+` and context ` ` lines) per file from
+// the already-generated unified diff (.review-context/diff.patch) and filters
+// findings so only in-diff anchors are submitted. Out-of-diff findings are
+// returned separately so the caller can log and drop them.
+//
+// CommonJS so it can be `require`d from actions/github-script steps. No I/O,
+// no network — pure functions over the patch text the workflow already has.
+
+// Parse a unified diff into a map of file path → Set of RIGHT-side (new file)
+// line numbers. RIGHT-side lines are added (`+`) and context (` `) lines —
+// exactly the lines GitHub will resolve as inline-comment anchors on side RIGHT.
+// Removed (`-`) lines do not exist on the RIGHT side and are not counted.
+// Deleted files (+++ /dev/null) produce no entry.
+function parseDiffRightLines(patch) {
+  const map = new Map();
+  if (typeof patch !== 'string' || patch.length === 0) return map;
+
+  const lines = patch.split('\n');
+  let currentFile = null; // null = no anchorable RIGHT side (e.g. deletion)
+  let newLine = 0;
+  let inHunk = false;
+
+  const hunkRe = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git ')) {
+      currentFile = null;
+      inHunk = false;
+      continue;
+    }
+    if (line.startsWith('+++ ')) {
+      currentFile = parseNewPath(line.slice(4));
+      inHunk = false;
+      if (currentFile !== null && !map.has(currentFile)) {
+        map.set(currentFile, new Set());
+      }
+      continue;
+    }
+    if (line.startsWith('--- ')) {
+      // Old-file header — ignored; RIGHT side comes from the +++ line.
+      continue;
+    }
+    const hunk = line.match(hunkRe);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk || currentFile === null) continue;
+
+    const c = line[0];
+    if (c === '+') {
+      map.get(currentFile).add(newLine);
+      newLine += 1;
+    } else if (c === ' ') {
+      map.get(currentFile).add(newLine);
+      newLine += 1;
+    } else if (c === '-') {
+      // RIGHT side unaffected — do not advance new-file line counter.
+    } else if (c === '\\') {
+      // "\ No newline at end of file" — metadata, not a content line.
+    } else {
+      // Anything else ends the hunk body (blank trailer, next header handled
+      // above). Stop counting until the next @@ / +++.
+      inHunk = false;
+    }
+  }
+
+  return map;
+}
+
+// Resolve the RIGHT-side file path from a `+++ ` header value (the part after
+// "+++ "). Returns null for /dev/null (deleted file). Strips the conventional
+// `b/` prefix and unwraps git's C-quoted paths for names with special chars.
+function parseNewPath(raw) {
+  let p = raw;
+  // git may append a trailing tab + timestamp in some diff variants; cut it.
+  const tab = p.indexOf('\t');
+  if (tab !== -1) p = p.slice(0, tab);
+  p = p.trim();
+  if (p === '/dev/null') return null;
+  if (p.length >= 2 && p.startsWith('"') && p.endsWith('"')) {
+    // Minimal C-style unquote for git's quoted paths.
+    try { p = JSON.parse(p); } catch { p = p.slice(1, -1); }
+  }
+  if (p.startsWith('b/')) p = p.slice(2);
+  return p;
+}
+
+// Compute the anchor line(s) the workflow will submit for a finding, mirroring
+// the inline-comment construction in the review workflows:
+//   anchor = (line is a positive int) ? line : start_line
+//   a multi-line range is emitted only when start_line is a positive int < anchor
+// Returns { anchor, ends } where `ends` is the list of line numbers that must
+// all resolve on the diff RIGHT side for the comment to be postable.
+function findingAnchorEnds(f) {
+  const line = (typeof f.line === 'number' && f.line > 0) ? f.line : f.start_line;
+  const ends = [];
+  if (typeof line === 'number' && line > 0) ends.push(line);
+  if (typeof f.start_line === 'number'
+      && f.start_line >= 1 && f.start_line < line) {
+    ends.push(f.start_line);
+  }
+  return { anchor: line, ends };
+}
+
+// Filter findings against a precomputed RIGHT-side line map.
+// Returns { valid, excluded }. A finding is valid only when its file is in the
+// diff AND every anchor end (line, and start_line when it forms a range) is in
+// that file's RIGHT-side line set. Excluded entries carry { file, line,
+// start_line, title, reason } for logging.
+function filterFindings(findings, lineMap) {
+  const valid = [];
+  const excluded = [];
+  for (const f of findings || []) {
+    const file = f.file;
+    const { anchor, ends } = findingAnchorEnds(f);
+    let reason = null;
+
+    if (!file || !lineMap.has(file)) {
+      reason = 'file not in PR diff';
+    } else if (ends.length === 0) {
+      reason = 'no positive anchor line';
+    } else {
+      const set = lineMap.get(file);
+      const outside = ends.filter((n) => !set.has(n));
+      if (outside.length > 0) {
+        reason = `line(s) outside PR diff: ${outside.join(', ')}`;
+      }
+    }
+
+    if (reason) {
+      excluded.push({
+        file: file || '(none)',
+        line: anchor,
+        start_line: f.start_line,
+        title: f.title,
+        reason,
+      });
+    } else {
+      valid.push(f);
+    }
+  }
+  return { valid, excluded };
+}
+
+// Convenience: parse the patch and filter in one call.
+function filterFindingsAgainstPatch(findings, patch) {
+  return filterFindings(findings, parseDiffRightLines(patch));
+}
+
+module.exports = {
+  parseDiffRightLines,
+  findingAnchorEnds,
+  filterFindings,
+  filterFindingsAgainstPatch,
+};

--- a/.github/scripts/diff-anchor-filter.test.js
+++ b/.github/scripts/diff-anchor-filter.test.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+'use strict';
+
+// Unit test for the shared diff-only anchor filter module.
+// Static, hermetic: no GitHub, npm, or model calls. Directly exercises
+// diff parsing → RIGHT-side line set → finding filtering, including the
+// edge cases called out in the SPEC's 위험 section (multi-hunk, context
+// lines, new/deleted files, multi-line start_line ranges).
+
+const assert = require('node:assert');
+const path = require('node:path');
+
+const { parseDiffRightLines, filterFindings, filterFindingsAgainstPatch } =
+  require(path.join(__dirname, 'diff-anchor-filter.js'));
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`OK: ${name}`);
+}
+
+// ---- parseDiffRightLines ----
+
+test('parse: added + context lines on RIGHT side, removed excluded', () => {
+  const patch = [
+    'diff --git a/src/a.js b/src/a.js',
+    'index 111..222 100644',
+    '--- a/src/a.js',
+    '+++ b/src/a.js',
+    '@@ -1,3 +1,4 @@',
+    ' ctx1',      // new line 1 (context)
+    '-removed',   // old only — does not advance new line
+    '+added2',    // new line 2
+    '+added3',    // new line 3
+    ' ctx4',      // new line 4 (context)
+  ].join('\n');
+  const map = parseDiffRightLines(patch);
+  assert.ok(map.has('src/a.js'), 'file present');
+  assert.deepStrictEqual(
+    [...map.get('src/a.js')].sort((x, y) => x - y),
+    [1, 2, 3, 4]);
+});
+
+test('parse: multi-hunk file accumulates both hunks', () => {
+  const patch = [
+    'diff --git a/m.js b/m.js',
+    '--- a/m.js',
+    '+++ b/m.js',
+    '@@ -1,1 +1,2 @@',
+    ' a',        // 1
+    '+b',        // 2
+    '@@ -10,1 +11,2 @@',
+    ' c',        // 11
+    '+d',        // 12
+  ].join('\n');
+  const map = parseDiffRightLines(patch);
+  assert.deepStrictEqual(
+    [...map.get('m.js')].sort((x, y) => x - y),
+    [1, 2, 11, 12]);
+});
+
+test('parse: new file (--- /dev/null) added lines counted', () => {
+  const patch = [
+    'diff --git a/new.js b/new.js',
+    'new file mode 100644',
+    '--- /dev/null',
+    '+++ b/new.js',
+    '@@ -0,0 +1,2 @@',
+    '+one',
+    '+two',
+  ].join('\n');
+  const map = parseDiffRightLines(patch);
+  assert.deepStrictEqual([...map.get('new.js')].sort((x, y) => x - y), [1, 2]);
+});
+
+test('parse: deleted file (+++ /dev/null) has no RIGHT side entry', () => {
+  const patch = [
+    'diff --git a/gone.js b/gone.js',
+    'deleted file mode 100644',
+    '--- a/gone.js',
+    '+++ /dev/null',
+    '@@ -1,2 +0,0 @@',
+    '-one',
+    '-two',
+  ].join('\n');
+  const map = parseDiffRightLines(patch);
+  assert.ok(!map.has('gone.js'), 'deleted file not anchorable');
+});
+
+// ---- filterFindings ----
+
+const PATCH = [
+  'diff --git a/src/x.js b/src/x.js',
+  '--- a/src/x.js',
+  '+++ b/src/x.js',
+  '@@ -1,2 +1,4 @@',
+  ' keep1',   // 1
+  '+add2',    // 2
+  '+add3',    // 3
+  ' keep4',   // 4
+].join('\n');
+
+test('filter: in-diff single-line finding is valid', () => {
+  const map = parseDiffRightLines(PATCH);
+  const { valid, excluded } = filterFindings(
+    [{ file: 'src/x.js', line: 2, title: 'T' }], map);
+  assert.strictEqual(valid.length, 1);
+  assert.strictEqual(excluded.length, 0);
+});
+
+test('filter: finding on file absent from diff is excluded', () => {
+  const map = parseDiffRightLines(PATCH);
+  const { valid, excluded } = filterFindings(
+    [{ file: 'src/other.js', line: 2, title: 'Nope' }], map);
+  assert.strictEqual(valid.length, 0);
+  assert.strictEqual(excluded.length, 1);
+  assert.strictEqual(excluded[0].file, 'src/other.js');
+  assert.strictEqual(excluded[0].title, 'Nope');
+});
+
+test('filter: finding on line outside hunk is excluded', () => {
+  const map = parseDiffRightLines(PATCH);
+  const { valid, excluded } = filterFindings(
+    [{ file: 'src/x.js', line: 99, title: 'OOB' }], map);
+  assert.strictEqual(valid.length, 0);
+  assert.strictEqual(excluded.length, 1);
+});
+
+test('filter: context (space) line is a valid RIGHT-side anchor', () => {
+  const map = parseDiffRightLines(PATCH);
+  const { valid } = filterFindings(
+    [{ file: 'src/x.js', line: 4, title: 'ctx' }], map);
+  assert.strictEqual(valid.length, 1);
+});
+
+test('filter: multi-line range valid only when BOTH ends in-diff', () => {
+  const map = parseDiffRightLines(PATCH);
+  // both ends in (start_line 2 .. line 3)
+  const both = filterFindings(
+    [{ file: 'src/x.js', start_line: 2, line: 3, title: 'both' }], map);
+  assert.strictEqual(both.valid.length, 1, 'both ends in-diff → valid');
+  // start_line outside (start 99 .. line 3) — but start must be < line, so use 0? craft start outside via gap
+  const oneOut = filterFindings(
+    [{ file: 'src/x.js', start_line: 5, line: 6, title: 'out' }], map);
+  assert.strictEqual(oneOut.valid.length, 0, 'range outside diff → excluded');
+});
+
+test('filter: mixed batch keeps valid, drops invalid', () => {
+  const map = parseDiffRightLines(PATCH);
+  const { valid, excluded } = filterFindings([
+    { file: 'src/x.js', line: 2, title: 'good' },
+    { file: 'src/x.js', line: 99, title: 'bad-line' },
+    { file: 'ghost.js', line: 1, title: 'bad-file' },
+  ], map);
+  assert.strictEqual(valid.length, 1);
+  assert.strictEqual(valid[0].title, 'good');
+  assert.strictEqual(excluded.length, 2);
+});
+
+test('filter: line falls back to start_line when line missing/<=0', () => {
+  const map = parseDiffRightLines(PATCH);
+  const { valid } = filterFindings(
+    [{ file: 'src/x.js', start_line: 3, title: 'anchor-via-start' }], map);
+  assert.strictEqual(valid.length, 1);
+});
+
+test('filterFindingsAgainstPatch convenience parses + filters', () => {
+  const { valid, excluded } = filterFindingsAgainstPatch([
+    { file: 'src/x.js', line: 2, title: 'good' },
+    { file: 'src/x.js', line: 99, title: 'bad' },
+  ], PATCH);
+  assert.strictEqual(valid.length, 1);
+  assert.strictEqual(excluded.length, 1);
+});
+
+console.log(`\nALL ${passed} CHECKS PASSED`);

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -510,7 +510,30 @@ jobs:
             // inline-only policy: every finding is posted as an inline comment.
             // There is no issue-level finding channel — findings never get routed
             // into an issue comment.
-            const inlineFindings = findings;
+            //
+            // diff-only anchor validation (shared unit, identical in both
+            // workflows): only findings whose anchor (file + line, and both ends
+            // of a start_line range) lands on the PR diff's RIGHT side may be
+            // submitted. Anchoring off-diff lines makes GitHub reject the WHOLE
+            // createReview batch (422 "Path could not be resolved"), silently
+            // dropping valid findings too. Out-of-diff findings are excluded
+            // BEFORE the submit batch is built and logged; they are never
+            // relocated or force-posted.
+            const { filterFindingsAgainstPatch } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/diff-anchor-filter.js`);
+            let diffPatch = '';
+            try {
+              diffPatch = fs.readFileSync('.review-context/diff.patch', 'utf8');
+            } catch (e) {
+              core.warning(`Could not read .review-context/diff.patch (${e.message}); treating diff as empty — all findings will be excluded as off-diff.`);
+            }
+            const { valid: inlineFindings, excluded: excludedFindings } =
+              filterFindingsAgainstPatch(findings, diffPatch);
+            for (const x of excludedFindings) {
+              core.warning(`Excluded out-of-diff finding ${x.file}:${x.line}${x.start_line ? ` (start ${x.start_line})` : ''} — "${x.title}" (${x.reason}).`);
+            }
+            if (excludedFindings.length > 0) {
+              core.info(`${excludedFindings.length} finding(s) excluded as off-diff; ${inlineFindings.length} in-diff finding(s) will be submitted.`);
+            }
 
             const verdict = result.verdict;
             const mayApprove = !!result.automation_safety?.may_approve;
@@ -620,10 +643,16 @@ jobs:
 
             // inline-only policy: do NOT fall back to dumping findings into an
             // issue comment — that would place finding evaluations in an issue-level
-            // comment (AC6). If createReview failed, the findings stay unposted and
-            // the failure is surfaced in the workflow log only.
+            // comment (AC6). If createReview failed, the findings stay unposted.
+            //
+            // false-green guard: when there were in-diff findings to post but the
+            // submission ultimately failed, fail the job instead of ending green
+            // with the findings silently dropped. Excluding off-diff findings is
+            // normal (inlineFindings is then empty → nothing to post → no
+            // failure), and APPROVE→COMMENT degradation only happens with zero
+            // findings, so neither is treated as a failure.
             if (!skipSubmit && !submitOk && inlineFindings.length > 0) {
-              core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) could not be posted. Not dumping to an issue comment (inline-only policy); see logs.`);
+              core.setFailed(`createReview failed; ${inlineFindings.length} in-diff inline finding(s) could not be posted (inline-only policy — not dumping to an issue comment). Failing the job to avoid a false-green review; see logs.`);
             }
 
             // Resolve self inline threads on a finding-unit (fingerprint) basis.

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -354,7 +354,30 @@ jobs:
             // inline-only policy: every finding is posted as an inline comment.
             // There is no issue-level finding channel — findings never get routed
             // into an issue comment.
-            const inlineFindings = findings;
+            //
+            // diff-only anchor validation (shared unit, identical in both
+            // workflows): only findings whose anchor (file + line, and both ends
+            // of a start_line range) lands on the PR diff's RIGHT side may be
+            // submitted. Anchoring off-diff lines makes GitHub reject the WHOLE
+            // createReview batch (422 "Path could not be resolved"), silently
+            // dropping valid findings too. Out-of-diff findings are excluded
+            // BEFORE the submit batch is built and logged; they are never
+            // relocated or force-posted.
+            const { filterFindingsAgainstPatch } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/diff-anchor-filter.js`);
+            let diffPatch = '';
+            try {
+              diffPatch = fs.readFileSync('.review-context/diff.patch', 'utf8');
+            } catch (e) {
+              core.warning(`Could not read .review-context/diff.patch (${e.message}); treating diff as empty — all findings will be excluded as off-diff.`);
+            }
+            const { valid: inlineFindings, excluded: excludedFindings } =
+              filterFindingsAgainstPatch(findings, diffPatch);
+            for (const x of excludedFindings) {
+              core.warning(`Excluded out-of-diff finding ${x.file}:${x.line}${x.start_line ? ` (start ${x.start_line})` : ''} — "${x.title}" (${x.reason}).`);
+            }
+            if (excludedFindings.length > 0) {
+              core.info(`${excludedFindings.length} finding(s) excluded as off-diff; ${inlineFindings.length} in-diff finding(s) will be submitted.`);
+            }
 
             const verdict = result.verdict;
             const mayApprove = !!result.automation_safety?.may_approve;
@@ -464,10 +487,16 @@ jobs:
 
             // inline-only policy: do NOT fall back to dumping findings into an
             // issue comment — that would place finding evaluations in an issue-level
-            // comment (AC6). If createReview failed, the findings stay unposted and
-            // the failure is surfaced in the workflow log only.
+            // comment (AC6). If createReview failed, the findings stay unposted.
+            //
+            // false-green guard: when there were in-diff findings to post but the
+            // submission ultimately failed, fail the job instead of ending green
+            // with the findings silently dropped. Excluding off-diff findings is
+            // normal (inlineFindings is then empty → nothing to post → no
+            // failure), and APPROVE→COMMENT degradation only happens with zero
+            // findings, so neither is treated as a failure.
             if (!skipSubmit && !submitOk && inlineFindings.length > 0) {
-              core.warning(`createReview failed; ${inlineFindings.length} inline finding(s) could not be posted. Not dumping to an issue comment (inline-only policy); see logs.`);
+              core.setFailed(`createReview failed; ${inlineFindings.length} in-diff inline finding(s) could not be posted (inline-only policy — not dumping to an issue comment). Failing the job to avoid a false-green review; see logs.`);
             }
 
             // Resolve self inline threads on a finding-unit (fingerprint) basis.

--- a/docs/specs/2026-06-03-review-diff-only-anchor-guard/SPEC.md
+++ b/docs/specs/2026-06-03-review-diff-only-anchor-guard/SPEC.md
@@ -1,0 +1,63 @@
+---
+scope:
+  include:
+    - .github/workflows/codex-review.yml
+    - .github/workflows/claude-review.yml
+    - .github/scripts/**
+    - tests/codex/**
+    - tests/claude/**
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+# ears_language: ko
+---
+
+# 리뷰 워크플로 diff-only anchor 검증과 false-green 가드
+
+## 무엇을 만들 것인가
+<!-- WHAT/HOW 방어선: 무엇을 만들지만 적고 구현 방법·파일·라이브러리·클래스명은 제약으로 이동. -->
+PR 리뷰 워크플로(codex·claude)가 모델 finding을 inline 리뷰 코멘트로 게시하기 전에, 각 finding의 anchor가 그 PR diff에 실제로 포함된 라인인지 검증하는 단계를 추가한다. diff에 포함되지 않은 라인(또는 PR에서 변경되지 않은 파일)에 붙은 finding은 게시 대상에서 제외하고, diff에 포함된 finding만 제출한다. 또한 게시할 finding이 있는데 그 제출 자체가 실패하면 워크플로 job을 실패로 끝내, finding이 조용히 사라진 채 job이 성공으로 보이는 일(false-green)을 없앤다. 검증 동작은 두 워크플로가 공유하는 단일 검증 단위로 두어 양쪽이 동일하게 동작하게 한다.
+
+## 목적 (왜)
+<!-- 이 변경을 왜 하는가(목표·동기)를 1–3문장으로. -->
+현재 리뷰 워크플로는 모델이 PR diff 밖 라인(컨텍스트로 읽은 unchanged 파일 등)에 finding을 anchor하면 GitHub `createReview`가 422 "Path could not be resolved"로 리뷰 전체를 거부하는데, 이 실패를 경고로만 삼키고 job은 성공으로 끝나, 같은 배치의 정상 finding까지 통째로 미게시되면서도 "리뷰 통과"처럼 보였다(PR #306 실증: codex의 blocking finding 1건이 PR diff 밖 `dispatch.sh:485`에 anchor되어 전량 폐기, job은 green). 리뷰는 그 PR이 바꾼 내용에 대해서만 판정해야 하며, finding이 사라졌으면 그 사실이 결과에 드러나야 한다.
+
+## 완료 조건
+<!-- 5문장 패턴. 각 조건은 관찰 가능하고 독립 검증 가능해야 함. -->
+- **항상** 리뷰 워크플로(codex·claude)는 모델 finding을 inline 코멘트로 제출하기 전에, 각 finding의 anchor(파일 경로, `line`, 그리고 `start_line`이 있으면 그 범위의 양 끝)가 그 PR diff의 추가·문맥 라인(우측/RIGHT side) 집합에 포함되는지 검증한다.
+- finding의 anchor가 PR diff 라인 집합 **밖일 때**(파일이 PR diff에 없거나, 라인이 변경 hunk 밖일 때) 워크플로는 그 finding을 제출 대상에서 제외하고, 다른 라인으로 옮겨 붙이거나 강제로 게시하지 않으며, 제외한 finding의 파일·라인·제목을 job 로그에 남긴다.
+- diff 라인 집합 안에 anchor된 finding이 하나 이상 있는 **동안** 그 finding들은 항상 게시되며, 같은 배치에 섞인 diff 밖 finding 때문에 함께 누락되지 않는다.
+- 게시할(diff 안에 anchor된) finding이 있는데 그 finding의 리뷰 제출이 최종적으로 실패하**면(오류)** 워크플로는 경고로만 끝내지 않고 job을 실패(비-성공)로 종료한다. (게시할 in-diff finding이 0건이라 제출할 것이 없는 경우, 그리고 self-approve가 권한 부족으로 일반 코멘트 제출로 정상 강등된 경우는 실패가 아니다.)
+- 검증·제외·실패 가드 로직이 공유 단위로 추출되는 **기능이 켜지면**, codex와 claude 워크플로는 동일한 단일 검증 단위를 호출하며 anchor 검증·제외·가드 동작에서 서로 동일하게 동작한다(두 워크플로에 같은 로직이 따로 복제되지 않는다).
+
+## 범위
+포함:
+- codex·claude 리뷰 워크플로의 inline 리뷰 제출 단계에 diff-only anchor 검증과 diff 밖 finding 제외를 추가.
+- 제출 실패 시 job을 실패로 끝내는 false-green 가드 추가(정상 강등·게시할 finding 없음은 제외).
+- 검증 로직을 두 워크플로가 공유하는 단일 단위로 추출.
+- 신규 검증 단위의 단위 테스트와, 두 워크플로 contract 테스트에 "검증 호출·실패 가드 존재" 정적 검사 추가.
+
+비-목표 / 제외:
+- 리뷰 모델이 diff 밖 파일을 **컨텍스트로 읽는** 능력은 제한하지 않는다(codex read-only sandbox, follow-up 컨텍스트 추출은 그대로 유지). 강제는 게시 레이어에서만 한다.
+- 리뷰 프롬프트(diff 밖 anchor 금지 지시 등) 자체는 이 변경에서 바꾸지 않는다 — 게시 레이어 검증이 단일 보장 지점이다.
+- inline-only 정책(요약/issue 코멘트로 finding fallback 안 함), fingerprint·marker·self-thread resolve, APPROVE/COMMENT 결정, 토큰 선택(App vs default) 등 기존 리뷰 게시 구조는 보존한다.
+- diff 계산 방식(`.review-context/diff.patch` 생성)은 바꾸지 않는다 — 이미 생성된 patch를 검증 입력으로 소비만 한다.
+- 플러그인 버전 범프는 대상이 아니다(`.github/`는 버전 watch 디렉토리가 아님).
+
+## 검증
+<!-- 검증 기준의 단일 출처는 위 "완료 조건"이다. -->
+이 SPEC의 인수 바는 위 **완료 조건**이다. 각 조건이 관찰 가능하게 충족되면 충족된 것으로 본다. 검증을 실행하는 진입 명령은 SPEC이 아니라 프로젝트 규칙(`rules/`)이 단일 출처로 정의한다.
+
+## 제약
+- anchor 검증 입력은 워크플로가 이미 만든 `.review-context/diff.patch`(unified diff)이며, RIGHT side(추가 `+`·문맥 ` ` 라인)의 파일별 라인 번호 집합을 그 patch에서 도출한다. 새로 diff를 계산하지 않는다.
+- 검증 로직은 `.github/scripts/` 아래 Node 모듈로 추출하고, 두 워크플로의 inline 제출 단계(`actions/github-script`)에서 이 단일 모듈을 불러 사용한다. 두 워크플로에 같은 검증 로직을 byte 단위로 복제하지 않는다.
+- `start_line`이 있는 multi-line finding은 `start_line`과 `line` 양 끝이 모두 diff 라인 집합에 있어야 게시 대상으로 인정한다(한쪽이라도 밖이면 제외).
+- 기존 게시 단계의 단일 `createReview` 호출에 invalid anchor가 섞여 valid finding까지 422로 함께 무너지지 않도록, invalid finding은 제출 배치 구성 **전에** 제외한다.
+- 실패 가드는 "게시할 in-diff finding이 있었는데 제출이 끝내 실패"한 경우에만 job을 실패시킨다 — diff 밖 finding 제외(정상 동작)나 APPROVE→COMMENT 정상 강등을 실패로 취급하지 않는다.
+- 두 워크플로의 contract 테스트(`tests/codex/`, `tests/claude/`)는 GitHub·모델을 호출하지 않는 정적 검사 컨벤션을 유지하며, 신규 검증 단위는 별도 단위 테스트로 diff 파싱→valid 라인 집합→finding 필터링을 직접 검증한다.
+
+## 위험
+- diff.patch 파싱의 정확도: 다중 hunk, 문맥 라인, 파일 rename/삭제, multi-line range를 잘못 해석하면 valid finding을 제외하거나 invalid finding을 통과시킬 수 있다 — 단위 테스트로 이 경계들을 덮어야 한다.
+- 실패 가드가 리뷰 체크를 required로 운용 중인 저장소에서 merge를 차단할 수 있다. 이는 false-green 제거라는 목적상 의도된 동작이며, 정상적인 diff 밖 제외는 실패로 보지 않아 과도한 차단을 피한다.
+- 게시 레이어에서만 강제하므로, 모델이 여전히 diff 밖 finding을 만들면 그 finding은 게시되지 않고 로그로만 남는다(리뷰 신호 손실 가능성) — 단, 그 finding은 해당 PR이 바꾸지 않은 코드에 대한 것이므로 이 PR 리뷰의 범위 밖이라는 것이 의도된 정책이다.

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -355,4 +355,39 @@ rbt="$(awk -v n="github.event.review.user.type != 'Bot'" 'index($0,n){c++} END{p
 ok "check 12: App 토큰 발급(SHA 고정) + 동적 봇 식별 + graceful degradation + id-token 보존 + self-trigger 배제"
 
 echo ""
+echo "=== check 13: diff-only anchor 검증 + false-green 가드 (공유 단위) (AC1/AC2/AC4/AC5/제약) ==="
+ANCHOR_MODULE="$REPO_ROOT/.github/scripts/diff-anchor-filter.js"
+[[ -f "$ANCHOR_MODULE" ]] \
+  || fail "공유 검증 모듈 .github/scripts/diff-anchor-filter.js 부재 (제약: 단일 공유 단위)"
+# 두 워크플로가 byte 복제 대신 같은 단일 모듈을 require 한다.
+grep -qF '.github/scripts/diff-anchor-filter.js' "$WORKFLOW" \
+  || fail "워크플로가 공유 검증 모듈(.github/scripts/diff-anchor-filter.js)을 require 하지 않음 (AC5/제약)"
+grep -qF 'filterFindingsAgainstPatch' "$WORKFLOW" \
+  || fail "공유 검증 단위 호출(filterFindingsAgainstPatch) 부재 (AC1/AC5)"
+# 검증 입력은 이미 생성된 diff.patch — 새로 diff 계산하지 않는다 (제약).
+grep -qF ".review-context/diff.patch" "$WORKFLOW" \
+  || fail "anchor 검증 입력으로 .review-context/diff.patch 소비 부재 (제약)"
+# valid(in-diff)만 inline 제출 배치로 사용 — 제외는 배치 구성 전에.
+grep -qF 'valid: inlineFindings' "$WORKFLOW" \
+  || fail "in-diff valid finding 만 inlineFindings 로 사용하지 않음 (AC2/제약)"
+grep -qF 'excluded: excludedFindings' "$WORKFLOW" \
+  || fail "diff 밖 finding 분리(excluded) 부재 (AC2)"
+# 제외 finding 의 file·line·title 을 로그로 남긴다 (AC2).
+grep -qF 'Excluded out-of-diff finding' "$WORKFLOW" \
+  || fail "제외 finding 로그(file·line·title) 부재 (AC2)"
+# false-green 가드: 게시할 in-diff finding 이 있는데 제출 실패면 job 실패.
+grep -qF 'core.setFailed' "$WORKFLOW" \
+  || fail "제출 실패 시 job 을 실패시키는 가드(core.setFailed) 부재 (AC4)"
+grep -qE 'setFailed\(.*createReview failed' "$WORKFLOW" \
+  || fail "createReview 실패가 false-green 가드(setFailed)로 연결되지 않음 (AC4)"
+# 가드는 inlineFindings(=in-diff) 가 있을 때만 — 0건/정상강등은 실패로 보지 않음 (AC4/제약).
+grep -qF '!skipSubmit && !submitOk && inlineFindings.length > 0' "$WORKFLOW" \
+  || fail "false-green 가드 게이트(in-diff finding 존재 시에만 실패)가 inlineFindings.length>0 로 한정되지 않음 (AC4/제약)"
+# 실패를 경고로만 끝내던 옛 경로가 setFailed 로 대체됐는지 — createReview 실패에 warning 잔존 금지.
+if grep -qE 'core\.warning\(`createReview failed' "$WORKFLOW"; then
+  fail "createReview 실패가 여전히 core.warning 으로만 처리됨 — false-green 가드(setFailed) 회귀 (AC4)"
+fi
+ok "check 13: 공유 diff-only anchor 검증 + 제외 로그 + false-green setFailed 가드"
+
+echo ""
 echo "ALL CHECKS PASSED"

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -429,4 +429,39 @@ grep -qF '"$CODEX_REVIEW_LANG"' "$WORKFLOW" \
 ok "check 25: untrusted block 끝 출력 언어 재강조"
 
 echo ""
+echo "=== check 26: diff-only anchor 검증 + false-green 가드 (공유 단위) (AC1/AC2/AC4/AC5/제약) ==="
+ANCHOR_MODULE="$REPO_ROOT/.github/scripts/diff-anchor-filter.js"
+[[ -f "$ANCHOR_MODULE" ]] \
+  || fail "공유 검증 모듈 .github/scripts/diff-anchor-filter.js 부재 (제약: 단일 공유 단위)"
+# 두 워크플로가 byte 복제 대신 같은 단일 모듈을 require 한다.
+grep -qF '.github/scripts/diff-anchor-filter.js' "$WORKFLOW" \
+  || fail "워크플로가 공유 검증 모듈(.github/scripts/diff-anchor-filter.js)을 require 하지 않음 (AC5/제약)"
+grep -qF 'filterFindingsAgainstPatch' "$WORKFLOW" \
+  || fail "공유 검증 단위 호출(filterFindingsAgainstPatch) 부재 (AC1/AC5)"
+# 검증 입력은 이미 생성된 diff.patch — 새로 diff 계산하지 않는다 (제약).
+grep -qF ".review-context/diff.patch" "$WORKFLOW" \
+  || fail "anchor 검증 입력으로 .review-context/diff.patch 소비 부재 (제약)"
+# valid(in-diff)만 inline 제출 배치로 사용 — 제외는 배치 구성 전에.
+grep -qF 'valid: inlineFindings' "$WORKFLOW" \
+  || fail "in-diff valid finding 만 inlineFindings 로 사용하지 않음 (AC2/제약)"
+grep -qF 'excluded: excludedFindings' "$WORKFLOW" \
+  || fail "diff 밖 finding 분리(excluded) 부재 (AC2)"
+# 제외 finding 의 file·line·title 을 로그로 남긴다 (AC2).
+grep -qF 'Excluded out-of-diff finding' "$WORKFLOW" \
+  || fail "제외 finding 로그(file·line·title) 부재 (AC2)"
+# false-green 가드: 게시할 in-diff finding 이 있는데 제출 실패면 job 실패.
+grep -qF 'core.setFailed' "$WORKFLOW" \
+  || fail "제출 실패 시 job 을 실패시키는 가드(core.setFailed) 부재 (AC4)"
+grep -qE 'setFailed\(.*createReview failed' "$WORKFLOW" \
+  || fail "createReview 실패가 false-green 가드(setFailed)로 연결되지 않음 (AC4)"
+# 가드는 inlineFindings(=in-diff) 가 있을 때만 — 0건/정상강등은 실패로 보지 않음 (AC4/제약).
+grep -qF '!skipSubmit && !submitOk && inlineFindings.length > 0' "$WORKFLOW" \
+  || fail "false-green 가드 게이트(in-diff finding 존재 시에만 실패)가 inlineFindings.length>0 로 한정되지 않음 (AC4/제약)"
+# 실패를 경고로만 끝내던 옛 경로가 setFailed 로 대체됐는지 — createReview 실패에 warning 잔존 금지.
+if grep -qE 'core\.warning\(`createReview failed' "$WORKFLOW"; then
+  fail "createReview 실패가 여전히 core.warning 으로만 처리됨 — false-green 가드(setFailed) 회귀 (AC4)"
+fi
+ok "check 26: 공유 diff-only anchor 검증 + 제외 로그 + false-green setFailed 가드"
+
+echo ""
 echo "ALL CHECKS PASSED"


### PR DESCRIPTION
## 배경

PR #306에서 codex 리뷰가 PR에 전혀 게시되지 않았다. 원인:

- codex가 PR diff **밖** 라인(`dispatch.sh:485`, read-only 샌드박스로 읽은 unchanged 코드)에 blocking finding을 anchor
- GitHub `createReview`가 `422 "Path could not be resolved"`로 **리뷰 배치 전체** 거부
- inline-only 정책이 fallback 없이 finding 폐기 → 그런데도 `core.warning`만 내고 **job은 green** (false-green)

리뷰는 그 PR이 바꾼 내용에 대해서만 판정해야 하고, finding이 사라졌으면 그 사실이 결과에 드러나야 한다.

## 변경

공유 단위 `.github/scripts/diff-anchor-filter.js` 도입 — codex·claude 워크플로가 inline finding 게시 전 동일 모듈로:

1. **diff-only anchor 검증** — `.review-context/diff.patch`에서 파일별 RIGHT-side(추가·문맥) 라인 집합을 도출, 각 finding의 anchor(`line`·`start_line` 범위 양 끝)가 그 집합에 드는지 검사.
2. **diff 밖 finding 제외** — 배치 구성 **전에** drop(파일·라인·title 로그), re-anchor·강제게시 안 함. valid finding은 invalid에 휩쓸려 누락되지 않음.
3. **false-green 가드** — 게시할 in-diff finding이 있는데 제출이 끝내 실패하면 `core.warning` 대신 `core.setFailed`로 job 실패. (off-diff 제외로 게시할 게 0건이거나 APPROVE→COMMENT 정상강등은 실패 아님.)

모델의 diff 밖 **읽기**(컨텍스트)는 제한하지 않음 — 강제는 게시 레이어에서만.

## 테스트

- `diff-anchor-filter.test.js` 단위 12종 (다중 hunk·문맥·신규/삭제 파일·multi-line range 경계)
- codex·claude contract 테스트에 공유 모듈 require·filter 호출·제외 로그·setFailed 가드 정적 검사 추가
- 기존 review-context 테스트 회귀 없음

자기완결 SPEC: `docs/specs/2026-06-03-review-diff-only-anchor-guard/SPEC.md`

> 주: 변조방지 차원에서 리뷰 워크플로는 base(main) 버전으로 실행되므로, 이 수정은 **머지 후** 리뷰부터 효력. 이 PR 자체 리뷰는 기존(구) 워크플로로 수행됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)