### PR TITLE
fix(review): incremental 모드 앵커 검증을 정본 PR-vs-base diff로 분리 (createReview 422·false-green 차단)

### DIFF
--- a/.github/scripts/pr-review-context.sh
+++ b/.github/scripts/pr-review-context.sh
@@ -64,6 +64,19 @@ case "$mode" in
     ;;
 esac
 
+# Anchor-validation patch — ALWAYS the canonical PR-vs-base diff that GitHub's
+# createReview validates inline-comment anchors against. The mode-specific
+# diff.patch above is for the MODEL (incremental on synchronize). Using that
+# incremental diff for anchor validation mis-classifies base-merged lines as
+# in-diff: a file absent in the previous-reviewed SHA (event.before) shows as
+# fully-added, so its unchanged-vs-base lines pass the off-diff filter and then
+# get 422 "Line could not be resolved" from createReview — which the inline-only
+# false-green guard turns into a failed job. `gh pr diff` is exactly the diff
+# GitHub resolves anchors against, so validate against it in every mode.
+gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --patch \
+  > "$REVIEW_OUTPUT_DIR/anchor.patch" \
+  || cp "$REVIEW_OUTPUT_DIR/diff.patch" "$REVIEW_OUTPUT_DIR/anchor.patch"
+
 {
   printf 'REVIEW_CONTEXT_MODE=%s\n' "$mode"
   printf 'REVIEW_INCREMENTAL_BASE=%s\n' "$incremental_base"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -534,9 +534,17 @@ jobs:
               const { filterFindingsAgainstPatch } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/diff-anchor-filter.js`);
               let diffPatch = '';
               try {
-                diffPatch = fs.readFileSync('.review-context/diff.patch', 'utf8');
+                // Anchor validation MUST use anchor.patch (canonical PR-vs-base
+                // diff), NOT the model-facing diff.patch (incremental on
+                // synchronize → base-merged lines look fully-added → createReview
+                // 422 + false-green). Fall back to diff.patch for older bundles.
+                try {
+                  diffPatch = fs.readFileSync('.review-context/anchor.patch', 'utf8');
+                } catch {
+                  diffPatch = fs.readFileSync('.review-context/diff.patch', 'utf8');
+                }
               } catch (e) {
-                core.warning(`Could not read .review-context/diff.patch (${e.message}); treating diff as empty — all findings will be excluded as off-diff.`);
+                core.warning(`Could not read anchor.patch/diff.patch (${e.message}); treating diff as empty — all findings will be excluded as off-diff.`);
               }
               ({ valid: inlineFindings, excluded: excludedFindings } =
                 filterFindingsAgainstPatch(findings, diffPatch));

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -378,9 +378,17 @@ jobs:
               const { filterFindingsAgainstPatch } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/diff-anchor-filter.js`);
               let diffPatch = '';
               try {
-                diffPatch = fs.readFileSync('.review-context/diff.patch', 'utf8');
+                // Anchor validation MUST use anchor.patch (canonical PR-vs-base
+                // diff), NOT the model-facing diff.patch (incremental on
+                // synchronize → base-merged lines look fully-added → createReview
+                // 422 + false-green). Fall back to diff.patch for older bundles.
+                try {
+                  diffPatch = fs.readFileSync('.review-context/anchor.patch', 'utf8');
+                } catch {
+                  diffPatch = fs.readFileSync('.review-context/diff.patch', 'utf8');
+                }
               } catch (e) {
-                core.warning(`Could not read .review-context/diff.patch (${e.message}); treating diff as empty — all findings will be excluded as off-diff.`);
+                core.warning(`Could not read anchor.patch/diff.patch (${e.message}); treating diff as empty — all findings will be excluded as off-diff.`);
               }
               ({ valid: inlineFindings, excluded: excludedFindings } =
                 filterFindingsAgainstPatch(findings, diffPatch));

--- a/tests/review-context/test-pr-review-context.sh
+++ b/tests/review-context/test-pr-review-context.sh
@@ -78,6 +78,18 @@ grep -q '+incremental' "$out/diff.patch" \
   || fail "incremental mode should use before..head diff"
 ok "synchronize event uses incremental diff"
 
+# Regression: anchor.patch must be the canonical PR-vs-base diff (gh pr diff,
+# here '+full') even in incremental mode — NOT the incremental diff.patch.
+# Validating anchors against the incremental diff mis-marks base-merged lines
+# as in-diff → createReview 422 + false-green job failure.
+[[ -f "$out/anchor.patch" ]] \
+  || fail "anchor.patch must always be produced for createReview anchor validation"
+grep -q '+full' "$out/anchor.patch" \
+  || fail "incremental mode anchor.patch must be canonical gh pr diff, not the incremental diff"
+grep -q '+incremental' "$out/anchor.patch" \
+  && fail "anchor.patch must NOT be the incremental diff (would 422 on base-merged lines)"
+ok "incremental mode anchor.patch = canonical PR-vs-base diff (createReview-safe)"
+
 out="$tmp/incremental-fallback-out"
 mkdir -p "$out"
 GITHUB_EVENT_NAME=pull_request \


### PR DESCRIPTION
## 증상

PR #317의 **Codex PR Review job이 실패**(`createReview failed; 1 in-diff inline finding could not be posted`). 직접 원인은 GitHub `createReview`의 `422 "Line could not be resolved"` + inline-only false-green 가드.

## 근본 원인

`synchronize`(incremental) 이벤트에서 `pr-review-context.sh`는 diff base를 `event.before`(직전 리뷰 SHA)로 잡는다. PR이 새 base 커밋을 머지하면, 그때 들어온 파일(직전 리뷰 SHA에 없던 파일)이 incremental diff에서 **통째 added(`new file`)**로 보인다. `diff-anchor-filter.js`는 이 diff를 읽어 그 파일의 **base-대비 unchanged 라인까지 in-diff(앵커 가능)로 오판**한다. 거기 앵커된 inline finding을 제출하면 GitHub은 PR 실제 diff(vs base)로 검증해 **422**로 거부하고, false-green 가드가 job을 실패시킨다.

(#317 사례: Codex가 `integration.sh:132`에 finding을 달았는데, 그 줄은 #317이 안 바꾼 unchanged 라인이지만 incremental diff에선 통째-added로 보여 통과 → 422.)

## 수정

앵커 검증용 diff를 모델용 diff와 **분리**:
- `pr-review-context.sh`: 모든 모드에서 별도 `anchor.patch` = **`gh pr diff`(GitHub가 앵커를 해석하는 정본 PR-vs-base diff)** 산출.
- `codex-review.yml`·`claude-review.yml`: submit 단계의 `diff-anchor-filter`가 `diff.patch` 대신 `anchor.patch`로 검증(없으면 `diff.patch` 폴백).
- 모델용 `diff.patch`(incremental)는 변경 없음.

`diff-anchor-filter.js` 자체는 불변 — 고친 건 "어떤 diff를 먹이는가".

## 검증

- `tests/review-context/test-pr-review-context.sh`에 회귀 테스트 추가: incremental 모드에서 `anchor.patch`가 정본(full PR diff)이고 incremental diff가 **아님**을 확인.
- `test-pr-review-context.sh`·`test-codex-review-workflow.sh`·`test-claude-review-workflow.sh` 모두 ALL PASS.
- 로컬 재현: 문제의 finding(`integration.sh:132`)이 incremental patch엔 valid(→422), 정본 patch엔 excluded(→안전).

## 한계

워크플로 수정은 trusted-base 체크아웃 특성상 **머지 후부터 효력**이다 — 이 PR 자신의 codex/claude 리뷰는 base(미수정) 워크플로로 돌아가므로 같은 incremental 앵커 문제를 다시 만날 수 있다(머지되면 해소).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
