### PR TITLE
feat(review): 인라인 코멘트에 리뷰어(Claude/Codex) 식별 헤더 추가

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -582,6 +582,9 @@ jobs:
             // appended fingerprint lets a later run map the model's resolved_threads
             // judgments back to this thread.
             const inlineMarkerBase = '<!-- claude-review-inline';
+            // 인라인 코멘트 작성 리뷰어 식별 — Claude·Codex 가 동일 App bot(courtesy-bot[bot])
+            // 신원으로 게시하므로 GitHub 작성자만으론 구분 불가. 본문 맨 위 헤더로 가시화한다.
+            const reviewerLabel = '🤖 **Claude 리뷰**';
             const inlineComments = inlineFindings.map((f) => {
               // Anchor to f.line; fall back to f.start_line so a finding is never
               // dropped (validation guarantees at least one is a positive int).
@@ -589,7 +592,7 @@ jobs:
               const fingerprintMarker = `${inlineMarkerBase} fingerprint=${computeFingerprint(f)} -->`;
               const c = {
                 path: f.file,
-                body: `**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${fingerprintMarker}`,
+                body: `${reviewerLabel}\n\n**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${fingerprintMarker}`,
                 side: 'RIGHT',
                 line: anchor,
               };

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -426,6 +426,9 @@ jobs:
             // appended fingerprint lets a later run map the model's resolved_threads
             // judgments back to this thread.
             const inlineMarkerBase = '<!-- codex-review-inline';
+            // 인라인 코멘트 작성 리뷰어 식별 — Claude·Codex 가 동일 App bot(courtesy-bot[bot])
+            // 신원으로 게시하므로 GitHub 작성자만으론 구분 불가. 본문 맨 위 헤더로 가시화한다.
+            const reviewerLabel = '🤖 **Codex 리뷰**';
             const inlineComments = inlineFindings.map((f) => {
               // Anchor to f.line; fall back to f.start_line so a finding is never
               // dropped (validation guarantees at least one is a positive int).
@@ -433,7 +436,7 @@ jobs:
               const fingerprintMarker = `${inlineMarkerBase} fingerprint=${computeFingerprint(f)} -->`;
               const c = {
                 path: f.file,
-                body: `**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${fingerprintMarker}`,
+                body: `${reviewerLabel}\n\n**[${f.severity}/${f.confidence_score}] ${f.title}**\n\n${f.body}\n\n**Suggestion:** ${f.suggestion}\n\n${fingerprintMarker}`,
                 side: 'RIGHT',
                 line: anchor,
               };

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -198,6 +198,8 @@ grep -qF "side: 'RIGHT'" "$WORKFLOW" \
   || fail "inline comment side='RIGHT' 지정 부재 (AC1)"
 grep -qF 'start_line' "$WORKFLOW" \
   || fail "multi-line inline comment 의 start_line 처리 부재 (AC1)"
+grep -qF '🤖 **Claude 리뷰**' "$WORKFLOW" \
+  || fail "인라인 코멘트 본문에 리뷰어 식별 헤더(🤖 **Claude 리뷰**) 부재 — 동일 App bot 신원이라 본문 라벨로 구분"
 if grep -qF 'inlineFallback' "$WORKFLOW"; then
   fail "inlineFallback 경로 잔존 — createReview 실패 시 이슈 코멘트 덤프 금지 (AC6)"
 fi

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -268,6 +268,8 @@ grep -qF "side: 'RIGHT'" "$WORKFLOW" \
   || fail "inline comment side='RIGHT' 지정 부재 (AC1)"
 grep -qF 'start_line' "$WORKFLOW" \
   || fail "multi-line inline comment 의 start_line 처리 부재 (AC1)"
+grep -qF '🤖 **Codex 리뷰**' "$WORKFLOW" \
+  || fail "인라인 코멘트 본문에 리뷰어 식별 헤더(🤖 **Codex 리뷰**) 부재 — 동일 App bot 신원이라 본문 라벨로 구분"
 # createReview 실패 시 finding 을 이슈 코멘트로 덤프하지 않는다 (inline-only).
 if grep -qF 'inlineFallback' "$WORKFLOW"; then
   fail "inlineFallback 경로 잔존 — createReview 실패 시 이슈 코멘트 덤프 금지 (AC6)"


### PR DESCRIPTION
## 배경

`claude-review.yml`·`codex-review.yml` 두 리뷰 워크플로는 PR 인라인 리뷰 코멘트를 **동일 App bot(`courtesy-bot[bot]`)** 신원으로 게시한다. 그래서 GitHub UI 상의 작성자만으론 어떤 AI(Claude vs Codex)가 단 코멘트인지 사람이 구분할 수 없었다 — 유일한 단서가 본문 끝의 숨김 HTML 마커(`<!-- claude-review-inline -->` / `<!-- codex-review-inline -->`)뿐이라 화면에 드러나지 않았다.

## 변경

인라인 코멘트 본문 맨 위에 리뷰어 식별 헤더 한 줄을 prepend:

- Claude → `🤖 **Claude 리뷰**`
- Codex → `🤖 **Codex 리뷰**`

```
🤖 **Claude 리뷰**

**[high/0.9] <title>**

<body>

**Suggestion:** <제안>

<!-- claude-review-inline fingerprint=... -->
```

라벨 텍스트는 기존 요약 헤딩(`## Claude PR 리뷰` / `## Codex PR 리뷰`)과 같은 제품명을 사용한다.

## 범위 밖 (변경 없음)

- 요약/review body(`buildBody`), idempotency 마커, fingerprint 자기-thread resolve 정규식, dedup prefix — 전부 그대로. 라벨은 가시 본문 prepend일 뿐 숨김 마커 기반 동작에 영향 없음.
- `diff-anchor-filter.js` 무관.
- 버전 범프 불필요 — 변경 파일(`.github/`·`tests/`)은 워치 디렉토리(`plugins`) 밖이다 (`rules/engineering/versioning.md`).

## 테스트

- `tests/claude/test-claude-review-workflow.sh` → ALL CHECKS PASSED (신규 `🤖 **Claude 리뷰**` 단언 포함)
- `tests/codex/test-codex-review-workflow.sh` → ALL CHECKS PASSED (신규 `🤖 **Codex 리뷰**` 단언 포함)
- `node .github/scripts/diff-anchor-filter.test.js` → ALL 12 CHECKS PASSED (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)