### PR TITLE
feat(project-init): version-control-rule-creator에 머지 방식 선택 추가

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "project-init",
       "source": "./plugins/project-init",
       "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
-      "version": "0.15.1",
+      "version": "0.16.0",
       "category": "scaffold",
       "tags": ["scaffold", "init", "bootstrap"]
     },

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",

--- a/plugins/project-init/skills/version-control-rule-creator/SKILL.md
+++ b/plugins/project-init/skills/version-control-rule-creator/SKILL.md
@@ -63,13 +63,14 @@ allowed-tools:
 4. **본문 조립.** 산출 대상인 각 sub-룰(백엔드 변형 sub-룰, 그리고 git 계열이면 동반 `git`)의 (백엔드 변형이 있으면 **2단계에서 판별된** 백엔드의) 템플릿에서 **frontmatter를 제거한 본문**을 그대로 취합니다. 본문은 placeholder 치환 외에 변형하지 않습니다.
    - 선택된 백엔드 변형 sub-룰에 2단계에서 판별된 백엔드의 변형 파일이 없으면, 그 사실을 알리고 종료합니다.
 
-4-bis. **입력(inputs) 치환 — 정적 multi-select 집계.** 산출 대상 템플릿 frontmatter에 `inputs`가 있으면 처리하고, 없으면 이 단계를 건너뜁니다. (현재 `git` 템플릿이 이 메커니즘을 씁니다.)
-   - **스키마.** 각 입력은 `name`, `header`, `question`, `multi_select`, `options[{label, description, value?, default?}]`를 가집니다. `multi_select: true`는 **한 질문에서 여러 정책을 다중 선택**함을 뜻합니다.
-   - **질문.** 입력을 `AskUserQuestion` **다중 선택(multi-select)**으로 **한 번** 묻습니다. 옵션 표시 순서는 frontmatter 순서를 따릅니다. `default: true`인 옵션은 **기본 선택(체크)** 상태로 제시합니다(추천·기본 옵션을 첫 번째에 둡니다). 사용자에게는 정책 선택지만 노출하고, 정책이 공통으로 분리된 내부 사정·분류 기준은 노출하지 않습니다.
-   - **집계 치환.** 본문의 **단일 집계 placeholder** `{{<name>}}`를, **선택된 옵션들의 값을 표시 순서대로 연결**한 텍스트로 치환합니다. 값은 `value`가 있으면 `value`, 없으면 `label`을 씁니다(value 우선). 비어 있지 않은 "Other" 자유 입력도 연결 대상에 포함합니다. 절과 절 사이는 빈 줄 하나로 구분해 마크다운 서식을 유지합니다. **정책별 개별 placeholder는 두지 않습니다.**
-   - **빈 선택.** 아무 옵션도 선택되지 않으면 집계 결과는 빈 문자열이고, placeholder가 놓인 줄을 절 단위로 정리·제거해 빈 줄·깨진 마크다운을 남기지 않습니다. 도입부(헤더 + git 계열 분류)는 그대로 남습니다.
-   - **누락 응답 (디폴트 경로).** 응답이 누락되면 `default: true`인 옵션들이 선택된 것으로 간주합니다. 따라서 force push 금지(기본 체크)가 적용되어 금지 절이 포함된 `git.md`가 생성됩니다(force push 미체크 = 허용).
-   - **확장.** 새 git 공통 정책은 frontmatter `options`에 **옵션 항목만 추가**하면 됩니다 — 이 SKILL.md 로직, 본문 집계 placeholder, 질문 수는 바뀌지 않습니다.
+4-bis. **입력(inputs) 치환 — 정적 multi-select 집계 / single-select 단일 선택.** 산출 대상 템플릿 frontmatter에 `inputs`가 있으면 처리하고, 없으면 이 단계를 건너뜁니다. 한 입력은 `multi_select` 값에 따라 **다중 선택(집계)** 또는 **단일 선택** 두 모드 중 하나로 동작합니다. (현재 `git` 템플릿이 multi-select를, `review-approval` 템플릿의 `merge_method`가 single-select를 씁니다.)
+   - **스키마.** 각 입력은 `name`, `header`, `question`, `multi_select`, `options[{label, description, value?, default?}]`를 가집니다. `multi_select: true`는 **한 질문에서 여러 정책을 다중 선택**함을 뜻하고, `multi_select: false`(또는 생략)는 **한 질문에서 정확히 하나를 고르는 단일 선택**을 뜻합니다.
+   - **질문.** 입력을 `AskUserQuestion`으로 **한 번** 묻되, 다중 선택 입력은 **multi-select**로, 단일 선택 입력은 **single-select**로 제시합니다. 옵션 표시 순서는 frontmatter 순서를 따릅니다. `default: true`인 옵션은 **기본 선택(체크)** 상태로 제시합니다(추천·기본 옵션을 첫 번째에 둡니다). 사용자에게는 정책·방식 선택지만 노출하고, 정책이 공통으로 분리된 내부 사정·분류 기준은 노출하지 않습니다.
+   - **집계 치환 (다중 선택).** 본문의 **단일 집계 placeholder** `{{<name>}}`를, **선택된 옵션들의 값을 표시 순서대로 연결**한 텍스트로 치환합니다. 값은 `value`가 있으면 `value`, 없으면 `label`을 씁니다(value 우선). 비어 있지 않은 "Other" 자유 입력도 연결 대상에 포함합니다. 절과 절 사이는 빈 줄 하나로 구분해 마크다운 서식을 유지합니다. **정책별 개별 placeholder는 두지 않습니다.**
+   - **단일 치환 (단일 선택).** 본문의 placeholder `{{<name>}}`를 **선택된 한 옵션의 값**으로 치환합니다(`value` 우선, 없으면 `label`). 연결은 일어나지 않습니다.
+   - **빈 선택.** (다중 선택에서) 아무 옵션도 선택되지 않으면 집계 결과는 빈 문자열이고, placeholder가 놓인 줄을 절 단위로 정리·제거해 빈 줄·깨진 마크다운을 남기지 않습니다. 도입부(헤더 + git 계열 분류)는 그대로 남습니다.
+   - **누락 응답 (디폴트 경로).** 응답이 누락되면 `default: true`인 옵션(들)이 선택된 것으로 간주합니다. 다중 선택에서는 force push 금지(기본 체크)가 적용되어 금지 절이 포함된 `git.md`가 생성되고(force push 미체크 = 허용), 단일 선택에서는 기본 옵션 하나가 적용됩니다(예: `merge_method` 미응답 시 "저장소 설정을 따름" 절이 들어가 기존 수동 안내로 자연 degrade).
+   - **확장.** 새 정책·방식은 frontmatter `options`에 **옵션 항목만 추가**하면 됩니다 — 이 SKILL.md 로직, 본문 placeholder, 질문 수는 바뀌지 않습니다.
 
 5. **파일 기록.** 산출 대상인 각 sub-룰(백엔드 변형 sub-룰, 그리고 git 계열이면 동반 `git`)을 아래 규칙으로 각각 기록합니다.
    - 대상 디렉터리 `rules/version-control/`가 없으면 기록 전에 생성합니다.

--- a/plugins/project-init/skills/version-control-rule-creator/templates/review-approval.github.md
+++ b/plugins/project-init/skills/version-control-rule-creator/templates/review-approval.github.md
@@ -3,6 +3,29 @@ sub_rule: review-approval
 backend: github
 label: 변경 제안 심사·승인 (GitHub)
 description: GitHub Pull Request의 승인 상태·스레드 해소·필수 체크·소유권 경계·머지 방식·Draft 규율을 백엔드 용어로 정의합니다.
+inputs:
+  - name: merge_method
+    multi_select: false
+    header: "머지 방식"
+    question: "리뷰가 끝난 PR을 머지할 때 이 프로젝트가 쓰는 방식을 하나 고르세요."
+    options:
+      - label: "저장소 설정을 따름"
+        default: true
+        description: "방식을 룰로 못 박지 않고 GitHub 저장소에 설정된 머지 방식을 그대로 따릅니다. 안전한 기본값입니다."
+        value: |-
+          - 이 저장소가 정한 머지 방식(merge commit / squash / rebase)을 따릅니다. 방식이 명시돼 있지 않으면 임의로 바꾸지 말고 저장소 관례·설정을 따릅니다.
+      - label: "merge commit"
+        description: "PR마다 머지 커밋을 만들어 토픽 브랜치 history를 base에 보존합니다."
+        value: |-
+          - 이 저장소의 머지 방식은 **merge commit**입니다. PR을 머지할 때 머지 커밋을 만들어 토픽 브랜치 history를 base 브랜치에 보존합니다. squash·rebase 방식으로 바꿔 머지하지 않습니다.
+      - label: "squash"
+        description: "PR의 커밋들을 하나로 합쳐 base에 단일 커밋으로 올립니다(선형 history)."
+        value: |-
+          - 이 저장소의 머지 방식은 **squash**입니다. PR을 머지할 때 커밋들을 하나로 합쳐(squash) base 브랜치에 단일 커밋으로 올립니다. merge commit·rebase 방식으로 바꿔 머지하지 않습니다.
+      - label: "rebase"
+        description: "PR 커밋들을 base 위에 rebase해 머지 커밋 없이 올립니다."
+        value: |-
+          - 이 저장소의 머지 방식은 **rebase**입니다. PR을 머지할 때 커밋들을 base 브랜치 위에 rebase해 머지 커밋 없이 올립니다. merge commit·squash 방식으로 바꿔 머지하지 않습니다.
 ---
 
 # 변경 제안 심사·승인 지침 — GitHub
@@ -41,7 +64,8 @@ GitHub 리뷰는 세 가지 상태로 제출되며, 각 상태의 의미를 다�
 
 ## 머지 방식
 
-- 이 저장소가 정한 머지 방식(merge commit / squash / rebase)을 따릅니다. 방식이 명시돼 있지 않으면 임의로 바꾸지 말고 저장소 관례·설정을 따릅니다.
+{{merge_method}}
+
 - 머지 직전 base 브랜치와의 충돌이 해소됐는지, 필수 체크가 최신 커밋 기준으로 green인지 확인합니다.
 
 ## Draft 상태

--- a/plugins/project-init/skills/version-control-rule-creator/templates/review-approval.gitlab.md
+++ b/plugins/project-init/skills/version-control-rule-creator/templates/review-approval.gitlab.md
@@ -3,6 +3,29 @@ sub_rule: review-approval
 backend: gitlab
 label: 변경 제안 심사·승인 (GitLab)
 description: GitLab Merge Request의 승인 규칙·스레드 해소·MR 파이프라인·소유권 경계·머지 방식·Draft 규율을 백엔드 용어로 정의합니다.
+inputs:
+  - name: merge_method
+    multi_select: false
+    header: "머지 방식"
+    question: "리뷰가 끝난 MR을 머지할 때 이 프로젝트가 쓰는 방식을 하나 고르세요."
+    options:
+      - label: "저장소 설정을 따름"
+        default: true
+        description: "방식을 룰로 못 박지 않고 GitLab 프로젝트에 설정된 머지 방식을 그대로 따릅니다. 안전한 기본값입니다."
+        value: |-
+          - 이 저장소가 정한 머지 방식(merge commit / squash / fast-forward)을 따릅니다. 방식이 명시돼 있지 않으면 임의로 바꾸지 말고 저장소 관례·설정을 따릅니다.
+      - label: "merge commit"
+        description: "MR마다 머지 커밋을 만들어 소스 브랜치 history를 타깃에 보존합니다."
+        value: |-
+          - 이 저장소의 머지 방식은 **merge commit**입니다. MR을 머지할 때 머지 커밋을 만들어 소스 브랜치 history를 타깃 브랜치에 보존합니다. squash·fast-forward 방식으로 바꿔 머지하지 않습니다.
+      - label: "squash"
+        description: "MR의 커밋들을 하나로 합쳐 타깃에 단일 커밋으로 올립니다."
+        value: |-
+          - 이 저장소의 머지 방식은 **squash**입니다. MR을 머지할 때 커밋들을 하나로 합쳐(squash) 타깃 브랜치에 단일 커밋으로 올립니다. merge commit·fast-forward 방식으로 바꿔 머지하지 않습니다.
+      - label: "fast-forward"
+        description: "머지 커밋 없이 타깃 브랜치를 소스 커밋으로 fast-forward합니다(선형 history)."
+        value: |-
+          - 이 저장소의 머지 방식은 **fast-forward**입니다. MR을 머지할 때 머지 커밋 없이 타깃 브랜치를 소스 커밋으로 fast-forward합니다(머지 전 소스 브랜치가 타깃 위에 선형으로 올라가 있어야 합니다). merge commit·squash 방식으로 바꿔 머지하지 않습니다.
 ---
 
 # 변경 제안 심사·승인 지침 — GitLab
@@ -39,7 +62,8 @@ description: GitLab Merge Request의 승인 규칙·스레드 해소·MR 파이�
 
 ## 머지 방식
 
-- 이 저장소가 정한 머지 방식(merge commit / squash / fast-forward)을 따릅니다. 방식이 명시돼 있지 않으면 임의로 바꾸지 말고 저장소 관례·설정을 따릅니다.
+{{merge_method}}
+
 - 머지 직전 타깃 브랜치와의 충돌이 해소됐는지, MR 파이프라인이 최신 커밋 기준으로 green인지 확인합니다.
 
 ## Draft 상태

--- a/plugins/project-init/skills/version-control-rule-creator/tests/review-approval-merge-method.test.sh
+++ b/plugins/project-init/skills/version-control-rule-creator/tests/review-approval-merge-method.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Structural acceptance test for the review-approval "머지 방식 single-select" SPEC.
+# Verifies the model:
+#   - both review-approval.<backend>.md templates declare an inputs block with a
+#     SINGLE input named merge_method.
+#   - merge_method is SINGLE-select (NOT multi_select: true) — the project picks
+#     exactly one merge method.
+#   - options carry backend-appropriate methods (github: rebase; gitlab:
+#     fast-forward; both: merge commit + squash) plus exactly one default-checked
+#     option (default: true) that degrades to the prior passive "follow repo
+#     config" guidance when the answer is missing.
+#   - body uses the single placeholder {{merge_method}} for the chosen clause, and
+#     the static pre-merge check bullet (conflicts resolved + checks/pipeline green)
+#     stands regardless of the choice.
+#   - SKILL.md documents single-select input handling (단일 선택, single value
+#     substitution, default-on-missing) alongside the existing multi-select doc.
+#
+# Run: bash review-approval-merge-method.test.sh   (exit 0 = pass)
+set -u
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL="$DIR/SKILL.md"
+GH="$DIR/templates/review-approval.github.md"
+GL="$DIR/templates/review-approval.gitlab.md"
+
+fail=0
+check() { # desc, cmd...
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "ok   - $desc"
+  else
+    echo "FAIL - $desc"; fail=1
+  fi
+}
+
+# number of distinct {{...}} placeholders in a file
+distinct_ph() { grep -oE '\{\{[a-zA-Z_]+\}\}' "$1" | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//'; }
+# line number of the second `---` (end of frontmatter), empty if none
+fmend() { grep -nE '^---[[:space:]]*$' "$1" | sed -n '2p' | cut -d: -f1; }
+
+# ===========================================================================
+# 1) both templates exist and declare sub_rule review-approval
+# ===========================================================================
+check "review-approval.github.md exists" test -f "$GH"
+check "review-approval.gitlab.md exists" test -f "$GL"
+check "github template declares sub_rule review-approval" grep -qE '^sub_rule:[[:space:]]*review-approval[[:space:]]*$' "$GH"
+check "gitlab template declares sub_rule review-approval" grep -qE '^sub_rule:[[:space:]]*review-approval[[:space:]]*$' "$GL"
+
+# ===========================================================================
+# 2) inputs block with a SINGLE input named merge_method
+# ===========================================================================
+for f in "$GH" "$GL"; do
+  b="$(basename "$f")"
+  check "$b declares an inputs block" grep -qF 'inputs:' "$f"
+  check "$b declares an input named merge_method" grep -qE '^[[:space:]]*-[[:space:]]*name:[[:space:]]*merge_method[[:space:]]*$' "$f"
+  ninputs="$(grep -cE '^[[:space:]]*-[[:space:]]*name:' "$f")"
+  check "$b declares exactly ONE input" bash -c "[ '$ninputs' -eq 1 ]"
+  # SINGLE-select: must NOT be multi_select: true
+  check "$b merge_method is single-select (no multi_select: true)" \
+    bash -c "! grep -qE 'multi_select:[[:space:]]*true' '$f'"
+done
+
+# ===========================================================================
+# 3) backend-appropriate method options + exactly one default-checked option
+# ===========================================================================
+check "github options include merge commit" grep -qF 'merge commit' "$GH"
+check "github options include squash" grep -qF 'squash' "$GH"
+check "github options include rebase (github-specific)" grep -qF 'rebase' "$GH"
+check "gitlab options include merge commit" grep -qF 'merge commit' "$GL"
+check "gitlab options include squash" grep -qF 'squash' "$GL"
+check "gitlab options include fast-forward (gitlab-specific)" grep -qF 'fast-forward' "$GL"
+# variant separation: github must NOT offer fast-forward; gitlab must NOT offer rebase
+check "github does NOT offer fast-forward" bash -c "! grep -qF 'fast-forward' '$GH'"
+check "gitlab does NOT offer rebase" bash -c "! grep -qF 'rebase' '$GL'"
+
+for f in "$GH" "$GL"; do
+  b="$(basename "$f")"
+  ndef="$(grep -cE 'default:[[:space:]]*true' "$f")"
+  check "$b has exactly one default-checked option" bash -c "[ '$ndef' -eq 1 ]"
+done
+
+# ===========================================================================
+# 4) single placeholder {{merge_method}} in body; static pre-merge bullet kept
+# ===========================================================================
+for f in "$GH" "$GL"; do
+  b="$(basename "$f")"
+  check "$b has a closed frontmatter block" bash -c "[ -n \"\$(grep -nE '^---[[:space:]]*\$' '$f' | sed -n '2p')\" ]"
+  ph="$(distinct_ph "$f")"
+  check "$b body uses the single placeholder {{merge_method}}" bash -c "[ '$ph' = '{{merge_method}}' ]"
+  check "$b retains the 머지 방식 section header" grep -qF '## 머지 방식' "$f"
+  # static pre-merge check bullet survives (conflict resolution + green) below frontmatter
+  e="$(fmend "$f")"
+  check "$b keeps a pre-merge green-check bullet" \
+    bash -c "tail -n +$e '$f' | grep -qF '충돌' && tail -n +$e '$f' | grep -qF 'green'"
+done
+
+# ===========================================================================
+# 5) SKILL.md documents single-select handling (additive, multi-select kept)
+# ===========================================================================
+check "SKILL.md documents single-select (단일 선택)" grep -qF '단일 선택' "$SKILL"
+check "SKILL.md still documents multi-select (multi_select)" grep -qF 'multi_select' "$SKILL"
+check "SKILL.md still documents aggregate placeholder (집계)" grep -qF '집계' "$SKILL"
+check "SKILL.md still documents {{name}} substitution" grep -qF '{{' "$SKILL"
+check "SKILL.md still documents value-over-label" grep -qF 'value' "$SKILL"
+check "SKILL.md still documents default-on-missing" grep -qF 'default' "$SKILL"
+check "SKILL.md mentions merge_method consumer" grep -qF 'merge_method' "$SKILL"
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS"; exit 0
+else
+  echo "FAILED"; exit 1
+fi


### PR DESCRIPTION
## 무엇을

`version-control-rule-creator`(git rule creator)가 PR/MR 심사·승인 룰을 생성할 때, **리뷰 후 머지 방식**(merge commit / squash / rebase·fast-forward)을 **single-select로 하나 고르도록** 추가했습니다.

기존 `## 머지 방식` 절은 *"저장소가 정한 방식을 따르고 임의로 바꾸지 말라"*는 **수동 안내**뿐이라, 룰 생성 시점에 프로젝트의 머지 방식을 못 박지 못했습니다. 이제 고른 방식이 생성된 `rules/version-control/review-approval.md`에 처방형으로 들어갑니다.

## 어떻게

- **`templates/review-approval.github.md`** — `merge_method` single-select input 신설 (`merge commit` / `squash` / `rebase` + default-checked **"저장소 설정을 따름"**). 본문 `## 머지 방식` 첫 줄은 `{{merge_method}}` placeholder, 사전점검 불릿(충돌 해소·체크 green)은 static 유지.
- **`templates/review-approval.gitlab.md`** — 동일 패턴, GitLab 용어(`fast-forward`).
- **`SKILL.md` 4-bis** — single-select 입력 처리를 기존 multi-select 집계와 **나란히 additive 문서화**. default-checked 옵션 덕에 **미응답 시 기존 수동 안내 텍스트로 자연 degrade**(하위 호환).
- **`tests/review-approval-merge-method.test.sh`** — 구조 수용 테스트 신설.
- **버전 범프** `0.15.1 → 0.16.0` (`plugin.json` + `marketplace.json` 미러, 값 일치).

## 검증

- 신규 테스트 RED(편집 전 실패) → GREEN(편집 후 PASS) 확인.
- 기존 `git-common-force-push.test.sh`·`branch-naming.test.sh` 회귀 없이 PASS.
- 두 JSON parse OK, 버전 두 곳 일치(0.16.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)