### PR TITLE
chore(dispatch): SKILL.md allowed-tools 선언 (v0.20.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "autopilot",
       "source": "./plugins/autopilot",
       "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션(옵트인 통합 모드면 push→PR→리뷰→ff-only 머지 게이트 소유), fsd로 spec→dispatch 자동화 파이프라인의 forge 호출 레이어 오케스트레이션, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "category": "automation",
       "tags": ["autonomous", "ralph-loop", "agent-runtime", "self-directed"]
     }

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션, fsd로 spec→dispatch 자동화 파이프라인의 forge 호출 레이어(intake·start·review·merge·poll) 오케스트레이션, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: dispatch
 description: "하나 이상의 SPEC 파일을 구현 단계로 넘기고 싶을 때 사용 — 의존성(depends_on)을 풀어 각 SPEC 을 준비되는 즉시 자율 실행기에 스트리밍 위임하고 결과를 취합. 옵트인 통합 모드(--integrate)면 SPEC별 push→PR→리뷰→머지 게이트로 완료를 '머지됨'으로 재정의해 의존자 해제를 머지 뒤로 미룬다. 호출 'Skill(skill=\"dispatch\", args=\"<subcommand> [<args>]\")' (start/list/status/stop/watch)."
+allowed-tools:
+  - Read
+  - Bash(bash * dispatch.sh start:*)
+  - Bash(bash * dispatch.sh list)
+  - Bash(bash * dispatch.sh status:*)
+  - Bash(bash * dispatch.sh stop:*)
+  - Bash(bash * dispatch.sh watch:*)
+  - Bash(bash * dispatch.sh selftest:*)
 ---
 
 # dispatch


### PR DESCRIPTION
## 무엇을 / 왜

`dispatch` 스킬을 실행하면 모델이 `bash dispatch.sh start|list|status|stop|watch` 등을 호출하는데, dispatch SKILL.md에 `allowed-tools` 선언이 없어 매번 권한 프롬프트가 떴다. 형제 스킬(`review`/`loop`/`spec`)은 이미 자기 드라이버 스크립트를 `allowed-tools`로 선언해 프롬프트를 줄이고 있다 — dispatch만 누락이었다.

## 무엇을 했나

- `dispatch/SKILL.md` 프론트매터에 `allowed-tools` 추가 — 기존 컨벤션 `Bash(bash * <script>.sh <sub>:*)`(이식 가능: `* `로 설치 경로/버전 무관, `:*`로 인자 와일드카드)를 그대로 따름:
  - `Read`, `Bash(bash * dispatch.sh start:*|list|status:*|stop:*|watch:*|selftest:*)`
- 동작 변경 없음(순수 프론트매터 메타데이터). `plugin.json`(SoT)+루트 `marketplace.json` 미러 PATCH 범프 v0.20.0→**0.20.1**.

## 범위

- `loop`/`spec`/`review`는 이미 `allowed-tools` 보유 → 변경 없음.
- `fsd`도 누락이나 병렬 세션이 활발히 수정 중이라 충돌 회피 위해 본 PR에서 제외(후속).

## 검증

- 프론트매터 YAML well-formed, 두 JSON 유효(중복 키 없음), 버전 0.20.1 일관.
- `dispatch.sh selftest` GREEN(.sh 무변경, 회귀 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
