### PR TITLE
feat(dispatch): 통합 상시화 + 대상 브랜치 일반화 + direct 적대적 리뷰 게이트

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,8 +20,8 @@
     {
       "name": "autopilot",
       "source": "./plugins/autopilot",
-      "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션(통합 모드 기본 활성: forge 구성이면 push→PR→리뷰→ff-only 머지, 미구성이면 ff-only 직접 머지 게이트 소유), fsd로 spec→dispatch 자동화 파이프라인을 완전자율(리뷰·머지는 dispatch 위임, 외부 승인 대기 없음)로 닫는 task 오케스트레이션(intake·start·poll), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
-      "version": "0.24.0",
+      "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션(통합 항상 활성: forge 구성이면 push→PR→리뷰→ff-only 머지, 미구성이면 PR 없는 로컬 적대적 리뷰 게이트 후 ff-only 직접 머지; 대상 브랜치 --target-branch 로 지정), fsd로 spec→dispatch 자동화 파이프라인을 완전자율(리뷰·머지는 dispatch 위임, 외부 승인 대기 없음)로 닫는 task 오케스트레이션(intake·start·poll), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
+      "version": "0.25.0",
       "category": "automation",
       "tags": ["autonomous", "ralph-loop", "agent-runtime", "self-directed"]
     }

--- a/docs/specs/2026-06-04-dispatch-always-on-integration-target-branch-direct-review-gate/SPEC.md
+++ b/docs/specs/2026-06-04-dispatch-always-on-integration-target-branch-direct-review-gate/SPEC.md
@@ -1,0 +1,75 @@
+---
+scope:
+  include:
+    - plugins/autopilot/skills/dispatch/**
+    - plugins/autopilot/.claude-plugin/plugin.json
+    - .claude-plugin/marketplace.json
+  exclude:
+    - rules/**
+    - milestones/**
+    - CLAUDE.md
+---
+
+# dispatch always-on integration, target branch, direct review gate
+
+## 무엇을 만들 것인가
+<!-- WHAT/HOW 방어선: 무엇을 만들지만 적고 구현 방법·파일·라이브러리·클래스명은 제약으로 이동. -->
+
+`autopilot:dispatch`의 통합(리뷰·머지) 모드에 세 가지 변경을 가한다.
+
+1. **통합 상시화** — 통합 모드를 켜고 끄는 토글을 없애고 통합을 항상 적용한다. `dispatch start`는 별도 플래그 없이 항상 통합(리뷰·머지) 모드로 시작하며, "구현만 하고 머지하지 않는" 비통합(레거시) 동작 경로를 제거한다. 기존에 받던 `--no-integrate`·`--integrate` 플래그는 하위 호환을 위해 받아들이되 아무 효과 없이 조용히 무시한다.
+
+2. **머지 타겟 브랜치 일반화** — 머지·동기화 대상 브랜치가 `main`에 고정되지 않고 호출 시 지정할 수 있게 한다. `dispatch start`에 대상 브랜치를 지정하는 새 옵션을 추가하고, 지정하지 않으면 기본 브랜치를 대상으로 삼는다. 지정한 대상 브랜치는 그 run의 모든 base 동기화·승인 요청 base·fast-forward 머지·base push에 일관되게 적용되며, run 동안(재개 포함) 유지된다.
+
+3. **direct 서브모드 적대적 리뷰 게이트** — forge가 구성되지 않은 환경(direct 서브모드)에서도 머지 직전에 적대적 리뷰를 한 단계 거치게 한다. 지금까지 direct 경로는 리뷰 없이 곧바로 직접 머지했으나, 변경 후에는 구현 완료(loop DONE) 결과를 머지하기 전에 리뷰 생산자(`autopilot:review`)로 적대적 리뷰를 받고, 그 판정이 통과(approve)일 때만 머지한다. 리뷰가 변경 요구(request_changes)를 내면 forge 서브모드와 동일한 리뷰 루프(변경 요구분 재구현 → 재리뷰)를 거친다.
+
+## 목적 (왜)
+<!-- 이 변경을 왜 하는가(목표·동기)를 1–3문장으로. -->
+
+머지 대상이 항상 `main`은 아니므로 대상 브랜치를 일반화해 release 브랜치·통합 브랜치 등 다른 베이스로도 dispatch를 운용할 수 있게 한다. 통합은 이제 dispatch의 단일 동작이므로 토글을 없애 분기와 레거시 경로의 유지 비용을 제거한다. direct 서브모드에 적대적 리뷰를 넣어, forge가 없는 환경에서도 "리뷰 없이 머지"의 품질 공백을 메운다.
+
+## 완료 조건
+<!-- 5문장 패턴(항상 / …할 때 / …인 동안 / …이면(오류) / …기능이 켜지면)과 언어 규칙은 references/ears-patterns.md. 각 조건은 관찰 가능하고 독립 검증 가능해야 함. -->
+
+1. 항상 `dispatch start`는 별도 플래그 없이 통합(리뷰·머지) 모드로 시작한다.
+2. `--no-integrate` 또는 `--integrate` 플래그를 받을 때, dispatch는 그 플래그를 아무 효과 없이 받아들이고(오류 없이) 통합 모드로 동작한다.
+3. 비통합(레거시) 경로 — loop DONE을 곧바로 `done`으로 전이시키고 `NO_INTEGRATE` 마커로 통합을 끄는 분기 — 는 코드·self-test에서 더 이상 존재하지 않는다.
+4. `dispatch start`에 대상 브랜치 지정 옵션을 줄 때, 그 run의 모든 base 동기화·승인 요청(PR) base·fast-forward 머지·base push가 지정한 브랜치를 대상으로 수행된다.
+5. 대상 브랜치 지정 옵션을 주지 않을 때, 대상은 기본 브랜치(`main`, 또는 주입된 기본 브랜치 값)이며 기존과 동일하게 동작한다.
+6. `--resume`로 재개하는 동안, 최초 시작 때 결정된 대상 브랜치와 서브모드(forge/direct)가 보존되어 현재 환경·플래그 값보다 우선 적용된다.
+7. forge가 구성되지 않은(direct) 환경에서 한 SPEC의 구현이 완료(loop DONE)될 때, 머지 직전에 적대적 리뷰(`autopilot:review`)를 거치며, 리뷰가 approve를 낼 때만 그 SPEC을 fast-forward 머지하고 `done`(=머지됨)으로 전이한다.
+8. direct 서브모드 리뷰가 변경 요구(request_changes)를 낼 때, forge 서브모드와 동일한 리뷰 루프(변경 요구분을 SPEC 델타로 재구현 → 같은 작업 브랜치 위 재리뷰)를 수행하고, 동일한 세 가드(라운드 상한·무진전·핑퐁) 안에서만 반복한다.
+9. direct 서브모드 리뷰·재구현이 진행되는 동안, 승인 요청(PR) 생성이나 원격 push 없이 로컬 작업 브랜치의 diff만으로 리뷰가 수행된다.
+10. direct 서브모드 리뷰 루프가 세 가드 중 하나에 걸려 approve 없이 종료되면(오류 조건), 그 SPEC을 머지하지 않고 비완료(blocked/escalated)로 기록하며 그 **이행적 의존자만** `skipped` 처리한다.
+11. 머지될 변경이 버전 워치 디렉토리(`plugins/**`)를 건드리는데 패키지 매니페스트 버전 범프가 없으면(오류 조건), forge·direct 어느 경로에서도 머지를 차단하고 차단 사실을 기록한다.
+12. 항상 모든 머지·동기화 경로는 fast-forward 전용 머지만 사용하고 force(강제) push·history 재작성 rebase push를 어떤 경로(forge·direct)에서도 쓰지 않는다.
+13. dispatch 스킬의 단위 self-test(스케줄러·통합·리뷰·머지 모듈)가 모두 통과(exit 0)하며, 위 분기(통합 상시 켜짐·플래그 no-op, 대상 브랜치 일반화·기본값, 재개 sticky, direct 리뷰 게이트의 approve/request_changes/가드-소진, 버전 게이트 차단, force 미사용)를 mock 인터페이스로 검증한다.
+14. dispatch `SKILL.md`가 위 동작(통합 상시화, 대상 브랜치 지정 옵션, direct 리뷰 게이트)을 반영하고, `--no-integrate` 레거시 모드 서술과 "direct 서브모드는 리뷰를 우회한다 / 적대적 리뷰는 후속 작업" 서술을 제거한다.
+
+## 범위
+포함:
+- `plugins/autopilot/skills/dispatch` 전체 — 스킬 정의(`SKILL.md`)와 `references/`의 셸 모듈(`dispatch.sh`, `integration.sh`, `review-loop.sh`, `merge.sh`, `lib-integration.sh`).
+- 패키지 매니페스트(`plugins/autopilot/.claude-plugin/plugin.json`)와 루트 `.claude-plugin/marketplace.json` 미러의 버전 범프.
+
+비-목표 / 제외:
+- forge 서브모드의 기존 리뷰 루프·통합·머지 로직 변경(direct 경로가 재사용할 뿐 forge 동작 자체는 불변).
+- 리뷰 생산자(`autopilot:review`) 스킬 자체의 판정 로직 변경.
+- `fsd`·`loop`·`spec` 등 dispatch 외 다른 스킬 수정.
+- `rules/`·`CLAUDE.md`·`milestones/` 변경.
+
+## 검증
+<!-- 검증 기준의 단일 출처는 위 "완료 조건"이다. 검증을 실행하는 진입 명령(테스트·lint·빌드)은 SPEC이 선언하지 않는다. -->
+이 SPEC의 인수 바는 위 **완료 조건**이다. 각 조건이 관찰 가능하게 충족되면 충족된 것으로 본다. 검증을 실행하는 진입 명령은 SPEC이 아니라 프로젝트 규칙(`rules/`)이 단일 출처로 정의한다.
+
+## 제약 (있을 때만)
+- 대상 브랜치 지정은 run-dir 마커로 영속화해 재개 시 sticky하게 유지하며, 기존 `DEFAULT_BRANCH` 주입 경로와 양립한다(재개 시 마커가 환경·플래그보다 우선). 현재 `main`을 하드코딩한 모든 사용처(usage 문자열 포함)를 대상 브랜치 값으로 일원화한다.
+- direct 서브모드 리뷰는 forge 의존성(forge CLI·PR) 없이 동작해야 한다 — 기존 forge 리뷰 루프 기계(리뷰 생산자 호출·변경 요구분 재구현·세 가드)를 PR 없는 로컬 작업 브랜치 리뷰로 재사용하되, PR 상태 조회·원격 push를 전제하지 않는다.
+- 모든 외부 인터페이스(`LOOP_CMD`·`GIT_CMD`·`FORGE_CMD`·`FORGE_BIN`·`DEFAULT_BRANCH`·`APPROVER`·`REVIEW_BOT`·`APPROVE_CMD`·`REVIEW_ROUNDS_MAX`·`WATCH_DIRS`·`REVIEW_PRODUCE_CMD`·`INTEGRATION_CMD`·`REVIEW_CMD`·`MERGE_CMD` 등)는 주입 가능하게 유지해 각 모듈을 mock으로 독립 검증한다(실제 PR·머지·push 미수행).
+- 머지는 `git merge --ff-only`만 사용하고, 어떤 경로에서도 force push·history 재작성을 쓰지 않는다. 기본 브랜치 체크아웃+머지 구간은 run-dir 락으로 직렬화한다.
+- 셸 모듈은 bash 3.2+ 호환으로 유지한다.
+- 버전 범프: 현재 `0.23.0` 기준 다음 MINOR(`0.24.0`). 레거시 비통합 동작 제거는 동작 변경(호환 깨짐)이나 pre-1.0(`0.y.z`)이므로 MINOR 증가로 수용한다. `plugin.json`(SoT)과 루트 `marketplace.json` 미러를 함께 올린다. 동시 변경과 버전 충돌 시 최종 번호는 통합자가 조정한다.
+
+## 위험 (있을 때만)
+- direct 리뷰에서 PR이 없으므로, 기존 리뷰 루프가 가정하던 PR 리뷰 상태 조회·브랜치 원격 push가 그대로 동작하지 않을 수 있다 → 로컬 diff 리뷰·push 생략 경로로 분리해 흡수한다.
+- 통합 상시화로 `--no-integrate`에 의존하던 기존 호출·self-test가 깨질 수 있다 → 해당 분기·검증·문서를 같은 변경에서 함께 정리한다.
+- 대상 브랜치 일반화가 일부 사용처만 덮으면 `main`이 잔존해 경로마다 대상이 갈리는 누수가 생긴다 → 모든 사용처를 대상 브랜치 단일 출처로 모은다.

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션(통합·리뷰·머지 소유), fsd로 spec→dispatch 자동화 파이프라인을 완전자율(리뷰·머지는 dispatch 위임)로 닫는 task 오케스트레이션(intake·start·poll), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch
-description: "하나 이상의 SPEC 파일을 구현 단계로 넘기고 싶을 때 사용 — 의존성(depends_on)을 풀어 각 SPEC 을 준비되는 즉시 자율 실행기에 스트리밍 위임하고 결과를 취합. 통합(리뷰·머지) 모드가 기본 활성이라 구현 완료 SPEC 을 대상 브랜치로 머지한다(forge 구성이면 push→PR→리뷰→ff-only 머지, 미구성이면 리뷰·승인 없이 ff-only 직접 머지). --no-integrate 로 끄면 레거시(loop DONE=done). 호출 'Skill(skill=\"dispatch\", args=\"<subcommand> [<args>]\")' (start/list/status/stop/watch)."
+description: "하나 이상의 SPEC 파일을 구현 단계로 넘기고 싶을 때 사용 — 의존성(depends_on)을 풀어 각 SPEC 을 준비되는 즉시 자율 실행기에 스트리밍 위임하고 결과를 취합. 통합(리뷰·머지)은 항상 활성이라 구현 완료 SPEC 을 대상 브랜치로 머지한다(forge 구성이면 push→PR→리뷰→ff-only 머지, 미구성이면 PR 없는 로컬 적대적 리뷰 게이트 후 ff-only 직접 머지). 대상 브랜치는 --target-branch 로 지정(기본: 기본 브랜치). 호출 'Skill(skill=\"dispatch\", args=\"<subcommand> [<args>]\")' (start/list/status/stop/watch)."
 allowed-tools:
   - Read
   - Bash(bash * dispatch.sh start:*)
@@ -30,34 +30,35 @@ allowed-tools:
 - 호출마다 결정성 있는 `run-id`(타임스탬프 + 입력 SPEC 집합 sha7)를 만들고 진행 상태를 `<project_root>/.dispatch/runs/<run-id>/` 아래에 보관한다.
 - 기존 `run-id` 로 재호출되면 보관된 상태를 읽어 이미 `done` 인 SPEC 은 재실행하지 않고, 미완 SPEC 만 스트리밍 스케줄에 따라 이어 수행한다.
 
-## 통합(리뷰·머지) 모드 — 기본 활성
+## 통합(리뷰·머지) — 항상 활성
 
-기본 활성인 통합 모드에서 dispatch 는 loop 가 DONE 으로 끝나면 그 결과를 대상 브랜치(main)로 머지하고, 그 SPEC 의 **완료를 "main 에 머지됨"으로 재정의**한다. 이전엔 loop DONE 시점의 코드가 격리 워크트리에만 있어 의존 SPEC 이 갱신되지 않은 HEAD 에서 분기했지만, 통합이 기본 켜짐이 되어 의존자는 의존성이 main 에 머지된 뒤에만 실행된다.
+통합은 dispatch 의 단일 동작이다(토글 없음). dispatch 는 loop 가 DONE 으로 끝나면 그 결과를 대상 브랜치로 머지하고, 그 SPEC 의 **완료를 "대상 브랜치에 머지됨"으로 재정의**한다. loop DONE 시점의 코드는 격리 워크트리에만 있으므로, 통합이 의존자를 푸는 게이트가 되어 의존자는 의존성이 대상 브랜치에 머지된 뒤에만 실행된다.
 
-- **활성 조건(기본 ON)**: `dispatch start` 는 별도 플래그 없이 통합 모드로 시작한다. `--no-integrate` 로만 끄며, 끄면 기존 동작(loop DONE = `done`, 머지·PR 없음)을 **완전한 하위 호환**으로 복원한다. (`--integrate` 는 기본 ON 이므로 하위호환 no-op 으로 수용된다.)
-- **서브모드(forge / direct)**: forge 구성 여부로 갈린다 — 분리 승인 신원(`APPROVER`)이 설정되고 forge CLI 가 사용 가능하면 **forge**(풀 파이프라인), 아니면 **direct**(승인 요청·리뷰·승인 의례 없이 대상 브랜치로 직접 머지). 두 서브모드 모두 fast-forward 전용 머지와 버전 범프 게이트를 통과해야 한다.
+- **항상 ON**: `dispatch start` 는 별도 플래그 없이 통합으로 시작한다. 비통합(레거시) 동작 경로는 없다. 하위 호환을 위해 `--no-integrate`·`--integrate` 플래그를 받아들이되 **아무 효과 없이 조용히 무시**한다(no-op).
+- **대상 브랜치**: 머지·동기화 대상 브랜치는 `--target-branch <branch>` 로 지정한다. 미지정이면 기본 브랜치(`main`, 또는 주입된 `DEFAULT_BRANCH`)를 대상으로 삼는다. 지정한 대상은 그 run 의 모든 base 동기화·승인 요청(PR) base·fast-forward 머지·base push 에 일관되게 적용되며, run-dir 마커(`TARGET_BRANCH`)로 영속해 `--resume` 에서 sticky 하다(재개 시 마커가 현재 env·플래그보다 우선).
+- **서브모드(forge / direct)**: forge 구성 여부로 갈린다 — 분리 승인 신원(`APPROVER`)이 설정되고 forge CLI 가 사용 가능하면 **forge**(풀 파이프라인), 아니면 **direct**(PR 없이 로컬 적대적 리뷰 게이트 후 대상 브랜치로 직접 머지). 두 서브모드 모두 적대적 리뷰·fast-forward 전용 머지·버전 범프 게이트를 통과해야 한다.
 - **per-SPEC 파이프라인**: loop 가 DONE 으로 끝나면 그 SPEC 은 `done` 이 아니라 중간 상태 `integrating` 으로 두고, 폴링 틱당 한 스텝씩 다음을 멱등 전진(드레인)시킨다.
   - **forge 서브모드**:
     1. **통합**(`integration.sh`): base sync(rebase, ff 가능 시) → 작업 브랜치(`feat/<run-id>-<slug>`) push → 같은 head 의 open PR 재사용/생성. `spec-gap` BLOCKED 면 push·PR 없이 스펙 보강 재개 안내, 하드 BLOCKED 면 push·PR 없이 사람 에스컬레이션(둘 다 비완료 종착).
-    2. **리뷰**(`review-loop.sh`): `autopilot:review` 생산자를 1회 호출해 단일 판정(approve/request_changes/unavailable). `request_changes` 면 `must_adopt` 를 run-dir 하위 SPEC 델타로 만들어 **같은 head 브랜치 위에서** 재구현·재푸시(새 PR 미생성). `defer` 는 현 PR 에 섞지 않고 별도 기록. 세 가드(라운드 상한 기본 3·무진전·핑퐁)와 사람/head 게이트로 무한루프를 막는다.
+    2. **리뷰**(`review-loop.sh run`): `autopilot:review` 생산자를 1회 호출해 단일 판정(approve/request_changes/unavailable). `request_changes` 면 `must_adopt` 를 run-dir 하위 SPEC 델타로 만들어 **같은 head 브랜치 위에서** 재구현·재푸시(새 PR 미생성). `defer` 는 현 PR 에 섞지 않고 별도 기록. 세 가드(라운드 상한 기본 3·무진전·핑퐁)와 사람/head 게이트로 무한루프를 막는다.
     3. **승인+머지**(`merge.sh`): 분리된 자율 approver 신원으로 PR 승인 제출·확인(리뷰 봇 self-approve 무효) → 버전 범프 게이트(`plugins/` 변경 시 `plugin.json` 범프 강제) → `--ff-only` 머지(+base push) → `merged`.
-  - **direct 서브모드**: `integration.sh integrate-direct` 로 작업 브랜치(`feat/<run-id>-<slug>`)만 식별하고(push·PR·리뷰·승인 우회) 바로 `merge.sh finish`(승인 게이트만 우회) 로 넘긴다 — **버전 범프 게이트와 `--ff-only` 머지·작업 공간 정리는 forge 서브모드와 동일하게 적용**된다. BLOCKED 분기(spec-gap/하드)는 forge 서브모드와 동일 헬퍼를 공유한다. 리뷰 부재의 완화(적대적 리뷰 삽입)는 후속 작업으로 분리되어 있다.
-- **머지 게이트**: `merged` 에 도달한 SPEC 만 `done` 으로 전이한다. 따라서 **의존자는 의존성이 main 에 머지된 뒤에만** 실행 큐에 풀리고, 갱신된 main 위에서 분기한다. 통합이 비완료 종착(`blocked`/`escalated`)이면 그 SPEC 은 `failed` 이고 그 **이행적 의존자만** `skipped` 된다.
-- **모드·서브모드 sticky**: 최초 시작 때 결정된 모드(켜짐/`--no-integrate` 꺼짐)와 서브모드(forge/direct)는 run-dir 마커(`INTEGRATE` 내용=서브모드 / `NO_INTEGRATE`)로 보존되어 `--resume` 에서 동일하게 재개된다(재개 시 현재 env·플래그보다 마커 우선).
-- **불변식**: 어떤 경로(forge·direct)에서도 force(강제) push·rebase·merge 를 쓰지 않는다(머지는 `git merge --ff-only` 만). main 체크아웃+머지 구간은 run-dir 락으로 **직렬화**되어 동시 머지 레이스가 없다.
-- **주입 가능한 인터페이스(mock 검증)**: `LOOP_CMD` `GIT_CMD` `FORGE_CMD`(기본 gh) `FORGE_BIN`(서브모드 판정용 forge CLI, 기본 gh) `DEFAULT_BRANCH`(main) `APPROVER` `REVIEW_BOT` `APPROVE_CMD` `REVIEW_ROUNDS_MAX`(3) `WATCH_DIRS`(plugins/) `REVIEW_PRODUCE_CMD` `INTEGRATION_CMD` `REVIEW_CMD` `MERGE_CMD`. 모든 외부 인터페이스가 주입 가능해 각 모듈을 mock 으로 독립 검증한다(실제 PR·머지 미수행).
+  - **direct 서브모드**: `integration.sh integrate-direct` 로 작업 브랜치(`feat/<run-id>-<slug>`)만 식별하고(push·PR 우회) **적대적 리뷰 게이트**(`review-loop.sh run-direct`)로 넘긴다 — PR·원격 push 없이 로컬 작업 브랜치 diff 로 `autopilot:review` 생산자를 호출한다. 판정이 `approve` 면 `merge.sh finish`(승인 게이트만 우회)로 넘어가고, `request_changes` 면 forge 와 동일한 리뷰 루프(변경 요구분을 SPEC 델타로 같은 작업 브랜치 위 재구현 → 다음 틱 재리뷰)를 동일한 세 가드(라운드 상한·무진전·핑퐁) 안에서 수행한다(원격 push 없음). 세 가드 중 하나에 걸려 approve 없이 종료되면 그 SPEC 은 머지하지 않고 비완료(escalated)로 기록된다. **버전 범프 게이트와 `--ff-only` 머지·작업 공간 정리는 forge 서브모드와 동일하게 적용**된다. BLOCKED 분기(spec-gap/하드)는 forge 서브모드와 동일 헬퍼를 공유한다.
+- **머지 게이트**: `merged` 에 도달한 SPEC 만 `done` 으로 전이한다. 따라서 **의존자는 의존성이 대상 브랜치에 머지된 뒤에만** 실행 큐에 풀리고, 갱신된 대상 브랜치 위에서 분기한다. 통합·리뷰가 비완료 종착(`blocked`/`escalated`)이면 그 SPEC 은 `failed` 이고 그 **이행적 의존자만** `skipped` 된다.
+- **서브모드·대상 브랜치 sticky**: 최초 시작 때 결정된 서브모드(forge/direct)와 대상 브랜치는 run-dir 마커(`INTEGRATE` 내용=서브모드 / `TARGET_BRANCH`)로 보존되어 `--resume` 에서 동일하게 재개된다(재개 시 현재 env·플래그보다 마커 우선).
+- **불변식**: 어떤 경로(forge·direct)에서도 force(강제) push·rebase·merge 를 쓰지 않는다(머지는 `git merge --ff-only` 만). 대상 브랜치 체크아웃+머지 구간은 run-dir 락으로 **직렬화**되어 동시 머지 레이스가 없다.
+- **주입 가능한 인터페이스(mock 검증)**: `LOOP_CMD` `GIT_CMD` `FORGE_CMD`(기본 gh) `FORGE_BIN`(서브모드 판정용 forge CLI, 기본 gh) `DEFAULT_BRANCH`(대상 브랜치, 기본 main) `APPROVER` `REVIEW_BOT` `APPROVE_CMD` `REVIEW_ROUNDS_MAX`(3) `WATCH_DIRS`(plugins/) `REVIEW_PRODUCE_CMD` `INTEGRATION_CMD` `REVIEW_CMD` `MERGE_CMD`. 모든 외부 인터페이스가 주입 가능해 각 모듈을 mock 으로 독립 검증한다(실제 PR·머지 미수행).
 
 ## Subcommands
 
-### dispatch start `<spec...>` [--max-parallel N] [--resume `<run-id>`] [--no-integrate]
+### dispatch start `<spec...>` [--max-parallel N] [--resume `<run-id>`] [--target-branch `<branch>`]
 
-1 개 이상의 SPEC 파일 경로를 받아 새 run 을 시작한다. 통합(리뷰·머지) 모드가 **기본 활성**이며(위 "통합 모드" 절), forge 구성 여부로 forge/direct 서브모드가 갈린다. 통합 모드에서는 state 에 중간 상태 `integrating` 이 추가되고 `done` 은 "머지됨"을 뜻한다. `--no-integrate` 면 통합을 꺼 기존 동작(loop DONE = `done`, 머지·PR 없음)으로 돌아간다.
+1 개 이상의 SPEC 파일 경로를 받아 새 run 을 시작한다. 통합(리뷰·머지)은 **항상 활성**이며(위 "통합" 절), forge 구성 여부로 forge/direct 서브모드가 갈린다. state 에 중간 상태 `integrating` 이 추가되고 `done` 은 "대상 브랜치에 머지됨"을 뜻한다. `--target-branch` 로 머지·동기화 대상 브랜치를 지정한다(미지정 시 기본 브랜치). 하위 호환을 위해 `--no-integrate`·`--integrate` 를 받되 무시한다(no-op).
 
 - 입력 검증: 각 경로가 파일로 존재하고 읽을 수 있어야 한다. 하나라도 누락이면 보고 후 즉시 abort.
 - DAG 구성: 각 SPEC frontmatter 의 `depends_on` 을 읽어 의존 인덱스를 만든다. cycle 이면 abort. 진단용 `WAVES.txt` 도 함께 기록(실행 스케줄은 준비도 기반).
 - `<project_root>/.dispatch/runs/<run-id>/MANIFEST.txt` · `WAVES.txt` · `state.<slug>-<sha7>` · `LOG.md` 생성. (`<slug>` 는 가독용, `<sha7>` 는 SPEC abspath 해시로 다른 날짜·디렉토리 동명 SPEC 충돌 방지.) state 값: `pending`/`running`/`done`/`failed`/`skipped`.
 - 준비도 스트리밍: 각 SPEC 의 모든 dep 이 done 이 되는 즉시 동시성 상한 이내에서 위임 시작. 한 SPEC 이 failed 면 그 이행적 의존자만 `skipped`, 독립 가지는 계속.
-- `--resume <run-id>` 이면 보관된 manifest 로 재개. `done` 인 SPEC 은 재호출하지 않고 나머지(미완)만 다시 스케줄한다.
+- `--resume <run-id>` 이면 보관된 manifest 로 재개. `done` 인 SPEC 은 재호출하지 않고 나머지(미완)만 다시 스케줄한다. 서브모드(forge/direct)와 대상 브랜치는 run-dir 마커로 보존되어 재개 시 현재 env·플래그보다 우선한다(sticky).
 - 한 child 가 `DISPATCH_WAVE_TIMEOUT_SECONDS`(기본 7200) 를 초과하면(per-SPEC runtime cap) 그 child 를 SIGTERM→SIGKILL 으로 정리하고 `failed` 로 마킹한다(이미 done 이면 보존).
 - exit code: `0`=전부 done, `1`=failed/skipped 있음, `2`=timeout.
 
@@ -81,23 +82,23 @@ per-SPEC 상태를 주기적으로 refresh 하며, 모든 child 가 terminal(`do
 
 | 파일 | 역할 |
 |---|---|
-| `dispatch.sh` | run-id 디렉토리 관리·의존 인덱스 구성·준비도 스트리밍 위임·구조화 종료 판정·통합 모드 드레인 driver |
-| `lib-integration.sh` | per-SPEC 통합 상태 헬퍼(run-dir + 키: branch/pr/head/review-round/verdict/phase). 통합 모드 전용 |
-| `integration.sh` | loop 종료신호 → base sync → push → PR 생성/재사용. 통합 모드 전용 |
-| `review-loop.sh` | 리뷰 생산자 판정 → SPEC 델타 재구현·재푸시(3가드·사람/head 게이트). 통합 모드 전용 |
-| `merge.sh` | 승인 게이트 → 버전 범프 게이트 → 직렬화 ff-only 머지. 통합 모드 전용 |
+| `dispatch.sh` | run-id 디렉토리 관리·의존 인덱스 구성·준비도 스트리밍 위임·구조화 종료 판정·통합 드레인 driver |
+| `lib-integration.sh` | per-SPEC 통합 상태 헬퍼(run-dir + 키: branch/pr/head/review-round/verdict/phase) |
+| `integration.sh` | loop 종료신호 → base sync → push → PR 생성/재사용(forge) / PR 없이 작업 브랜치 식별(direct) |
+| `review-loop.sh` | 리뷰 생산자 판정 → SPEC 델타 재구현(3가드). `run`=forge(PR·push), `run-direct`=PR 없는 로컬 리뷰 |
+| `merge.sh` | 승인 게이트(forge) → 버전 범프 게이트 → 직렬화 ff-only 머지(대상 브랜치) |
 
 각 통합 모듈은 `bash <module>.sh selftest` 로 mock 인터페이스 기반 독립 검증을 제공한다(실제 PR·머지 미수행). 스케줄러 통합 검증은 `bash dispatch.sh selftest`.
 
 ## 의존성
 
-`git`, `bash` 3.2+, `sha256sum` 또는 `shasum`, `autopilot:loop` 스킬, `yq`(mikefarah). `yq` 는 depends_on 파싱(없으면 awk 폴백)뿐 아니라 **loop 구조화 상태(`status --json`) 판정의 단일 출처**이므로 `start`/`status`/`stop`/`watch` 에서 필수다(부재 시 명확히 정지 — 텍스트 컬럼으로 silent fallback 하지 않음). 통합 모드 **forge 서브모드**는 추가로 `jq`(리뷰 판정 JSON 파싱)와 forge CLI(`gh`, 주입 가능)·리뷰 생산자(`autopilot:review`)를 쓴다. **direct 서브모드**(forge 미구성)는 forge CLI·리뷰 생산자 없이 git 만으로 ff-only 직접 머지하므로 이들이 불필요하다. `--no-integrate` 레거시 모드에는 통합 관련 의존성이 모두 불필요하다.
+`git`, `bash` 3.2+, `sha256sum` 또는 `shasum`, `autopilot:loop` 스킬, `yq`(mikefarah). `yq` 는 depends_on 파싱(없으면 awk 폴백)뿐 아니라 **loop 구조화 상태(`status --json`) 판정의 단일 출처**이므로 `start`/`status`/`stop`/`watch` 에서 필수다(부재 시 명확히 정지 — 텍스트 컬럼으로 silent fallback 하지 않음). **forge 서브모드**는 추가로 `jq`(리뷰 판정 JSON 파싱)와 forge CLI(`gh`, 주입 가능)·리뷰 생산자(`autopilot:review`)를 쓴다. **direct 서브모드**(forge 미구성)는 forge CLI 없이 동작하지만, 적대적 리뷰 게이트를 위해 `jq` 와 리뷰 생산자(`autopilot:review`)는 쓴다(PR·원격 push 없이 로컬 작업 브랜치 diff 로 리뷰).
 
 ## 규칙
 
-- 자체 작성·갱신하는 영역은 `<project_root>/.dispatch/runs/<run-id>/` 디렉토리 안의 파일들(통합 모드의 SPEC 델타·백로그·통합 상태 포함)과 본 스킬의 정의 파일뿐이다. 작업 브랜치·PR·머지 같은 forge 부수효과를 제외하면 이 외 경로를 만들지 않는다.
+- 자체 작성·갱신하는 영역은 `<project_root>/.dispatch/runs/<run-id>/` 디렉토리 안의 파일들(SPEC 델타·백로그·통합 상태 포함)과 본 스킬의 정의 파일뿐이다. 작업 브랜치·PR·머지 같은 forge 부수효과를 제외하면 이 외 경로를 만들지 않는다.
 - 자율 실행기 인터페이스(`loop.sh start|status|stop|cleanup|logs`) 외 child 워크트리·신호 파일을 직접 들여다보지 않는다.
-- **통합·머지 소유권**: 통합 모드가 기본 활성이므로 **dispatch 가 통합·(forge 서브모드에서) 리뷰·머지를 직접 소유**한다 — 머지가 의존자를 푸는 게이트는 본질적으로 dispatch 의 웨이브 스케줄링에 속하기 때문이다. `--no-integrate` 레거시 모드에서만 forge(PR/머지) 연동이 호출 레이어 책임이고 dispatch 는 위임만 한다. 어느 모드에서도 모든 forge·git·loop·리뷰 인터페이스는 주입 가능한 명령으로 두어 mock 검증되며, force 는 어떤 경로(forge·direct)에서도 쓰지 않는다.
+- **통합·머지 소유권**: 통합이 항상 활성이므로 **dispatch 가 통합·리뷰·머지를 직접 소유**한다 — 머지가 의존자를 푸는 게이트는 본질적으로 dispatch 의 웨이브 스케줄링에 속하기 때문이다. 모든 forge·git·loop·리뷰 인터페이스는 주입 가능한 명령으로 두어 mock 검증되며, force 는 어떤 경로(forge·direct)에서도 쓰지 않는다.
 - 분해(여러 SPEC 작성) 책임은 SPEC 작성 도구(`autopilot:spec` 등)에 있고, dispatch 는 이미 만들어진 SPEC 들만 받는다.
 - child 의 종료 의도(완료/차단)는 자율 실행기가 신호로 표현하고, dispatch 는 그 공개 인터페이스가 제공하는 **구조화된 상태**(`loop.sh status --json` 의 `.state`·`.signals[]`)로만 읽는다 — 표 컬럼 위치·부분 문자열 일치에 의존하지 않는다. `signals` 의 의미(`DONE`/`BLOCKED`)는 워커 컨벤션이며 dispatch 는 정확 일치 멤버십으로 판정한다.
 - run 디렉토리는 git 추적에서 제외한다(`.gitignore` 처리 권장).

--- a/plugins/autopilot/skills/dispatch/references/dispatch.sh
+++ b/plugins/autopilot/skills/dispatch/references/dispatch.sh
@@ -6,22 +6,22 @@
 #     wave 단위로 자율 실행기(loop.sh)에 위임 호출.
 #   - run-id 단위로 진행 상태를 <project_root>/.dispatch/runs/<run-id>/ 에 보관.
 #   - list / status / stop / watch / --resume 운영 인터페이스 제공.
-#   - (통합 모드는 기본 활성) per-SPEC 통합→(forge 서브모드)리뷰→머지 파이프라인을 소유:
+#   - (통합은 항상 활성 — 토글 없음) per-SPEC 통합→리뷰→머지 파이프라인을 소유:
 #     loop DONE 을 곧 done 으로 보지 않고 ff-only 머지에 성공한 SPEC 만 done 으로 전이해
 #     의존자 해제를 머지 뒤로 미룬다. forge 구성이면 풀 파이프라인(push→PR→리뷰→ff-only
-#     머지), forge 미구성이면 리뷰·승인 없이 ff-only 직접 머지(direct 서브모드).
-#     `--no-integrate` 면 통합을 꺼 loop DONE=done(레거시). 통합 모듈(integration/
-#     review-loop/merge.sh)은 서브프로세스로 격리 호출하고 상태는 lib-integration.sh 로 보관.
+#     머지), forge 미구성이면 PR 없는 로컬 적대적 리뷰 게이트 후 ff-only 직접 머지(direct
+#     서브모드). 통합 모듈(integration/review-loop/merge.sh)은 서브프로세스로 격리 호출하고
+#     상태는 lib-integration.sh 로 보관. 머지·동기화 대상 브랜치는 --target-branch 로 지정
+#     (미지정 시 기본 브랜치)하고 run-dir 마커로 영속(재개 sticky).
 #
 # **하지 않는 일**:
 #   - 입력 SPEC 의 frontmatter 형식·내용 검증 (자율 실행기 책임).
-#   - forge(PR/issue/label) 연동 — **`--no-integrate` 레거시 모드에서만** 호출 레이어 책임이다.
-#     통합 모드(기본)가 활성이면 dispatch 가 통합·리뷰·머지를 직접 소유한다(위 책임 참조).
-#     어느 모드·서브모드(forge·direct)에서도 force(강제) push·rebase·merge 는 쓰지 않는다.
+#   - 통합은 dispatch 가 직접 소유한다(통합·리뷰·머지). 어느 서브모드(forge·direct)에서도
+#     force(강제) push·rebase·merge 는 쓰지 않는다(머지는 ff-only).
 #   - 자율 실행기 내부 신호 파일 포맷·iteration·worktree 결정 (loop.sh 책임).
 #
 # 사용:
-#   bash dispatch.sh start <spec...> [--max-parallel N] [--resume <run-id>]
+#   bash dispatch.sh start <spec...> [--max-parallel N] [--resume <run-id>] [--target-branch <b>]
 #   bash dispatch.sh list
 #   bash dispatch.sh status <run-id>
 #   bash dispatch.sh stop <run-id>
@@ -55,9 +55,12 @@ WAVE_TIMEOUT_SECONDS="${DISPATCH_WAVE_TIMEOUT_SECONDS:-7200}"
 INTEGRATION_CMD="${INTEGRATION_CMD:-bash $SCRIPT_DIR/integration.sh}"
 REVIEW_CMD="${REVIEW_CMD:-bash $SCRIPT_DIR/review-loop.sh}"
 MERGE_CMD="${MERGE_CMD:-bash $SCRIPT_DIR/merge.sh}"
-INTEGRATE_MODE=0
-# 통합 서브모드: forge(풀 파이프라인) | direct(forge 미구성 직접 머지). cmd_start 가 결정.
+# 통합 서브모드: forge(풀 파이프라인) | direct(forge 미구성 — 적대적 리뷰 게이트 후 직접 머지).
+# cmd_start 가 결정·영속(INTEGRATE 마커). 통합 자체는 항상 활성(토글 없음).
 INTEGRATE_SUBMODE=""
+# 머지·동기화 대상 브랜치(--target-branch 로 지정, 미지정 시 기본 브랜치). cmd_start 가
+# run-dir 마커(TARGET_BRANCH)로 영속하고 통합 모듈에 DEFAULT_BRANCH 로 export 한다.
+TARGET_BRANCH=""
 # forge CLI 바이너리(서브모드 판정용). FORGE_CMD 와 별개로 '사용 가능' 판정에만 쓴다.
 FORGE_BIN="${FORGE_BIN:-gh}"
 # shellcheck source=lib-integration.sh
@@ -336,21 +339,18 @@ child_terminal_state() {
 # ----- 통합 모드: loop 종료 매핑 + per-SPEC 드레인 -----
 
 # mark_loop_terminal <run_dir> <spec> <term> — loop 가 종료(done/failed/그외)했을 때
-# 스케줄러 상태로 매핑한다. 통합 모드면 done/failed 를 곧장 done/failed 로 보지 않고
-# `integrating` 으로 두어 통합→리뷰→머지 드레인이 분류·전진하게 한다(spec-gap 여부 포함).
-# 비활성이면 기존 동작과 동일(done→done, 그 외→failed).
+# 스케줄러 상태로 매핑한다. 통합은 항상 활성이므로 깨끗한 loop 종착(done/failed)은 곧장
+# done/failed 로 보지 않고 `integrating` 으로 두어 통합→리뷰→머지 드레인이 분류·전진하게
+# 한다(spec-gap 여부 포함). 그 외(running/unknown 등 비깨끗 종착)는 보수적으로 failed.
 mark_loop_terminal() {
   local rd="$1" spec="$2" term="$3"
-  if (( INTEGRATE_MODE == 1 )) && { [[ "$term" == "done" ]] || [[ "$term" == "failed" ]]; }; then
+  if [[ "$term" == "done" ]] || [[ "$term" == "failed" ]]; then
     set_state "$rd" "$spec" "integrating"
     int_set_phase "$rd" "$(int_key "$spec")" "loop-done"
     int_set "$rd" "$(int_key "$spec")" integ-start "$(date +%s)"
     log_event "$rd" "integrate-enter $(spec_slug "$spec") loop-terminal=$term"
   else
-    case "$term" in
-      done) set_state "$rd" "$spec" "done";   log_event "$rd" "done $(spec_slug "$spec")" ;;
-      *)    set_state "$rd" "$spec" "failed"; log_event "$rd" "failed $(spec_slug "$spec") (term=$term)" ;;
-    esac
+    set_state "$rd" "$spec" "failed"; log_event "$rd" "failed $(spec_slug "$spec") (term=$term)"
   fi
 }
 
@@ -389,8 +389,15 @@ drain_integration() {
       fi
       ;;
     review)
-      # shellcheck disable=SC2086
-      $REVIEW_CMD run "$rd" "$key" "$spec" "$pr" "$branch" >/dev/null 2>&1 || true
+      if [[ "$INTEGRATE_SUBMODE" == "direct" ]]; then
+        # direct 서브모드: PR 없는 로컬 작업 브랜치 적대적 리뷰 게이트(원격 push·PR 미사용).
+        #   approve→phase=merging, request_changes→로컬 재구현(다음 틱 재리뷰), 가드→escalated.
+        # shellcheck disable=SC2086
+        $REVIEW_CMD run-direct "$rd" "$key" "$spec" "$branch" >/dev/null 2>&1 || true
+      else
+        # shellcheck disable=SC2086
+        $REVIEW_CMD run "$rd" "$key" "$spec" "$pr" "$branch" >/dev/null 2>&1 || true
+      fi
       ;;
     approved)
       # 분리 approver 신원 승인 1회 제출 후 머지 시도(멱등: 제출 표시).
@@ -526,14 +533,15 @@ cmd_start() {
   require_yq
   local resume=""
   local max_parallel=0
-  local no_integrate_opt=0
+  local target_branch_opt=""
   local -a inputs=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --resume) resume="$2"; shift 2 ;;
       --max-parallel) max_parallel="$2"; shift 2 ;;
-      --integrate) shift ;;                        # 기본 ON 이므로 하위호환 no-op.
-      --no-integrate) no_integrate_opt=1; shift ;;
+      --target-branch) target_branch_opt="$2"; shift 2 ;;
+      # 통합은 항상 활성(토글 제거). 하위호환을 위해 두 플래그를 받되 아무 효과 없이 무시한다.
+      --integrate|--no-integrate) shift ;;
       --) shift; while [[ $# -gt 0 ]]; do inputs+=("$1"); shift; done ;;
       -*) die "알 수 없는 옵션: $1" ;;
       *) inputs+=("$1"); shift ;;
@@ -581,32 +589,33 @@ cmd_start() {
     for s in "${specs_abs[@]}"; do set_state "$rd" "$s" "pending"; done
   fi
 
-  # ----- 통합 모드·서브모드 활성 판정 (기본 ON; --no-integrate 로 OFF) -----
-  # 기본값은 통합 켜짐이고 `--no-integrate` 로만 끈다. 모드(on/off)와 서브모드(forge/direct)는
-  # run-dir 마커로 보존해 --resume 에서 sticky 하다(최초 시작 결정을 그대로 재개):
-  #   $rd/NO_INTEGRATE 존재 → OFF(레거시).  $rd/INTEGRATE 존재 → ON(내용=서브모드).
-  # 마커가 있으면(=재개) 현재 env/플래그보다 마커가 우선한다.
-  if [[ -f "$rd/NO_INTEGRATE" ]]; then
-    INTEGRATE_MODE=0
-  elif [[ -f "$rd/INTEGRATE" ]]; then
-    INTEGRATE_MODE=1
+  # ----- 통합 서브모드 판정 (통합은 항상 활성 — 토글 없음) -----
+  # 서브모드(forge/direct)는 run-dir 마커($rd/INTEGRATE, 내용=서브모드)로 보존해 --resume 에서
+  # sticky 하다(최초 시작 결정을 그대로 재개). 마커가 있으면(=재개) 현재 env/플래그보다 우선.
+  if [[ -f "$rd/INTEGRATE" ]]; then
     INTEGRATE_SUBMODE="$(cat "$rd/INTEGRATE" 2>/dev/null || true)"
-  elif (( no_integrate_opt == 1 )); then
-    INTEGRATE_MODE=0
-    : > "$rd/NO_INTEGRATE"
-  else
-    INTEGRATE_MODE=1
   fi
-  if (( INTEGRATE_MODE == 1 )); then
-    # 서브모드 미정(최초 시작 또는 빈 마커)이면 forge 구성 여부로 결정.
-    if [[ -z "$INTEGRATE_SUBMODE" ]]; then
-      if forge_configured; then INTEGRATE_SUBMODE=forge; else INTEGRATE_SUBMODE=direct; fi
-    fi
-    printf '%s\n' "$INTEGRATE_SUBMODE" > "$rd/INTEGRATE"
-    log_event "$rd" "integration mode ON submode=$INTEGRATE_SUBMODE (done=머지됨)"
-  else
-    log_event "$rd" "integration mode OFF (--no-integrate; loop DONE=done)"
+  # 서브모드 미정(최초 시작 또는 빈 마커)이면 forge 구성 여부로 결정.
+  if [[ -z "$INTEGRATE_SUBMODE" ]]; then
+    if forge_configured; then INTEGRATE_SUBMODE=forge; else INTEGRATE_SUBMODE=direct; fi
   fi
+  printf '%s\n' "$INTEGRATE_SUBMODE" > "$rd/INTEGRATE"
+
+  # ----- 대상 브랜치 판정 (--target-branch, 미지정 시 기본 브랜치) -----
+  # run-dir 마커($rd/TARGET_BRANCH)로 영속해 --resume 에서 sticky 하다. 마커가 있으면(=재개)
+  # 현재 env(DEFAULT_BRANCH)·--target-branch 플래그보다 마커가 우선한다. 결정된 대상은 모든
+  # 통합 모듈(base sync·승인 요청 base·ff 머지·base push)에 DEFAULT_BRANCH 로 export 된다.
+  if [[ -f "$rd/TARGET_BRANCH" ]]; then
+    TARGET_BRANCH="$(cat "$rd/TARGET_BRANCH" 2>/dev/null || true)"
+  elif [[ -n "$target_branch_opt" ]]; then
+    TARGET_BRANCH="$target_branch_opt"
+  else
+    TARGET_BRANCH="${DEFAULT_BRANCH:-main}"
+  fi
+  [[ -n "$TARGET_BRANCH" ]] || TARGET_BRANCH="${DEFAULT_BRANCH:-main}"
+  printf '%s\n' "$TARGET_BRANCH" > "$rd/TARGET_BRANCH"
+  export DEFAULT_BRANCH="$TARGET_BRANCH"
+  log_event "$rd" "integration submode=$INTEGRATE_SUBMODE target-branch=$TARGET_BRANCH (done=머지됨)"
 
   # ----- 스트리밍 스케줄러 (SPEC별 준비도 기반) -----
   # WAVES.txt 는 진단용으로 보존하되, 실제 실행은 wave 배리어가 아니라 각 SPEC 의
@@ -700,14 +709,12 @@ cmd_start() {
       PIDS[i]=""
     done
 
-    # 3.5) 통합 모드 드레인 — integrating SPEC 을 틱당 한 스텝씩 멱등 전진.
+    # 3.5) 통합 드레인 — integrating SPEC 을 틱당 한 스텝씩 멱등 전진(통합은 항상 활성).
     #   integrate→review→(approve)→merge. merged→done(=의존자 해제), 비완료 종착→failed.
-    if (( INTEGRATE_MODE == 1 )); then
-      for ((i=0; i<n; i++)); do
-        [[ "$(get_state "$rd" "${specs_abs[i]}")" == "integrating" ]] || continue
-        drain_integration "$rd" "${specs_abs[i]}"
-      done
-    fi
+    for ((i=0; i<n; i++)); do
+      [[ "$(get_state "$rd" "${specs_abs[i]}")" == "integrating" ]] || continue
+      drain_integration "$rd" "${specs_abs[i]}"
+    done
 
     # 4) 종료 판정 — 모든 SPEC 이 done/failed/skipped 이면 끝.
     local pending_or_running=0
@@ -851,12 +858,14 @@ cmd_watch() {
 
 # =====================================================================
 # selftest — 스케줄러 통합 검증(mock loop/integration/review/merge).
-#   AC1: 기본 ON(플래그 없이 통합 활성). 의존자는 의존성이 머지(done)된 뒤에만 launch.
-#   AC2: forge 구성 시 풀 파이프라인(integrate→review→merge) 순서.
-#   AC3: forge 미구성 시 직접 머지(integrate-direct→merge, 리뷰·승인 우회).
-#   AC4: --no-integrate → 레거시(loop DONE=done, 통합 모듈 미호출, NO_INTEGRATE 마커).
-#   AC7: --resume 에서 모드(on/off)·서브모드(forge/direct) sticky(run-dir 마커).
-#   비완료 종착(통합 차단)이면 이행적 의존자만 skipped.
+#   AC1: 통합 항상 활성(플래그 없이). 의존자는 의존성이 머지(done)된 뒤에만 launch.
+#   AC2: --no-integrate/--integrate 플래그 no-op(받되 무시, 통합 동작).
+#   AC3: 비통합(레거시) 경로 부재 — NO_INTEGRATE 마커·loop DONE=done 분기 없음.
+#   AC4/AC5: --target-branch 지정/미지정(기본 브랜치) → 통합 모듈에 DEFAULT_BRANCH export.
+#   AC6: --resume 에서 서브모드(forge/direct)·대상 브랜치 sticky(run-dir 마커).
+#   AC7/AC8/AC10: direct 서브모드 적대적 리뷰 게이트(integrate-direct→review→merge),
+#                 리뷰 가드 소진(escalated)→failed + 이행적 의존자만 skipped.
+#   forge 풀 파이프라인(integrate→review→merge) 순서·차단 전파.
 #   self-referential: 실제 PR·머지 미수행(모두 mock).
 # =====================================================================
 cmd_selftest() {
@@ -875,7 +884,7 @@ esac
 exit 0
 EOF
   # mock integration: integrate / integrate-direct <spec> <rd> <key>.
-  #   integrate(풀)→phase=review(+pr). integrate-direct(직접)→phase=merging(승인·PR 없음).
+  #   integrate(풀)→phase=review(+pr). integrate-direct(direct)→phase=review(리뷰 게이트, PR 없음).
   #   MOCK_INT_BLOCK 이면 그 spec 을 blocked.
   cat > "$TMP/m-int.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -885,31 +894,42 @@ printf '%s:%s\n' "$sub" "$(basename "$spec")" >> "$EVENTLOG"
 if [[ -n "${MOCK_INT_BLOCK:-}" && "$(basename "$spec")" == "$MOCK_INT_BLOCK" ]]; then
   int_set_phase "$rd" "$key" blocked
 elif [[ "$sub" == "integrate-direct" ]]; then
-  int_set_branch "$rd" "$key" "feat/x-$key"
-  int_set_phase "$rd" "$key" merging
+  int_set_branch "$rd" "$key" "feat/x-$key"   # PR 없음 — 리뷰 게이트로.
+  int_set_phase "$rd" "$key" review
 else
   int_set_branch "$rd" "$key" "feat/x-$key"; int_set_pr "$rd" "$key" 100
   int_set_phase "$rd" "$key" review
 fi
 exit 0
 EOF
-  # mock review: run <rd> <key> <spec> <pr> <branch> → approved.
+  # mock review: run(forge)→approved / run-direct(direct)→merging(approve, 승인 의례 없음).
+  #   MOCK_REVIEW_BLOCK 이면 direct 리뷰가 가드 소진처럼 escalated 로 종료(머지 안 함).
   cat > "$TMP/m-review.sh" <<'EOF'
 #!/usr/bin/env bash
 . "$LIBINT"
-rd="$2"; key="$3"; spec="$4"
-printf 'review:%s\n' "$(basename "$spec")" >> "$EVENTLOG"
-int_set_phase "$rd" "$key" approved
+sub="$1"; rd="$2"; key="$3"; spec="$4"
+if [[ "$sub" == "run-direct" ]]; then
+  printf 'review-direct:%s\n' "$(basename "$spec")" >> "$EVENTLOG"
+  if [[ -n "${MOCK_REVIEW_BLOCK:-}" && "$(basename "$spec")" == "$MOCK_REVIEW_BLOCK" ]]; then
+    int_set_phase "$rd" "$key" escalated
+  else
+    int_set_phase "$rd" "$key" merging
+  fi
+else
+  printf 'review:%s\n' "$(basename "$spec")" >> "$EVENTLOG"
+  int_set_phase "$rd" "$key" approved
+fi
 exit 0
 EOF
-  # mock merge: approve <pr> / finish <spec> <rd> <key> <pr> → merged.
+  # mock merge: approve <pr> / finish <spec> <rd> <key> [pr] [skip_approval] → merged.
+  #   merge 로그에 대상 브랜치(DEFAULT_BRANCH)를 함께 적어 --target-branch export 를 검증.
   cat > "$TMP/m-merge.sh" <<'EOF'
 #!/usr/bin/env bash
 . "$LIBINT"
 case "$1" in
   approve) printf 'approve:%s\n' "$2" >> "$EVENTLOG" ;;
   finish)  spec="$2"; rd="$3"; key="$4"
-           printf 'merge:%s\n' "$(basename "$spec")" >> "$EVENTLOG"
+           printf 'merge:%s:%s\n' "$(basename "$spec")" "${DEFAULT_BRANCH:-main}" >> "$EVENTLOG"
            int_set_phase "$rd" "$key" merged ;;
 esac
 exit 0
@@ -936,44 +956,60 @@ EOF
     cat "$rd/state.$key" 2>/dev/null || echo "MISSING"
   }
   latest_run() { ls -1dt "$REPO"/.dispatch/runs/*/ 2>/dev/null | head -1 | sed 's:/$::'; }
-  marker() { cat "$1/INTEGRATE" 2>/dev/null; }
+  marker()  { cat "$1/INTEGRATE" 2>/dev/null; }
+  tmarker() { cat "$1/TARGET_BRANCH" 2>/dev/null; }
   # 공통 주입 env(서브모듈 mock + 결정성). 호출자가 APPROVER/FORGE_BIN 으로 서브모드 제어.
   dsp_env() { env EVENTLOG="$1" LOOP_CMD="bash $TMP/m-loop.sh" \
       INTEGRATION_CMD="bash $TMP/m-int.sh" REVIEW_CMD="bash $TMP/m-review.sh" MERGE_CMD="bash $TMP/m-merge.sh" \
       LIBINT="$LIBINT" DISPATCH_POLL_SECONDS=0 DISPATCH_WAVE_TIMEOUT_SECONDS=120 "${@:2}"; }
 
-  # ---- S1: AC1/AC2 기본 ON + forge 구성 → 풀 파이프라인(integrate→review→merge) ----
-  #   플래그 없이 시작해도 통합 모드 활성(AC1). APPROVER+forge CLI(FORGE_BIN=bash) → submode=forge.
+  # ---- S1: AC1 통합 항상 활성 + forge 구성 → 풀 파이프라인(integrate→review→merge) ----
+  #   플래그 없이 시작해도 통합 활성(AC1). APPROVER+forge CLI(FORGE_BIN=bash) → submode=forge.
   rm -rf "$REPO/.dispatch"
   local EVENTLOG="$TMP/ev1.log"; : > "$EVENTLOG"
   ( cd "$REPO" && dsp_env "$EVENTLOG" APPROVER=approver-bot FORGE_BIN=bash \
       bash "$DSP" start feature-a.md feature-b.md ) >/dev/null 2>&1 || true
   local rd1; rd1="$(latest_run)"
-  [[ "$(run_state "$rd1" feature-a.md)" == "done" ]] && ok "AC1 기본 ON A 머지(done)" || bad "AC1 기본 ON A 머지(done) got=$(run_state "$rd1" feature-a.md)"
-  [[ "$(run_state "$rd1" feature-b.md)" == "done" ]] && ok "AC1 기본 ON B 머지(done)" || bad "AC1 기본 ON B 머지(done) got=$(run_state "$rd1" feature-b.md)"
+  [[ "$(run_state "$rd1" feature-a.md)" == "done" ]] && ok "AC1 통합 활성 A 머지(done)" || bad "AC1 통합 활성 A 머지(done) got=$(run_state "$rd1" feature-a.md)"
+  [[ "$(run_state "$rd1" feature-b.md)" == "done" ]] && ok "AC1 통합 활성 B 머지(done)" || bad "AC1 통합 활성 B 머지(done) got=$(run_state "$rd1" feature-b.md)"
   before "$EVENTLOG" 'merge:feature-a.md' 'launch:feature-b.md' \
-    && ok "AC2 A 머지 후에만 B launch" || bad "AC2 A 머지 후에만 B launch"
+    && ok "AC1 A 머지 후에만 B launch" || bad "AC1 A 머지 후에만 B launch"
   before "$EVENTLOG" 'integrate:feature-a.md' 'review:feature-a.md' \
-    && ok "AC2 forge integrate→review 순서" || bad "AC2 forge integrate→review 순서"
+    && ok "forge integrate→review 순서" || bad "forge integrate→review 순서"
   before "$EVENTLOG" 'review:feature-a.md' 'merge:feature-a.md' \
-    && ok "AC2 forge review→merge 순서" || bad "AC2 forge review→merge 순서"
-  [[ "$(marker "$rd1")" == "forge" ]] && ok "AC1/AC7 마커 submode=forge" || bad "AC1/AC7 마커 submode=forge got=$(marker "$rd1")"
-  [[ ! -f "$rd1/NO_INTEGRATE" ]] && ok "AC1 NO_INTEGRATE 마커 없음" || bad "AC1 NO_INTEGRATE 마커 없음"
+    && ok "forge review→merge 순서" || bad "forge review→merge 순서"
+  [[ "$(marker "$rd1")" == "forge" ]] && ok "AC6 마커 submode=forge" || bad "AC6 마커 submode=forge got=$(marker "$rd1")"
+  [[ ! -f "$rd1/NO_INTEGRATE" ]] && ok "AC3 NO_INTEGRATE 마커 부재(레거시 경로 없음)" || bad "AC3 NO_INTEGRATE 마커 부재"
+  # AC5: --target-branch 미지정 → 대상 = 기본 브랜치(main). 머지 모듈에 export 됨.
+  [[ "$(tmarker "$rd1")" == "main" ]] && ok "AC5 기본 대상 브랜치=main 마커" || bad "AC5 기본 대상=main 마커 got=$(tmarker "$rd1")"
+  grep -q 'merge:feature-a.md:main' "$EVENTLOG" && ok "AC5 기본 대상 main 이 머지 모듈에 export" || bad "AC5 기본 대상 main export"
 
-  # ---- S1b: AC3 기본 ON + forge 미구성 → 직접 머지(리뷰·승인 우회) ----
-  #   APPROVER 미설정 → submode=direct. integrate-direct→merge 만(review·approve 없음).
+  # ---- S1b: AC7 forge 미구성(direct) → 적대적 리뷰 게이트(integrate-direct→review-direct→merge) ----
+  #   APPROVER 미설정 → submode=direct. 머지 직전 PR 없는 로컬 리뷰 한 단계(run-direct)를 거친다.
   rm -rf "$REPO/.dispatch"
   local EVENTLOGD="$TMP/ev1b.log"; : > "$EVENTLOGD"
   ( cd "$REPO" && dsp_env "$EVENTLOGD" \
       bash "$DSP" start feature-a.md feature-b.md ) >/dev/null 2>&1 || true
   local rdD; rdD="$(latest_run)"
-  [[ "$(run_state "$rdD" feature-a.md)" == "done" ]] && ok "AC3 direct A 머지(done)" || bad "AC3 direct A 머지(done) got=$(run_state "$rdD" feature-a.md)"
-  [[ "$(run_state "$rdD" feature-b.md)" == "done" ]] && ok "AC3 direct B 머지(done)" || bad "AC3 direct B 머지(done) got=$(run_state "$rdD" feature-b.md)"
-  before "$EVENTLOGD" 'integrate-direct:feature-a.md' 'merge:feature-a.md' \
-    && ok "AC3 direct integrate-direct→merge 순서" || bad "AC3 direct integrate-direct→merge 순서"
-  if grep -qE 'review:|approve:' "$EVENTLOGD"; then bad "AC3 direct 리뷰·승인 우회"; else ok "AC3 direct 리뷰·승인 우회(미호출)"; fi
-  if grep -q '^integrate:' "$EVENTLOGD"; then bad "AC3 direct 풀-integrate 미호출"; else ok "AC3 direct 풀-integrate 미호출"; fi
-  [[ "$(marker "$rdD")" == "direct" ]] && ok "AC3/AC7 마커 submode=direct" || bad "AC3/AC7 마커 submode=direct got=$(marker "$rdD")"
+  [[ "$(run_state "$rdD" feature-a.md)" == "done" ]] && ok "AC7 direct A 머지(done)" || bad "AC7 direct A 머지(done) got=$(run_state "$rdD" feature-a.md)"
+  [[ "$(run_state "$rdD" feature-b.md)" == "done" ]] && ok "AC7 direct B 머지(done)" || bad "AC7 direct B 머지(done) got=$(run_state "$rdD" feature-b.md)"
+  before "$EVENTLOGD" 'integrate-direct:feature-a.md' 'review-direct:feature-a.md' \
+    && ok "AC7 direct integrate-direct→리뷰 게이트 순서" || bad "AC7 direct integrate-direct→리뷰 게이트 순서"
+  before "$EVENTLOGD" 'review-direct:feature-a.md' 'merge:feature-a.md' \
+    && ok "AC7 direct 리뷰 게이트→merge 순서(approve 후 머지)" || bad "AC7 direct 리뷰 게이트→merge 순서"
+  if grep -q '^integrate:' "$EVENTLOGD"; then bad "AC7 direct 풀-integrate 미호출"; else ok "AC7 direct 풀-integrate 미호출"; fi
+  if grep -q '^approve:' "$EVENTLOGD"; then bad "AC7 direct 분리승인 의례 미호출"; else ok "AC7 direct 분리승인 의례 미호출(승인 게이트 우회)"; fi
+  [[ "$(marker "$rdD")" == "direct" ]] && ok "AC6 마커 submode=direct" || bad "AC6 마커 submode=direct got=$(marker "$rdD")"
+
+  # ---- S1c: AC10 direct 리뷰 가드 소진(escalated) → A failed, 이행적 의존자 B skipped(머지 안 함) ----
+  rm -rf "$REPO/.dispatch"
+  local EVENTLOGDB="$TMP/ev1c.log"; : > "$EVENTLOGDB"
+  ( cd "$REPO" && dsp_env "$EVENTLOGDB" MOCK_REVIEW_BLOCK="feature-a.md" \
+      bash "$DSP" start feature-a.md feature-b.md ) >/dev/null 2>&1 || true
+  local rdDB; rdDB="$(latest_run)"
+  [[ "$(run_state "$rdDB" feature-a.md)" == "failed" ]] && ok "AC10 direct 리뷰 가드소진 A failed" || bad "AC10 direct A failed got=$(run_state "$rdDB" feature-a.md)"
+  [[ "$(run_state "$rdDB" feature-b.md)" == "skipped" ]] && ok "AC10 direct 리뷰 차단 B 이행적 skipped" || bad "AC10 direct B skipped got=$(run_state "$rdDB" feature-b.md)"
+  if grep -q '^merge:feature-a.md' "$EVENTLOGDB"; then bad "AC10 direct 리뷰 차단 시 머지 안 함"; else ok "AC10 direct 리뷰 차단 시 머지 안 함"; fi
 
   # ---- S2: AC: 통합 차단(A, forge) → 이행적 의존자 B skipped ----
   rm -rf "$REPO/.dispatch"
@@ -985,41 +1021,47 @@ EOF
   [[ "$(run_state "$rd2" feature-b.md)" == "skipped" ]] && ok "차단 B 이행적 skipped" || bad "차단 B skipped got=$(run_state "$rd2" feature-b.md)"
   if grep -q 'launch:feature-b.md' "$EVENTLOG2"; then bad "차단 B 미launch"; else ok "차단 B 미launch(차단 전파)"; fi
 
-  # ---- S3: AC4 --no-integrate → 레거시(loop DONE=done, 통합 모듈 미호출) ----
+  # ---- S3: AC2 --no-integrate/--integrate 플래그 no-op → 통합 그대로 동작(레거시 경로 없음) ----
   rm -rf "$REPO/.dispatch"
   local EVENTLOG3="$TMP/ev3.log"; : > "$EVENTLOG3"
   ( cd "$REPO" && dsp_env "$EVENTLOG3" APPROVER=approver-bot FORGE_BIN=bash \
-      bash "$DSP" start --no-integrate feature-a.md feature-b.md ) >/dev/null 2>&1 || true
+      bash "$DSP" start --no-integrate --integrate feature-a.md feature-b.md ) >/dev/null 2>&1 || true
   local rd3; rd3="$(latest_run)"
-  [[ "$(run_state "$rd3" feature-a.md)" == "done" ]] && ok "AC4 레거시 A loop DONE=done" || bad "AC4 레거시 A done got=$(run_state "$rd3" feature-a.md)"
-  [[ "$(run_state "$rd3" feature-b.md)" == "done" ]] && ok "AC4 레거시 B loop DONE=done" || bad "AC4 레거시 B done got=$(run_state "$rd3" feature-b.md)"
-  if grep -qE 'integrate:|integrate-direct:|review:|merge:' "$EVENTLOG3"; then bad "AC4 레거시 통합 모듈 미호출"; else ok "AC4 레거시 통합 모듈 미호출(--no-integrate)"; fi
-  before "$EVENTLOG3" 'launch:feature-a.md' 'launch:feature-b.md' \
-    && ok "AC4 A done 후 B launch(기존 게이트)" || bad "AC4 A done 후 B launch"
-  [[ -f "$rd3/NO_INTEGRATE" ]] && ok "AC4 NO_INTEGRATE 마커" || bad "AC4 NO_INTEGRATE 마커"
-  [[ ! -f "$rd3/INTEGRATE" ]] && ok "AC4 INTEGRATE 마커 없음" || bad "AC4 INTEGRATE 마커 없음"
+  [[ "$(run_state "$rd3" feature-a.md)" == "done" ]] && ok "AC2 플래그 no-op A 머지(done)" || bad "AC2 플래그 no-op A done got=$(run_state "$rd3" feature-a.md)"
+  grep -qE 'integrate:|review:|merge:' "$EVENTLOG3" && ok "AC2 플래그 no-op 통합 모듈 호출됨(통합 동작)" || bad "AC2 플래그 no-op 통합 동작"
+  [[ ! -f "$rd3/NO_INTEGRATE" ]] && ok "AC3 --no-integrate 줘도 NO_INTEGRATE 마커 없음" || bad "AC3 NO_INTEGRATE 마커 없음(no-op)"
+  [[ -f "$rd3/INTEGRATE" ]] && ok "AC2 플래그 no-op INTEGRATE 마커 존재" || bad "AC2 INTEGRATE 마커 존재"
 
-  # ---- S4a: AC7 --resume 서브모드 sticky — direct 시작 후 APPROVER 설정 재개해도 direct 유지 ----
+  # ---- S3b: AC4 --target-branch 지정 → 대상 브랜치가 통합 모듈에 DEFAULT_BRANCH 로 export ----
+  rm -rf "$REPO/.dispatch"
+  local EVENTLOGT="$TMP/ev3b.log"; : > "$EVENTLOGT"
+  ( cd "$REPO" && dsp_env "$EVENTLOGT" APPROVER=approver-bot FORGE_BIN=bash \
+      bash "$DSP" start --target-branch release feature-a.md feature-b.md ) >/dev/null 2>&1 || true
+  local rdT; rdT="$(latest_run)"
+  [[ "$(tmarker "$rdT")" == "release" ]] && ok "AC4 대상 브랜치 마커=release" || bad "AC4 대상 마커=release got=$(tmarker "$rdT")"
+  grep -q 'merge:feature-a.md:release' "$EVENTLOGT" && ok "AC4 지정 대상 release 가 머지 모듈에 export" || bad "AC4 release export(got merges: $(grep -o 'merge:[^ ]*' "$EVENTLOGT" | tr '\n' ' '))"
+  if grep -q 'merge:feature-a.md:main' "$EVENTLOGT"; then bad "AC4 main 잔존 누수"; else ok "AC4 main 하드코딩 잔존 없음"; fi
+
+  # ---- S4a: AC6 --resume 서브모드 sticky — direct 시작 후 APPROVER 설정 재개해도 direct 유지 ----
   rm -rf "$REPO/.dispatch"
   local EVENTLOG4="$TMP/ev4.log"; : > "$EVENTLOG4"
   ( cd "$REPO" && dsp_env "$EVENTLOG4" \
       bash "$DSP" start feature-a.md feature-b.md ) >/dev/null 2>&1 || true
   local rd4; rd4="$(latest_run)"; local rid4; rid4="$(basename "$rd4")"
-  [[ "$(marker "$rd4")" == "direct" ]] && ok "AC7 최초 시작 submode=direct" || bad "AC7 최초 시작 submode=direct got=$(marker "$rd4")"
+  [[ "$(marker "$rd4")" == "direct" ]] && ok "AC6 최초 시작 submode=direct" || bad "AC6 최초 시작 submode=direct got=$(marker "$rd4")"
   ( cd "$REPO" && dsp_env "$EVENTLOG4" APPROVER=approver-bot FORGE_BIN=bash \
       bash "$DSP" start --resume "$rid4" ) >/dev/null 2>&1 || true
-  [[ "$(marker "$rd4")" == "direct" ]] && ok "AC7 재개 후 submode 여전히 direct(sticky)" || bad "AC7 재개 후 submode sticky got=$(marker "$rd4")"
-  [[ ! -f "$rd4/NO_INTEGRATE" ]] && ok "AC7 재개 후 모드 ON 유지" || bad "AC7 재개 후 모드 ON 유지"
+  [[ "$(marker "$rd4")" == "direct" ]] && ok "AC6 재개 후 submode 여전히 direct(sticky)" || bad "AC6 재개 후 submode sticky got=$(marker "$rd4")"
 
-  # ---- S4b: AC7 --resume 모드 sticky — --no-integrate 시작 후 APPROVER 재개해도 OFF 유지 ----
+  # ---- S4b: AC6 --resume 대상 브랜치 sticky — release 로 시작 후 플래그 없이 재개해도 release 유지 ----
   rm -rf "$REPO/.dispatch"
   local EVENTLOG5="$TMP/ev5.log"; : > "$EVENTLOG5"
-  ( cd "$REPO" && dsp_env "$EVENTLOG5" \
-      bash "$DSP" start --no-integrate feature-a.md feature-b.md ) >/dev/null 2>&1 || true
-  local rd5; rd5="$(latest_run)"; local rid5; rid5="$(basename "$rd5")"
   ( cd "$REPO" && dsp_env "$EVENTLOG5" APPROVER=approver-bot FORGE_BIN=bash \
+      bash "$DSP" start --target-branch release feature-a.md feature-b.md ) >/dev/null 2>&1 || true
+  local rd5; rd5="$(latest_run)"; local rid5; rid5="$(basename "$rd5")"
+  ( cd "$REPO" && dsp_env "$EVENTLOG5" DEFAULT_BRANCH=main APPROVER=approver-bot FORGE_BIN=bash \
       bash "$DSP" start --resume "$rid5" ) >/dev/null 2>&1 || true
-  [[ -f "$rd5/NO_INTEGRATE" && ! -f "$rd5/INTEGRATE" ]] && ok "AC7 재개 후 모드 OFF 유지(sticky)" || bad "AC7 재개 후 모드 OFF 유지(sticky)"
+  [[ "$(tmarker "$rd5")" == "release" ]] && ok "AC6 재개 후 대상 브랜치 release 유지(sticky, env 보다 우선)" || bad "AC6 재개 후 대상 sticky got=$(tmarker "$rd5")"
 
   echo "----"
   [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"
@@ -1033,12 +1075,13 @@ usage() {
 usage: dispatch.sh <subcommand> [args]
 
 Subcommands:
-  start <spec...> [--max-parallel N] [--resume <run-id>] [--no-integrate]
-        통합(리뷰·머지) 모드는 기본 활성이다. forge 구성(APPROVER+forge CLI)이면 풀
-        파이프라인(push→PR→리뷰→ff-only 머지), 미구성이면 직접 ff-only 머지(리뷰·승인
-        우회, version 게이트 유지)로 SPEC 을 main 에 머지한다. --no-integrate 면 통합을
-        끄고 레거시(loop DONE=done, 머지·PR 없음)로 동작한다. 모드·서브모드는 --resume 에서
-        sticky 하다.
+  start <spec...> [--max-parallel N] [--resume <run-id>] [--target-branch <b>]
+        통합(리뷰·머지)은 항상 활성이다(토글 없음). forge 구성(APPROVER+forge CLI)이면 풀
+        파이프라인(push→PR→리뷰→ff-only 머지), 미구성이면 PR 없는 로컬 적대적 리뷰 게이트
+        후 ff-only 직접 머지(version 게이트 유지)로 SPEC 을 대상 브랜치에 머지한다.
+        --target-branch 로 머지·동기화 대상 브랜치를 지정(미지정 시 기본 브랜치). 하위호환을
+        위해 --integrate/--no-integrate 를 받되 무시한다(no-op). 서브모드·대상 브랜치는
+        --resume 에서 sticky 하다(run-dir 마커).
         1 개 이상의 SPEC 파일 경로를 받아 depends_on 으로 DAG 를 만들고,
         각 SPEC 을 그 의존성이 모두 done 이 되는 즉시(준비도 기반 스트리밍,
         동시성 상한 이내) loop driver 에 위임한다. 한 SPEC 이 failed 면 그

--- a/plugins/autopilot/skills/dispatch/references/integration.sh
+++ b/plugins/autopilot/skills/dispatch/references/integration.sh
@@ -299,10 +299,11 @@ in_handle_blocked() {
 }
 
 # in_integrate_direct <spec> <run_dir> <key> — forge 미구성 직접 머지 서브모드.
-#   승인 요청(PR)·리뷰·승인 의례 없이, 종료신호 판정·작업 브랜치 식별만 기존 헬퍼로 재사용해
-#   바로 머지 단계(phase=merging)로 넘긴다. push·PR 을 수행하지 않는다(머지는 호출자의 머지
-#   헬퍼가 ff-only + version 게이트로 직접 수행). BLOCKED 분기는 in_integrate 와 동일(공유 헬퍼).
-#   반환: 0=직접 머지 준비(phase=merging) / 3=spec-gap 차단 / 4=하드 차단 / 20=미종료(대기).
+#   승인 요청(PR) 없이, 종료신호 판정·작업 브랜치 식별만 기존 헬퍼로 재사용해 **적대적 리뷰
+#   게이트(phase=review)** 로 넘긴다. push·PR 을 수행하지 않는다(리뷰는 로컬 작업 브랜치 diff
+#   로 수행하고, approve 후 머지는 호출자의 머지 헬퍼가 ff-only + version 게이트로 직접 수행).
+#   BLOCKED 분기는 in_integrate 와 동일(공유 헬퍼).
+#   반환: 0=리뷰 게이트 진입(phase=review) / 3=spec-gap 차단 / 4=하드 차단 / 20=미종료(대기).
 in_integrate_direct() {
   local spec="$1" rd="$2" key="$3"
   [[ -n "$spec" && -n "$rd" && -n "$key" ]] || { in_die "사용: integration.sh integrate-direct <spec> <run_dir> <key>"; return 1; }
@@ -318,10 +319,10 @@ in_integrate_direct() {
       int_set_branch "$rd" "$key" "$branch"
       # 다리: 머지 대상으로 쓰기 전에 작업 브랜치가 없으면 loop 결과 커밋에서 생성(멱등·공통 헬퍼).
       in_ensure_work_branch "$branch" "$spec" || { int_set_phase "$rd" "$key" blocked; return 4; }
-      int_set_phase "$rd" "$key" merging
-      int_log "$rd" "$key" "직접 머지 준비(승인 요청·PR·리뷰 우회): branch=$branch → merging"
+      int_set_phase "$rd" "$key" review
+      int_log "$rd" "$key" "직접 통합(승인 요청·PR·push 우회) → 적대적 리뷰 게이트: branch=$branch → review"
       echo "key:    $key"
-      echo "phase:  merging"
+      echo "phase:  review"
       echo "branch: $branch"
       return 0
       ;;
@@ -351,8 +352,9 @@ Commands:
                                         DONE→push→PR(phase=review) /
                                         spec-gap→blocked-spec-gap / 하드 BLOCKED→blocked.
   integrate-direct <spec> <run_dir> <key>
-                                     forge 미구성 직접 머지: 승인·PR·리뷰 없이 작업 브랜치만
-                                        식별(phase=merging) / BLOCKED 분기는 integrate 와 동일.
+                                     forge 미구성 직접 통합: 승인·PR·push 없이 작업 브랜치만
+                                        식별해 적대적 리뷰 게이트로(phase=review) / BLOCKED
+                                        분기는 integrate 와 동일.
   terminal  <spec>                   child 종료 상태(done|failed|running|pending|unknown).
   category  <spec>                   BLOCKED 범주(spec-gap|...|other).
 
@@ -496,13 +498,15 @@ in_selftest() {
   chk "running rc=20(보류)" "$rc" "20"
   chk "running phase 미설정" "$(int_get_phase "$rd" "$kP")" ""
 
-  # ---- AC3: integrate-direct DONE → branch 세팅·phase=merging, push·PR 미수행 ----
+  # ---- AC3/AC7: integrate-direct DONE → branch 세팅·phase=review(적대적 리뷰 게이트 진입),
+  #   push·PR 미수행. (direct 서브모드도 머지 직전 리뷰 한 단계를 거치므로 merging 이 아니라
+  #   review 로 떨어진다 — 머지는 리뷰 approve 뒤.)
   #   (GITLOG 은 비우지 않는다 — 아래 'git/push 실제 수행됨' 위생 단언이 누적 GITLOG 를 본다.)
   local kD="x-ddd6666"; : > "$PUSHLOG"; : > "$PRLOG"
   st_done > "$LP/SPEC.md.json"; : > "$LP/SPEC.md.logs"
   in_integrate_direct "$spec" "$rd" "$kD" >/dev/null; rc=$?
   chk "AC3 integrate-direct rc=0" "$rc" "0"
-  chk "AC3 direct phase=merging" "$(int_get_phase "$rd" "$kD")" "merging"
+  chk "AC7 direct phase=review(리뷰 게이트)" "$(int_get_phase "$rd" "$kD")" "review"
   chk "AC3 direct branch=feat/<rid>-<slug>" "$(int_get_branch "$rd" "$kD")" "feat/20260604T000000-abc1234-x"
   [[ ! -s "$PUSHLOG" && ! -s "$PRLOG" ]] && ok "AC3 direct push·PR 미수행" || bad "AC3 direct push·PR 미수행"
 

--- a/plugins/autopilot/skills/dispatch/references/review-loop.sh
+++ b/plugins/autopilot/skills/dispatch/references/review-loop.sh
@@ -285,6 +285,127 @@ rl_review_loop() {
 }
 
 # =====================================================================
+# direct 서브모드 리뷰 — forge 미구성(PR 없음) 환경의 적대적 리뷰 게이트.
+#   forge 리뷰 루프 기계(생산자 1회 호출·must 재구현·세 가드·defer 분리·SPEC 델타)를
+#   그대로 재사용하되, PR 의존(사람/PR 메타 게이트·원격 push)을 제거한다:
+#     - 판정: 리뷰 생산자(REVIEW_PRODUCE_CMD)를 키 기준 1회 호출(로컬 작업 브랜치 diff 리뷰).
+#     - 멱등 head 게이트: 원격/PR 메타가 아니라 로컬 작업 브랜치 HEAD 로 본다.
+#     - request_changes: must 를 SPEC 델타로 로컬 작업 브랜치 위 재구현(원격 push 없음).
+#     - approve: 머지 진행가능(호출자가 phase=merging 으로 전이).
+#   세 가드(라운드 상한·무진전·핑퐁)는 forge 경로와 동일 헬퍼로 공유한다.
+# =====================================================================
+
+# rl_local_head <branch> — 로컬 작업 브랜치 HEAD(원격·PR 조회 없음). 없으면 빈값.
+rl_local_head() {
+  # shellcheck disable=SC2086
+  $GIT_CMD rev-parse --verify --quiet "refs/heads/$1" 2>/dev/null
+}
+
+# rl_round_direct <run_dir> <key> <base-spec> <branch>
+#   반환: 0=재작업(로컬 재구현), 10=에스컬레이션, 20=대기(새 커밋 없음), 30=approve.
+rl_round_direct() {
+  local rd="$1" key="$2" base="$3" branch="$4"
+  mkdir -p "$rd"
+  local pr="local"   # PR 없음 — 파일 네이밍용 고정 토큰(원격 PR 미참조).
+
+  # --- 멱등 head 게이트 — 로컬 작업 브랜치 HEAD(사람/PR 메타 게이트는 PR 없으므로 미적용) ---
+  local head last
+  head="$(rl_local_head "$branch")"
+  last="$(int_get_head "$rd" "$key")"
+  if [[ -n "$head" && "$head" == "$last" ]]; then
+    int_log "$rd" "$key" "head 동일($head) — 새 커밋 없음, 라운드 미시작(direct)"
+    return 20
+  fi
+
+  # --- 리뷰 생산자 1회 호출 → 단일 판정(PR 없이 키 기준, 로컬 diff 리뷰) ---
+  local produce verdict
+  # shellcheck disable=SC2086
+  produce="$($REVIEW_PRODUCE_CMD "$key" 2>/dev/null)"
+  verdict="$(printf '%s' "$produce" | jq -r '.pipeline_verdict // ""' 2>/dev/null)"
+
+  case "$verdict" in
+    unavailable)
+      rl_escalate "$rd" "$key" "리뷰 판정 unavailable(diff 잘림·컨텍스트 불완전) — 자동수정 보류(direct)"
+      return 10 ;;
+    approve)
+      int_set_verdict "$rd" "$key" approve
+      int_set_head "$rd" "$key" "$head"
+      int_log "$rd" "$key" "리뷰 판정 approve(direct) — 머지 진행가능(추가 라운드 미시작)"
+      return 30 ;;
+    request_changes) : ;;
+    *)
+      if [[ -z "$produce" ]]; then
+        rl_escalate "$rd" "$key" "리뷰 생산자 출력 비었음(생산 실패·미설정) — 자동수정 보류(direct)"
+      else
+        rl_escalate "$rd" "$key" "리뷰 판정 미상(verdict='$verdict') — 생산자 출력 파싱 실패(direct)"
+      fi
+      return 10 ;;
+  esac
+
+  # --- request_changes: 재작업 라운드(세 가드 공유) ---
+  int_set_verdict "$rd" "$key" request_changes
+  local round; round="$(int_bump_review_round "$rd" "$key")"
+  int_log "$rd" "$key" "재작업 라운드 $round 시작(direct, verdict=request_changes head=$head)"
+  if [[ "$round" -gt "$REVIEW_ROUNDS_MAX" ]]; then
+    rl_escalate "$rd" "$key" "라운드 상한($REVIEW_ROUNDS_MAX) 초과 — 자동수정 중지(direct)"
+    return 10
+  fi
+  int_set_head "$rd" "$key" "$head"
+
+  local mustfile deferfile
+  mustfile="$rd/must.$key.$pr"; deferfile="$rd/defer.$key.$pr"
+  rl_produce_extract "$produce" must_adopt "$mustfile"
+  rl_produce_extract "$produce" defer      "$deferfile"
+
+  if [[ ! -s "$mustfile" ]]; then
+    rl_escalate "$rd" "$key" "must_adopt 0 인데 여전히 request_changes — 무진전(direct)"
+    return 10
+  fi
+
+  local bh prev
+  bh="$(rl_blocking_hash "$mustfile")"
+  prev="$(int_get_blocking_hash "$rd" "$key")"
+  if [[ -n "$prev" && "$bh" == "$prev" ]]; then
+    rl_escalate "$rd" "$key" "차단성 지적 집합이 직전 라운드와 동일(핑퐁) — 무한루프 차단(direct)"
+    return 10
+  fi
+  int_set_blocking_hash "$rd" "$key" "$bh"
+
+  rl_spinoff_backlog "$rd" "$key" "$pr" "$deferfile"
+
+  local delta; delta="$(rl_spec_delta "$rd" "$key" "$base" "$pr" "$mustfile")"
+  # 로컬 작업 브랜치 워크트리에서 재구현(원격 push 없음). 실패 시 거짓 성공 대신 에스컬레이션.
+  # shellcheck disable=SC2086
+  if ! $IMPLEMENT_CMD "$delta" "$branch"; then
+    rl_escalate "$rd" "$key" "재구현 실패 — 작업 브랜치($branch) 워크트리에서 구현 불가(direct, 자동수정 보류)"
+    return 10
+  fi
+  int_log "$rd" "$key" "라운드 $round: must 로컬 재구현(원격 push·PR 없음, 작업 브랜치=$branch). 재리뷰는 다음 드레인."
+  return 0
+}
+
+# rl_review_loop_direct <run_dir> <key> <base-spec> [branch] — direct 단일 라운드 진입.
+#   approve 면 phase=merging 으로 전이(승인 의례 없이 머지 헬퍼가 skip_approval 로 머지).
+rl_review_loop_direct() {
+  local rd="$1" key="$2" base="$3" branch="${4:-}"
+  [[ -n "$rd" && -n "$key" && -n "$base" ]] \
+    || { rl_die "사용: review-loop.sh run-direct <run_dir> <key> <spec> [branch]"; return 1; }
+  mkdir -p "$rd"
+  [[ -n "$branch" ]] || branch="$(int_get_branch "$rd" "$key")"
+  [[ -n "$branch" ]] || branch="$(in_work_branch "$(basename "$rd")" "$base")"
+  int_set_branch "$rd" "$key" "$branch"
+
+  rl_round_direct "$rd" "$key" "$base" "$branch"
+  case "$?" in
+    30) int_set_phase "$rd" "$key" merging
+        echo "review-loop(direct): approve — 머지 진행가능 (key=$key branch=$branch)"; return 0 ;;
+    0)  echo "review-loop(direct): 재작업 라운드 — 로컬 재구현 (key=$key branch=$branch)"; return 0 ;;
+    20) echo "review-loop(direct): 대기 — 새 커밋 없음 (key=$key branch=$branch)"; return 0 ;;
+    *)  echo "review-loop(direct): 에스컬레이션으로 종료 (key=$key branch=$branch)"; return 0 ;;
+  esac
+}
+
+# =====================================================================
 # selftest — mock 인터페이스로 판정 분기·세 가드·사람/head 게이트·force 미사용 검증.
 # =====================================================================
 rl_selftest() {
@@ -295,7 +416,10 @@ rl_selftest() {
   local PUSHLOG="$TMP/pushlog"; : > "$PUSHLOG"
   mock_git() {
     local a; for a in "$@"; do case "$a" in *force*|-f) echo "FORCE USED" >&2; exit 99;; esac; done
-    case "$1" in push) printf '%s\n' "$*" >> "$PUSHLOG" ;; esac
+    case "$1" in
+      push)      printf '%s\n' "$*" >> "$PUSHLOG" ;;
+      rev-parse) printf '%s\n' "${MOCK_HEAD:-}" ;;   # direct 로컬 작업 브랜치 HEAD 모사.
+    esac
     return 0
   }
   GIT_CMD=mock_git; FORGE_CMD=:; DEFAULT_BRANCH=main
@@ -423,6 +547,65 @@ rl_selftest() {
   chk "AC4 핑퐁 에스컬레이션(rc=10)" "$rc" "10"
   case "$out" in *핑퐁*) ok "AC4 핑퐁 사유";; *) bad "AC4 핑퐁 사유";; esac
 
+  # =====================================================================
+  # direct 서브모드 리뷰 게이트 — PR 없는 로컬 작업 브랜치 리뷰(원격 push 없음).
+  #   approve/request_changes/세 가드/unavailable 를 mock 으로 검증.
+  # =====================================================================
+
+  # ---- AC7: direct approve → phase=merging(승인 의례 없이 머지 진행가능), push 없음 ----
+  local kDA="da-aaaa1" bp ap
+  prod_simple sha-DA approve > "$RV/$kDA.produce"
+  bp=$(wc -l < "$PUSHLOG")
+  MOCK_HEAD=sha-DA rl_review_loop_direct "$rd" "$kDA" "$base" "feat/run1-da" >/dev/null; rc=$?
+  chk "AC7 direct approve rc=0" "$rc" "0"
+  chk "AC7 direct approve→phase=merging" "$(int_get_phase "$rd" "$kDA")" "merging"
+  chk "AC7 direct verdict=approve" "$(int_get_verdict "$rd" "$kDA")" "approve"
+  ap=$(wc -l < "$PUSHLOG")
+  [[ "$bp" == "$ap" ]] && ok "AC9 direct approve 원격 push 없음" || bad "AC9 direct approve 원격 push 없음"
+
+  # ---- AC8/AC9: direct request_changes → 로컬 재구현(push 없음), 라운드 카운터·델타 ----
+  local kDR="dr-rrrr2"; : > "$IMPLLOG"
+  prod_rc sha-DR '로컬 보안 검증 추가' > "$RV/$kDR.produce"
+  bp=$(wc -l < "$PUSHLOG")
+  MOCK_HEAD=sha-DR rl_round_direct "$rd" "$kDR" "$base" "feat/run1-dr"; rc=$?
+  chk "AC8 direct request_changes 라운드 수행(rc=0)" "$rc" "0"
+  chk "AC8 direct 라운드 카운터=1" "$(int_review_round "$rd" "$kDR")" "1"
+  [[ -s "$IMPLLOG" ]] && ok "AC8 direct 로컬 재구현 실행" || bad "AC8 direct 로컬 재구현 실행"
+  ap=$(wc -l < "$PUSHLOG")
+  [[ "$bp" == "$ap" ]] && ok "AC9 direct 재구현 원격 push 없음" || bad "AC9 direct 재구현 원격 push 없음"
+  delta="$rd/delta.$kDR.local.spec.md"
+  grep -q '로컬 보안 검증' "$delta" && ok "AC8 direct must 델타 반영" || bad "AC8 direct must 델타 반영"
+  # 같은 head 재호출 → no-op(rc=20).
+  MOCK_HEAD=sha-DR rl_round_direct "$rd" "$kDR" "$base" "feat/run1-dr"; chk "AC8 direct 동일 head 미시작(rc=20)" "$?" "20"
+
+  # ---- AC10 가드: direct 라운드 상한(3) 초과 → 에스컬레이션(머지 안 함) ----
+  local kDC="dc-cccc3"
+  int_set "$rd" "$kDC" review-round 3
+  prod_rc sha-DC '또 수정' > "$RV/$kDC.produce"
+  out="$(MOCK_HEAD=sha-DC rl_round_direct "$rd" "$kDC" "$base" "feat/run1-dc")"; rc=$?
+  chk "AC10 direct 상한 초과 에스컬레이션(rc=10)" "$rc" "10"
+  chk "AC10 direct phase=escalated" "$(int_get_phase "$rd" "$kDC")" "escalated"
+
+  # ---- AC10 가드: direct must 0 인데 request_changes → 무진전 에스컬레이션 ----
+  local kDN="dn-nnnn4"
+  prod_rc_empty sha-DN > "$RV/$kDN.produce"
+  out="$(MOCK_HEAD=sha-DN rl_round_direct "$rd" "$kDN" "$base" "feat/run1-dn")"; rc=$?
+  chk "AC10 direct 무진전 에스컬레이션(rc=10)" "$rc" "10"
+
+  # ---- AC10 가드: direct 핑퐁(차단성 집합 직전과 동일) → 에스컬레이션 ----
+  local kDP="dp-pppp5"
+  prod_rc sha-DP1 '같은 차단 지적' > "$RV/$kDP.produce"
+  MOCK_HEAD=sha-DP1 rl_round_direct "$rd" "$kDP" "$base" "feat/run1-dp" >/dev/null; chk "AC10 direct 핑퐁 1R 수행" "$?" "0"
+  prod_rc sha-DP2 '같은 차단 지적' > "$RV/$kDP.produce"
+  out="$(MOCK_HEAD=sha-DP2 rl_round_direct "$rd" "$kDP" "$base" "feat/run1-dp")"; rc=$?
+  chk "AC10 direct 핑퐁 에스컬레이션(rc=10)" "$rc" "10"
+
+  # ---- AC7: direct unavailable → 에스컬레이션 ----
+  local kDU="du-uuuu6"
+  prod_simple sha-DU unavailable > "$RV/$kDU.produce"
+  MOCK_HEAD=sha-DU rl_round_direct "$rd" "$kDU" "$base" "feat/run1-du" >/dev/null; rc=$?
+  chk "AC7 direct unavailable 에스컬레이션(rc=10)" "$rc" "10"
+
   # ---- force 미사용 (mock_git force 보면 exit99; 여기 도달했으면 미사용) ----
   [[ -s "$PUSHLOG" ]] && ok "재작업 라운드 실제 push 수행" || bad "재작업 라운드 실제 push 수행"
   if grep -qiE 'force|(^| )-f( |$)' "$PUSHLOG"; then bad "force push 미사용"; else ok "force push 미사용(push 인자에 force 없음)"; fi
@@ -435,9 +618,11 @@ rl_selftest() {
 # ===== CLI 진입 (source 시 미실행) =====
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   case "${1:-}" in
-    run)      shift; rl_review_loop "$@" ;;
-    round)    shift; rl_round "$@" ;;
+    run)         shift; rl_review_loop "$@" ;;
+    run-direct)  shift; rl_review_loop_direct "$@" ;;
+    round)       shift; rl_round "$@" ;;
+    round-direct) shift; rl_round_direct "$@" ;;
     selftest) rl_selftest ;;
-    *) echo "usage: review-loop.sh {run <run_dir> <key> <spec> <pr> [branch]|round <run_dir> <key> <spec> <pr> <branch>|selftest}" >&2; exit 1 ;;
+    *) echo "usage: review-loop.sh {run <run_dir> <key> <spec> <pr> [branch]|run-direct <run_dir> <key> <spec> [branch]|round ...|round-direct <run_dir> <key> <spec> <branch>|selftest}" >&2; exit 1 ;;
   esac
 fi


### PR DESCRIPTION
## 무엇

`autopilot:dispatch` 통합 모드 개선 3건 (SPEC: `docs/specs/2026-06-04-dispatch-always-on-integration-target-branch-direct-review-gate/SPEC.md`).

1. **통합 상시화** — 통합 모드 토글 제거. `dispatch start`는 항상 통합으로 시작하고 비통합(레거시 `loop DONE=done`) 경로·`NO_INTEGRATE` 마커를 제거. `--no-integrate`·`--integrate`는 하위호환 위해 받되 조용히 no-op.
2. **머지 타겟 브랜치 일반화** — `--target-branch <branch>` 추가(미지정 시 기본 브랜치). 모든 base sync·PR base·ff 머지·base push에 일관 적용, run-dir `TARGET_BRANCH` 마커로 sticky(재개 시 마커 > env·플래그), `DEFAULT_BRANCH`로 통합 모듈에 export. `main` 하드코딩 일원화.
3. **direct 서브모드 적대적 리뷰 게이트** — direct 경로가 머지 직전 `review-loop.sh`로 `autopilot:review` 적대 리뷰를 거침(PR·원격 push 없이 로컬 작업 브랜치 diff). approve에만 ff 머지, request_changes면 forge와 동일 루프(SPEC 델타 재구현 → 재리뷰, 3가드: 라운드 상한·무진전·핑퐁), 가드 소진 시 비완료(escalated).

## 검증

- 5개 모듈 self-test 전부 PASS (`lib-integration`/`integration`/`review-loop`/`merge`/`dispatch` selftest, exit 0) — AC2(플래그 no-op)·AC3(direct ff)·AC4(타겟 브랜치 export·main 잔존 없음)·AC6(sticky 재개)·AC7(direct phase=review)·AC8(리뷰 루프 재사용)·AC9(원격 push 없음)·AC10(3가드→escalated)·AC5(버전 게이트)·force 미사용 어서션 매칭.
- 버전 0.24.0 → **0.25.0** (plugin.json SoT + 루트 marketplace.json 미러).

## 비-목표

forge 서브모드 로직·`autopilot:review` 판정 로직·dispatch 외 스킬·`rules/` 미변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)