### PR TITLE
fix(review): validator require를 try/catch로 감싸 self-bootstrap crash 방지

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -519,15 +519,30 @@ jobs:
             // dropping valid findings too. Out-of-diff findings are excluded
             // BEFORE the submit batch is built and logged; they are never
             // relocated or force-posted.
-            const { filterFindingsAgainstPatch } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/diff-anchor-filter.js`);
-            let diffPatch = '';
+            //
+            // The shared validator is loaded from the trusted-base checkout
+            // ($GITHUB_WORKSPACE = base ref). On the very PR that introduces or
+            // modifies the validator the base predates it, so the require can
+            // fail — that is the expected "the workflow modifies itself, so it
+            // validates only post-merge" bootstrap. Degrade loudly (a clear
+            // warning, never an unhandled crash) to the pre-change unfiltered
+            // submission; the false-green guard below still fails the job on any
+            // genuine submit error.
+            let inlineFindings = findings;
+            let excludedFindings = [];
             try {
-              diffPatch = fs.readFileSync('.review-context/diff.patch', 'utf8');
+              const { filterFindingsAgainstPatch } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/diff-anchor-filter.js`);
+              let diffPatch = '';
+              try {
+                diffPatch = fs.readFileSync('.review-context/diff.patch', 'utf8');
+              } catch (e) {
+                core.warning(`Could not read .review-context/diff.patch (${e.message}); treating diff as empty — all findings will be excluded as off-diff.`);
+              }
+              ({ valid: inlineFindings, excluded: excludedFindings } =
+                filterFindingsAgainstPatch(findings, diffPatch));
             } catch (e) {
-              core.warning(`Could not read .review-context/diff.patch (${e.message}); treating diff as empty — all findings will be excluded as off-diff.`);
+              core.warning(`Shared diff-anchor validator unavailable in trusted-base checkout (${e.message}); expected on the PR that introduces or modifies it (validates post-merge). Falling back to unfiltered inline submission for this run.`);
             }
-            const { valid: inlineFindings, excluded: excludedFindings } =
-              filterFindingsAgainstPatch(findings, diffPatch);
             for (const x of excludedFindings) {
               core.warning(`Excluded out-of-diff finding ${x.file}:${x.line}${x.start_line ? ` (start ${x.start_line})` : ''} — "${x.title}" (${x.reason}).`);
             }

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -363,15 +363,30 @@ jobs:
             // dropping valid findings too. Out-of-diff findings are excluded
             // BEFORE the submit batch is built and logged; they are never
             // relocated or force-posted.
-            const { filterFindingsAgainstPatch } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/diff-anchor-filter.js`);
-            let diffPatch = '';
+            //
+            // The shared validator is loaded from the trusted-base checkout
+            // ($GITHUB_WORKSPACE = base ref). On the very PR that introduces or
+            // modifies the validator the base predates it, so the require can
+            // fail — that is the expected "the workflow modifies itself, so it
+            // validates only post-merge" bootstrap. Degrade loudly (a clear
+            // warning, never an unhandled crash) to the pre-change unfiltered
+            // submission; the false-green guard below still fails the job on any
+            // genuine submit error.
+            let inlineFindings = findings;
+            let excludedFindings = [];
             try {
-              diffPatch = fs.readFileSync('.review-context/diff.patch', 'utf8');
+              const { filterFindingsAgainstPatch } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/diff-anchor-filter.js`);
+              let diffPatch = '';
+              try {
+                diffPatch = fs.readFileSync('.review-context/diff.patch', 'utf8');
+              } catch (e) {
+                core.warning(`Could not read .review-context/diff.patch (${e.message}); treating diff as empty — all findings will be excluded as off-diff.`);
+              }
+              ({ valid: inlineFindings, excluded: excludedFindings } =
+                filterFindingsAgainstPatch(findings, diffPatch));
             } catch (e) {
-              core.warning(`Could not read .review-context/diff.patch (${e.message}); treating diff as empty — all findings will be excluded as off-diff.`);
+              core.warning(`Shared diff-anchor validator unavailable in trusted-base checkout (${e.message}); expected on the PR that introduces or modifies it (validates post-merge). Falling back to unfiltered inline submission for this run.`);
             }
-            const { valid: inlineFindings, excluded: excludedFindings } =
-              filterFindingsAgainstPatch(findings, diffPatch);
             for (const x of excludedFindings) {
               core.warning(`Excluded out-of-diff finding ${x.file}:${x.line}${x.start_line ? ` (start ${x.start_line})` : ''} — "${x.title}" (${x.reason}).`);
             }

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -387,7 +387,15 @@ grep -qF '!skipSubmit && !submitOk && inlineFindings.length > 0' "$WORKFLOW" \
 if grep -qE 'core\.warning\(`createReview failed' "$WORKFLOW"; then
   fail "createReview 실패가 여전히 core.warning 으로만 처리됨 — false-green 가드(setFailed) 회귀 (AC4)"
 fi
-ok "check 13: 공유 diff-only anchor 검증 + 제외 로그 + false-green setFailed 가드"
+# 공유 검증 모듈은 trusted-base 체크아웃에서 로드되므로, 모듈을 도입·수정하는
+# 워크플로 PR 에선 base 에 아직 없어 require 가 실패한다(self-bootstrap). 이때
+# unhandled crash 대신 unfiltered 로 graceful degrade 해야 한다 — require 를
+# try/catch 로 감싸고 기본값(findings)으로 fallback 한다.
+grep -qF 'let inlineFindings = findings;' "$WORKFLOW" \
+  || fail "validator 부재 시 fallback 기본값(let inlineFindings = findings) 부재 — self-bootstrap 시 unhandled crash 위험 (robustness)"
+grep -qF 'Shared diff-anchor validator unavailable' "$WORKFLOW" \
+  || fail "validator require 실패를 graceful degrade(경고+unfiltered fallback)로 처리하지 않음 (robustness)"
+ok "check 13: 공유 diff-only anchor 검증 + 제외 로그 + false-green setFailed 가드 + validator 부재 graceful degrade"
 
 echo ""
 echo "ALL CHECKS PASSED"

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -461,7 +461,15 @@ grep -qF '!skipSubmit && !submitOk && inlineFindings.length > 0' "$WORKFLOW" \
 if grep -qE 'core\.warning\(`createReview failed' "$WORKFLOW"; then
   fail "createReview 실패가 여전히 core.warning 으로만 처리됨 — false-green 가드(setFailed) 회귀 (AC4)"
 fi
-ok "check 26: 공유 diff-only anchor 검증 + 제외 로그 + false-green setFailed 가드"
+# 공유 검증 모듈은 trusted-base 체크아웃에서 로드되므로, 모듈을 도입·수정하는
+# 워크플로 PR 에선 base 에 아직 없어 require 가 실패한다(self-bootstrap). 이때
+# unhandled crash 대신 unfiltered 로 graceful degrade 해야 한다 — require 를
+# try/catch 로 감싸고 기본값(findings)으로 fallback 한다.
+grep -qF 'let inlineFindings = findings;' "$WORKFLOW" \
+  || fail "validator 부재 시 fallback 기본값(let inlineFindings = findings) 부재 — self-bootstrap 시 unhandled crash 위험 (robustness)"
+grep -qF 'Shared diff-anchor validator unavailable' "$WORKFLOW" \
+  || fail "validator require 실패를 graceful degrade(경고+unfiltered fallback)로 처리하지 않음 (robustness)"
+ok "check 26: 공유 diff-only anchor 검증 + 제외 로그 + false-green setFailed 가드 + validator 부재 graceful degrade"
 
 echo ""
 echo "ALL CHECKS PASSED"


### PR DESCRIPTION
## 배경

PR #307(머지 완료)에서 diff-only anchor 검증을 `.github/scripts/diff-anchor-filter.js` 공유 모듈로 추출했다. 그 모듈은 submit 단계에서 `require($GITHUB_WORKSPACE/.github/scripts/diff-anchor-filter.js)`로 로드되는데, 워크플로는 `Check out trusted base`로 **base(main)를 워크스페이스에 체크아웃**한다(보안: 악성 PR이 검증 스크립트로 App 토큰 탈취 방지).

그 결과 **모듈을 도입·수정하는 워크플로 PR**에서는 base에 아직 모듈이 없어 `require`가 throw → submit 단계가 **unhandled crash(job red)**가 된다 (PR #307 codex 리뷰 실측: `Cannot find module diff-anchor-filter.js`).

## 변경

submit 단계의 `require`를 `try/catch`로 감싼다:
- 모듈 로드 성공 → 기존대로 diff-only 필터링
- 모듈 부재(self-bootstrap) → **명확한 경고 + unfiltered 제출로 graceful degrade** (unhandled crash 없음). `claude-code-action`이 같은 상황을 "정상이니 무시"로 다루는 것과 동일한 결.
- **false-green setFailed 가드는 그대로** — degrade 모드에서도 genuine 제출 실패는 job을 실패시킴.

머지 후 일반 PR은 base=main에 모듈이 있어 정상 필터링한다. 이 변경은 향후 리뷰 워크플로를 또 수정하는 PR에서만 의미가 있다.

## 테스트

- 단위 12종 + 두 contract 테스트 통과 (fallback 기본값·degrade 경고 정적 검사 추가)
- main에 이미 모듈이 있어 이 PR 자체는 bootstrap crash 없이 codex가 정상 리뷰함

🤖 Generated with [Claude Code](https://claude.com/claude-code)