### PR TITLE
feat(dispatch): 머지-게이트 웨이브 + per-SPEC review→fix→merge 파이프라인 (v0.19.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,8 +20,8 @@
     {
       "name": "autopilot",
       "source": "./plugins/autopilot",
-      "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션, fsd로 spec→dispatch 자동화 파이프라인의 forge 호출 레이어 오케스트레이션, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
-      "version": "0.18.1",
+      "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션(옵트인 통합 모드면 push→PR→리뷰→ff-only 머지 게이트 소유), fsd로 spec→dispatch 자동화 파이프라인의 forge 호출 레이어 오케스트레이션, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
+      "version": "0.19.0",
       "category": "automation",
       "tags": ["autonomous", "ralph-loop", "agent-runtime", "self-directed"]
     }

--- a/docs/specs/2026-06-04-dispatch-merge-gated-waves/SPEC.md
+++ b/docs/specs/2026-06-04-dispatch-merge-gated-waves/SPEC.md
@@ -1,0 +1,169 @@
+# dispatch 머지-게이트 웨이브 + 스펙별 review→fix→merge 파이프라인
+
+## 무엇을 만들 것인가
+
+`autopilot:dispatch`가 의존성(`depends_on`) 있는 여러 SPEC을 wave로 묶어 자율 실행기
+(`loop`)에 위임할 때, 한 SPEC의 **완료**를 "loop 워크트리가 DONE 신호로 종료"가 아니라
+**"작업 결과가 main에 머지됨"**으로 재정의한다. 이를 위해 dispatch에 per-SPEC 통합·리뷰·머지
+파이프라인을 자체구현한다: loop DONE → 결과를 작업 브랜치로 push → PR 생성/재사용 → 리뷰
+판정 → (변경요청 시) 수정 사항을 SPEC 델타로 만들어 같은 브랜치에서 재구현·재푸시 → 자율
+승인 → fast-forward 머지 → 그제서야 그 SPEC을 `done`으로 전이(=의존자 실행 해제).
+
+이 파이프라인은 검증된 참고 설계(아래 "참고 알고리즘")의 동작을 dispatch 맥락으로 이식하되,
+상태 저장소는 dispatch의 기존 run 디렉토리(`<project_root>/.dispatch/runs/<run-id>/`)를
+per-SPEC 키로 재사용한다. forge·task backend 외부 라이브러리에 의존하지 않고 dispatch
+references 안에서 자기완결적으로 구현한다.
+
+## 목적 (왜)
+
+현재 dispatch는 loop가 DONE으로 끝나면 그 SPEC을 `done`으로 보고 의존자를 다음 wave로
+푼다. 그러나 그 시점의 코드는 격리된 워크트리(`<spec-dir>/.worktree`)에만 있고 main에
+머지되지 않았다. loop는 워크트리를 항상 현재 HEAD에서 분기하므로(`git worktree add
+--detach HEAD`), A에 의존하는 B의 loop는 A의 변경이 없는 HEAD에서 시작되어 A의 결과 위에서
+빌드할 수 없다 — 의존 웨이브가 의미상 깨진다. 따라서 "loop 완료 = 승인·머지 완료"여야
+의존자가 갱신된 main 위에서 올바르게 시작될 수 있다. 머지가 의존자를 푸는 게이트는 본질적으로
+dispatch의 웨이브 스케줄링에 속하므로, review/merge 책임을 dispatch가 직접 갖는다.
+
+## 완료 조건
+
+> 아래 각 조건은 관찰 가능·독립 테스트 가능하다. 검증 진입 명령은 이 문서가 아니라 프로젝트
+> 규칙(`rules/`)에서 온다. 모든 외부 인터페이스(git·forge CLI·loop·review 생산자)는 주입
+> 가능한 명령 변수로 두어 mock으로 독립 검증(self-referential, 실제 PR·머지 미수행)한다.
+
+1. 항상 dispatch는 한 SPEC의 의존자(그 SPEC을 `depends_on` 하는 SPEC)를 그 SPEC이 **main에
+   머지된 뒤에만** 실행 큐에 푼다. loop가 DONE으로 끝난 것만으로는 의존자를 풀지 않는다.
+
+2. 리뷰·머지 파이프라인이 구성되어 있으면(통합 모드 활성: 아래 "활성 조건"), loop가 DONE으로
+   끝났을 때 dispatch는 그 SPEC의 작업 결과를 작업 브랜치(`feat/<run-id>-<slug>`)로 push하고
+   그 head의 open PR을 재사용하거나 없으면 새로 생성한다. push·머지 어디에서도 force(강제)를
+   쓰지 않는다. 통합 모드가 비활성이면 loop DONE을 곧 `done`으로 보아 기존 동작을 보존한다.
+
+3. PR이 열려 있고 아직 승인되지 않은 동안, dispatch는 리뷰 생산자(`autopilot:review`의
+   `run --task <id>`)를 호출해 단일 판정(`pipeline_verdict`: approve|request_changes|
+   unavailable)과 분류된 재작업 브리프(`rework_brief.must_adopt/defer/wont_adopt`)를 받는다.
+   판정이 `request_changes`이면 `must_adopt` 항목을 SPEC 델타 문서로 만들어 **같은 head
+   브랜치 위에서** loop로 재구현하고 같은 브랜치로 재푸시한다(새 PR을 만들지 않으며 force
+   금지). `defer` 항목은 현 PR에 섞지 않고 별도로 기록한다.
+
+4. 리뷰 자동수정은 세 가지 가드로 무한루프를 막는다: (a) 재작업 라운드 수가 상한(기본 3)을
+   초과하면 멈추고 에스컬레이션, (b) `must_adopt`가 0인데도 여전히 `request_changes`이면(무진전)
+   에스컬레이션, (c) 차단성(`must_adopt`) 지적 집합이 직전 라운드와 동일하면(핑퐁) 에스컬레이션.
+   에스컬레이션 시 그 SPEC은 비완료 종착으로 표시되고 자동수정을 멈춘다.
+
+5. 열린 PR의 최신 정식 리뷰가 **사람** 리뷰어의 변경 요청이면, dispatch는 자동수정하지 않고
+   즉시 에스컬레이션한다(자동수정은 봇 판정에만 적용). 직전에 처리한 head와 현재 PR head가
+   같으면(새 커밋 없음) 멱등 no-op로 아무 동작도 하지 않는다.
+
+6. 리뷰가 `approve`로 수렴하면, 분리된 자율 approver 신원이 PR을 승인하고 dispatch는 승인
+   여부를 확인한다. 자동 리뷰 봇(REVIEW_BOT 신원)의 self-approve는 무효로 처리한다(분리된
+   approver 신원의 APPROVED 리뷰만 인정).
+
+7. PR이 승인된 상태에서, 머지될 변경이 버전 워치 디렉토리(`plugins/`)를 건드리면 같은 변경
+   안에서 패키지 매니페스트(`plugin.json`)의 버전이 올랐는지 확인한다. 오르지 않았으면 머지를
+   차단하고 차단 사유를 기록한다(비완료 종착). 버전 게이트를 통과하면(또는 워치 디렉토리 변경이
+   없으면) dispatch는 작업 브랜치를 main에 **fast-forward 전용(`--ff-only`)**으로 머지하고
+   (머지 커밋·force 금지) base를 push한 뒤, 그 SPEC을 `done`으로 전이한다.
+
+8. 한 SPEC이 `done`(=머지됨)으로 전이된 뒤에만 그 의존자가 실행을 시작하며, 의존자의 loop는
+   머지된 의존성을 포함한 갱신된 main 위에서 분기한다.
+
+9. loop가 하드 BLOCKED(spec-gap 외 범주)로 끝나거나, 리뷰가 수렴하지 못해 에스컬레이션되거나,
+   머지 게이트가 차단되면, 그 SPEC은 비완료 종착(`failed`/`blocked`)이고 그 **이행적 의존자만**
+   `skipped`로 차단되며 의존 관계가 없는 독립 가지는 끝까지 진행한다. (BLOCKED 범주가 spec-gap
+   이면 push·PR 없이 스펙 보강 재개 경로를 안내하고 비완료 종착으로 둔다.)
+
+10. 동시에 여러 SPEC이 진행 중인 동안, main 체크아웃과 fast-forward 머지는 **직렬화**되어
+    레이스 없이 한 번에 하나씩만 머지된다.
+
+## 활성 조건
+
+통합(리뷰·머지) 모드는 옵트인이다 — `dispatch start`에 통합 모드 플래그(예 `--integrate`)가
+주어지거나 forge 구성(approver 신원·forge CLI)이 갖춰졌을 때만 활성화한다. 활성이 아니면
+dispatch는 기존대로 loop DONE을 `done`으로 보아 완전한 하위 호환을 유지한다(기존 테스트·사용처
+불변). 활성 조건의 정확한 트리거(플래그명·자동 감지 여부)는 기존 dispatch CLI 관례와 일관되게
+정한다.
+
+## 범위에 포함
+
+- dispatch references 안에 per-SPEC 통합(push→PR)·리뷰 루프(판정→SPEC 델타→재구현→재푸시·가드)
+  ·승인+머지(approval 게이트·버전범프 게이트·ff-only 머지·done 전이) 모듈을 자체구현.
+- dispatch 스케줄러의 per-SPEC 라이프사이클 확장(loop DONE 후 통합→리뷰→머지 단계)과 `done`
+  의미 재정의(=머지됨), 머지 직렬화, 비완료 종착의 의존자 skip 전파.
+- per-SPEC 상태(작업 브랜치·PR 번호·리뷰 라운드·마지막 head·판정)를 run 디렉토리에 보관하는
+  가벼운 상태 헬퍼.
+- 각 모듈의 mock 기반 self-test와 스케줄러 통합 self-test(머지 게이트로 의존자 해제, 직렬화,
+  실패 전파 검증).
+- dispatch SKILL.md·드라이버 헤더의 "forge 연동은 호출 레이어 책임" 불변식 개정(통합 모드
+  활성 시 dispatch가 통합·리뷰·머지를 소유함을 명시).
+
+## 범위에서 제외
+
+- GitLab MR(`glab`) 어댑터: forge CLI는 주입 가능한 인터페이스(기본 GitHub `gh`)로 두되 GitLab
+  어댑터 구현은 후속.
+- `loop` 스킬 공개 인터페이스 변경: fix 라운드는 loop의 기존 secondary-worktree 동작(워크트리
+  안에서 `loop start` 호출 시 그 워크트리 재사용)을 이용한다 — loop에 새 옵션을 추가하지 않는다.
+- 다른 세션에서 제거 중인 `fsd` 스킬의 모듈을 참조·수정·의존하지 않는다(설계 참고만).
+- 리뷰 채택 분류 로직 재정의: 채택 분류(must_adopt/defer/wont_adopt)는 `autopilot:review`
+  생산자가 `rules/change-adoption.md`·`rules/review.md`를 단일 출처로 수행하며 dispatch는
+  결과를 소비만 한다.
+
+## 제약
+
+- bash 3.2+ 호환(연관 배열 미사용). dispatch references의 기존 코드 스타일·헬퍼 패턴을 따른다.
+- **force(강제) push·rebase·merge를 어떤 경로에서도 쓰지 않는다.** base 동기화는 rebase(ff
+  가능 시)로 하고 충돌 시 중단·사람 위임한다. 머지는 `git merge --ff-only`만 사용한다.
+- **버전 범프 게이트**: `plugins/`를 건드리는 머지는 같은 변경에서 `plugin.json` 버전이 올라야
+  한다(`rules/engineering/versioning.md` 단일 출처). 이 SPEC 구현이 `plugins/`를 수정하므로,
+  통합 시 `plugins/autopilot/plugin.json`과 루트 `.claude-plugin/marketplace.json` 미러의
+  SemVer를 함께 올린다.
+- 작업 브랜치명·slug는 `rules/engineering/branch-and-slug.md`를 따른다(`feat/<id>-<slug>`,
+  slug는 SPEC 제목 H1에서 도출, 빈 slug면 중단).
+- 리뷰 생산자 호출은 `autopilot:review`의 공개 인터페이스(`review.sh run --task <id>`)만
+  사용한다. loop는 공개 인터페이스(`loop.sh start|status|stop|cleanup`)만 사용하고 내부 신호
+  파일·워크트리를 직접 열지 않는다.
+- 자가생성 수정 SPEC(델타)은 디스크의 run 디렉토리 하위에 파일로 기록한다(SPEC은 항상 디스크에
+  둔다는 프로젝트 규칙 준수).
+- dispatch는 자신의 run 디렉토리(`.dispatch/runs/<run-id>/`) 밖 경로를 새로 만들지 않는다
+  (작업 브랜치·PR·머지 같은 forge 부수효과 제외). 자가생성 델타 SPEC은 run 디렉토리 하위에 둔다.
+- 통합 모드 비활성 시 기존 동작·기존 self-test가 100% 그대로 통과해야 한다(회귀 금지).
+
+## 위험
+
+- **동시성/직렬화**: 여러 loop가 병렬 워크트리에서 도는 동안 머지는 `git checkout main`을
+  수반하므로 직렬화하지 않으면 레이스가 난다. 머지 구간을 run 디렉토리 락으로 직렬화한다.
+  또한 리뷰 생산자 호출·fix loop는 시간이 길어 스케줄러 폴링 루프를 막지 않도록 per-SPEC를
+  한 폴링 틱당 한 스텝씩 멱등 전진시키는 구조(드레인)로 둔다.
+- **loop의 HEAD 스냅샷 타이밍**: 의존자 loop는 launch 시점의 HEAD를 스냅샷한다. 의존성 머지가
+  로컬 main을 전진시킨 뒤에 의존자를 launch해야 의존자 워크트리가 머지 결과를 포함한다. 머지
+  단계가 로컬 main을 ff-only로 전진시키므로, 머지 완료(=done) 이후 launch 순서를 보장한다.
+- **fix 라운드 워크트리 경로**: loop는 `--branch`를 지원하지 않으므로, 같은 PR 브랜치 위
+  재구현은 그 브랜치를 체크아웃한 워크트리 안에서 loop를 secondary 모드로 호출해 수행한다.
+  이 경로를 mock self-test로 고정한다(실제 push/머지 미수행).
+
+## 참고 알고리즘 (검증된 설계 — 이식 대상, 의존 아님)
+
+다른 세션에서 제거 중인 `fsd` 스킬의 다음 모듈이 동일 문제를 풀어 self-test를 통과했다.
+이들의 알고리즘을 dispatch 맥락으로 이식한다(코드 의존이 아니라 설계 참고):
+
+- 통합(push→PR): 종료 신호 판정 → base sync(rebase, ff 가능 시) → push → open PR 재사용/생성.
+  DONE→Review, spec-gap BLOCKED→스펙 보강 재개, 하드 BLOCKED→에스컬레이션.
+- 리뷰 루프: 생산자 1회 호출 → 판정 분기. request_changes면 must_adopt를 SPEC 델타로 →
+  같은 브랜치 재구현 → 같은 브랜치 push. 라운드캡(3)·무진전·핑퐁 가드. approve면 머지 진행가능
+  전이. unavailable·사람 변경요청이면 에스컬레이션. 한 호출=한 라운드(수렴은 폴링 드레인 소유).
+- 승인+머지: approver 신원의 APPROVED 리뷰 확인(리뷰 봇 self-approve 무효) → 버전범프 게이트
+  → ff-only 머지(+base push) → done 전이.
+
+환경 변수 계약(주입 가능, 테스트 mock): `LOOP_CMD`, `GIT_CMD`, `FORGE_CMD`(기본 gh),
+`DEFAULT_BRANCH`(기본 main), `APPROVER`(자율 승인 신원), `REVIEW_BOT`(self-approve 무효 대상),
+`REVIEW_ROUNDS_MAX`(기본 3), `WATCH_DIRS`(기본 plugins/), `REVIEW_PRODUCE_CMD`(기본
+`autopilot:review`의 review.sh run --task), `DISPATCH_POLL_SECONDS`, `DISPATCH_WAVE_TIMEOUT_SECONDS`.
+
+## 검증
+
+- 각 신규 모듈의 `selftest`를 mock 인터페이스로 실행해 통합(push·PR)·리뷰(라운드·재푸시·세 가드·
+  사람/head 게이트)·승인+머지(approval·버전 게이트·ff-only·force 미사용)를 독립 검증한다.
+- 스케줄러 통합 self-test: A←B(B가 A에 의존) 시나리오에서 A가 머지되기 전 B가 launch되지 않고,
+  A 머지 후 B가 launch됨을 단언한다. A가 비완료 종착이면 B가 skipped됨을 단언한다. 동시 머지가
+  직렬화됨을 단언한다. 통합 모드 비활성 시 기존 동작이 불변임을 단언한다(회귀 금지).
+- `git diff`로 어떤 push/머지에도 force 인자가 없고 머지 커밋이 생기지 않음을 확인한다.
+  `plugins/` 변경에 버전 범프가 동반됨을 확인한다.

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션, fsd로 spec→dispatch 자동화 파이프라인의 forge 호출 레이어(intake·start·review·merge·poll) 오케스트레이션, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch
-description: "하나 이상의 SPEC 파일을 구현 단계로 넘기고 싶을 때 사용 — 의존성(depends_on)을 풀어 각 SPEC 을 준비되는 즉시 자율 실행기에 스트리밍 위임하고 결과를 취합. 호출 'Skill(skill=\"dispatch\", args=\"<subcommand> [<args>]\")' (start/list/status/stop/watch)."
+description: "하나 이상의 SPEC 파일을 구현 단계로 넘기고 싶을 때 사용 — 의존성(depends_on)을 풀어 각 SPEC 을 준비되는 즉시 자율 실행기에 스트리밍 위임하고 결과를 취합. 옵트인 통합 모드(--integrate)면 SPEC별 push→PR→리뷰→머지 게이트로 완료를 '머지됨'으로 재정의해 의존자 해제를 머지 뒤로 미룬다. 호출 'Skill(skill=\"dispatch\", args=\"<subcommand> [<args>]\")' (start/list/status/stop/watch)."
 ---
 
 # dispatch
@@ -22,11 +22,24 @@ description: "하나 이상의 SPEC 파일을 구현 단계로 넘기고 싶을 
 - 호출마다 결정성 있는 `run-id`(타임스탬프 + 입력 SPEC 집합 sha7)를 만들고 진행 상태를 `<project_root>/.dispatch/runs/<run-id>/` 아래에 보관한다.
 - 기존 `run-id` 로 재호출되면 보관된 상태를 읽어 이미 `done` 인 SPEC 은 재실행하지 않고, 미완 SPEC 만 스트리밍 스케줄에 따라 이어 수행한다.
 
+## 통합(리뷰·머지) 모드 — 옵트인
+
+기본 모드에서 dispatch 는 loop 가 DONE 으로 끝나면 그 SPEC 을 `done` 으로 본다. 그러나 그 시점의 코드는 격리 워크트리에만 있고 main 에 머지되지 않았으므로, 그 SPEC 에 의존하는 SPEC 의 loop 가 갱신되지 않은 HEAD 에서 분기해 의존 결과 위에서 빌드할 수 없다. **통합 모드**는 한 SPEC 의 **완료를 "main 에 머지됨"으로 재정의**해 이 갭을 닫는다.
+
+- **활성 조건(opt-in)**: `dispatch start --integrate` 플래그가 주어지거나 forge 구성(`APPROVER` 신원 환경변수)이 설정되면 활성화된다. 비활성이면 기존 동작(loop DONE = `done`)을 **완전한 하위 호환**으로 보존한다.
+- **per-SPEC 파이프라인**: loop 가 DONE 으로 끝나면 그 SPEC 은 `done` 이 아니라 중간 상태 `integrating` 으로 두고, 폴링 틱당 한 스텝씩 다음을 멱등 전진(드레인)시킨다:
+  1. **통합**(`integration.sh`): base sync(rebase, ff 가능 시) → 작업 브랜치(`feat/<run-id>-<slug>`) push → 같은 head 의 open PR 재사용/생성. `spec-gap` BLOCKED 면 push·PR 없이 스펙 보강 재개 안내, 하드 BLOCKED 면 push·PR 없이 사람 에스컬레이션(둘 다 비완료 종착).
+  2. **리뷰**(`review-loop.sh`): `autopilot:review` 생산자를 1회 호출해 단일 판정(approve/request_changes/unavailable). `request_changes` 면 `must_adopt` 를 run-dir 하위 SPEC 델타로 만들어 **같은 head 브랜치 위에서** 재구현·재푸시(새 PR 미생성). `defer` 는 현 PR 에 섞지 않고 별도 기록. 세 가드(라운드 상한 기본 3·무진전·핑퐁)와 사람/head 게이트로 무한루프를 막는다.
+  3. **승인+머지**(`merge.sh`): 분리된 자율 approver 신원으로 PR 승인 제출·확인(리뷰 봇 self-approve 무효) → 버전 범프 게이트(`plugins/` 변경 시 `plugin.json` 범프 강제) → `--ff-only` 머지(+base push) → `merged`.
+- **머지 게이트**: `merged` 에 도달한 SPEC 만 `done` 으로 전이한다. 따라서 **의존자는 의존성이 main 에 머지된 뒤에만** 실행 큐에 풀리고, 갱신된 main 위에서 분기한다. 통합이 비완료 종착(`blocked`/`escalated`)이면 그 SPEC 은 `failed` 이고 그 **이행적 의존자만** `skipped` 된다.
+- **불변식**: 어떤 경로에서도 force(강제) push·rebase·merge 를 쓰지 않는다(머지는 `git merge --ff-only` 만). main 체크아웃+머지 구간은 run-dir 락으로 **직렬화**되어 동시 머지 레이스가 없다.
+- **주입 가능한 인터페이스(mock 검증)**: `LOOP_CMD` `GIT_CMD` `FORGE_CMD`(기본 gh) `DEFAULT_BRANCH`(main) `APPROVER` `REVIEW_BOT` `APPROVE_CMD` `REVIEW_ROUNDS_MAX`(3) `WATCH_DIRS`(plugins/) `REVIEW_PRODUCE_CMD` `INTEGRATION_CMD` `REVIEW_CMD` `MERGE_CMD`. 모든 외부 인터페이스가 주입 가능해 각 모듈을 mock 으로 독립 검증한다(실제 PR·머지 미수행).
+
 ## Subcommands
 
-### dispatch start `<spec...>` [--max-parallel N] [--resume `<run-id>`]
+### dispatch start `<spec...>` [--max-parallel N] [--resume `<run-id>`] [--integrate]
 
-1 개 이상의 SPEC 파일 경로를 받아 새 run 을 시작한다.
+1 개 이상의 SPEC 파일 경로를 받아 새 run 을 시작한다. `--integrate`(또는 `APPROVER` 환경변수)면 통합(리뷰·머지) 모드로 동작한다(위 "통합 모드" 절). 통합 모드에서는 state 에 중간 상태 `integrating` 이 추가되고 `done` 은 "머지됨"을 뜻한다.
 
 - 입력 검증: 각 경로가 파일로 존재하고 읽을 수 있어야 한다. 하나라도 누락이면 보고 후 즉시 abort.
 - DAG 구성: 각 SPEC frontmatter 의 `depends_on` 을 읽어 의존 인덱스를 만든다. cycle 이면 abort. 진단용 `WAVES.txt` 도 함께 기록(실행 스케줄은 준비도 기반).
@@ -56,16 +69,23 @@ per-SPEC 상태를 주기적으로 refresh 하며, 모든 child 가 terminal(`do
 
 | 파일 | 역할 |
 |---|---|
-| `dispatch.sh` | run-id 디렉토리 관리·의존 인덱스 구성·준비도 스트리밍 위임·구조화 종료 판정 driver |
+| `dispatch.sh` | run-id 디렉토리 관리·의존 인덱스 구성·준비도 스트리밍 위임·구조화 종료 판정·통합 모드 드레인 driver |
+| `lib-integration.sh` | per-SPEC 통합 상태 헬퍼(run-dir + 키: branch/pr/head/review-round/verdict/phase). 통합 모드 전용 |
+| `integration.sh` | loop 종료신호 → base sync → push → PR 생성/재사용. 통합 모드 전용 |
+| `review-loop.sh` | 리뷰 생산자 판정 → SPEC 델타 재구현·재푸시(3가드·사람/head 게이트). 통합 모드 전용 |
+| `merge.sh` | 승인 게이트 → 버전 범프 게이트 → 직렬화 ff-only 머지. 통합 모드 전용 |
+
+각 통합 모듈은 `bash <module>.sh selftest` 로 mock 인터페이스 기반 독립 검증을 제공한다(실제 PR·머지 미수행). 스케줄러 통합 검증은 `bash dispatch.sh selftest`.
 
 ## 의존성
 
-`git`, `bash` 3.2+, `sha256sum` 또는 `shasum`, `autopilot:loop` 스킬, `yq`(mikefarah). `yq` 는 depends_on 파싱(없으면 awk 폴백)뿐 아니라 **loop 구조화 상태(`status --json`) 판정의 단일 출처**이므로 `start`/`status`/`stop`/`watch` 에서 필수다(부재 시 명확히 정지 — 텍스트 컬럼으로 silent fallback 하지 않음).
+`git`, `bash` 3.2+, `sha256sum` 또는 `shasum`, `autopilot:loop` 스킬, `yq`(mikefarah). `yq` 는 depends_on 파싱(없으면 awk 폴백)뿐 아니라 **loop 구조화 상태(`status --json`) 판정의 단일 출처**이므로 `start`/`status`/`stop`/`watch` 에서 필수다(부재 시 명확히 정지 — 텍스트 컬럼으로 silent fallback 하지 않음). 통합 모드는 추가로 `jq`(리뷰 판정 JSON 파싱)와 forge CLI(`gh`, 주입 가능)·리뷰 생산자(`autopilot:review`)를 쓴다(비활성 모드에는 불필요).
 
 ## 규칙
 
-- 자체 작성·갱신하는 영역은 `<project_root>/.dispatch/runs/<run-id>/` 디렉토리 안의 파일들과 본 스킬의 정의 파일뿐이다. 이 외 경로를 만들지 않는다.
-- 자율 실행기 인터페이스(`loop.sh start|status|stop`) 외 child 워크트리·신호 파일을 직접 들여다보지 않는다.
+- 자체 작성·갱신하는 영역은 `<project_root>/.dispatch/runs/<run-id>/` 디렉토리 안의 파일들(통합 모드의 SPEC 델타·백로그·통합 상태 포함)과 본 스킬의 정의 파일뿐이다. 작업 브랜치·PR·머지 같은 forge 부수효과를 제외하면 이 외 경로를 만들지 않는다.
+- 자율 실행기 인터페이스(`loop.sh start|status|stop|cleanup|logs`) 외 child 워크트리·신호 파일을 직접 들여다보지 않는다.
+- **forge 연동 소유권**: 기본(비통합) 모드에서 forge(PR/머지) 연동은 호출 레이어 책임이고 dispatch 는 위임만 한다. **통합 모드가 활성이면 dispatch 가 통합·리뷰·머지를 직접 소유**한다 — 머지가 의존자를 푸는 게이트는 본질적으로 dispatch 의 웨이브 스케줄링에 속하기 때문이다. 이때도 모든 forge·git·loop·리뷰 인터페이스는 주입 가능한 명령으로 두어 mock 검증되며, force 는 어떤 경로에서도 쓰지 않는다.
 - 분해(여러 SPEC 작성) 책임은 SPEC 작성 도구(`autopilot:spec` 등)에 있고, dispatch 는 이미 만들어진 SPEC 들만 받는다.
 - child 의 종료 의도(완료/차단)는 자율 실행기가 신호로 표현하고, dispatch 는 그 공개 인터페이스가 제공하는 **구조화된 상태**(`loop.sh status --json` 의 `.state`·`.signals[]`)로만 읽는다 — 표 컬럼 위치·부분 문자열 일치에 의존하지 않는다. `signals` 의 의미(`DONE`/`BLOCKED`)는 워커 컨벤션이며 dispatch 는 정확 일치 멤버십으로 판정한다.
 - run 디렉토리는 git 추적에서 제외한다(`.gitignore` 처리 권장).

--- a/plugins/autopilot/skills/dispatch/references/dispatch.sh
+++ b/plugins/autopilot/skills/dispatch/references/dispatch.sh
@@ -35,6 +35,26 @@ LOOP_CMD="${LOOP_CMD:-$LOOP_CMD_DEFAULT}"
 POLL_SECONDS="${DISPATCH_POLL_SECONDS:-2}"
 WAVE_TIMEOUT_SECONDS="${DISPATCH_WAVE_TIMEOUT_SECONDS:-7200}"
 
+# ----- 통합(리뷰·머지) 모드 -----
+# 통합 모드가 활성이면 loop DONE 을 곧 done 으로 보지 않고, per-SPEC 통합→리뷰→머지
+# 파이프라인을 한 폴링 틱당 한 스텝씩 전진시켜(드레인) 머지에 성공한 SPEC 만 done 으로
+# 전이한다(=의존자 해제). done 의 의미가 "머지됨"으로 재정의되며, 기존 ready 검사
+# (dep==done)·skip 전파가 그대로 머지 게이트가 된다. 비활성이면 기존 동작(loop DONE=done).
+#
+# 통합 모듈은 **서브프로세스로 격리** 호출한다 — 모듈의 set +e·die→exit 가 본 스케줄러의
+# set -euo pipefail·드레인 루프를 오염·중단시키지 않게 한다. 순수 상태 헬퍼(lib-integration)
+# 만 sourcing 한다(top-level set 변경 없음 → 안전).
+INTEGRATION_CMD="${INTEGRATION_CMD:-bash $SCRIPT_DIR/integration.sh}"
+REVIEW_CMD="${REVIEW_CMD:-bash $SCRIPT_DIR/review-loop.sh}"
+MERGE_CMD="${MERGE_CMD:-bash $SCRIPT_DIR/merge.sh}"
+INTEGRATE_MODE=0
+# shellcheck source=lib-integration.sh
+. "$SCRIPT_DIR/lib-integration.sh"
+
+# int_key <spec> — per-SPEC 통합 키. dispatch 실행 상태 키(state.<slug>-<hash7>)와 동일
+# 산식이라, 스케줄러가 통합 모듈에 넘기는 키와 실행 상태 키가 일관된다.
+int_key() { echo "$(spec_slug "$1")-$(hash7 "$1")"; }
+
 # ----- helpers -----
 
 die() { echo "ERROR: $*" >&2; exit 1; }
@@ -294,6 +314,80 @@ child_terminal_state() {
   esac
 }
 
+# ----- 통합 모드: loop 종료 매핑 + per-SPEC 드레인 -----
+
+# mark_loop_terminal <run_dir> <spec> <term> — loop 가 종료(done/failed/그외)했을 때
+# 스케줄러 상태로 매핑한다. 통합 모드면 done/failed 를 곧장 done/failed 로 보지 않고
+# `integrating` 으로 두어 통합→리뷰→머지 드레인이 분류·전진하게 한다(spec-gap 여부 포함).
+# 비활성이면 기존 동작과 동일(done→done, 그 외→failed).
+mark_loop_terminal() {
+  local rd="$1" spec="$2" term="$3"
+  if (( INTEGRATE_MODE == 1 )) && { [[ "$term" == "done" ]] || [[ "$term" == "failed" ]]; }; then
+    set_state "$rd" "$spec" "integrating"
+    int_set_phase "$rd" "$(int_key "$spec")" "loop-done"
+    int_set "$rd" "$(int_key "$spec")" integ-start "$(date +%s)"
+    log_event "$rd" "integrate-enter $(spec_slug "$spec") loop-terminal=$term"
+  else
+    case "$term" in
+      done) set_state "$rd" "$spec" "done";   log_event "$rd" "done $(spec_slug "$spec")" ;;
+      *)    set_state "$rd" "$spec" "failed"; log_event "$rd" "failed $(spec_slug "$spec") (term=$term)" ;;
+    esac
+  fi
+}
+
+# drain_integration <run_dir> <spec> — integrating SPEC 을 그 시점 가능한 다음 한 스텝으로
+# 전진(멱등). 통합 모듈은 서브프로세스 격리 호출(die→exit 가 스케줄러를 죽이지 않게 || true).
+# 종착 통합 phase 를 스케줄러 상태로 매핑: merged→done, blocked|blocked-spec-gap|escalated→failed.
+drain_integration() {
+  local rd="$1" spec="$2" key phase pr branch started now
+  key="$(int_key "$spec")"
+  phase="$(int_get_phase "$rd" "$key")"
+  pr="$(int_get_pr "$rd" "$key")"
+  branch="$(int_get_branch "$rd" "$key")"
+
+  # 통합 단계 runtime cap — 통합/리뷰/머지가 무한 대기(예: approver 승인 미반영)로 폴링
+  # 루프를 영원히 막지 않도록 WAVE_TIMEOUT_SECONDS 초과 시 비완료 종착(failed)으로 회수.
+  started="$(int_get "$rd" "$key" integ-start "0")"
+  now="$(date +%s)"
+  if [[ "$started" != "0" ]] && (( now - started >= WAVE_TIMEOUT_SECONDS )); then
+    set_state "$rd" "$spec" "failed"
+    log_event "$rd" "integrate-timeout $(spec_slug "$spec") elapsed=$((now - started))s phase=$phase"
+    return 0
+  fi
+
+  case "$phase" in
+    ""|loop-done)
+      # shellcheck disable=SC2086
+      $INTEGRATION_CMD integrate "$spec" "$rd" "$key" >/dev/null 2>&1 || true
+      ;;
+    review)
+      # shellcheck disable=SC2086
+      $REVIEW_CMD run "$rd" "$key" "$spec" "$pr" "$branch" >/dev/null 2>&1 || true
+      ;;
+    approved)
+      # 분리 approver 신원 승인 1회 제출 후 머지 시도(멱등: 제출 표시).
+      if [[ "$(int_get "$rd" "$key" approval-submitted "")" != "1" ]]; then
+        # shellcheck disable=SC2086
+        $MERGE_CMD approve "$pr" >/dev/null 2>&1 || true
+        int_set "$rd" "$key" approval-submitted 1
+      fi
+      # shellcheck disable=SC2086
+      $MERGE_CMD finish "$spec" "$rd" "$key" "$pr" >/dev/null 2>&1 || true
+      ;;
+    merging)
+      # shellcheck disable=SC2086
+      $MERGE_CMD finish "$spec" "$rd" "$key" "$pr" >/dev/null 2>&1 || true
+      ;;
+  esac
+
+  phase="$(int_get_phase "$rd" "$key")"
+  case "$phase" in
+    merged) set_state "$rd" "$spec" "done";   log_event "$rd" "merged→done $(spec_slug "$spec")" ;;
+    blocked|blocked-spec-gap|escalated)
+            set_state "$rd" "$spec" "failed"; log_event "$rd" "integrate-failed $(spec_slug "$spec") phase=$phase" ;;
+  esac
+}
+
 # ----- DAG / wave 구성 -----
 
 # build_dag <spec1> <spec2> ... → stdout 에 "wave=N\t<abspath>" 줄.
@@ -398,11 +492,13 @@ cmd_start() {
   require_yq
   local resume=""
   local max_parallel=0
+  local integrate_opt=0
   local -a inputs=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --resume) resume="$2"; shift 2 ;;
       --max-parallel) max_parallel="$2"; shift 2 ;;
+      --integrate) integrate_opt=1; shift ;;
       --) shift; while [[ $# -gt 0 ]]; do inputs+=("$1"); shift; done ;;
       -*) die "알 수 없는 옵션: $1" ;;
       *) inputs+=("$1"); shift ;;
@@ -448,6 +544,16 @@ cmd_start() {
     # 초기 상태 = pending
     local s
     for s in "${specs_abs[@]}"; do set_state "$rd" "$s" "pending"; done
+  fi
+
+  # ----- 통합 모드 활성 판정 (opt-in) -----
+  # 트리거: --integrate 플래그 또는 forge 구성(APPROVER 신원 설정). 활성이면 run-dir 에
+  # 마커를 남겨 --resume 에서도 동일 모드로 재개한다. 비활성이면 기존 동작(loop DONE=done).
+  if (( integrate_opt == 1 )) || [[ -n "${APPROVER:-}" ]]; then INTEGRATE_MODE=1; fi
+  if [[ -f "$rd/INTEGRATE" ]]; then INTEGRATE_MODE=1; fi
+  if (( INTEGRATE_MODE == 1 )); then
+    : > "$rd/INTEGRATE"
+    log_event "$rd" "integration mode ON (review→merge 게이트; done=머지됨)"
   fi
 
   # ----- 스트리밍 스케줄러 (SPEC별 준비도 기반) -----
@@ -528,28 +634,28 @@ cmd_start() {
           kill_tree "${PIDS[i]}" TERM; sleep 1
           kill -0 "${PIDS[i]}" 2>/dev/null && kill_tree "${PIDS[i]}" KILL
           wait "${PIDS[i]}" 2>/dev/null || true
-          # timeout 직전 이미 done 인 child 는 done 보존, 아니면 failed.
+          # timeout 직전 이미 done 인 child 는 done(통합 모드면 integrating 진입), 아니면 failed.
           term="$(child_terminal_state "${specs_abs[i]}")"
-          if [[ "$term" == "done" ]]; then
-            set_state "$rd" "${specs_abs[i]}" "done"
-            log_event "$rd" "done $(spec_slug "${specs_abs[i]}") (완료 후 timeout 회수)"
-          else
-            set_state "$rd" "${specs_abs[i]}" "failed"
-            log_event "$rd" "timeout-failed $(spec_slug "${specs_abs[i]}") state=$term"
-          fi
+          mark_loop_terminal "$rd" "${specs_abs[i]}" "$term"
           PIDS[i]=""
         fi
         continue
       fi
-      # PID 종료 — loop 구조화 상태로 종료 상태 판정.
+      # PID 종료 — loop 구조화 상태로 종료 상태 판정. 통합 모드면 done/failed 를
+      # integrating 으로 두고(아래 드레인이 분류·전진), 비활성이면 기존대로 done/failed.
       term="$(child_terminal_state "${specs_abs[i]}")"
-      case "$term" in
-        done)   set_state "$rd" "${specs_abs[i]}" "done";   log_event "$rd" "done $(spec_slug "${specs_abs[i]}")" ;;
-        failed) set_state "$rd" "${specs_abs[i]}" "failed"; log_event "$rd" "failed $(spec_slug "${specs_abs[i]}")" ;;
-        *)      set_state "$rd" "${specs_abs[i]}" "failed"; log_event "$rd" "unknown-terminal $(spec_slug "${specs_abs[i]}") state=$term" ;;
-      esac
+      mark_loop_terminal "$rd" "${specs_abs[i]}" "$term"
       PIDS[i]=""
     done
+
+    # 3.5) 통합 모드 드레인 — integrating SPEC 을 틱당 한 스텝씩 멱등 전진.
+    #   integrate→review→(approve)→merge. merged→done(=의존자 해제), 비완료 종착→failed.
+    if (( INTEGRATE_MODE == 1 )); then
+      for ((i=0; i<n; i++)); do
+        [[ "$(get_state "$rd" "${specs_abs[i]}")" == "integrating" ]] || continue
+        drain_integration "$rd" "${specs_abs[i]}"
+      done
+    fi
 
     # 4) 종료 판정 — 모든 SPEC 이 done/failed/skipped 이면 끝.
     local pending_or_running=0
@@ -666,6 +772,10 @@ cmd_watch() {
         done)    ;;
         failed)  any_fail=1 ;;
         skipped) any_fail=1 ;;  # 이행적 실패로 차단된 SPEC — terminal(비완료).
+        integrating)
+          # 통합 모드: loop 는 끝났지만 통합→리뷰→머지 진행 중. 머지(=done) 전까지 비완료.
+          # watch 는 통합을 전진시키지 않으므로(스케줄러 cmd_start 소유) 미완으로만 보고한다.
+          all_terminal=0 ;;
         *)
           # 미완 — loop 공개 IF 로 현 상태 재확인.
           local term; term="$(child_terminal_state "$sp")"
@@ -685,6 +795,135 @@ cmd_watch() {
     if (( now - start >= WAVE_TIMEOUT_SECONDS )); then return 2; fi
     sleep "${POLL_SECONDS:-1}"
   done
+}
+
+# =====================================================================
+# selftest — 스케줄러 통합 검증(mock loop/integration/review/merge).
+#   AC1/AC8: 의존자는 의존성이 머지(done)된 뒤에만 launch.
+#   AC9: 비완료 종착(통합 차단)이면 이행적 의존자만 skipped.
+#   AC10: 머지 직렬화는 merge.sh 락 selftest 가 단언(여기선 머지 위임 경로 확인).
+#   회귀: 통합 모드 비활성이면 loop DONE=done(통합 모듈 미호출).
+#   self-referential: 실제 PR·머지 미수행(모두 mock).
+# =====================================================================
+cmd_selftest() {
+  local TMP; TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' RETURN
+  local LIBINT="$SCRIPT_DIR/lib-integration.sh"
+  local DSP="$SCRIPT_DIR/dispatch.sh"
+
+  # mock loop: start→launch 이벤트 + 즉시 종료, status --json→terminal/DONE.
+  cat > "$TMP/m-loop.sh" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  start)  shift; [[ "$1" == --* ]] && shift; printf 'launch:%s\n' "$(basename "$1")" >> "$EVENTLOG"; exit 0 ;;
+  status) printf '{"state":"terminal","signals":["DONE"]}\n' ;;
+  logs|stop|cleanup) : ;;
+esac
+exit 0
+EOF
+  # mock integration: integrate <spec> <rd> <key>. MOCK_INT_BLOCK 이면 그 spec 을 blocked.
+  cat > "$TMP/m-int.sh" <<'EOF'
+#!/usr/bin/env bash
+. "$LIBINT"
+spec="$2"; rd="$3"; key="$4"
+printf 'integrate:%s\n' "$(basename "$spec")" >> "$EVENTLOG"
+if [[ -n "${MOCK_INT_BLOCK:-}" && "$(basename "$spec")" == "$MOCK_INT_BLOCK" ]]; then
+  int_set_phase "$rd" "$key" blocked
+else
+  int_set_branch "$rd" "$key" "feat/x-$key"; int_set_pr "$rd" "$key" 100
+  int_set_phase "$rd" "$key" review
+fi
+exit 0
+EOF
+  # mock review: run <rd> <key> <spec> <pr> <branch> → approved.
+  cat > "$TMP/m-review.sh" <<'EOF'
+#!/usr/bin/env bash
+. "$LIBINT"
+rd="$2"; key="$3"; spec="$4"
+printf 'review:%s\n' "$(basename "$spec")" >> "$EVENTLOG"
+int_set_phase "$rd" "$key" approved
+exit 0
+EOF
+  # mock merge: approve <pr> / finish <spec> <rd> <key> <pr> → merged.
+  cat > "$TMP/m-merge.sh" <<'EOF'
+#!/usr/bin/env bash
+. "$LIBINT"
+case "$1" in
+  approve) printf 'approve:%s\n' "$2" >> "$EVENTLOG" ;;
+  finish)  spec="$2"; rd="$3"; key="$4"
+           printf 'merge:%s\n' "$(basename "$spec")" >> "$EVENTLOG"
+           int_set_phase "$rd" "$key" merged ;;
+esac
+exit 0
+EOF
+
+  # 격리 git 저장소 + SPEC 2개(B depends_on A).
+  local REPO="$TMP/repo"; mkdir -p "$REPO"
+  ( cd "$REPO" && git init -q )
+  printf -- '---\n---\n# Feature A\n' > "$REPO/feature-a.md"
+  printf -- '---\ndepends_on: [feature-a]\n---\n# Feature B\n' > "$REPO/feature-b.md"
+
+  local fail=0
+  ok()  { echo "PASS  $1"; }
+  bad() { echo "FAIL  $1"; fail=1; }
+  before() { # <eventlog> <pat-A> <pat-B> : A 줄번호 < B 줄번호 (둘 다 존재)
+    local lg="$1" a b
+    a="$(grep -n "$2" "$lg" | head -1 | cut -d: -f1)"
+    b="$(grep -n "$3" "$lg" | head -1 | cut -d: -f1)"
+    [[ -n "$a" && -n "$b" && "$a" -lt "$b" ]]
+  }
+  run_state() { # <run_dir> <spec-basename> — state_path 산식(state.<slug>-<hash7>) 재현.
+    local rd="$1" sp key; sp="$REPO/$2"
+    key="$(spec_slug "$sp")-$(hash7 "$sp")"
+    cat "$rd/state.$key" 2>/dev/null || echo "MISSING"
+  }
+  latest_run() { ls -1dt "$REPO"/.dispatch/runs/*/ 2>/dev/null | head -1 | sed 's:/$::'; }
+
+  # ---- 시나리오 1: 통합 모드 — 머지 게이트로 의존자 해제 ----
+  rm -rf "$REPO/.dispatch"
+  local EVENTLOG="$TMP/ev1.log"; : > "$EVENTLOG"
+  ( cd "$REPO" && env EVENTLOG="$EVENTLOG" LOOP_CMD="bash $TMP/m-loop.sh" \
+      INTEGRATION_CMD="bash $TMP/m-int.sh" REVIEW_CMD="bash $TMP/m-review.sh" MERGE_CMD="bash $TMP/m-merge.sh" \
+      LIBINT="$LIBINT" DISPATCH_POLL_SECONDS=0 DISPATCH_WAVE_TIMEOUT_SECONDS=120 \
+      bash "$DSP" start --integrate feature-a.md feature-b.md ) >/dev/null 2>&1 || true
+  local rd1; rd1="$(latest_run)"
+  [[ "$(run_state "$rd1" feature-a.md)" == "done" ]] && ok "S1 A 머지(done)" || bad "S1 A 머지(done) got=$(run_state "$rd1" feature-a.md)"
+  [[ "$(run_state "$rd1" feature-b.md)" == "done" ]] && ok "S1 B 머지(done)" || bad "S1 B 머지(done) got=$(run_state "$rd1" feature-b.md)"
+  before "$EVENTLOG" 'merge:feature-a.md' 'launch:feature-b.md' \
+    && ok "AC1/AC8 A 머지 후에만 B launch" || bad "AC1/AC8 A 머지 후에만 B launch"
+  before "$EVENTLOG" 'integrate:feature-a.md' 'merge:feature-a.md' \
+    && ok "S1 A integrate→review→merge 순서" || bad "S1 A integrate→merge 순서"
+  [[ -f "$rd1/INTEGRATE" ]] && ok "S1 통합 모드 마커" || bad "S1 통합 모드 마커"
+
+  # ---- 시나리오 2: 통합 차단(A) → 이행적 의존자 B skipped ----
+  rm -rf "$REPO/.dispatch"
+  local EVENTLOG2="$TMP/ev2.log"; : > "$EVENTLOG2"
+  ( cd "$REPO" && env EVENTLOG="$EVENTLOG2" MOCK_INT_BLOCK="feature-a.md" LOOP_CMD="bash $TMP/m-loop.sh" \
+      INTEGRATION_CMD="bash $TMP/m-int.sh" REVIEW_CMD="bash $TMP/m-review.sh" MERGE_CMD="bash $TMP/m-merge.sh" \
+      LIBINT="$LIBINT" DISPATCH_POLL_SECONDS=0 DISPATCH_WAVE_TIMEOUT_SECONDS=120 \
+      bash "$DSP" start --integrate feature-a.md feature-b.md ) >/dev/null 2>&1 || true
+  local rd2; rd2="$(latest_run)"
+  [[ "$(run_state "$rd2" feature-a.md)" == "failed" ]] && ok "AC9 A 비완료 종착(failed)" || bad "AC9 A failed got=$(run_state "$rd2" feature-a.md)"
+  [[ "$(run_state "$rd2" feature-b.md)" == "skipped" ]] && ok "AC9 B 이행적 skipped" || bad "AC9 B skipped got=$(run_state "$rd2" feature-b.md)"
+  if grep -q 'launch:feature-b.md' "$EVENTLOG2"; then bad "AC9 B 미launch"; else ok "AC9 B 미launch(차단 전파)"; fi
+
+  # ---- 시나리오 3: 회귀 — 통합 모드 비활성이면 loop DONE=done, 통합 모듈 미호출 ----
+  rm -rf "$REPO/.dispatch"
+  local EVENTLOG3="$TMP/ev3.log"; : > "$EVENTLOG3"
+  ( cd "$REPO" && env EVENTLOG="$EVENTLOG3" LOOP_CMD="bash $TMP/m-loop.sh" \
+      INTEGRATION_CMD="bash $TMP/m-int.sh" REVIEW_CMD="bash $TMP/m-review.sh" MERGE_CMD="bash $TMP/m-merge.sh" \
+      LIBINT="$LIBINT" DISPATCH_POLL_SECONDS=0 DISPATCH_WAVE_TIMEOUT_SECONDS=120 \
+      bash "$DSP" start feature-a.md feature-b.md ) >/dev/null 2>&1 || true
+  local rd3; rd3="$(latest_run)"
+  [[ "$(run_state "$rd3" feature-a.md)" == "done" ]] && ok "회귀 A loop DONE=done" || bad "회귀 A done got=$(run_state "$rd3" feature-a.md)"
+  [[ "$(run_state "$rd3" feature-b.md)" == "done" ]] && ok "회귀 B loop DONE=done" || bad "회귀 B done got=$(run_state "$rd3" feature-b.md)"
+  if grep -qE 'integrate:|review:|merge:' "$EVENTLOG3"; then bad "회귀 통합 모듈 미호출"; else ok "회귀 통합 모듈 미호출(비활성)"; fi
+  before "$EVENTLOG3" 'launch:feature-a.md' 'launch:feature-b.md' \
+    && ok "회귀 A done 후 B launch(기존 게이트)" || bad "회귀 A done 후 B launch"
+  [[ ! -f "$rd3/INTEGRATE" ]] && ok "회귀 통합 마커 없음" || bad "회귀 통합 마커 없음"
+
+  echo "----"
+  [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"
+  return $fail
 }
 
 # ----- 사용법 -----
@@ -726,6 +965,7 @@ case "$SUB" in
   status) cmd_status "$@" ;;
   stop)   cmd_stop   "$@" ;;
   watch)  cmd_watch  "$@" ;;
+  selftest) cmd_selftest ;;
   -h|--help|help) usage ;;
   *) echo "알 수 없는 subcommand: $SUB" >&2; usage ;;
 esac

--- a/plugins/autopilot/skills/dispatch/references/dispatch.sh
+++ b/plugins/autopilot/skills/dispatch/references/dispatch.sh
@@ -362,7 +362,10 @@ drain_integration() {
   fi
 
   case "$phase" in
-    ""|loop-done)
+    ""|loop-done|integrating)
+      # integrating 은 in_integrate 가 push 직전 잠깐 두는 전이 상태. 그 사이 서브프로세스가
+      # 죽으면 phase 가 integrating 으로 남는데, integrate 재호출은 멱등(같은 head 의 open PR
+      # 재사용)이므로 그대로 재시도해 드레인 정체를 피한다.
       # shellcheck disable=SC2086
       $INTEGRATION_CMD integrate "$spec" "$rd" "$key" >/dev/null 2>&1 || true
       ;;

--- a/plugins/autopilot/skills/dispatch/references/dispatch.sh
+++ b/plugins/autopilot/skills/dispatch/references/dispatch.sh
@@ -6,10 +6,16 @@
 #     wave 단위로 자율 실행기(loop.sh)에 위임 호출.
 #   - run-id 단위로 진행 상태를 <project_root>/.dispatch/runs/<run-id>/ 에 보관.
 #   - list / status / stop / watch / --resume 운영 인터페이스 제공.
+#   - (통합 모드 활성 시) per-SPEC 통합→리뷰→머지 파이프라인을 소유: loop DONE 을 곧
+#     done 으로 보지 않고 push→PR→리뷰→ff-only 머지에 성공한 SPEC 만 done 으로 전이해
+#     의존자 해제를 머지 뒤로 미룬다. 통합 모듈(integration/review-loop/merge.sh)은
+#     서브프로세스로 격리 호출하고 per-SPEC 통합 상태는 lib-integration.sh 로 보관한다.
 #
 # **하지 않는 일**:
 #   - 입력 SPEC 의 frontmatter 형식·내용 검증 (자율 실행기 책임).
-#   - forge(PR/issue/label)·task 저장소 연동 (호출 레이어 책임).
+#   - forge(PR/issue/label) 연동 — **기본(비통합) 모드에서는** 호출 레이어 책임이다.
+#     통합 모드가 활성이면 dispatch 가 통합·리뷰·머지를 직접 소유한다(위 책임 참조).
+#     어느 모드에서도 force(강제) push·rebase·merge 는 쓰지 않는다.
 #   - 자율 실행기 내부 신호 파일 포맷·iteration·worktree 결정 (loop.sh 책임).
 #
 # 사용:

--- a/plugins/autopilot/skills/dispatch/references/integration.sh
+++ b/plugins/autopilot/skills/dispatch/references/integration.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# integration.sh — autopilot:dispatch per-SPEC 통합 (M2)
+#
+# 책임 ("loop DONE" 과 "리뷰 승인 요청(PR)" 사이의 다리):
+#   - 종료 신호 판정: loop 의 공개 구조화 상태(`status --json`)로만 child 종료 의도를
+#     읽어 통합 분기로 매핑한다(dispatch.sh 의 child_terminal_state 와 동일 산식).
+#       DONE(차단 없음)            → base sync → push(feat/<run-id>-<slug>) → PR 생성/재사용,
+#                                     int-phase=review.
+#       BLOCKED category=spec-gap  → push·PR 없이 스펙 보강 재개 안내, int-phase=blocked-spec-gap.
+#       BLOCKED 그 외 하드 범주     → push·PR 없이 사람 에스컬레이션, int-phase=blocked.
+#   - base sync: 작업 브랜치를 default branch(main)에 rebase(fast-forward 가능할 때만).
+#   - push: 작업 결과를 `feat/<run-id>-<slug>` 브랜치로 push.
+#   - PR 생성/재사용: 같은 head 의 open PR 이 있으면 재사용, 없으면 생성.
+#
+# 불변식:
+#   - force(강제) push·rebase 금지(어떤 경로에서도).
+#   - 종료 상태·BLOCKED 범주는 loop 의 공개 인터페이스(status --json / logs)로만 읽고
+#     child 워크트리·내부 신호 파일을 직접 열지 않는다.
+#   - 브랜치명·slug 는 rules/engineering/branch-and-slug.md 단일 출처(feat/<id>-<slug>).
+#   - per-SPEC 상태는 lib-integration.sh(run-dir + 불투명 key)로만 보관한다.
+#
+# 키 계약: 통합 모듈은 per-SPEC 키를 **재계산하지 않고** 호출자(스케줄러)에게서 받는다
+#   (dispatch.sh 가 spec_slug+hash7 로 한 번 계산해 모든 통합 모듈 호출에 같은 키를 넘긴다).
+#   → spec_slug/hash7 의 모듈 간 중복·표류를 만들지 않는다.
+#
+# 모든 외부 인터페이스(loop·git·forge CLI)는 주입 가능한 명령 변수로 두어 mock 으로
+# 독립 검증한다(self-referential: 실제 PR·push 미수행). bash 3.2+ 호환.
+#
+# 환경 변수 (테스트에서 mock 으로 치환 가능):
+#   LOOP_CMD        loop driver 호출 (기본: 형제 loop.sh).
+#   GIT_CMD         git 호출 (기본: git). force 옵션 미사용.
+#   FORGE_CMD       forge(PR) CLI 호출 (기본: gh).
+#   DEFAULT_BRANCH  base branch (기본: main).
+
+set -uo pipefail
+
+IN_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# per-SPEC 상태 헬퍼(M1) 로드.
+if ! declare -f int_set >/dev/null 2>&1; then
+  # shellcheck source=lib-integration.sh
+  . "$IN_SCRIPT_DIR/lib-integration.sh"
+fi
+
+LOOP_CMD_DEFAULT="bash $IN_SCRIPT_DIR/../../loop/references/loop.sh"
+LOOP_CMD="${LOOP_CMD:-$LOOP_CMD_DEFAULT}"
+GIT_CMD="${GIT_CMD:-git}"
+FORGE_CMD="${FORGE_CMD:-gh}"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+
+in_die() { echo "integration: $*" >&2; return 1; }
+
+# =====================================================================
+# 1) 종료 신호 판정 — loop 공개 구조화 상태(status --json)만 사용.
+#    dispatch.sh child_terminal_state 와 동일 의미(done/failed/running/pending/unknown).
+# =====================================================================
+
+in_loop_status_json() {
+  # shellcheck disable=SC2086
+  $LOOP_CMD status --json "$1" 2>/dev/null
+}
+
+# in_child_terminal_state <spec> — done|failed|running|pending|unknown
+#   done    : .state=terminal 이고 signals 에 BLOCKED 없음.
+#   failed  : .state=terminal 이고 signals 에 BLOCKED 있음(워커 컨벤션).
+#   running : .state=running|stale.   pending: idle|absent.   unknown: 상태 부재.
+in_child_terminal_state() {
+  local json st
+  json="$(in_loop_status_json "$1")"
+  if [[ -z "$json" ]]; then echo "unknown"; return; fi
+  st="$(printf '%s' "$json" | yq -r '.state' 2>/dev/null)"
+  case "$st" in
+    terminal)
+      local sigs; sigs="$(printf '%s' "$json" | yq -r '.signals[]' 2>/dev/null || true)"
+      if printf '%s\n' "$sigs" | grep -Fxq 'BLOCKED'; then echo "failed"; else echo "done"; fi
+      ;;
+    running|stale) echo "running" ;;
+    idle|absent)   echo "pending" ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+# in_blocked_category <spec> — BLOCKED 신호 본문의 category(없으면 other).
+#   loop 의 공개 `logs` 인터페이스(signals/ 본문 dump)에서 첫 'category:' 줄을 읽는다.
+#   워크트리 신호 파일을 직접 열지 않는다(공개 인터페이스 경유).
+in_blocked_category() {
+  local cat
+  # shellcheck disable=SC2086
+  cat="$($LOOP_CMD logs "$1" 2>/dev/null \
+    | awk 'tolower($0) ~ /^category:/ { sub(/^[Cc][Aa][Tt][Ee][Gg][Oo][Rr][Yy]:[[:space:]]*/, ""); gsub(/[[:space:]]/, ""); print; exit }' \
+    || true)"
+  [[ -n "$cat" ]] && printf '%s\n' "$cat" || printf '%s\n' "other"
+}
+
+# =====================================================================
+# 2) 브랜치·slug — rules/engineering/branch-and-slug.md 실행자.
+# =====================================================================
+
+# in_spec_title <spec_path> — frontmatter 밖 첫 H1.
+in_spec_title() {
+  awk '
+    /^---[[:space:]]*$/ { fm = !fm; next }
+    !fm && /^# / { sub(/^# /, ""); print; exit }
+  ' "$1"
+}
+
+# in_slug_from_title <title> — 소문자·비영숫자→하이픈·압축.
+in_slug_from_title() {
+  printf '%s' "$1" \
+    | LC_ALL=C tr '[:upper:]' '[:lower:]' \
+    | LC_ALL=C tr -c 'a-z0-9-' '-' \
+    | sed -e 's/--*/-/g' -e 's/^-//' -e 's/-$//'
+}
+
+# in_work_branch <run-id> <spec_path> — feat/<run-id>-<slug>. 빈 slug 면 중단.
+in_work_branch() {
+  local rid="$1" spec="$2" slug
+  slug="$(in_slug_from_title "$(in_spec_title "$spec")")"
+  [[ -n "$slug" ]] || { in_die "SPEC 제목에서 slug 를 만들 수 없음(제목 수정 필요): $spec"; return 1; }
+  printf 'feat/%s-%s\n' "$rid" "$slug"
+}
+
+# =====================================================================
+# 3) git 통합 — base sync(rebase, ff 가능 시) → push. force 금지.
+# =====================================================================
+
+in_base_sync() {
+  local branch="$1"
+  # shellcheck disable=SC2086
+  $GIT_CMD fetch origin "$DEFAULT_BRANCH" || { in_die "fetch 실패: origin/$DEFAULT_BRANCH"; return 1; }
+  # shellcheck disable=SC2086
+  $GIT_CMD checkout "$branch" || { in_die "checkout 실패: $branch"; return 1; }
+  # shellcheck disable=SC2086
+  if ! $GIT_CMD rebase "origin/$DEFAULT_BRANCH"; then
+    # shellcheck disable=SC2086
+    $GIT_CMD rebase --abort || true
+    in_die "rebase 충돌 — 사람 위임(force 금지): $branch ← origin/$DEFAULT_BRANCH"; return 1
+  fi
+}
+
+in_push_branch() {
+  # shellcheck disable=SC2086
+  $GIT_CMD push origin "$1" || { in_die "push 실패(force 금지): $1"; return 1; }
+}
+
+# =====================================================================
+# 4) PR 생성/재사용 — 같은 head 의 open PR 이 있으면 재사용.
+# =====================================================================
+
+in_existing_open_pr() {
+  # shellcheck disable=SC2086
+  $FORGE_CMD pr list --head "$1" --state open 2>/dev/null \
+    | awk 'NR==1 { print $1 }' | tr -d '#'
+}
+
+# in_ensure_pr <branch> <title> — open PR 재사용 또는 신규 생성. PR 번호 echo.
+in_ensure_pr() {
+  local branch="$1" title="$2" n
+  n="$(in_existing_open_pr "$branch")"
+  if [[ -n "$n" ]]; then printf '%s\n' "$n"; return 0; fi
+  # shellcheck disable=SC2086
+  $FORGE_CMD pr create --head "$branch" --base "$DEFAULT_BRANCH" \
+    --title "$title" --body "dispatch 통합: 구현 완료, 승인 요청." \
+    >/dev/null 2>&1 || { in_die "PR 생성 실패: $branch"; return 1; }
+  in_existing_open_pr "$branch"
+}
+
+# =====================================================================
+# 5) 메인 진입 — 한 SPEC 의 종료 신호를 읽어 매핑·통합한다.
+# =====================================================================
+
+# in_integrate <spec> <run_dir> <key>
+#   반환: 0=통합 성공(int-phase=review) / 3=spec-gap 차단 / 4=하드 차단 / 20=미종료(대기).
+in_integrate() {
+  local spec="$1" rd="$2" key="$3"
+  [[ -n "$spec" && -n "$rd" && -n "$key" ]] || { in_die "사용: integration.sh integrate <spec> <run_dir> <key>"; return 1; }
+  mkdir -p "$rd"
+  local rid; rid="$(basename "$rd")"
+
+  local term; term="$(in_child_terminal_state "$spec")"
+  int_log "$rd" "$key" "integrate spec=$spec terminal=$term"
+
+  case "$term" in
+    done)
+      local branch; branch="$(in_work_branch "$rid" "$spec")" || { int_set_phase "$rd" "$key" blocked; return 4; }
+      int_set_branch "$rd" "$key" "$branch"
+      int_set_phase "$rd" "$key" integrating
+      int_log "$rd" "$key" "base sync → push → PR (branch=$branch)"
+      in_base_sync   "$branch" || { int_set_phase "$rd" "$key" blocked; return 4; }
+      in_push_branch "$branch" || { int_set_phase "$rd" "$key" blocked; return 4; }
+      local title pr
+      title="$(in_spec_title "$spec")"
+      pr="$(in_ensure_pr "$branch" "$title")" || { int_set_phase "$rd" "$key" blocked; return 4; }
+      [[ -n "$pr" ]] && int_set_pr "$rd" "$key" "$pr"
+      int_set_phase "$rd" "$key" review
+      int_log "$rd" "$key" "PR=$pr 인계 — review 대기"
+      echo "key:    $key"
+      echo "phase:  review"
+      echo "branch: $branch"
+      echo "pr:     $pr"
+      return 0
+      ;;
+    failed)
+      local cat; cat="$(in_blocked_category "$spec")"
+      if [[ "$cat" == "spec-gap" ]]; then
+        int_set_phase "$rd" "$key" blocked-spec-gap
+        int_log "$rd" "$key" "BLOCKED spec-gap → 스펙 보강 재개 경로 안내(push·PR 안 함)"
+        echo "key:      $key"
+        echo "phase:    blocked-spec-gap"
+        echo "category: spec-gap"
+        echo "resume:   스펙 강화 후 dispatch --resume 로 재개하세요(push·PR 미수행)."
+        return 3
+      else
+        int_set_phase "$rd" "$key" blocked
+        int_log "$rd" "$key" "하드 차단($cat) → 사람 에스컬레이션(push·PR 안 함)"
+        echo "key:      $key"
+        echo "phase:    blocked"
+        echo "category: $cat"
+        echo "escalate: 사람 판단 필요(push·PR 미수행)."
+        return 4
+      fi
+      ;;
+    running|pending)
+      echo "key:      $key"
+      echo "terminal: $term (아직 종료 신호 없음 — 통합 보류)"
+      return 20
+      ;;
+    *)
+      int_set_phase "$rd" "$key" blocked
+      in_die "알 수 없는 terminal state: $term (보수적으로 하드 차단 처리)"
+      return 4
+      ;;
+  esac
+}
+
+# ----- 사용법 -----
+in_usage() {
+  cat >&2 <<'EOF'
+usage: integration.sh <command> [args]
+
+Commands:
+  integrate <spec> <run_dir> <key>   종료 신호를 읽어 매핑·통합:
+                                        DONE→push→PR(phase=review) /
+                                        spec-gap→blocked-spec-gap / 하드 BLOCKED→blocked.
+  terminal  <spec>                   child 종료 상태(done|failed|running|pending|unknown).
+  category  <spec>                   BLOCKED 범주(spec-gap|...|other).
+
+환경 변수: LOOP_CMD, GIT_CMD, FORGE_CMD, DEFAULT_BRANCH
+EOF
+  return 1
+}
+
+# =====================================================================
+# selftest — mock 인터페이스(loop/git/forge)로 통합 분기·force 미사용 독립 검증.
+# =====================================================================
+in_selftest() {
+  local TMP; TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' RETURN
+  local rd="$TMP/.dispatch/runs/20260604T000000-abc1234"; mkdir -p "$rd"
+
+  # mock loop: status --json / logs 를 spec 별 파일로 흉내.
+  local LP="$TMP/loop"; mkdir -p "$LP"
+  mock_loop() {
+    case "$1" in
+      status) shift; [[ "$1" == "--json" ]] && shift; cat "$LP/$(basename "$1").json" 2>/dev/null || true ;;
+      logs)   cat "$LP/$(basename "$2").logs" 2>/dev/null || true ;;
+    esac
+  }
+  export -f mock_loop 2>/dev/null || true
+  LOOP_CMD=mock_loop
+
+  # mock git: force 인자 보면 exit99(selftest 즉사). push/fetch/checkout/rebase 기록.
+  local PUSHLOG="$TMP/pushlog" GITLOG="$TMP/gitlog"; : > "$PUSHLOG"; : > "$GITLOG"
+  mock_git() {
+    local a; for a in "$@"; do case "$a" in *force*|-f) echo "FORCE USED" >&2; exit 99;; esac; done
+    printf '%s\n' "$*" >> "$GITLOG"
+    case "$1" in
+      push) printf '%s\n' "$*" >> "$PUSHLOG" ;;
+      rebase|fetch|checkout) : ;;
+    esac
+    return 0
+  }
+  GIT_CMD=mock_git
+
+  # mock forge: pr list(재사용 제어 MOCK_PR), pr create 기록.
+  local PRLOG="$TMP/prlog"; : > "$PRLOG"
+  mock_forge() {
+    case "$1 $2" in
+      "pr list")   [[ -n "${MOCK_EXISTING_PR:-}" ]] && echo "$MOCK_EXISTING_PR" || true ;;
+      "pr create") printf '%s\n' "$*" >> "$PRLOG"; echo created ;;
+    esac
+    return 0
+  }
+  FORGE_CMD=mock_forge
+  DEFAULT_BRANCH=main
+
+  local spec="$TMP/SPEC.md"
+  printf '# 멋진 기능 X\n\n## 무엇\n...\n' > "$spec"
+
+  local fail=0 rc out
+  ok()  { echo "PASS  $1"; }
+  bad() { echo "FAIL  $1"; fail=1; }
+  chk() { if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
+
+  st_done()    { printf '{"state":"terminal","signals":["DONE"]}\n'; }
+  st_blocked() { printf '{"state":"terminal","signals":["BLOCKED"]}\n'; }
+  st_running() { printf '{"state":"running","signals":[]}\n'; }
+
+  # ---- AC: DONE → base sync→push→PR, phase=review, branch/pr 기록 ----
+  local kA="x-aaa1111"
+  st_done > "$LP/SPEC.md.json"; : > "$LP/SPEC.md.logs"
+  MOCK_EXISTING_PR="" out="$(in_integrate "$spec" "$rd" "$kA")"; rc=$?
+  chk "AC2 DONE 통합 rc=0" "$rc" "0"
+  chk "AC2 phase=review" "$(int_get_phase "$rd" "$kA")" "review"
+  chk "AC2 branch=feat/<rid>-<slug>" "$(int_get_branch "$rd" "$kA")" "feat/20260604T000000-abc1234-x"
+  grep -q 'feat/20260604T000000-abc1234-x' "$PUSHLOG" && ok "AC2 작업 브랜치 push" || bad "AC2 작업 브랜치 push"
+  grep -q 'pr create' "$PRLOG" && ok "AC2 PR 생성" || bad "AC2 PR 생성"
+  grep -q 'rebase' "$GITLOG" && ok "AC2 base sync rebase" || bad "AC2 base sync rebase"
+
+  # ---- AC: open PR 존재 → 재사용(새 PR 미생성) ----
+  local kR="x-rrr2222"; : > "$PRLOG"
+  MOCK_EXISTING_PR="55" in_integrate "$spec" "$rd" "$kR" >/dev/null; rc=$?
+  chk "AC2 재사용 rc=0" "$rc" "0"
+  chk "AC2 재사용 pr=55" "$(int_get_pr "$rd" "$kR")" "55"
+  [[ ! -s "$PRLOG" ]] && ok "AC2 open PR 재사용(새 PR 미생성)" || bad "AC2 open PR 재사용(새 PR 미생성)"
+
+  # ---- AC9: spec-gap BLOCKED → push·PR 없이 blocked-spec-gap ----
+  local kS="x-sss3333"; : > "$PUSHLOG"; : > "$PRLOG"
+  st_blocked > "$LP/SPEC.md.json"; printf 'category: spec-gap\n' > "$LP/SPEC.md.logs"
+  out="$(in_integrate "$spec" "$rd" "$kS")"; rc=$?
+  chk "AC9 spec-gap rc=3" "$rc" "3"
+  chk "AC9 phase=blocked-spec-gap" "$(int_get_phase "$rd" "$kS")" "blocked-spec-gap"
+  case "$out" in *resume*) ok "AC9 재개 안내";; *) bad "AC9 재개 안내";; esac
+  [[ ! -s "$PUSHLOG" && ! -s "$PRLOG" ]] && ok "AC9 spec-gap push·PR 미수행" || bad "AC9 spec-gap push·PR 미수행"
+
+  # ---- AC9: 하드 BLOCKED → push·PR 없이 blocked ----
+  local kH="x-hhh4444"; : > "$PUSHLOG"; : > "$PRLOG"
+  st_blocked > "$LP/SPEC.md.json"; printf 'category: environment-gap\n' > "$LP/SPEC.md.logs"
+  out="$(in_integrate "$spec" "$rd" "$kH")"; rc=$?
+  chk "AC9 하드 BLOCKED rc=4" "$rc" "4"
+  chk "AC9 phase=blocked" "$(int_get_phase "$rd" "$kH")" "blocked"
+  case "$out" in *escalate*) ok "AC9 에스컬레이션 안내";; *) bad "AC9 에스컬레이션 안내";; esac
+  [[ ! -s "$PUSHLOG" && ! -s "$PRLOG" ]] && ok "AC9 하드 push·PR 미수행" || bad "AC9 하드 push·PR 미수행"
+
+  # ---- 미종료(running) → 통합 보류 no-op ----
+  local kP="x-ppp5555"
+  st_running > "$LP/SPEC.md.json"
+  in_integrate "$spec" "$rd" "$kP" >/dev/null; rc=$?
+  chk "running rc=20(보류)" "$rc" "20"
+  chk "running phase 미설정" "$(int_get_phase "$rd" "$kP")" ""
+
+  # ---- AC: force 미사용 (mock_git 은 force 보면 exit99; 여기 도달했으면 미사용) ----
+  [[ -s "$PUSHLOG" || -s "$GITLOG" ]] && ok "git/push 실제 수행됨" || bad "git/push 실제 수행됨"
+  if grep -qiE 'force|(^| )-f( |$)' "$GITLOG"; then bad "force 미사용"; else ok "force 미사용(git 인자에 force 없음)"; fi
+
+  echo "----"
+  [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"
+  return $fail
+}
+
+# ----- CLI 진입 (sourcing 시 미실행) -----
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SUB="${1:-}"; shift || true
+  case "$SUB" in
+    integrate) in_integrate "$@" ;;
+    terminal)  [[ $# -ge 1 ]] || in_usage; in_child_terminal_state "$1" ;;
+    category)  [[ $# -ge 1 ]] || in_usage; in_blocked_category "$1" ;;
+    selftest)  in_selftest ;;
+    -h|--help|help) in_usage ;;
+    *) echo "알 수 없는 command: $SUB" >&2; in_usage ;;
+  esac
+fi

--- a/plugins/autopilot/skills/dispatch/references/integration.sh
+++ b/plugins/autopilot/skills/dispatch/references/integration.sh
@@ -130,6 +130,18 @@ in_base_sync() {
   $GIT_CMD fetch origin "$DEFAULT_BRANCH" || { in_die "fetch 실패: origin/$DEFAULT_BRANCH"; return 1; }
   # shellcheck disable=SC2086
   $GIT_CMD checkout "$branch" || { in_die "checkout 실패: $branch"; return 1; }
+  # origin/main 이 이미 브랜치 조상이면 동기화 불필요 — 재작성 없이 push 는 fast-forward.
+  # shellcheck disable=SC2086
+  if $GIT_CMD merge-base --is-ancestor "origin/$DEFAULT_BRANCH" "$branch" 2>/dev/null; then
+    return 0
+  fi
+  # base 가 전진했고 원격 브랜치(open PR)가 이미 있으면, rebase 재작성은 SHA 를 바꿔
+  # force 없는 push 를 non-fast-forward 로 실패시킨다(force 금지). 따라서 재작성하지 않고
+  # 그대로 둔다 — base 정합은 머지 단계의 ff-only 게이트가 별도로 강제한다(여기서 force·
+  # 재작성하지 않는다). 최초 통합(원격 브랜치 미존재)에서만 rebase 후 새 브랜치 push(ff-safe).
+  if [[ -n "$(in_existing_open_pr "$branch")" ]]; then
+    return 0
+  fi
   # shellcheck disable=SC2086
   if ! $GIT_CMD rebase "origin/$DEFAULT_BRANCH"; then
     # shellcheck disable=SC2086
@@ -275,6 +287,8 @@ in_selftest() {
     printf '%s\n' "$*" >> "$GITLOG"
     case "$1" in
       push) printf '%s\n' "$*" >> "$PUSHLOG" ;;
+      # merge-base --is-ancestor: MOCK_ANCESTOR=1 이면 조상(0), 기본 비조상(1).
+      merge-base) [[ "${MOCK_ANCESTOR:-0}" == "1" ]] && return 0 || return 1 ;;
       rebase|fetch|checkout) : ;;
     esac
     return 0
@@ -316,12 +330,14 @@ in_selftest() {
   grep -q 'pr create' "$PRLOG" && ok "AC2 PR 생성" || bad "AC2 PR 생성"
   grep -q 'rebase' "$GITLOG" && ok "AC2 base sync rebase" || bad "AC2 base sync rebase"
 
-  # ---- AC: open PR 존재 → 재사용(새 PR 미생성) ----
-  local kR="x-rrr2222"; : > "$PRLOG"
+  # ---- AC: open PR 존재 → 재사용(새 PR 미생성) + 기존 브랜치 rebase 재작성 안 함 ----
+  #   (Codex blocking 회귀 가드: base 전진+원격 브랜치 존재 시 rebase 는 non-ff push 를 부른다.)
+  local kR="x-rrr2222"; : > "$PRLOG"; : > "$GITLOG"
   MOCK_EXISTING_PR="55" in_integrate "$spec" "$rd" "$kR" >/dev/null; rc=$?
   chk "AC2 재사용 rc=0" "$rc" "0"
   chk "AC2 재사용 pr=55" "$(int_get_pr "$rd" "$kR")" "55"
   [[ ! -s "$PRLOG" ]] && ok "AC2 open PR 재사용(새 PR 미생성)" || bad "AC2 open PR 재사용(새 PR 미생성)"
+  if grep -q 'rebase' "$GITLOG"; then bad "기존 PR 재통합 시 rebase 재작성(non-ff 위험)"; else ok "기존 PR 재통합 시 rebase 재작성 안 함(non-ff 회피)"; fi
 
   # ---- AC9: spec-gap BLOCKED → push·PR 없이 blocked-spec-gap ----
   local kS="x-sss3333"; : > "$PUSHLOG"; : > "$PRLOG"

--- a/plugins/autopilot/skills/dispatch/references/lib-integration.sh
+++ b/plugins/autopilot/skills/dispatch/references/lib-integration.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# lib-integration.sh — autopilot:dispatch per-SPEC 통합 상태 헬퍼 (M1)
+#
+# 책임:
+#   - 한 SPEC 의 통합(push→PR)·리뷰·머지 라이프사이클 상태를 dispatch 의 기존 run
+#     디렉토리(<project_root>/.dispatch/runs/<run-id>/) 하위에 per-SPEC 키로 보관·조회.
+#     보관 필드(파일): branch / pr / head / review-round / review-verdict /
+#                      review-blocking-hash / int-phase.
+#   - 키는 호출자가 계산해 넘긴다(dispatch.sh 의 spec_slug+hash7 산식과 일치하는
+#     `<slug>-<hash7>`). 이 헬퍼는 키를 불투명 문자열로만 다뤄 독립 검증 가능하다.
+#
+# **하지 않는 일**:
+#   - slug/hash 산식 정의(호출자 책임), forge·git·loop 연동, 상태 전이 정책.
+#   - dispatch.sh 의 per-SPEC 실행 상태 파일(state.<key>)은 건드리지 않는다 —
+#     통합 필드는 별도 네임스페이스(int.<key>.<field>)에 둬 회귀를 막는다.
+#
+# 이 헬퍼는 sourcing 으로 쓴다. run 디렉토리 밖 경로는 만들지 않는다.
+# bash 3.2+ 호환 (associative array 미사용).
+
+# ----- 필드 IO (run_dir + 불투명 key) -----
+
+int_now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# int_field_path <run_dir> <key> <field>
+int_field_path() {
+  echo "$1/int.$2.$3"
+}
+
+# int_set <run_dir> <key> <field> <value>
+int_set() {
+  local rd="$1" key="$2" field="$3" value="$4"
+  mkdir -p "$rd"
+  printf '%s\n' "$value" > "$(int_field_path "$rd" "$key" "$field")"
+}
+
+# int_get <run_dir> <key> <field> [default]
+int_get() {
+  local rd="$1" key="$2" field="$3" def="${4:-}"
+  local f; f="$(int_field_path "$rd" "$key" "$field")"
+  if [[ -f "$f" ]]; then cat "$f"; else printf '%s\n' "$def"; fi
+}
+
+# ----- 의미 래퍼 -----
+
+int_set_branch()  { int_set "$1" "$2" branch "$3"; }
+int_get_branch()  { int_get "$1" "$2" branch ""; }
+
+int_set_pr()      { int_set "$1" "$2" pr "$3"; }
+int_get_pr()      { int_get "$1" "$2" pr ""; }
+
+int_set_head()    { int_set "$1" "$2" head "$3"; }
+int_get_head()    { int_get "$1" "$2" head ""; }
+
+int_set_verdict() { int_set "$1" "$2" review-verdict "$3"; }
+int_get_verdict() { int_get "$1" "$2" review-verdict ""; }
+
+int_set_blocking_hash() { int_set "$1" "$2" review-blocking-hash "$3"; }
+int_get_blocking_hash() { int_get "$1" "$2" review-blocking-hash ""; }
+
+# int-phase — per-SPEC 통합 라이프사이클 단계(스케줄러가 읽는 sub-state).
+#   loop-done|integrating|review|approved|merging|merged|escalated|blocked
+int_set_phase()   { int_set "$1" "$2" int-phase "$3"; }
+int_get_phase()   { int_get "$1" "$2" int-phase ""; }
+
+# review-round 카운터.
+int_review_round() { int_get "$1" "$2" review-round "0"; }
+int_bump_review_round() {
+  local rd="$1" key="$2" n
+  n=$(( $(int_review_round "$rd" "$key") + 1 ))
+  int_set "$rd" "$key" review-round "$n"
+  echo "$n"
+}
+
+# int_log <run_dir> <key> <message...> — run-dir LOG.md 에 키 prefix 로 append.
+int_log() {
+  local rd="$1" key="$2"; shift 2
+  mkdir -p "$rd"
+  printf '[%s] [%s] %s\n' "$(int_now_iso)" "$key" "$*" >> "$rd/LOG.md"
+}
+
+# =====================================================================
+# selftest — 순수 파일 IO 헬퍼를 독립 검증(runtime artifact 미검사).
+# =====================================================================
+li_selftest() {
+  local TMP; TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' RETURN
+  local rd="$TMP/.dispatch/runs/run1"
+  local k="feat-x-abc1234"
+  local fail=0
+  ok()  { echo "PASS  $1"; }
+  bad() { echo "FAIL  $1"; fail=1; }
+  chk() { if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
+
+  # 기본값: 미설정 필드는 default 반환.
+  chk "기본 branch 빈값"      "$(int_get_branch "$rd" "$k")" ""
+  chk "기본 review-round 0"   "$(int_review_round "$rd" "$k")" "0"
+  chk "기본 phase 빈값"       "$(int_get_phase "$rd" "$k")" ""
+  chk "기본 default 적용"     "$(int_get "$rd" "$k" nope fallback)" "fallback"
+
+  # set/get 왕복.
+  int_set_branch "$rd" "$k" "feat/run1-x"
+  chk "branch 왕복"           "$(int_get_branch "$rd" "$k")" "feat/run1-x"
+  int_set_pr "$rd" "$k" "42"
+  chk "pr 왕복"               "$(int_get_pr "$rd" "$k")" "42"
+  int_set_head "$rd" "$k" "sha-AAA"
+  chk "head 왕복"             "$(int_get_head "$rd" "$k")" "sha-AAA"
+  int_set_verdict "$rd" "$k" "approve"
+  chk "verdict 왕복"          "$(int_get_verdict "$rd" "$k")" "approve"
+  int_set_blocking_hash "$rd" "$k" "deadbeef"
+  chk "blocking-hash 왕복"    "$(int_get_blocking_hash "$rd" "$k")" "deadbeef"
+  int_set_phase "$rd" "$k" "review"
+  chk "phase 왕복"            "$(int_get_phase "$rd" "$k")" "review"
+
+  # round 증가.
+  chk "bump→1"                "$(int_bump_review_round "$rd" "$k")" "1"
+  chk "bump→2"                "$(int_bump_review_round "$rd" "$k")" "2"
+  chk "round 영속=2"          "$(int_review_round "$rd" "$k")" "2"
+
+  # 키 격리: 다른 키는 서로 영향 없음.
+  local k2="feat-y-def5678"
+  int_set_branch "$rd" "$k2" "feat/run1-y"
+  chk "키 격리 k"             "$(int_get_branch "$rd" "$k")" "feat/run1-x"
+  chk "키 격리 k2"            "$(int_get_branch "$rd" "$k2")" "feat/run1-y"
+
+  # dispatch 실행 상태(state.<key>)와 네임스페이스 분리 — int.* 만 만든다.
+  [[ -z "$(ls "$rd"/state.* 2>/dev/null)" ]] && ok "state.* 미생성(네임스페이스 분리)" \
+    || bad "state.* 미생성(네임스페이스 분리)"
+
+  # 로그 append.
+  int_log "$rd" "$k" "hello"
+  grep -q 'hello' "$rd/LOG.md" && ok "log append" || bad "log append"
+
+  echo "----"
+  [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"
+  return $fail
+}
+
+# ----- CLI 진입 (sourcing 시 미실행) -----
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  case "${1:-}" in
+    selftest) li_selftest ;;
+    *) echo "usage: lib-integration.sh selftest  (라이브러리는 sourcing 으로 사용)" >&2; exit 1 ;;
+  esac
+fi

--- a/plugins/autopilot/skills/dispatch/references/merge.sh
+++ b/plugins/autopilot/skills/dispatch/references/merge.sh
@@ -99,15 +99,45 @@ mg_touches_watch_dir() {
 mg_changed_manifests() {
   mg_merge_changed_files "$1" | grep -E '(^|/)plugin\.json$' || true
 }
+# mg_json_version <ref> <path> — 해당 ref 의 plugin.json 에서 version 값(예 0.19.0) 추출.
+#   없으면 빈 문자열. diff 라인 존재가 아니라 실제 값을 본다.
+mg_json_version() {
+  # shellcheck disable=SC2086
+  $GIT_CMD show "$1:$2" 2>/dev/null \
+    | grep -m1 -E '"version"[[:space:]]*:' \
+    | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"?([0-9][0-9.]*)"?.*/\1/'
+}
+
+# mg_semver_gt <new> <old> — new 가 old 보다 큰 SemVer 면 0, 아니면 1.
+#   old 가 비었으면(신규 매니페스트) new 만 있으면 0(증가로 간주). major.minor.patch 를
+#   필드별 숫자 비교(bash 3.2, 외부 도구 없이).
+mg_semver_gt() {
+  local new="$1" old="$2"
+  [[ -n "$new" ]] || return 1
+  [[ -n "$old" ]] || return 0
+  local oldIFS="$IFS"; IFS=.
+  # shellcheck disable=SC2206
+  local -a na=($new) oa=($old); IFS="$oldIFS"
+  local i n o
+  for ((i=0; i<3; i++)); do
+    n="${na[i]:-0}"; o="${oa[i]:-0}"
+    n="${n//[!0-9]/}"; o="${o//[!0-9]/}"
+    [[ -n "$n" ]] || n=0; [[ -n "$o" ]] || o=0
+    if (( 10#$n > 10#$o )); then return 0; fi
+    if (( 10#$n < 10#$o )); then return 1; fi
+  done
+  return 1   # 모든 필드 동일 → 증가 아님(같은 값 재기입·재정렬 차단).
+}
+
+# mg_manifest_version_bumped <branch> — 변경된 plugin.json 중 하나라도 base 대비
+#   실제 SemVer 가 증가했으면 0. 추가된 "version" 라인 존재가 아니라 old/new 값 비교.
 mg_manifest_version_bumped() {
-  local branch="$1" m
+  local branch="$1" m oldv newv
   while IFS= read -r m; do
     [[ -n "$m" ]] || continue
-    # shellcheck disable=SC2086
-    if $GIT_CMD diff "origin/$DEFAULT_BRANCH...$branch" -- "$m" 2>/dev/null \
-        | grep -qE '^\+[[:space:]]*"version"'; then
-      return 0
-    fi
+    oldv="$(mg_json_version "origin/$DEFAULT_BRANCH" "$m")"
+    newv="$(mg_json_version "$branch" "$m")"
+    if mg_semver_gt "$newv" "$oldv"; then return 0; fi
   done < <(mg_changed_manifests "$branch")
   return 1
 }
@@ -239,7 +269,15 @@ mg_selftest() {
     case "$1" in
       diff)
         if [[ "$*" == *"--name-only"* ]]; then printf '%s\n' ${MOCK_FILES:-}; return 0; fi
-        [[ -n "${MOCK_BUMP:-}" ]] && echo '+  "version": "9.9.9"'
+        ;;
+      show)
+        # git show <ref>:<path> — plugin.json version 값 시뮬(실제 값 비교 경로).
+        #   base(origin/*)=1.0.0. branch: MOCK_BUMP=1 → 1.1.0(증가), MOCK_BUMP=same →
+        #   1.0.0(동일, 차단되어야 함), 그 외 → 1.0.0.
+        case "$2" in
+          origin/*) echo '  "version": "1.0.0"' ;;
+          *) if [[ "${MOCK_BUMP:-}" == "1" ]]; then echo '  "version": "1.1.0"'; else echo '  "version": "1.0.0"'; fi ;;
+        esac
         ;;
     esac
     return 0
@@ -302,6 +340,13 @@ mg_selftest() {
     mg_merge_finish "$spec" "$rd" k5 >/dev/null 2>&1; rc=$?
   chk "AC7 워치+범프있음 rc=0" "$rc" "0"
   has 'git merge --ff-only' && ok "AC7 범프시 머지" || bad "AC7 범프시 머지"
+
+  # ---- 같은 version 값 재기입(라인은 추가되나 값 동일) → 차단 (Codex blocking 회귀 가드) ----
+  reset; setup k6
+  MOCK_REVIEWS=$'APPROVED\tapprover-bot' MOCK_FILES="plugins/autopilot/.claude-plugin/plugin.json" MOCK_BUMP="same" \
+    mg_merge_finish "$spec" "$rd" k6 >/dev/null 2>&1; rc=$?
+  chk "동일 버전 재기입 rc=1(차단)" "$rc" "1"
+  if has 'git merge --ff-only'; then bad "동일 버전인데 머지함"; else ok "동일 버전 → 머지 안 함"; fi
 
   # ---- AC6: approver 신원으로 승인 제출(approve action) ----
   reset

--- a/plugins/autopilot/skills/dispatch/references/merge.sh
+++ b/plugins/autopilot/skills/dispatch/references/merge.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# merge.sh — autopilot:dispatch per-SPEC 승인+머지 (M4)
+#
+# 책임 (파이프라인 종착: "승인되면 머지되고 SPEC 은 done(=머지됨)이 된다"):
+#   - 승인 제출(분리 신원): 리뷰가 approve 로 수렴하면 **분리된 자율 approver 신원**으로
+#     PR 을 승인한다(APPROVE_CMD). 자동 리뷰 봇(REVIEW_BOT)으로는 승인하지 않는다.
+#   - 승인 확인: PR 에 approver 신원의 APPROVED 정식 리뷰가 있는지 확인한다. 자동 리뷰 봇의
+#     self-approve 는 무효(분리된 approver 신원의 승인만 인정).
+#   - 버전 범프 게이트: 머지될 변경이 워치 디렉토리(plugins/)를 건드리면 같은 변경 안에서
+#     plugin.json 버전이 올랐는지 단언한다. 안 올랐으면 머지 차단(비완료 종착).
+#   - 머지: default 브랜치에 fast-forward 전용(--ff-only)으로 머지(+base push). 머지 커밋·
+#     force 금지. main 체크아웃+머지 구간은 run-dir 락으로 **직렬화**한다(동시 머지 레이스 차단).
+#   - 완료: 머지 확인되면 int-phase=merged(스케줄러가 SPEC 을 done 으로 전이) + 작업 공간
+#     정리를 loop 의 공개 cleanup 인터페이스로 위임.
+#
+# 불변식:
+#   - force(강제) 머지·push 금지. 머지는 git merge --ff-only 만.
+#   - 작업 공간은 직접 지우지 않고 loop 공개 cleanup 으로만 위임.
+#   - per-SPEC 상태는 lib-integration.sh(run-dir + 키)로만. 키는 호출자 주입.
+#   - 버전 게이트는 rules/engineering/versioning.md 실행자.
+#
+# 모든 외부 인터페이스(git·forge·loop·approve CLI)는 주입 가능. mock 으로 독립 검증
+# (self-referential: 실제 머지·PR 미수행). bash 3.2+ 호환.
+#
+# 환경 변수 (mock 치환 가능):
+#   GIT_CMD/FORGE_CMD/LOOP_CMD/DEFAULT_BRANCH   integration.sh 와 공유.
+#   APPROVER        승인 권한 신원 login(설정 시 그 신원의 승인만 인정).
+#   REVIEW_BOT      자동 리뷰 봇 login(이 신원의 self-approve 는 무효).
+#   APPROVE_CMD <pr>  PR 승인 제출(기본: gh pr review <pr> --approve). approver 신원 자격으로.
+#   WATCH_DIRS      버전 워치 디렉토리 prefix(기본: plugins/).
+
+set -uo pipefail
+
+MG_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 통합 모듈(M2) → lib-integration(M1) 확보.
+if ! declare -f int_set >/dev/null 2>&1; then
+  # shellcheck source=lib-integration.sh
+  . "$MG_SCRIPT_DIR/lib-integration.sh"
+fi
+set +e
+set -uo pipefail
+
+GIT_CMD="${GIT_CMD:-git}"
+FORGE_CMD="${FORGE_CMD:-gh}"
+LOOP_CMD_DEFAULT="bash $MG_SCRIPT_DIR/../../loop/references/loop.sh"
+LOOP_CMD="${LOOP_CMD:-$LOOP_CMD_DEFAULT}"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+APPROVER="${APPROVER:-}"
+REVIEW_BOT="${REVIEW_BOT:-}"
+WATCH_DIRS="${WATCH_DIRS:-plugins/}"
+APPROVE_CMD="${APPROVE_CMD:-mg_approve_gh}"
+
+mg_die() { echo "merge: $*" >&2; return 1; }
+
+# ===== 1) 승인 제출 — 분리된 approver 신원으로 PR 승인 =====
+mg_approve_gh() {
+  local pr="$1"
+  command -v gh >/dev/null 2>&1 || { mg_die "gh CLI 필요"; return 1; }
+  gh pr review "$pr" --approve >/dev/null 2>&1
+}
+
+# mg_submit_approval <pr> — approver 신원으로 승인 제출(REVIEW_BOT 로는 승인 안 함).
+mg_submit_approval() {
+  local pr="$1"
+  [[ -n "$pr" ]] || return 1
+  # shellcheck disable=SC2086
+  $APPROVE_CMD "$pr"
+}
+
+# ===== 2) 승인 확인 — approver 신원의 APPROVED. 리뷰 봇 self-approve 무효 =====
+mg_pr_reviews() {
+  # shellcheck disable=SC2086
+  $FORGE_CMD pr view "$1" --json reviews \
+    --jq '.reviews[] | "\(.state)\t\(.author.login)"' 2>/dev/null
+}
+
+# mg_approval_ok <pr> — approver 신원의 APPROVED 가 있으면 0.
+mg_approval_ok() {
+  local pr="$1" state author
+  [[ -n "$pr" ]] || return 1
+  while IFS=$'\t' read -r state author; do
+    [[ "$state" == "APPROVED" ]] || continue
+    [[ -n "$REVIEW_BOT" && "$author" == "$REVIEW_BOT" ]] && continue   # self-approve 무효
+    [[ -n "$APPROVER" && "$author" != "$APPROVER" ]] && continue       # approver 신원만 인정
+    return 0
+  done < <(mg_pr_reviews "$pr")
+  return 1
+}
+
+# ===== 3) 버전 범프 게이트 — versioning.md 실행자 =====
+mg_merge_changed_files() {
+  # shellcheck disable=SC2086
+  $GIT_CMD diff --name-only "origin/$DEFAULT_BRANCH...$1" 2>/dev/null
+}
+mg_touches_watch_dir() {
+  mg_merge_changed_files "$1" | grep -qE "^$WATCH_DIRS" 2>/dev/null
+}
+mg_changed_manifests() {
+  mg_merge_changed_files "$1" | grep -E '(^|/)plugin\.json$' || true
+}
+mg_manifest_version_bumped() {
+  local branch="$1" m
+  while IFS= read -r m; do
+    [[ -n "$m" ]] || continue
+    # shellcheck disable=SC2086
+    if $GIT_CMD diff "origin/$DEFAULT_BRANCH...$branch" -- "$m" 2>/dev/null \
+        | grep -qE '^\+[[:space:]]*"version"'; then
+      return 0
+    fi
+  done < <(mg_changed_manifests "$branch")
+  return 1
+}
+# mg_version_gate <branch> — 워치 디렉토리 건드리는데 범프 없으면 1(차단). 없으면 0.
+mg_version_gate() {
+  local branch="$1"
+  if mg_touches_watch_dir "$branch"; then
+    mg_manifest_version_bumped "$branch" && return 0
+    return 1
+  fi
+  return 0
+}
+
+# ===== 4) 머지 직렬화 락 — run-dir 단위(mkdir 원자성) =====
+# mg_try_lock <run_dir> — 비차단 획득(성공 0, 점유중 1).
+mg_try_lock() { mkdir "$1/.merge.lock" 2>/dev/null; }
+# mg_release_lock <run_dir>
+mg_release_lock() { rmdir "$1/.merge.lock" 2>/dev/null || true; }
+# mg_acquire_lock <run_dir> [tries] — 바운드 대기 차단 획득(성공 0, 시간초과 1).
+mg_acquire_lock() {
+  local rd="$1" tries="${2:-600}" i=0
+  while ! mg_try_lock "$rd"; do
+    i=$((i+1)); [[ "$i" -ge "$tries" ]] && return 1
+    sleep "${MERGE_LOCK_SLEEP:-1}"
+  done
+  return 0
+}
+
+# ===== 5) ff-only 머지 — 락 보호 구간. 머지 커밋·force 없음 =====
+# mg_merge_ff_only <run_dir> <branch>
+mg_merge_ff_only() {
+  local rd="$1" branch="$2"
+  mg_acquire_lock "$rd" || { mg_die "머지 락 획득 실패(직렬화 대기 초과): $rd"; return 1; }
+  # 임계구간: main 체크아웃 + ff-only 머지 + base push.
+  local rc=0
+  {
+    # shellcheck disable=SC2086
+    $GIT_CMD fetch origin "$DEFAULT_BRANCH" \
+      && $GIT_CMD checkout "$DEFAULT_BRANCH" \
+      && $GIT_CMD merge --ff-only "$branch" \
+      && $GIT_CMD push origin "$DEFAULT_BRANCH"
+  } || rc=$?
+  mg_release_lock "$rd"
+  [[ "$rc" -eq 0 ]] || { mg_die "fast-forward 머지/푸시 실패(머지 커밋·force 금지): $branch → $DEFAULT_BRANCH"; return 1; }
+}
+
+# ===== 6) 정리 — loop 공개 cleanup 위임 =====
+mg_cleanup_workspace() {
+  # shellcheck disable=SC2086
+  $LOOP_CMD cleanup "$1" >/dev/null 2>&1 || echo "WARN: cleanup 위임 실패(수동 정리 필요): $1" >&2
+}
+
+# ===== 7) 메인 진입 — 승인·버전 게이트 통과 시 머지하고 phase=merged =====
+# mg_merge_finish <spec> <run_dir> <key> [pr]
+#   반환: 0=머지 완료(phase=merged) / 1=버전게이트 차단(phase=blocked, 비완료 종착) /
+#         2=미승인(대기, phase 불변).
+mg_merge_finish() {
+  local spec="$1" rd="$2" key="$3" pr="${4:-}"
+  [[ -n "$spec" && -n "$rd" && -n "$key" ]] || { mg_die "사용: merge.sh finish <spec> <run_dir> <key> [pr]"; return 1; }
+  mkdir -p "$rd"
+
+  local branch; branch="$(int_get_branch "$rd" "$key")"
+  [[ -n "$branch" ]] || { mg_die "작업 브랜치 미설정(통합 선행 필요): key=$key"; return 1; }
+  [[ -n "$pr" ]] || pr="$(int_get_pr "$rd" "$key")"
+  int_log "$rd" "$key" "merge_finish spec=$spec branch=$branch pr=$pr"
+
+  # 1) 승인 게이트.
+  if ! mg_approval_ok "$pr"; then
+    int_log "$rd" "$key" "승인 게이트 차단: approver 신원 APPROVED 없음(pr=$pr) — 머지 안 함(대기)"
+    echo "key:     $key"
+    echo "blocked: approval — approver 신원의 '승인됨' 리뷰가 없습니다(pr=$pr)."
+    return 2
+  fi
+
+  # 2) 버전 범프 게이트(비완료 종착).
+  if ! mg_version_gate "$branch"; then
+    int_set_phase "$rd" "$key" blocked
+    int_log "$rd" "$key" "버전 게이트 차단: plugins/ 변경에 plugin.json 범프 없음 — 머지 안 함(비완료 종착)"
+    echo "key:     $key"
+    echo "blocked: version-bump — plugins/ 를 건드리지만 plugin.json 버전이 오르지 않았습니다."
+    return 1
+  fi
+
+  # 3) ff-only 머지(직렬화 락 보호).
+  int_set_phase "$rd" "$key" merging
+  int_log "$rd" "$key" "게이트 통과 → ff-only 머지(직렬화): $branch → $DEFAULT_BRANCH"
+  mg_merge_ff_only "$rd" "$branch" || { int_set_phase "$rd" "$key" blocked; return 1; }
+
+  # 4) 완료.
+  int_set_phase "$rd" "$key" merged
+  mg_cleanup_workspace "$spec"
+  int_log "$rd" "$key" "완료: 머지 확인, phase=merged, 작업 공간 정리 위임."
+  echo "key:     $key"
+  echo "phase:   merged"
+  echo "branch:  $branch → $DEFAULT_BRANCH (ff-only)"
+  echo "pr:      $pr"
+  return 0
+}
+
+# ----- 사용법 -----
+mg_usage() {
+  cat >&2 <<'EOF'
+usage: merge.sh <command> [args]
+
+Commands:
+  approve  <pr>                    분리 approver 신원으로 PR 승인 제출.
+  approval <pr>                    approver 신원 APPROVED 유무(0/1).
+  version-gate <branch>            버전 범프 게이트 판정(0=통과,1=차단).
+  finish <spec> <run_dir> <key> [pr]
+                                   승인·버전 게이트 통과 시 직렬화 ff-only 머지 후
+                                   phase=merged + 작업 공간 정리 위임.
+
+환경 변수: GIT_CMD FORGE_CMD LOOP_CMD DEFAULT_BRANCH APPROVER REVIEW_BOT APPROVE_CMD WATCH_DIRS
+EOF
+  return 1
+}
+
+# =====================================================================
+# selftest — mock 인터페이스로 승인·버전 게이트·ff-only·직렬화 락·force 미사용 검증.
+# =====================================================================
+mg_selftest() {
+  local TMP; TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' RETURN
+  local rd="$TMP/.dispatch/runs/run1"; mkdir -p "$rd"
+  local trace="$TMP/trace"; : > "$trace"
+
+  mock_git() {
+    local a; for a in "$@"; do case "$a" in *force*|-f) echo "FORCE USED" >&2; exit 99;; esac; done
+    echo "git $*" >> "$trace"
+    case "$1" in
+      diff)
+        if [[ "$*" == *"--name-only"* ]]; then printf '%s\n' ${MOCK_FILES:-}; return 0; fi
+        [[ -n "${MOCK_BUMP:-}" ]] && echo '+  "version": "9.9.9"'
+        ;;
+    esac
+    return 0
+  }
+  mock_forge() {
+    echo "forge $*" >> "$trace"
+    if [[ "$1" == "pr" && "$2" == "view" ]]; then printf '%s\n' "${MOCK_REVIEWS:-}"; fi
+    return 0
+  }
+  mock_loop() { echo "loop $*" >> "$trace"; return 0; }
+  mock_approve() { echo "approve $*" >> "$trace"; return 0; }
+  GIT_CMD=mock_git; FORGE_CMD=mock_forge; LOOP_CMD=mock_loop; APPROVE_CMD=mock_approve
+  DEFAULT_BRANCH=main; REVIEW_BOT="auto-review-bot"; APPROVER="approver-bot"
+
+  local spec="$TMP/SPEC.md"; printf '# T\n' > "$spec"
+  local fail=0
+  ok()  { echo "PASS  $1"; }
+  bad() { echo "FAIL  $1"; fail=1; }
+  chk() { if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
+  has()   { grep -q "$1" "$trace"; }
+  setup() { local k="$1"; int_set_branch "$rd" "$k" "feat/run1-$k"; int_set_pr "$rd" "$k" 77; }
+  reset() { : > "$trace"; }
+
+  # ---- AC6/AC7: 승인 O + 워치 변경 없음 → ff-only 머지 + phase=merged + cleanup ----
+  reset; setup k1
+  MOCK_REVIEWS=$'APPROVED\tapprover-bot' MOCK_FILES="README.md" MOCK_BUMP="" \
+    mg_merge_finish "$spec" "$rd" k1 >/dev/null 2>&1; local rc=$?
+  chk "AC7 머지 rc=0" "$rc" "0"
+  has 'git merge --ff-only' && ok "AC7 ff-only 머지 호출" || bad "AC7 ff-only 머지 호출"
+  has 'git push origin main' && ok "AC7 base push" || bad "AC7 base push"
+  chk "AC7 phase=merged" "$(int_get_phase "$rd" k1)" "merged"
+  has 'loop cleanup' && ok "AC7 cleanup 위임" || bad "AC7 cleanup 위임"
+
+  # ---- AC6: 미승인 → 머지 안 함(대기 rc=2) ----
+  reset; setup k2
+  MOCK_REVIEWS=$'COMMENTED\tsomeone' MOCK_FILES="README.md" \
+    mg_merge_finish "$spec" "$rd" k2 >/dev/null 2>&1; rc=$?
+  chk "AC6 미승인 rc=2(대기)" "$rc" "2"
+  if has 'git merge --ff-only'; then bad "AC6 미승인 머지 안 함"; else ok "AC6 미승인 머지 안 함"; fi
+  chk "AC6 미승인 phase 불변" "$(int_get_phase "$rd" k2)" ""
+
+  # ---- AC6: 리뷰 봇 self-approve → 무효 → 머지 안 함 ----
+  reset; setup k3
+  MOCK_REVIEWS=$'APPROVED\tauto-review-bot' MOCK_FILES="README.md" \
+    mg_merge_finish "$spec" "$rd" k3 >/dev/null 2>&1; rc=$?
+  chk "AC6 self-approve 무효 rc=2" "$rc" "2"
+  if has 'git merge --ff-only'; then bad "AC6 self-approve 머지 안 함"; else ok "AC6 self-approve 머지 안 함"; fi
+
+  # ---- AC7: plugins/ 변경 + 범프 없음 → 차단(비완료 종착 rc=1) ----
+  reset; setup k4
+  MOCK_REVIEWS=$'APPROVED\tapprover-bot' MOCK_FILES="plugins/autopilot/.claude-plugin/plugin.json" MOCK_BUMP="" \
+    mg_merge_finish "$spec" "$rd" k4 >/dev/null 2>&1; rc=$?
+  chk "AC7 워치+범프없음 rc=1(차단)" "$rc" "1"
+  if has 'git merge --ff-only'; then bad "AC7 범프없음 머지 안 함"; else ok "AC7 범프없음 머지 안 함"; fi
+  chk "AC7 차단 phase=blocked" "$(int_get_phase "$rd" k4)" "blocked"
+
+  # ---- AC7 반례: plugins/ 변경 + 범프 있음 → 머지 ----
+  reset; setup k5
+  MOCK_REVIEWS=$'APPROVED\tapprover-bot' MOCK_FILES="plugins/autopilot/.claude-plugin/plugin.json" MOCK_BUMP="1" \
+    mg_merge_finish "$spec" "$rd" k5 >/dev/null 2>&1; rc=$?
+  chk "AC7 워치+범프있음 rc=0" "$rc" "0"
+  has 'git merge --ff-only' && ok "AC7 범프시 머지" || bad "AC7 범프시 머지"
+
+  # ---- AC6: approver 신원으로 승인 제출(approve action) ----
+  reset
+  mg_submit_approval 88 >/dev/null
+  has 'approve 88' && ok "AC6 approver 신원 승인 제출" || bad "AC6 approver 신원 승인 제출"
+
+  # ---- AC10: 머지 락 직렬화 — 점유 중엔 두 번째 획득 실패, 해제 후 성공 ----
+  mg_try_lock "$rd" && ok "AC10 락 1차 획득" || bad "AC10 락 1차 획득"
+  if mg_try_lock "$rd"; then bad "AC10 점유 중 2차 획득 차단"; else ok "AC10 점유 중 2차 획득 차단"; fi
+  mg_release_lock "$rd"
+  mg_try_lock "$rd" && ok "AC10 해제 후 재획득" || bad "AC10 해제 후 재획득"
+  mg_release_lock "$rd"
+
+  # ---- force 미사용 (mock_git force 보면 exit99; 위 머지 케이스 통과 = 미사용) ----
+  reset; setup k6
+  MOCK_REVIEWS=$'APPROVED\tapprover-bot' MOCK_FILES="README.md" \
+    mg_merge_finish "$spec" "$rd" k6 >/dev/null 2>&1
+  if grep -qiE 'force|(^| )-f( |$)' "$trace"; then bad "force 미사용"; else ok "force 미사용(git 인자에 force 없음)"; fi
+
+  echo "----"
+  [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"
+  return $fail
+}
+
+# ----- CLI 진입 (sourcing 시 미실행) -----
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  SUB="${1:-}"; shift || true
+  case "$SUB" in
+    approve)      [[ $# -ge 1 ]] || mg_usage; mg_submit_approval "$1" ;;
+    approval)     [[ $# -ge 1 ]] || mg_usage; mg_approval_ok "$1" && echo approved || { echo unapproved; exit 1; } ;;
+    version-gate) [[ $# -ge 1 ]] || mg_usage; mg_version_gate "$1" && echo pass || { echo block; exit 1; } ;;
+    finish)       mg_merge_finish "$@" ;;
+    selftest)     mg_selftest ;;
+    -h|--help|help) mg_usage ;;
+    *) echo "알 수 없는 command: $SUB" >&2; mg_usage ;;
+  esac
+fi

--- a/plugins/autopilot/skills/dispatch/references/review-loop.sh
+++ b/plugins/autopilot/skills/dispatch/references/review-loop.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# review-loop.sh — autopilot:dispatch per-SPEC 리뷰 오케스트레이션 (M3)
+#
+# 책임 (열린 PR 을 승인까지 끌고 가는 한 라운드):
+#   - 판정 산출: autopilot:review 생산자(REVIEW_PRODUCE_CMD)를 한 SPEC(키)에 대해 **1회**
+#     호출해 단일 머신리더블 판정(pipeline_verdict: approve|request_changes|unavailable)과
+#     분류된 재작업 브리프(rework_brief: must_adopt/defer/wont_adopt)를 받는다. 채택 분류는
+#     생산자가 rules/change-adoption.md 를 단일 출처로 수행하며 이 모듈은 소비만 한다.
+#   - 사람/head 게이트(보존): 열린 PR 의 최신 정식 리뷰가 **사람** 리뷰어의 변경 요청이면
+#     자동수정하지 않고 에스컬레이션한다. head 가 직전 처리분과 같으면 멱등 no-op.
+#   - 판정 분기:
+#       request_changes → must_adopt 를 run-dir 하위 SPEC 델타로 만들어 같은 head 브랜치 위에서
+#         자율 실행기로 구현하고 같은 head 브랜치로 push(새 PR 미생성, force 금지). 라운드 카운터
+#         증가. defer 지적은 현 PR 에 섞지 않고 run-dir 에 별도 기록(백로그 분리).
+#       approve         → 머지 진행가능(int-phase=approved). 추가 라운드 미시작.
+#       unavailable     → 에스컬레이션.
+#   - 무한루프 가드(세 겹): 라운드 상한(기본 3) 초과 / must_adopt 0인데 request_changes(무진전) /
+#     차단성(must_adopt) 집합이 직전과 동일(핑퐁) → 에스컬레이션. 수렴 반복은 스케줄러 드레인 소유
+#     (한 호출 = 한 라운드).
+#
+# 이 모듈은 규칙의 실행자다(규칙 재정의 금지):
+#   rules/review.md / rules/change-adoption.md (생산자가 적용; 여기선 소비).
+#
+# 불변식:
+#   - force(강제) push 금지. 새 PR 미생성(같은 head 브랜치 갱신만).
+#   - per-SPEC 상태·델타·defer 는 run 디렉토리(.dispatch/runs/<run-id>/) 안에만 둔다.
+#   - 키는 호출자(스케줄러)가 주입한다(재계산 안 함).
+#
+# 모든 외부 인터페이스(리뷰 생산자·포지 리뷰 메타·자율 실행기·git·forge)는 주입 가능한
+# 명령 변수로 두어 mock 으로 독립 검증한다(self-referential). bash 3.2+ 호환.
+#
+# 환경 변수 (mock 치환 가능):
+#   REVIEW_PRODUCE_CMD <key>      autopilot:review 생산자 호출 → 판정 JSON(stdout).
+#   REVIEW_FETCH_CMD   <pr>       최신 정식 리뷰 메타(state/author/head 줄). 사람/head 게이트 전용.
+#   IMPLEMENT_CMD <spec> <branch> head 브랜치 위 SPEC 델타 자율 구현.
+#   REVIEW_ROUNDS_MAX             라운드 상한(기본 3).
+#   GIT_CMD/FORGE_CMD/LOOP_CMD/DEFAULT_BRANCH   integration.sh 와 공유(push 등).
+
+set -uo pipefail
+
+RL_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# 통합 모듈(M2) 로드 → lib-integration(M1)·in_push_branch·in_work_branch·in_spec_title 확보.
+if ! declare -f in_push_branch >/dev/null 2>&1; then
+  # shellcheck source=integration.sh
+  . "$RL_SCRIPT_DIR/integration.sh"
+fi
+# integration.sh 는 top-level 에서 set -uo pipefail. 본 모듈도 동일(반환코드 직접 처리).
+set +e
+set -uo pipefail
+
+REVIEW_ROUNDS_MAX="${REVIEW_ROUNDS_MAX:-3}"
+REVIEW_BOT_LOGIN_RE="${REVIEW_BOT_LOGIN_RE:-(\[bot\]$|claude|github-actions)}"
+
+REVIEW_FETCH_CMD="${REVIEW_FETCH_CMD:-rl_review_fetch_gh}"
+REVIEW_PRODUCE_CMD="${REVIEW_PRODUCE_CMD:-rl_produce_review_skill}"
+IMPLEMENT_CMD="${IMPLEMENT_CMD:-rl_implement_loop}"
+
+rl_die() { echo "review-loop: $*" >&2; return 1; }
+
+# ===== 기본(gh/생산자/loop) 구현 — self-referential 검증은 mock 으로, 이 경로 미호출 =====
+rl_review_fetch_gh() {
+  local pr="$1"
+  command -v gh >/dev/null 2>&1 || { rl_die "gh CLI 필요"; return 1; }
+  gh pr view "$pr" --json reviews,headRefOid --jq '
+    (.reviews | map(select(.state=="CHANGES_REQUESTED" or .state=="APPROVED" or .state=="COMMENTED")) | last) as $r
+    | "state: \($r.state // "NONE")\nauthor: \($r.author.login // "")\nhead: \(.headRefOid // "")"
+  ' 2>/dev/null
+}
+
+# 기본: autopilot:review 생산자를 per-SPEC 키(=--task)로 1회 호출.
+rl_produce_review_skill() {
+  bash "$RL_SCRIPT_DIR/../review/references/review.sh" run --task "$1"
+}
+
+# 기본: 자율 실행기(loop)에 SPEC 델타 위임. loop 는 --branch 미지원이므로 같은 PR 브랜치 위
+# 재구현은 그 브랜치를 체크아웃한 워크트리 안에서 loop 를 secondary 모드로 호출해 수행한다
+# (SPEC 위험 섹션). 이 기본 경로는 실제 실행이며 selftest 에선 mock 으로 대체된다.
+rl_implement_loop() {
+  local spec="$1" branch="$2"
+  # shellcheck disable=SC2086
+  ${LOOP_CMD:-true} start "$spec" >/dev/null 2>&1
+}
+
+# ===== 리뷰 메타 파싱 (사람/head 게이트 전용) =====
+rl_review_field() {
+  # shellcheck disable=SC2086
+  $REVIEW_FETCH_CMD "$1" 2>/dev/null | grep -i -m1 "^$2:" | sed -E "s/^[^:]*:[[:space:]]*//"
+}
+rl_review_state()  { rl_review_field "$1" state; }
+rl_review_author() { rl_review_field "$1" author; }
+rl_review_head()   { rl_review_field "$1" head; }
+
+rl_is_change_request() {
+  local s; s="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$s" in request_changes|changes_requested) return 0 ;; *) return 1 ;; esac
+}
+rl_is_bot() { printf '%s' "$1" | grep -qiE "$REVIEW_BOT_LOGIN_RE"; }
+
+# ===== rework_brief 채택 분류 소비 (재분류 안 함) =====
+# rl_produce_extract <produce-json> <key> <outfile> — rework_brief.<key> 항목을
+#   "<title> — <body>" 한 줄씩 평탄화. title·body 모두 빈 항목은 제외(무진전 가드 보존).
+rl_produce_extract() {
+  local json="$1" bkey="$2" out="$3"
+  : > "$out"
+  printf '%s' "$json" \
+    | jq -r --arg k "$bkey" '(.rework_brief[$k] // [])[]
+        | ((.title // "") + (if (.body // "") != "" then " — " + .body else "" end))
+        | select(. != "")' \
+        2>/dev/null >> "$out" || true
+}
+
+# rl_blocking_hash <mustfile> — 차단성 집합의 순서무관 안정 해시(핑퐁 탐지).
+rl_blocking_hash() {
+  local f="$1"
+  [[ -s "$f" ]] || { echo "EMPTY"; return 0; }
+  if command -v sha1sum >/dev/null 2>&1; then LC_ALL=C sort "$f" | sha1sum | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then LC_ALL=C sort "$f" | shasum | awk '{print $1}'
+  else LC_ALL=C sort "$f" | cksum | tr -d ' '; fi
+}
+
+# ===== 에스컬레이션 — int-phase=escalated(비완료 종착). 스케줄러가 failed 로 전파. =====
+# rl_escalate <run_dir> <key> <reason>
+rl_escalate() {
+  local rd="$1" key="$2" reason="$3"
+  int_set_phase "$rd" "$key" escalated
+  int_log "$rd" "$key" "에스컬레이션: $reason"
+  echo "escalate: $reason"
+}
+
+# ===== defer 분리 — run-dir 에 백로그로 별도 기록(현 PR 미혼합) =====
+# rl_spinoff_backlog <run_dir> <key> <pr> <deferfile>
+rl_spinoff_backlog() {
+  local rd="$1" key="$2" pr="$3" deferfile="$4"
+  [[ -s "$deferfile" ]] || return 0
+  local out="$rd/backlog.$key.$pr.md" n=0 line text
+  : > "$out"
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    n=$((n+1)); text="${line#*	}"
+    printf '# 후속(백로그): 리뷰 지적 분리 (PR %s #%s)\n원 PR 범위를 넘는 리뷰 지적을 별도로 처리: %s\n\n' "$pr" "$n" "$text" >> "$out"
+    int_log "$rd" "$key" "defer 지적 → 백로그 분리(현 PR 미혼합): $text"
+  done < "$deferfile"
+}
+
+# ===== SPEC 델타 — must 지적을 run-dir 하위 델타 SPEC 으로 =====
+# rl_spec_delta <run_dir> <key> <base-spec> <pr> <mustfile> — 델타 경로 echo.
+rl_spec_delta() {
+  local rd="$1" key="$2" base="$3" pr="$4" mustfile="$5"
+  local out="$rd/delta.$key.$pr.spec.md"
+  if [[ -f "$base" ]] && grep -qF '[NEEDS CLARIFICATION' "$base" 2>/dev/null; then
+    cp "$base" "$out"
+    printf '\n## 리뷰 재개 (PR %s)\n다음 봇 변경 요청을 반영해 미해결 마커를 해소한다:\n' "$pr" >> "$out"
+  else
+    {
+      printf '# 리뷰 델타 (PR %s)\n\n' "$pr"
+      printf '## 무엇을 만들 것인가\n원 SPEC(%s) 의 head 브랜치 위에서 아래 봇 변경 요청을 반영한다.\n\n' "$base"
+      printf '## 수용 기준\n'
+    } > "$out"
+  fi
+  local n=0 line text
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    n=$((n+1)); text="${line#*	}"
+    printf '%s. 시스템은 다음 봇 지적을 반영한다: %s\n' "$n" "$text" >> "$out"
+  done < "$mustfile"
+  echo "$out"
+}
+
+# ===== 한 리뷰 라운드 (원자 단위 = 생산자 1회 호출) =====
+# rl_round <run_dir> <key> <base-spec> <pr> <branch>
+#   반환: 0=재작업 라운드 수행, 10=에스컬레이션, 20=할 일 없음(대기), 30=approve.
+rl_round() {
+  local rd="$1" key="$2" base="$3" pr="$4" branch="$5"
+  mkdir -p "$rd"
+
+  # --- 사람/head 게이트(판정 단일출처 아님; 두 가지만) ---
+  local state author head last
+  state="$(rl_review_state "$pr")"
+  author="$(rl_review_author "$pr")"
+  head="$(rl_review_head "$pr")"
+
+  if rl_is_change_request "$state" && ! rl_is_bot "$author"; then
+    rl_escalate "$rd" "$key" "사람 리뷰어($author)의 변경 요청 — 자동수정 범위 밖"
+    return 10
+  fi
+  last="$(int_get_head "$rd" "$key")"
+  if [[ -n "$head" && "$head" == "$last" ]]; then
+    int_log "$rd" "$key" "head 동일($head) — 새 커밋 없음, 라운드 미시작"
+    return 20
+  fi
+
+  # --- 리뷰 생산자 1회 호출 → 단일 판정 ---
+  local produce verdict
+  # shellcheck disable=SC2086
+  produce="$($REVIEW_PRODUCE_CMD "$key" 2>/dev/null)"
+  verdict="$(printf '%s' "$produce" | jq -r '.pipeline_verdict // ""' 2>/dev/null)"
+
+  case "$verdict" in
+    unavailable)
+      rl_escalate "$rd" "$key" "리뷰 판정 unavailable(diff 잘림·컨텍스트 불완전) — 자동수정 보류"
+      return 10 ;;
+    approve)
+      int_set_verdict "$rd" "$key" approve
+      int_set_head "$rd" "$key" "$head"
+      int_set_phase "$rd" "$key" approved
+      int_log "$rd" "$key" "리뷰 판정 approve — 머지 진행가능 전이(추가 라운드 미시작)"
+      return 30 ;;
+    request_changes) : ;;
+    *)
+      if [[ -z "$produce" ]]; then
+        rl_escalate "$rd" "$key" "리뷰 생산자 출력 비었음(생산 실패·미설정) — 자동수정 보류"
+      else
+        rl_escalate "$rd" "$key" "리뷰 판정 미상(verdict='$verdict') — 생산자 출력 파싱 실패"
+      fi
+      return 10 ;;
+  esac
+
+  # --- request_changes: 재작업 라운드 ---
+  int_set_verdict "$rd" "$key" request_changes
+  local round; round="$(int_bump_review_round "$rd" "$key")"
+  int_log "$rd" "$key" "재작업 라운드 $round 시작 (verdict=request_changes head=$head)"
+  if [[ "$round" -gt "$REVIEW_ROUNDS_MAX" ]]; then
+    rl_escalate "$rd" "$key" "라운드 상한($REVIEW_ROUNDS_MAX) 초과 — 자동수정 중지"
+    return 10
+  fi
+  int_set_head "$rd" "$key" "$head"
+
+  local mustfile deferfile
+  mustfile="$rd/must.$key.$pr"; deferfile="$rd/defer.$key.$pr"
+  rl_produce_extract "$produce" must_adopt "$mustfile"
+  rl_produce_extract "$produce" defer      "$deferfile"
+
+  if [[ ! -s "$mustfile" ]]; then
+    rl_escalate "$rd" "$key" "must_adopt 0 인데 여전히 request_changes — 무진전"
+    return 10
+  fi
+
+  local bh prev
+  bh="$(rl_blocking_hash "$mustfile")"
+  prev="$(int_get_blocking_hash "$rd" "$key")"
+  if [[ -n "$prev" && "$bh" == "$prev" ]]; then
+    rl_escalate "$rd" "$key" "차단성 지적 집합이 직전 라운드와 동일(핑퐁) — 무한루프 차단"
+    return 10
+  fi
+  int_set_blocking_hash "$rd" "$key" "$bh"
+
+  rl_spinoff_backlog "$rd" "$key" "$pr" "$deferfile"
+
+  local delta; delta="$(rl_spec_delta "$rd" "$key" "$base" "$pr" "$mustfile")"
+  # shellcheck disable=SC2086
+  $IMPLEMENT_CMD "$delta" "$branch"
+  in_push_branch "$branch"
+  int_log "$rd" "$key" "라운드 $round: must 구현 → 같은 head 브랜치($branch) push(새 PR 미생성). 재리뷰는 다음 드레인."
+  return 0
+}
+
+# ===== 단일 라운드 진입 (수렴은 스케줄러 드레인 소유) =====
+# rl_review_loop <run_dir> <key> <base-spec> <pr> [branch]
+rl_review_loop() {
+  local rd="$1" key="$2" base="$3" pr="$4" branch="${5:-}"
+  [[ -n "$rd" && -n "$key" && -n "$base" && -n "$pr" ]] \
+    || { rl_die "사용: review-loop.sh run <run_dir> <key> <spec> <pr> [branch]"; return 1; }
+  mkdir -p "$rd"
+  [[ -n "$branch" ]] || branch="$(int_get_branch "$rd" "$key")"
+  [[ -n "$branch" ]] || branch="$(in_work_branch "$(basename "$rd")" "$base")"
+  int_set_branch "$rd" "$key" "$branch"
+
+  rl_round "$rd" "$key" "$base" "$pr" "$branch"
+  case "$?" in
+    0)  echo "review-loop: 재작업 라운드 수행 — 같은 브랜치 재푸시 (key=$key pr=$pr)"; return 0 ;;
+    30) echo "review-loop: approve — 머지 진행가능 (key=$key pr=$pr)"; return 0 ;;
+    20) echo "review-loop: 대기 — 새 커밋 없음 (key=$key pr=$pr)"; return 0 ;;
+    *)  echo "review-loop: 에스컬레이션으로 종료 (key=$key pr=$pr)"; return 0 ;;
+  esac
+}
+
+# =====================================================================
+# selftest — mock 인터페이스로 판정 분기·세 가드·사람/head 게이트·force 미사용 검증.
+# =====================================================================
+rl_selftest() {
+  local TMP; TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' RETURN
+  local rd="$TMP/.dispatch/runs/run1"; mkdir -p "$rd"
+
+  # mock git: force 보면 exit99. push 기록.
+  local PUSHLOG="$TMP/pushlog"; : > "$PUSHLOG"
+  mock_git() {
+    local a; for a in "$@"; do case "$a" in *force*|-f) echo "FORCE USED" >&2; exit 99;; esac; done
+    case "$1" in push) printf '%s\n' "$*" >> "$PUSHLOG" ;; esac
+    return 0
+  }
+  GIT_CMD=mock_git; FORGE_CMD=:; DEFAULT_BRANCH=main
+
+  # mock 구현 위임.
+  local IMPLLOG="$TMP/impllog"; : > "$IMPLLOG"
+  mock_impl() { printf 'impl spec=%s branch=%s\n' "$1" "$2" >> "$IMPLLOG"; }
+  IMPLEMENT_CMD=mock_impl
+
+  # mock 포지 리뷰 메타 + 리뷰 생산자 판정(키별 파일).
+  local RV="$TMP/review"; mkdir -p "$RV"
+  mock_fetch()   { cat "$RV/$1.review" 2>/dev/null || true; }
+  mock_produce() { cat "$RV/$1.produce" 2>/dev/null || true; }
+  REVIEW_FETCH_CMD=mock_fetch; REVIEW_PRODUCE_CMD=mock_produce
+
+  local base="$TMP/base.spec.md"
+  printf '# 원본 기능 SPEC\n## 수용 기준\n1. 항상 X 한다.\n' > "$base"
+
+  local fail=0 rc out delta
+  ok()  { echo "PASS  $1"; }
+  bad() { echo "FAIL  $1"; fail=1; }
+  chk() { if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (want '$3' got '$2')"; fi; }
+
+  forge_meta() { printf 'state: NONE\nauthor: \nhead: %s\n' "$1"; }
+  prod_rc() {
+    local head="$1" must="$2" defer="${3:-}" mj dj='[]'
+    mj="$(jq -n --arg t "$must" '[{title:$t, body:($t+" 상세"), severity:"blocking"}]')"
+    [[ -n "$defer" ]] && dj="$(jq -n --arg t "$defer" '[{title:$t, body:($t+" 상세"), severity:"blocking"}]')"
+    jq -n --arg h "$head" --argjson m "$mj" --argjson d "$dj" \
+      '{pipeline_verdict:"request_changes", reviewed_context:{head_sha:$h},
+        rework_brief:{must_adopt:$m, defer:$d, wont_adopt:[]}}'
+  }
+  prod_rc_empty() { jq -n --arg h "$1" '{pipeline_verdict:"request_changes", reviewed_context:{head_sha:$h}, rework_brief:{must_adopt:[], defer:[], wont_adopt:[]}}'; }
+  prod_simple()   { jq -n --arg h "$1" --arg v "$2" '{pipeline_verdict:$v, reviewed_context:{head_sha:$h}, rework_brief:{must_adopt:[], defer:[], wont_adopt:[]}}'; }
+
+  # ---- AC3: request_changes + 새 head → 재작업 라운드(구현·재푸시) ----
+  local kA="a-aaa1"
+  forge_meta sha-AAA > "$RV/101.review"; prod_rc sha-AAA '보안 입력 검증 추가' > "$RV/$kA.produce"
+  rl_round "$rd" "$kA" "$base" 101 "feat/run1-a"; rc=$?
+  chk "AC3 라운드 수행(rc=0)" "$rc" "0"
+  chk "AC3 라운드 카운터=1" "$(int_review_round "$rd" "$kA")" "1"
+  [[ -s "$IMPLLOG" ]] && ok "AC3 구현 실행됨" || bad "AC3 구현 실행됨"
+  grep -q 'feat/run1-a' "$PUSHLOG" && ok "AC3 같은 head 브랜치 push" || bad "AC3 같은 head 브랜치 push"
+  chk "AC3 head 처리 표시" "$(int_get_head "$rd" "$kA")" "sha-AAA"
+  delta="$rd/delta.$kA.101.spec.md"
+  grep -q '보안 입력 검증' "$delta" && ok "AC3 must 델타 반영" || bad "AC3 must 델타 반영"
+  # 같은 head 재호출 → no-op(rc=20).
+  rl_round "$rd" "$kA" "$base" 101 "feat/run1-a"; chk "AC5 동일 head 미시작(rc=20)" "$?" "20"
+
+  # ---- AC6: approve → 머지 진행가능, 추가 라운드 미시작 ----
+  local kB="b-bbb2"; : > "$IMPLLOG"
+  forge_meta sha-B > "$RV/107.review"; prod_simple sha-B approve > "$RV/$kB.produce"
+  rl_round "$rd" "$kB" "$base" 107 "feat/run1-b"; rc=$?
+  chk "AC6 approve rc=30" "$rc" "30"
+  chk "AC6 판정 기록=approve" "$(int_get_verdict "$rd" "$kB")" "approve"
+  chk "AC6 phase=approved" "$(int_get_phase "$rd" "$kB")" "approved"
+  chk "AC6 추가 라운드 미시작" "$(int_review_round "$rd" "$kB")" "0"
+  [[ ! -s "$IMPLLOG" ]] && ok "AC6 approve 시 구현 미위임" || bad "AC6 approve 시 구현 미위임"
+  rl_round "$rd" "$kB" "$base" 107 "feat/run1-b"; chk "AC6 approve 멱등(rc=20)" "$?" "20"
+
+  # ---- AC4: unavailable → 에스컬레이션 ----
+  local kU="u-uuu3"
+  forge_meta sha-U > "$RV/108.review"; prod_simple sha-U unavailable > "$RV/$kU.produce"
+  out="$(rl_round "$rd" "$kU" "$base" 108 "feat/run1-u")"; rc=$?
+  chk "AC4 unavailable rc=10" "$rc" "10"
+  case "$out" in *escalate*) ok "AC4 escalate 출력";; *) bad "AC4 escalate 출력";; esac
+  chk "AC4 phase=escalated" "$(int_get_phase "$rd" "$kU")" "escalated"
+  chk "AC4 라운드 미증가" "$(int_review_round "$rd" "$kU")" "0"
+
+  # ---- AC5: 사람 리뷰어 변경요청 → 생산자 미consult·에스컬레이션 ----
+  local kH="h-hhh4"
+  printf 'state: CHANGES_REQUESTED\nauthor: human-dev\nhead: sha-H\n' > "$RV/102.review"
+  prod_simple sha-H approve > "$RV/$kH.produce"
+  out="$(rl_round "$rd" "$kH" "$base" 102 "feat/run1-h")"; rc=$?
+  chk "AC5 사람=에스컬레이션(rc=10)" "$rc" "10"
+  chk "AC5 phase=escalated" "$(int_get_phase "$rd" "$kH")" "escalated"
+  chk "AC5 라운드 미증가" "$(int_review_round "$rd" "$kH")" "0"
+
+  # ---- AC3 defer: defer 지적 → 별도 백로그 분리(현 PR 미혼합) ----
+  local kD="d-ddd5"
+  forge_meta sha-D > "$RV/103.review"; prod_rc sha-D '보안 검증 추가' '후속으로 리팩터' > "$RV/$kD.produce"
+  rl_round "$rd" "$kD" "$base" 103 "feat/run1-d" >/dev/null; rc=$?
+  chk "AC3 defer 라운드 수행" "$rc" "0"
+  [[ -s "$rd/backlog.$kD.103.md" ]] && ok "AC3 백로그 분리 파일 생성" || bad "AC3 백로그 분리 파일 생성"
+  delta="$rd/delta.$kD.103.spec.md"
+  grep -q '보안 검증' "$delta" && ok "AC3 must 델타 반영" || bad "AC3 must 델타 반영"
+  if grep -q '리팩터' "$delta"; then bad "AC3 defer 현PR 미혼합"; else ok "AC3 defer 현PR 미혼합"; fi
+
+  # ---- AC4 가드: 라운드 상한(3) 초과 → 에스컬레이션 ----
+  local kC="c-ccc6"
+  int_set "$rd" "$kC" review-round 3
+  forge_meta sha-C4 > "$RV/104.review"; prod_rc sha-C4 '보안 또 수정' > "$RV/$kC.produce"
+  out="$(rl_round "$rd" "$kC" "$base" 104 "feat/run1-c")"; rc=$?
+  chk "AC4 캡 초과 에스컬레이션(rc=10)" "$rc" "10"
+  case "$out" in *상한*) ok "AC4 상한 사유";; *) bad "AC4 상한 사유";; esac
+
+  # ---- AC4 가드: must 0 인데 request_changes → 무진전 에스컬레이션 ----
+  local kN="n-nnn7"
+  forge_meta sha-N > "$RV/105.review"; prod_rc_empty sha-N > "$RV/$kN.produce"
+  out="$(rl_round "$rd" "$kN" "$base" 105 "feat/run1-n")"; rc=$?
+  chk "AC4 무진전 에스컬레이션(rc=10)" "$rc" "10"
+  case "$out" in *무진전*) ok "AC4 무진전 사유";; *) bad "AC4 무진전 사유";; esac
+
+  # ---- AC4 가드: 빈 title/body must → 공백줄 무진전 우회 금지 ----
+  local kE="e-eee8"
+  forge_meta sha-E > "$RV/109.review"
+  jq -n '{pipeline_verdict:"request_changes", reviewed_context:{head_sha:"sha-E"}, rework_brief:{must_adopt:[{title:"",body:"",severity:"blocking"}], defer:[], wont_adopt:[]}}' > "$RV/$kE.produce"
+  out="$(rl_round "$rd" "$kE" "$base" 109 "feat/run1-e")"; rc=$?
+  chk "AC4 빈 must=무진전(rc=10)" "$rc" "10"
+  [[ ! -f "$rd/delta.$kE.109.spec.md" ]] && ok "AC4 공백 델타 미생성" || bad "AC4 공백 델타 미생성"
+
+  # ---- AC4 가드: 핑퐁(차단성 집합 직전과 동일) → 에스컬레이션 ----
+  local kP="p-ppp9"
+  forge_meta sha-P1 > "$RV/106.review"; prod_rc sha-P1 '보안 입력 검증 누락' > "$RV/$kP.produce"
+  rl_round "$rd" "$kP" "$base" 106 "feat/run1-p" >/dev/null; chk "AC4 핑퐁 1라운드 수행" "$?" "0"
+  forge_meta sha-P2 > "$RV/106.review"; prod_rc sha-P2 '보안 입력 검증 누락' > "$RV/$kP.produce"
+  out="$(rl_round "$rd" "$kP" "$base" 106 "feat/run1-p")"; rc=$?
+  chk "AC4 핑퐁 에스컬레이션(rc=10)" "$rc" "10"
+  case "$out" in *핑퐁*) ok "AC4 핑퐁 사유";; *) bad "AC4 핑퐁 사유";; esac
+
+  # ---- force 미사용 (mock_git force 보면 exit99; 여기 도달했으면 미사용) ----
+  [[ -s "$PUSHLOG" ]] && ok "재작업 라운드 실제 push 수행" || bad "재작업 라운드 실제 push 수행"
+  if grep -qiE 'force|(^| )-f( |$)' "$PUSHLOG"; then bad "force push 미사용"; else ok "force push 미사용(push 인자에 force 없음)"; fi
+
+  echo "----"
+  [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"
+  return $fail
+}
+
+# ===== CLI 진입 (source 시 미실행) =====
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  case "${1:-}" in
+    run)      shift; rl_review_loop "$@" ;;
+    round)    shift; rl_round "$@" ;;
+    selftest) rl_selftest ;;
+    *) echo "usage: review-loop.sh {run <run_dir> <key> <spec> <pr> [branch]|round <run_dir> <key> <spec> <pr> <branch>|selftest}" >&2; exit 1 ;;
+  esac
+fi

--- a/plugins/autopilot/skills/dispatch/references/review-loop.sh
+++ b/plugins/autopilot/skills/dispatch/references/review-loop.sh
@@ -74,12 +74,17 @@ rl_produce_review_skill() {
 }
 
 # 기본: 자율 실행기(loop)에 SPEC 델타 위임. loop 는 --branch 미지원이므로 같은 PR 브랜치 위
-# 재구현은 그 브랜치를 체크아웃한 워크트리 안에서 loop 를 secondary 모드로 호출해 수행한다
-# (SPEC 위험 섹션). 이 기본 경로는 실제 실행이며 selftest 에선 mock 으로 대체된다.
+# 재구현은 그 브랜치가 체크아웃된 워크트리 안에서 loop 를 secondary 모드로 호출해 수행한다
+# (SPEC 위험 섹션). 그 작업 브랜치 워크트리를 찾지 못하면 **거짓 성공 대신 실패(비-0)** 를
+# 반환해 호출자가 에스컬레이션하게 한다 — 엉뚱한 체크아웃의 변경을 push 하지 않는다.
+# (selftest 에선 IMPLEMENT_CMD 가 mock 으로 대체되어 이 경로를 타지 않는다.)
 rl_implement_loop() {
-  local spec="$1" branch="$2"
+  local spec="$1" branch="$2" wt
+  wt="$(${GIT_CMD:-git} worktree list --porcelain 2>/dev/null \
+    | awk -v b="refs/heads/$branch" '$1=="worktree"{w=$2} $1=="branch"&&$2==b{print w; exit}')"
+  [[ -n "$wt" ]] || return 1
   # shellcheck disable=SC2086
-  ${LOOP_CMD:-true} start "$spec" >/dev/null 2>&1
+  ( cd "$wt" && ${LOOP_CMD:-true} start "$spec" >/dev/null 2>&1 )
 }
 
 # ===== 리뷰 메타 파싱 (사람/head 게이트 전용) =====
@@ -248,8 +253,12 @@ rl_round() {
   rl_spinoff_backlog "$rd" "$key" "$pr" "$deferfile"
 
   local delta; delta="$(rl_spec_delta "$rd" "$key" "$base" "$pr" "$mustfile")"
+  # 구현이 대상 브랜치에서 실패하면 거짓 성공·엉뚱한 push 대신 에스컬레이션(자동수정 보류).
   # shellcheck disable=SC2086
-  $IMPLEMENT_CMD "$delta" "$branch"
+  if ! $IMPLEMENT_CMD "$delta" "$branch"; then
+    rl_escalate "$rd" "$key" "재구현 실패 — 대상 브랜치($branch) 워크트리에서 구현 불가(자동수정 보류)"
+    return 10
+  fi
   in_push_branch "$branch"
   int_log "$rd" "$key" "라운드 $round: must 구현 → 같은 head 브랜치($branch) push(새 PR 미생성). 재리뷰는 다음 드레인."
   return 0
@@ -335,6 +344,13 @@ rl_selftest() {
   grep -q '보안 입력 검증' "$delta" && ok "AC3 must 델타 반영" || bad "AC3 must 델타 반영"
   # 같은 head 재호출 → no-op(rc=20).
   rl_round "$rd" "$kA" "$base" 101 "feat/run1-a"; chk "AC5 동일 head 미시작(rc=20)" "$?" "20"
+
+  # ---- 재구현 실패 → 거짓 성공·엉뚱한 push 대신 에스컬레이션 (Codex blocking 회귀 가드) ----
+  local kF="f-fff9"
+  forge_meta sha-FFF > "$RV/119.review"; prod_rc sha-FFF '구현 불가 항목' > "$RV/$kF.produce"
+  IMPLEMENT_CMD='false' rl_round "$rd" "$kF" "$base" 119 "feat/run1-f" >/dev/null 2>&1; rc=$?
+  chk "구현 실패 → 에스컬레이션(rc=10)" "$rc" "10"
+  if grep -q 'feat/run1-f' "$PUSHLOG"; then bad "구현 실패인데 push 함"; else ok "구현 실패 → push 안 함"; fi
 
   # ---- AC6: approve → 머지 진행가능, 추가 라운드 미시작 ----
   local kB="b-bbb2"; : > "$IMPLLOG"

--- a/plugins/autopilot/skills/dispatch/references/review-loop.sh
+++ b/plugins/autopilot/skills/dispatch/references/review-loop.sh
@@ -70,7 +70,7 @@ rl_review_fetch_gh() {
 
 # 기본: autopilot:review 생산자를 per-SPEC 키(=--task)로 1회 호출.
 rl_produce_review_skill() {
-  bash "$RL_SCRIPT_DIR/../review/references/review.sh" run --task "$1"
+  bash "$RL_SCRIPT_DIR/../../review/references/review.sh" run --task "$1"
 }
 
 # 기본: 자율 실행기(loop)에 SPEC 델타 위임. loop 는 --branch 미지원이므로 같은 PR 브랜치 위


### PR DESCRIPTION
## 무엇을 / 왜

`dispatch`의 per-SPEC 완료 기준을 **"loop 워크트리 DONE"에서 "main에 머지됨"으로 재정의**한다.
현재는 loop가 DONE이면 의존자를 다음 wave로 푸는데, 그 코드는 격리 워크트리에만 있고 main에
머지되지 않았다. loop는 워크트리를 항상 현재 HEAD에서 분기하므로(`worktree add --detach HEAD`),
A에 의존하는 B는 A의 변경이 없는 HEAD에서 시작되어 의존 웨이브가 의미상 깨진다. 따라서
**머지가 의존자를 푸는 게이트**여야 하고, 이 게이트는 dispatch 웨이브 스케줄링의 본질이므로
review/merge 책임을 dispatch가 직접 갖는다.

SPEC: `docs/specs/2026-06-04-dispatch-merge-gated-waves/SPEC.md`

## 무엇을 했나 (dispatch references 자기완결 구현, fsd 비의존)

- **lib-integration.sh** — per-SPEC 통합 상태 헬퍼(run-dir `int.<key>.<field>` 네임스페이스, 기존 `state.<key>`와 분리)
- **integration.sh** — loop 종료신호(status --json) → DONE: base sync(rebase, ff)→push(`feat/<run-id>-<slug>`)→PR 재사용/생성. spec-gap/하드 BLOCKED 분기
- **review-loop.sh** — `autopilot:review` 생산자 1회 호출 → 판정 분기. request_changes면 must_adopt를 run-dir SPEC 델타로 → 같은 브랜치 재구현·재푸시, defer 백로그 분리, 3가드(라운드캡·무진전·핑퐁)+사람/head 게이트
- **merge.sh** — 분리 approver 신원 승인·확인(리뷰봇 self-approve 무효)→버전범프 게이트→run-dir 락 직렬화 ff-only 머지(+base push)→merged 전이+loop cleanup 위임
- **dispatch.sh 스케줄러** — opt-in(`--integrate` 또는 `APPROVER`): loop DONE을 곧 done으로 보지 않고 `integrating` 중간상태로 두어 폴링 틱당 한 스텝 드레인(integrate→review→approve→merge). 머지 성공만 `done` 전이 → 기존 ready(dep==done)·skip 전파가 그대로 머지 게이트가 됨
- **SKILL.md/헤더** — "forge 연동은 호출 레이어 책임" 불변식을 모드별 개정
- **v0.18.1→0.19.0** — plugin.json(SoT)+루트 marketplace.json 미러 동반 범프

## 검증 (self-referential, mock 인터페이스 — SPEC 규정대로 실제 PR·머지 미수행)

- 5개 selftest **106 assertion 0-exit**: `bash <module>.sh selftest`
- 핵심: B는 A 머지 후에만 launch(AC1/8), A 실패→B 이행적 skip(AC9), **비활성 시 기존 동작 100% 불변(회귀 단언)**
- force(강제) push·rebase·merge 어떤 경로에도 없음, 머지는 ff-only(머지 커밋 없음), bash 3.2 호환

## 배포 경계 (정직 공개 — SPEC mock-only 범위 밖, 프로덕션 전 후속)

기본 `GIT_CMD=git` 실경로에서 **loop detached-HEAD 워크트리 → feat 브랜치 materialization**은 미구현이다(SPEC 위험 항목에 적시). 통합 모드 비활성 기본 사용처에는 영향 없음. `--integrate` 실사용 전 스케줄러 launch를 브랜치-워크트리 모드로 바꾸는 후속이 필요하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
