### PR TITLE
feat(fsd): 진행 중 버그를 큐잉 task 로 분리 (intake --origin·start 마커 가드)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "autopilot",
       "source": "./plugins/autopilot",
       "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션, fsd로 spec→dispatch 자동화 파이프라인의 forge 호출 레이어 오케스트레이션, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "category": "automation",
       "tags": ["autonomous", "ralph-loop", "agent-runtime", "self-directed"]
     }

--- a/docs/specs/2026-06-04-fsd-start-bug-spinoff-to-queued-task/SPEC.md
+++ b/docs/specs/2026-06-04-fsd-start-bug-spinoff-to-queued-task/SPEC.md
@@ -1,0 +1,93 @@
+---
+scope:
+  include:
+    - plugins/autopilot/skills/fsd/**
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+---
+
+# fsd start bug spinoff to queued task
+
+## 무엇을 만들 것인가
+<!-- WHAT/HOW 방어선: 무엇을 만들지만 적고 구현 방법·파일·라이브러리·클래스명은 제약으로 이동. -->
+`fsd start` 진행 중 오케스트레이터가 작업과 별개의 버그를 관찰했을 때, 그 버그를
+**현재 task를 중단하지 않고** 별도의 **큐잉 버그-수정 task**로 분리하는 능력을
+fsd에 추가한다. 분리된 버그 task의 SPEC에서 **사용자 결정이 필요한 지점은 비워둔
+채**(미해결 마커) 등록되며, 그 task를 나중에 `fsd start`로 진행할 때 빈 칸이 먼저
+채워진 뒤에야 구현(dispatch)이 시작된다. 분리된 버그 task는 자신을 촉발한 **원본
+task와의 연결(origin)** 을 기록한다.
+
+구체적으로 다음 관찰 가능한 능력을 갖춘다:
+- `fsd intake` 가 분리 task의 출처를 기록하는 선택적 origin 링크를 받는다.
+- `fsd start` 가 입력 SPEC의 미해결 사용자-결정 마커를 감지해, 해결 전에는 구현
+  위임을 막고 어느 SPEC을 해결해야 하는지 알린다.
+- `fsd status` 가 origin 링크를 노출한다.
+- fsd 스킬 정의 문서가 "진행 중 버그 분리" 절차와 위 계약을 단일 출처로 기술한다.
+
+## 목적 (왜)
+<!-- 이 변경을 왜 하는가(목표·동기)를 1–3문장으로. -->
+fsd 구현 도중 발견한 부수 버그를 현재 task의 의도를 흐리지 않고 안전하게 별도
+작업으로 떼어내, 누락 없이 같은 파이프라인으로 흘려보내기 위함이다. 동시에 그
+버그에 대한 사용자 결정은 실제로 그 task를 진행하는 시점까지 미뤄, 발견 즉시
+사람을 붙잡지 않으면서도 미결정 상태로 자동 구현이 시작되는 것을 막는다.
+
+## 완료 조건
+<!-- 5문장 패턴(항상 / …할 때 / …인 동안 / …이면(오류) / …기능이 켜지면) -->
+1. `fsd intake --origin <task-id> <spec...>` 로 task를 등록**할 때**, 등록된 task의
+   origin이 그 `<task-id>` 로 기록되고 `fsd status` 출력에 그 값이 표시된다.
+2. `--origin` 없이 `fsd intake <spec...>` 를 호출**할 때**, origin 기록 없이 기존과
+   동일하게 task가 등록된다(하위 호환 — 기존 출력·상태 전이 불변).
+3. `fsd start <spec...>` 의 입력 SPEC 중 하나라도 미해결 사용자-결정 마커
+   (`[NEEDS CLARIFICATION` 로 시작하는 마커)를 포함**하면(오류성 가드)**, dispatch
+   위임이 일어나지 않고 task state가 `needs-clarification` 으로 기록되며, 마커를 가진
+   SPEC마다 `needs-resume: <SPEC-경로>` 가 출력되고 명령은 비-0으로 종료한다.
+4. 입력 SPEC에 미해결 마커가 없을 **때**, `fsd start` 는 기존대로 dispatch에 구현을
+   위임하고 run-id를 기록하며 task state가 `dispatched` 가 된다(회귀 없음).
+5. **항상** `fsd.sh selftest` 는 (a) `--origin` 기록, (b) 마커 보유 SPEC의 start
+   차단·미-dispatch·`needs-resume:` 출력, (c) 마커 없는 SPEC의 정상 dispatch 회귀를
+   각각 검증하는 케이스를 포함하여 전부 통과한다.
+6. **항상** spec·loop·dispatch 스킬의 정의 파일과 그 공개 인터페이스(서브커맨드·시그널
+   계약)는 이 변경으로 수정되지 않는다 — SPEC 작성은 spec, task 등록·run 소유는 fsd
+   라는 역할 분리가 유지된다.
+7. fsd 스킬 정의 문서(SKILL.md)에 다음이 기술**될 때** 충족된다: "진행 중 버그 분리"
+   절차(start 중 버그 관찰 → spec으로 버그 SPEC 작성하되 사용자-결정 지점은 마커로
+   비워둠 → `intake --origin` 으로 큐잉 → 현재 task 계속 → 나중 `start` 시 마커 감지로
+   `spec --resume` 후 dispatch), 그리고 intake의 `--origin` 인자·start의 마커 가드·상태
+   레이아웃의 origin 필드.
+
+## 범위
+포함:
+- `plugins/autopilot/skills/fsd/references/lib-state.sh` — origin 필드 set/get 래퍼.
+- `plugins/autopilot/skills/fsd/references/fsd.sh` — intake `--origin`, start 마커 가드,
+  status origin 출력, selftest 케이스, usage 표기.
+- `plugins/autopilot/skills/fsd/SKILL.md` — 버그 분리 절차·계약·레이아웃 문서화.
+
+비-목표 / 제외:
+- spec·loop·dispatch 스킬 정의 파일 수정.
+- loop 시그널 계약(`signals/DONE`·`BLOCKED`)에 새 시그널 추가(버그 자동 감지 경로 미채택).
+- `fsd bug` 같은 신규 서브커맨드(분리는 start 절차 + 기존 intake 재사용).
+- review·merge·poll 서브커맨드 동작 변경.
+- spec 스킬이 마커를 만들고 `--resume` 로 해소하는 기존 메커니즘 자체의 변경.
+
+## 검증
+<!-- 검증 기준의 단일 출처는 위 "완료 조건"이다. -->
+이 SPEC의 인수 바는 위 **완료 조건**이다. 각 조건이 관찰 가능하게 충족되면 충족된
+것으로 본다. 검증을 실행하는 진입 명령은 SPEC이 아니라 프로젝트 규칙(`rules/`)이
+단일 출처로 정의한다.
+
+## 제약 (있을 때만)
+- bash 3.2+ 호환(associative array 미사용) — 기존 `fsd.sh`·`lib-state.sh` 규약 유지.
+- 미해결 마커 감지는 `[NEEDS CLARIFICATION` prefix 매칭으로 spec 스킬의 기존 관례와
+  일치시킨다(닫는 괄호에 의존하지 않음).
+- origin·마커-가드 구현은 기존 헬퍼(`set_field`/`get_field`, `validate_specs`,
+  `derive_task_id`, `ensure_task_dir`)와 selftest의 mock 주입 패턴(`FSD_STATE_ROOT`·
+  `DISPATCH_CMD` 치환·TRACE 파일)을 재사용한다.
+- 빈 칸 표현·진행 시 채움은 새 메커니즘을 도입하지 않고 spec의 기존
+  `[NEEDS CLARIFICATION]` 마커 + `spec --resume` 관례를 재사용한다.
+- fsd는 `.fsd/` 밖 경로를 만들지 않으며 SPEC을 직접 저작하지 않는다(저작은 spec 스킬).
+
+## 위험 (있을 때만)
+- start의 마커 가드가 자연어 진입(spec→intake→start) 흐름을 깨면 안 된다 — 승인된
+  SPEC은 마커가 없으므로 가드에 걸리지 않아야 한다(완료 조건 4가 이 회귀를 고정).

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션, fsd로 spec→dispatch 자동화 파이프라인의 forge 호출 레이어(intake·start·review·merge·poll) 오케스트레이션, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/fsd/SKILL.md
+++ b/plugins/autopilot/skills/fsd/SKILL.md
@@ -45,6 +45,7 @@ fsd 는 `spec`·`loop`·`dispatch` 를 **공개 인터페이스로만** 조합�
         ├── run-id          # 이 task 가 소유한 dispatch run 식별자
         ├── review-round    # 리뷰 라운드 카운터          (review 오케스트레이션이 누적)
         ├── head            # 마지막으로 관측한 head 식별자
+        ├── origin          # 이 task 를 촉발한 원본 task 식별자 (버그 분리 연결, 선택)
         └── LOG.md          # append-only 이벤트 로그
 ```
 
@@ -52,12 +53,13 @@ fsd 는 `spec`·`loop`·`dispatch` 를 **공개 인터페이스로만** 조합�
 
 본 골격(C0)이 6 서브커맨드(`intake`·`start`·`review`·`merge`·`poll`·`status`/`list`/`stop`)의 책임과 입출력 계약을 **완전판**으로 고정한다. 후속 단위(C1~C5)는 이 계약을 입력 컨텍스트로 차용하며 SKILL.md 는 C0 단독 소유로 둔다(병렬 wave 충돌 방지).
 
-### fsd intake `<spec...>`
+### fsd intake `[--origin <task-id>]` `<spec...>`
 
 자연어 의도를 SPEC 으로 떠서(상위 spec 스킬 위임 결과) 얻은 SPEC 경로(들)로 새 task 를 등록한다.
 
 - 입력: 1 개 이상의 SPEC 파일 경로. 각 경로는 파일로 존재하고 읽을 수 있어야 한다(아니면 abort).
-- 동작: task-id 를 도출하고 `.fsd/tasks/<task-id>/` 를 생성, SPEC 경로를 `SPECS.txt` 에 기록, `state=intake` 로 설정, `LOG.md` 에 이벤트를 남긴다.
+- 옵션 `--origin <task-id>`: 이 task 를 촉발한 **원본 task** 와의 연결을 `origin` 필드에 기록한다(진행 중 버그 분리에서 사용). 생략하면 origin 기록 없이 기존과 동일하게 등록한다(하위 호환).
+- 동작: task-id 를 도출하고 `.fsd/tasks/<task-id>/` 를 생성, SPEC 경로를 `SPECS.txt` 에 기록, `state=intake` 로 설정, `--origin` 이 주어지면 `origin` 에 기록, `LOG.md` 에 이벤트를 남긴다.
 - 출력: `task-id: <task-id>`.
 - **후속(C1)**: task backend(Issue/Project) 항목 생성·연결.
 
@@ -66,7 +68,8 @@ fsd 는 `spec`·`loop`·`dispatch` 를 **공개 인터페이스로만** 조합�
 task 의 SPEC(들)을 자율 실행기 오케스트레이터(`dispatch`)에 위임해 구현을 시작한다.
 
 - 입력: 1 개 이상의 SPEC 파일 경로(검증·절대경로화).
-- 동작: task-id 도출 후 디렉토리를 보장하고(미등록이면 `SPECS.txt` 기록), `state=dispatching` → `dispatch start <spec...>` 공개 서브커맨드로 위임 → 그 출력에서 run 식별자를 추출해 `run-id` 에 기록 → `state=dispatched`.
+- **미해결 마커 가드**: 입력 SPEC 중 하나라도 미해결 사용자-결정 마커(`[NEEDS CLARIFICATION` 로 시작)를 포함하면 dispatch 위임을 하지 않는다 — `state=needs-clarification` 으로 기록하고, 마커를 가진 SPEC 마다 `needs-resume: <SPEC-경로>` 를 출력한 뒤 비-0 으로 종료한다. 빈 칸은 `spec --resume <SPEC-경로>` 로 채운 뒤 다시 `start` 한다.
+- 동작(마커 없을 때): task-id 도출 후 디렉토리를 보장하고(미등록이면 `SPECS.txt` 기록), `state=dispatching` → `dispatch start <spec...>` 공개 서브커맨드로 위임 → 그 출력에서 run 식별자를 추출해 `run-id` 에 기록 → `state=dispatched`.
 - 출력: `task-id: <task-id>` 와 `run-id: <run-id>`.
 - 실패: dispatch 출력에서 run-id 를 얻지 못하면 `state=dispatch-failed` 로 기록하고 dispatch 출력과 함께 abort.
 - **후속(C2)**: DONE→push→PR forge 통합.
@@ -99,7 +102,7 @@ task 의 SPEC(들)을 자율 실행기 오케스트레이터(`dispatch`)에 위�
 
 ### fsd status `<task-id>`
 
-task 단위로 상태 미러·소유 run-id·브랜치·PR·리뷰 라운드·head·SPEC 목록을 표 형태로 출력한다.
+task 단위로 상태 미러·origin(원본 task 연결)·소유 run-id·브랜치·PR·리뷰 라운드·head·SPEC 목록을 표 형태로 출력한다. origin 이 없으면 빈 값으로 표시한다.
 
 ### fsd list
 
@@ -108,6 +111,25 @@ task 단위로 상태 미러·소유 run-id·브랜치·PR·리뷰 라운드·he
 ### fsd stop `<task-id>`
 
 task 가 소유한 dispatch run 을 `dispatch` 의 공개 `stop` 서브커맨드로 정지 위임하고 `state=stopped` 로 기록한다. 연결된 run 이 없으면 안내만 출력하고 0 exit.
+
+## 진행 중 버그 분리 (start 중 관찰한 버그를 큐잉 task 로)
+
+`fsd start` 로 한 task 를 진행하는 도중 오케스트레이터가 **작업과 별개의 버그**를 관찰하면, 현재 task 를 중단하지 않고 그 버그를 별도의 **큐잉 버그-수정 task** 로 분리한다. 사용자 결정은 그 버그 task 를 실제로 진행하는 시점까지 미룬다.
+
+절차:
+
+1. **버그 관찰** — 현재 task 진행 중 부수 버그를 발견한다(현재 task 는 계속 진행).
+2. **버그 SPEC 작성** — `spec` 스킬로 버그 SPEC 을 작성하되, **사용자 결정이 필요한 지점은 비워둔다** — spec 의 기존 `[NEEDS CLARIFICATION]` 마커로 표시한다(새 메커니즘 도입 없음). SPEC 저작은 spec 스킬의 책임이다.
+3. **큐잉** — `fsd intake --origin <현재-task-id> <버그-SPEC>` 로 버그 task 를 등록한다. `origin` 에 원본 task 연결이 기록된다.
+4. **현재 task 계속** — 버그 task 는 큐에 남고, 현재 task 의 의도를 흐리지 않는다. 발견 즉시 사람을 붙잡지 않는다.
+5. **나중 진행** — 버그 task 를 `fsd start <버그-SPEC>` 로 진행하면 미해결 마커 가드가 마커를 감지해 dispatch 를 막고 `needs-resume: <SPEC-경로>` 를 알린다. `spec --resume <SPEC-경로>` 로 빈 칸(사용자 결정)을 채운 뒤 다시 `start` 하면 마커가 사라져 dispatch 가 시작된다.
+
+계약 요약:
+- intake 의 `--origin <task-id>` — 분리 task 의 출처를 origin 필드로 기록(선택).
+- start 의 마커 가드 — `[NEEDS CLARIFICATION` 보유 SPEC 은 dispatch 전 차단, `state=needs-clarification`, SPEC 마다 `needs-resume:` 출력, 비-0 종료.
+- 상태 레이아웃의 `origin` 필드 — `fsd status` 에 노출.
+
+이 분리는 `fsd bug` 같은 신규 서브커맨드 없이 **start 절차 + 기존 intake 재사용**으로 이뤄지며, loop 시그널 계약(`signals/DONE`·`BLOCKED`)에 새 시그널을 추가하지 않는다. 빈 칸 표현·진행 시 채움은 spec 의 기존 `[NEEDS CLARIFICATION]` 마커 + `spec --resume` 관례를 그대로 쓴다.
 
 ## references
 

--- a/plugins/autopilot/skills/fsd/references/fsd.sh
+++ b/plugins/autopilot/skills/fsd/references/fsd.sh
@@ -119,18 +119,34 @@ extract_run_id() {
   sed -n 's/^run-id: //p' | tail -1
 }
 
+# spec_has_marker <spec> — 미해결 사용자-결정 마커(`[NEEDS CLARIFICATION` prefix) 포함 여부.
+#   spec 스킬 관례와 일치(닫는 괄호에 의존하지 않음). 매치 시 0, 아니면 1.
+spec_has_marker() {
+  grep -qF '[NEEDS CLARIFICATION' "$1"
+}
+
 # ----- subcommand: intake -----
 # SPEC 경로(들)로 task 를 등록한다. (backend 이슈 생성은 후속 C1.)
 cmd_intake() {
   require_git_root
-  [[ $# -ge 1 ]] || die "사용: fsd intake <spec...>"
+  # 선택적 --origin <task-id>: 이 task 를 촉발한 원본 task 와의 연결을 기록.
+  local origin=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --origin)   origin="${2:-}"; [[ -n "$origin" ]] || die "사용: --origin <task-id>"; shift 2 ;;
+      --origin=*) origin="${1#--origin=}"; shift ;;
+      *) break ;;
+    esac
+  done
+  [[ $# -ge 1 ]] || die "사용: fsd intake [--origin <task-id>] <spec...>"
   validate_specs "$@"
   local id
   id="$(derive_task_id "${ABS_SPECS[@]}")"
   ensure_task_dir "$id"
   add_spec "$id" "${ABS_SPECS[@]}"
   set_state "$id" "intake"
-  log_event "$id" "intake specs=${#ABS_SPECS[@]}"
+  [[ -n "$origin" ]] && set_origin "$id" "$origin"
+  log_event "$id" "intake specs=${#ABS_SPECS[@]}${origin:+ origin=$origin}"
   echo "task-id: $id"
 }
 
@@ -145,6 +161,23 @@ cmd_start() {
   ensure_task_dir "$id"
   # 아직 등록되지 않은 SPEC 이면 함께 기록(start 단독 호출 허용).
   [[ -f "$(task_dir "$id")/SPECS.txt" ]] || add_spec "$id" "${ABS_SPECS[@]}"
+
+  # 미해결 사용자-결정 마커 가드: 마커 보유 SPEC 이 하나라도 있으면 dispatch 를 막는다.
+  #   spec --resume 로 빈 칸을 채운 뒤에야 구현이 시작된다(버그 분리 흐름).
+  local marked=() p
+  for p in "${ABS_SPECS[@]}"; do
+    if spec_has_marker "$p"; then marked+=("$p"); fi
+  done
+  if [[ ${#marked[@]} -gt 0 ]]; then
+    set_state "$id" "needs-clarification"
+    log_event "$id" "start 차단 — 미해결 마커 SPEC=${#marked[@]} (spec --resume 필요)"
+    echo "task-id: $id"
+    for p in "${marked[@]}"; do
+      echo "needs-resume: $p"
+    done
+    exit 1
+  fi
+
   set_state "$id" "dispatching"
   log_event "$id" "start → dispatch 위임 specs=${#ABS_SPECS[@]}"
 
@@ -216,6 +249,7 @@ cmd_status() {
   echo "task-id:  $id"
   echo "path:     $(task_dir "$id")"
   echo "state:    $(get_state "$id")"
+  echo "origin:   $(get_origin "$id")"
   echo "run-id:   $(get_run_id "$id")"
   echo "branch:   $(get_branch "$id")"
   echo "pr:       $(get_pr "$id")"
@@ -307,6 +341,56 @@ EOF
   [[ "$rc" == "0" ]] && ok "poll 위임 0 exit(미구현 아님)" || bad "poll 위임 0 exit (rc=$rc)"
   grep -q "^poll poll" "$TRACE" && ok "poll→poll 드레인 위임" || bad "poll→poll 드레인 위임"
 
+  # ----- 버그 분리 계약: origin 기록 / 마커 가드 / 회귀 -----
+  # 별도 SPEC 들(서로 다른 task-id 도출용): clean / 마커보유.
+  local spec_clean="$TMP/SPEC-clean.md"
+  printf '# Clean\n## 수용 기준\n1. Y.\n' > "$spec_clean"
+  local spec_mark="$TMP/SPEC-mark.md"
+  printf '# Marked\n## 수용 기준\n1. Z [NEEDS CLARIFICATION: 무엇을?]\n' > "$spec_mark"
+  local spec_reg="$TMP/SPEC-reg.md"
+  printf '# Reg\n## 수용 기준\n1. W.\n' > "$spec_reg"
+
+  # dispatch mock: run-id 발급 + TRACE 기록.
+  cat > "$TMP/m-dispatch.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "dispatch $*" >> "$TRACE"
+echo "run-id: RUN-MOCK"
+EOF
+  export DISPATCH_CMD="bash $TMP/m-dispatch.sh"
+
+  # (a) intake --origin: origin 기록 + status 노출.
+  local oid
+  oid="$(cmd_intake --origin parent-task "$spec_clean" 2>/dev/null | sed -n 's/^task-id: //p')"
+  [[ "$(get_origin "$oid")" == "parent-task" ]] && ok "intake --origin 기록" || bad "intake --origin 기록"
+  # 파일로 캡처 후 grep: 함수→grep -q 파이프는 pipefail+SIGPIPE 로 거짓 실패한다.
+  cmd_status "$oid" > "$TMP/status.out" 2>/dev/null
+  grep -q "^origin: *parent-task" "$TMP/status.out" \
+    && ok "status origin 노출" || bad "status origin 노출"
+
+  # (a') 하위호환: --origin 없으면 origin 비어있음(기존 동작 불변).
+  local nid
+  nid="$(cmd_intake "$spec_reg" 2>/dev/null | sed -n 's/^task-id: //p')"
+  [[ -z "$(get_origin "$nid")" ]] && ok "intake origin 없음 하위호환" || bad "intake origin 없음 하위호환"
+
+  # (b) 마커 보유 SPEC: start 차단·미-dispatch·needs-resume 출력·state.
+  : > "$TRACE"
+  ( cmd_start "$spec_mark" ) > "$TMP/start-mark.out" 2>&1; rc=$?
+  [[ "$rc" != "0" ]] && ok "마커 start 비-0 종료" || bad "마커 start 비-0 종료 (rc=$rc)"
+  grep -q "^needs-resume: .*SPEC-mark.md" "$TMP/start-mark.out" \
+    && ok "마커 needs-resume 출력" || bad "마커 needs-resume 출력"
+  grep -q "^dispatch start" "$TRACE" && bad "마커 SPEC dispatch 미위임" || ok "마커 SPEC dispatch 미위임"
+  local mid; mid="$(derive_task_id "$(abspath "$spec_mark")")"
+  [[ "$(get_state "$mid")" == "needs-clarification" ]] \
+    && ok "마커 state=needs-clarification" || bad "마커 state=needs-clarification"
+
+  # (c) 마커 없는 SPEC: 정상 dispatch 회귀.
+  : > "$TRACE"
+  ( cmd_start "$spec_clean" ) > "$TMP/start-clean.out" 2>&1; rc=$?
+  [[ "$rc" == "0" ]] && ok "마커없는 start 0 exit" || bad "마커없는 start 0 exit (rc=$rc)"
+  grep -q "^dispatch start" "$TRACE" && ok "마커없는 SPEC dispatch 위임" || bad "마커없는 SPEC dispatch 위임"
+  grep -q "^run-id: RUN-MOCK" "$TMP/start-clean.out" && ok "마커없는 run-id 기록" || bad "마커없는 run-id 기록"
+  [[ "$(get_state "$oid")" == "dispatched" ]] && ok "마커없는 state=dispatched" || bad "마커없는 state=dispatched"
+
   echo "----"
   [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"
   return $fail
@@ -318,7 +402,9 @@ usage() {
 usage: fsd.sh <subcommand> [args]
 
 Subcommands:
-  intake <spec...>   SPEC 경로(들)로 task 를 등록(상태 저장소에 기록).
+  intake [--origin <task-id>] <spec...>
+                     SPEC 경로(들)로 task 를 등록(상태 저장소에 기록).
+                     --origin: 이 task 를 촉발한 원본 task 와의 연결을 기록(버그 분리).
   start  <spec...>   task 의 SPEC(들)을 dispatch 에 위임하고 run-id 를 기록.
   review <task-id>   리뷰 생산자 1회 호출 → 판정 분기(재구현·재푸시 / 머지진행가능 / 에스컬레이션).
   merge  <task-id>   머지·Done·cleanup (미구현 — C4).

--- a/plugins/autopilot/skills/fsd/references/lib-state.sh
+++ b/plugins/autopilot/skills/fsd/references/lib-state.sh
@@ -12,6 +12,7 @@
 #       run-id         이 task 가 소유한 dispatch run 식별자
 #       review-round   리뷰 라운드 카운터                (review 루프는 후속 단위)
 #       head           마지막으로 관측한 head 식별자
+#       origin         이 task 를 촉발한 원본 task 식별자  (버그 분리 연결, 선택)
 #       LOG.md         append-only 이벤트 로그
 #
 # **하지 않는 일**:
@@ -77,6 +78,10 @@ get_pr()      { get_field "$1" "pr" ""; }
 
 set_head()    { set_field "$1" "head" "$2"; }
 get_head()    { get_field "$1" "head" ""; }
+
+# origin — 이 task 를 촉발한 원본 task 의 식별자(버그 분리 연결). 없으면 빈 값.
+set_origin()  { set_field "$1" "origin" "$2"; }
+get_origin()  { get_field "$1" "origin" ""; }
 
 # review round counter — 후속 단위(review 루프)가 라운드마다 증가시킨다.
 review_round() { get_field "$1" "review-round" "0"; }


### PR DESCRIPTION
## 무엇을

`fsd start` 진행 중 오케스트레이터가 작업과 별개의 버그를 관찰했을 때, 현재 task를 중단하지 않고 그 버그를 **별도의 큐잉 버그-수정 task**로 분리하는 능력을 fsd에 추가한다. 사용자 결정이 필요한 지점은 `[NEEDS CLARIFICATION]` 마커로 **비워둔 채** 등록하고, 그 task를 나중에 `fsd start`로 진행할 때 빈 칸을 먼저 채운 뒤에야 dispatch가 시작된다.

## 왜

fsd 구현 도중 발견한 부수 버그를 현재 task의 의도를 흐리지 않고 안전하게 떼어내 누락 없이 같은 파이프라인으로 흘려보내기 위함. 버그에 대한 사용자 결정은 실제 진행 시점까지 미뤄, 발견 즉시 사람을 붙잡지 않으면서 미결정 상태로 자동 구현이 시작되는 것을 막는다.

## 변경

- **lib-state.sh** — `set_origin`/`get_origin` 래퍼(원본 task 연결 기록), 레이아웃 주석에 `origin` 필드.
- **fsd.sh**
  - `intake [--origin <task-id>]` — 분리 task의 출처 링크(선택, 하위호환).
  - `start` **미해결 마커 가드** — 입력 SPEC 중 `[NEEDS CLARIFICATION` 보유 시 dispatch 차단, `state=needs-clarification`, SPEC마다 `needs-resume:` 출력, 비-0 종료.
  - `status` — origin 노출.
  - `selftest` — origin 기록 / 마커 차단 / 정상 dispatch 회귀 3그룹.
- **SKILL.md** — origin 레이아웃, intake/start/status 계약, "진행 중 버그 분리" 절차 절.
- **버전** — autopilot 0.18.1 → 0.19.0 (plugin.json SoT + marketplace.json 미러), 워치 디렉토리(plugins) 변경 동반.

## 설계 결정 (사용자 합의)

- 버그 신호 = 오케스트레이터 판단(프로시저) — loop/dispatch 공개 계약 불변.
- 버그 SPEC 생성 시점 = `fsd start` 흐름 내부(별도 `fsd bug` 서브커맨드 아님).
- 생성 직후 = intake(큐잉)만, 현재 task 계속.
- 빈 칸 = 기존 `[NEEDS CLARIFICATION]` 마커 + `spec --resume` 재사용.
- 진행 시 채움 = start 마커 가드 → `spec --resume` → dispatch.
- origin = 버그 task에 원본 task-id 기록.

## 검증

- `fsd.sh selftest` → **15/15 ALL PASS (exit 0)** — origin·status·하위호환·마커 차단(needs-resume/미dispatch/needs-clarification)·마커없음 정상 dispatch 회귀.
- `bash -n` 구문 정상(fsd.sh·lib-state.sh).
- 변경 파일은 fsd 3개 + 두 매니페스트뿐 — **spec/loop/dispatch 정의 파일 불변**(역할 분리 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
