### PR TITLE
feat(fsd): start가 dispatch 위임 직전 SPEC을 타겟 브랜치에 ff-merge (v0.26.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,8 +20,8 @@
     {
       "name": "autopilot",
       "source": "./plugins/autopilot",
-      "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션(통합 항상 활성: forge 구성이면 push→PR→리뷰→ff-only 머지, 미구성이면 PR 없는 로컬 적대적 리뷰 게이트 후 ff-only 직접 머지; 대상 브랜치 --target-branch 로 지정), fsd로 spec→dispatch 자동화 파이프라인을 완전자율(리뷰·머지는 dispatch 위임, 외부 승인 대기 없음)로 닫는 task 오케스트레이션(intake·start·poll), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
-      "version": "0.25.0",
+      "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션(통합 항상 활성: forge 구성이면 push→PR→리뷰→ff-only 머지, 미구성이면 PR 없는 로컬 적대적 리뷰 게이트 후 ff-only 직접 머지; 대상 브랜치 --target-branch 로 지정), fsd로 spec→dispatch 자동화 파이프라인을 완전자율(리뷰·머지는 dispatch 위임, 외부 승인 대기 없음)로 닫는 task 오케스트레이션(intake·start·poll; start는 dispatch 위임 직전 SPEC을 타겟 통합 브랜치에 ff-merge 선반영), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
+      "version": "0.26.0",
       "category": "automation",
       "tags": ["autonomous", "ralph-loop", "agent-runtime", "self-directed"]
     }

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/fsd/review 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 spec-list-driven 다중 SPEC 오케스트레이션(통합·리뷰·머지 소유), fsd로 spec→dispatch 자동화 파이프라인을 완전자율(리뷰·머지는 dispatch 위임)로 닫는 task 오케스트레이션(intake·start·poll), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/fsd/SKILL.md
+++ b/plugins/autopilot/skills/fsd/SKILL.md
@@ -48,7 +48,7 @@ fsd 는 `spec`·`loop`·`dispatch` 를 **공개 인터페이스로만** 조합�
 <project_root>/.fsd/
 └── tasks/
     └── <task-id>/
-        ├── state          # 상태 로컬 미러 (intake|dispatching|dispatched|stopped|done|dispatch-failed)
+        ├── state          # 상태 로컬 미러 (intake|spec-merging|spec-merge-failed|dispatching|dispatched|stopped|done|dispatch-failed)
         ├── SPECS.txt       # 이 task 의 SPEC 경로 목록 (append-only, 한 줄에 하나)
         ├── run-id          # 이 task 가 소유한 dispatch run 식별자
         ├── origin          # 이 task 를 촉발한 원본 task 식별자 (버그 분리 연결, 선택)
@@ -73,8 +73,13 @@ fsd 는 4 서브커맨드(`intake`·`start`·`poll`·`status`/`list`/`stop`)를 
 task 의 SPEC(들)을 자율 실행기 오케스트레이터(`dispatch`)에 위임해 구현을 시작한다.
 
 - 입력: 1 개 이상의 SPEC 파일 경로(검증·절대경로화).
-- **미해결 마커 가드**: 입력 SPEC 중 하나라도 미해결 사용자-결정 마커(`[NEEDS CLARIFICATION` 로 시작)를 포함하면 dispatch 위임을 하지 않는다 — `state=needs-clarification` 으로 기록하고, 마커를 가진 SPEC 마다 `needs-resume: <SPEC-경로>` 를 출력한 뒤 비-0 으로 종료한다. 빈 칸은 `spec --resume <SPEC-경로>` 로 채운 뒤 다시 `start` 한다.
-- 동작(마커 없을 때): task-id 도출 후 디렉토리를 보장하고(미등록이면 `SPECS.txt` 기록), `state=dispatching` → `dispatch start <spec...>` 공개 서브커맨드로 위임 → 그 출력에서 run 식별자를 추출해 `run-id` 에 기록 → `state=dispatched`.
+- **미해결 마커 가드**: 입력 SPEC 중 하나라도 미해결 사용자-결정 마커(`[NEEDS CLARIFICATION` 로 시작)를 포함하면 dispatch 위임을 하지 않는다 — `state=needs-clarification` 으로 기록하고, 마커를 가진 SPEC 마다 `needs-resume: <SPEC-경로>` 를 출력한 뒤 비-0 으로 종료한다. 빈 칸은 `spec --resume <SPEC-경로>` 로 채운 뒤 다시 `start` 한다. **이 가드는 SPEC-to-target 머지보다 먼저 실행되므로 마커를 가진 미완 SPEC 은 타겟 브랜치 이력에 올라가지 않는다.**
+- **SPEC-to-target-branch ff-merge 전제조건**: 마커 가드를 통과하면, dispatch 위임 **직전에** 입력 SPEC 문서(들)를 감지된 **타겟 기본 통합 브랜치**에 fast-forward 로 안착시킨다(`spec-merge.sh` 위임, 주입 가능 `FSD_SPEC_MERGE_CMD`). 이로써 dispatch 가 구현을 시작하기 전에 의도(SPEC)가 통합 브랜치 이력에 **구현과 분리된 별도 commit** 으로 항상 남는다.
+  - **타겟 브랜치 감지**: 리터럴 `main` 으로 하드코딩하지 않고 레포의 기본 통합 브랜치를 감지한다(`DEFAULT_BRANCH` env > `origin/HEAD` > `remote show origin` HEAD > 로컬 `main`/`master` > 현재 브랜치). 기본 브랜치가 `main` 이 아닌 레포에서도 그 브랜치에 안착한다.
+  - **멱등**: 같은 내용이 이미 타겟 브랜치에 올라가 있으면 새 commit 없이 통과한다 — 같은 SPEC 으로 `start` 를 재실행해도 중복 SPEC commit 이 생기지 않는다.
+  - **절차 단일 출처**: `rules/engineering/branch-and-slug.md` 의 "feat 브랜치 + commit" · "원격 동기화" 절차 형태(feat 브랜치 경유 · ff-only · **force push 금지**)를 소비하며 fsd 안에서 중복 재정의하지 않는다. `git` 만 쓰고 forge CLI 를 호출하지 않는다.
+  - **실패 시 차단**: SPEC 을 타겟 브랜치에 ff-merge 하거나 원격에 반영하지 못하면(비-fast-forward·push 거부 등 **오류**), `state=spec-merge-failed` 로 기록하고 **dispatch 위임을 시작하지 않은 채 중단**한다. 출력은 SPEC 이 타겟 브랜치에 안착하지 못했음(=dispatch 실패가 아님)과 재시도·PR 흐름 안내를 담으며, 어떤 경우에도 force push 를 하지 않는다.
+- 동작(마커 없음 + SPEC 안착 성공): task-id 도출 후 디렉토리를 보장하고(미등록이면 `SPECS.txt` 기록), `state=spec-merging` → SPEC 을 타겟 브랜치에 안착 → `state=dispatching` → `dispatch start <spec...>` 공개 서브커맨드로 위임 → 그 출력에서 run 식별자를 추출해 `run-id` 에 기록 → `state=dispatched`.
 - 출력: `task-id: <task-id>` 와 `run-id: <run-id>`.
 - 실패: dispatch 출력에서 run-id 를 얻지 못하면 `state=dispatch-failed` 로 기록하고 dispatch 출력과 함께 abort.
 - **리뷰·머지**: `dispatch start` 는 통합 모드(기본 ON)로 위임되므로(`--no-integrate` 미전달), dispatch 가 loop 구현 후 통합(PR)→리뷰→(direct 서브모드)ff-only 머지까지 자기 run 안에서 수행한다. fsd 는 이를 다시 하지 않는다.
@@ -122,6 +127,7 @@ task 가 소유한 dispatch run 을 `dispatch` 의 공개 `stop` 서브커맨드
 | 파일 | 역할 |
 |---|---|
 | `fsd.sh` | 서브커맨드 라우터 + 프로젝트 루트 탐지 + intake/start 의 spec·dispatch 블랙박스 조합 |
+| `spec-merge.sh` | dispatch 위임 직전 SPEC 을 감지된 기본 통합 브랜치에 ff-merge 안착(타겟 감지·멱등 no-op·비-ff/push거부 시 중단, force 금지). branch-and-slug.md 절차 형태 소비 |
 | `poll.sh` | dispatch run 관측 드레인(`dispatch status` 공개 인터페이스로 done 전이, 멱등) |
 | `lib-state.sh` | `.fsd/tasks/<task-id>/` 상태 저장소 헬퍼(set/get 필드·log_event·run-id 기록·list 등) |
 | `operational-guide.md` | 상시 호스트 무인 운영 가이드(토큰 스코프·실행기 권한 격리·폴링 주기) |
@@ -133,8 +139,8 @@ task 가 소유한 dispatch run 을 `dispatch` 의 공개 `stop` 서브커맨드
 
 ## 불변식 / 규칙
 
-- fsd 는 `.fsd/` 디렉토리 밖 경로를 만들지 않는다(자기 스킬 정의 파일 제외).
-- `spec`·`loop`·`dispatch` 의 정의 파일을 수정하지 않고, 공개 인터페이스만 소비한다.
+- fsd 는 `.fsd/` 디렉토리 밖 경로를 만들지 않는다(자기 스킬 정의 파일 제외). SPEC 을 타겟 브랜치에 안착시키는 것은 git 이력 생성이지 `.fsd/` 밖 파일 경로 생성이 아니며, forge CLI 없이 `git` 만 쓴다.
+- **SPEC 을 통합 브랜치에 반영하는 책임은 fsd(오케스트레이터)에만 있다** — `spec` 스킬은 SPEC 문서만 산출하고 외부 상태(이슈·브랜치·원격)를 만들지 않는 불변식이 보존된다. fsd 는 `spec`·`loop`·`dispatch` 의 정의 파일을 수정하지 않고, 공개 인터페이스만 소비한다.
 - 구현·리뷰·머지 위임은 `dispatch start <spec...>`(통합 모드 ON) 공개 서브커맨드로만 하고, dispatch run 관측은 `dispatch status` 로만 한다 — dispatch·loop 의 내부 신호 파일·run 디렉토리·워크트리를 직접 들여다보지 않는다.
 - fsd 는 리뷰·머지·통합(PR)을 직접 하지 않고 forge CLI 를 호출하지 않는다 — 그 책임은 dispatch 통합 모드에 있다.
 - 완전자율: fsd 파이프라인에는 외부 승인 보류·사람 개입 게이트가 없다.

--- a/plugins/autopilot/skills/fsd/references/fsd.sh
+++ b/plugins/autopilot/skills/fsd/references/fsd.sh
@@ -47,6 +47,10 @@ DISPATCH_CMD="${DISPATCH_CMD:-$DISPATCH_CMD_DEFAULT}"
 # 드레인 위임(주입 가능, 기본: 형제 모듈, 서브프로세스 격리).
 FSD_POLL_CMD="${FSD_POLL_CMD:-bash $SCRIPT_DIR/poll.sh}"
 
+# SPEC-to-target-branch ff-merge 위임(주입 가능, 기본: 형제 모듈).
+# dispatch 위임 직전 SPEC 을 감지된 기본 통합 브랜치에 안착시킨다(spec-merge.sh).
+FSD_SPEC_MERGE_CMD="${FSD_SPEC_MERGE_CMD:-bash $SCRIPT_DIR/spec-merge.sh merge}"
+
 # ----- 공통 헬퍼 -----
 
 die() { echo "ERROR: $*" >&2; exit 1; }
@@ -174,6 +178,27 @@ cmd_start() {
     done
     exit 1
   fi
+
+  # ----- SPEC-to-target-branch ff-merge 전제조건 (dispatch 위임 직전) -----
+  # 마커 가드를 통과한 SPEC 만 여기 도달한다 — 미해결 마커 SPEC 은 위에서 이미
+  # 차단되어 타겟 브랜치에 올라가지 않는다(마커 가드가 머지보다 먼저). 감지된 기본
+  # 통합 브랜치에 입력 SPEC 을 ff-merge 안착시켜, dispatch 가 구현을 시작하기 전
+  # 의도(SPEC)가 통합 브랜치 이력에 별도 commit 으로 남도록 보장한다. 멱등: 이미
+  # 같은 내용이 안착해 있으면 새 commit 없이 통과. 실패(비-ff·push 거부 등 오류)면
+  # dispatch 를 시작하지 않고 중단한다(force push 없음).
+  set_state "$id" "spec-merging"
+  log_event "$id" "spec-merge → 타겟 브랜치 안착 시도 specs=${#ABS_SPECS[@]}"
+  local sm_out
+  # shellcheck disable=SC2086
+  if ! sm_out="$($FSD_SPEC_MERGE_CMD "$id" "${ABS_SPECS[@]}" 2>&1)"; then
+    set_state "$id" "spec-merge-failed"
+    log_event "$id" "spec-merge 실패 — dispatch 미시작"
+    echo "task-id: $id"
+    printf '%s\n' "$sm_out" >&2
+    die "SPEC 을 타겟 통합 브랜치에 안착하지 못했습니다 — dispatch 를 시작하지 않았습니다(SPEC 미안착이며 dispatch 실패가 아님). force push 없이 중단. 위 안내(재시도·PR 흐름)대로 처리하세요."
+  fi
+  printf '%s\n' "$sm_out"
+  log_event "$id" "spec-merge 완료 — 타겟 브랜치 안착"
 
   set_state "$id" "dispatching"
   log_event "$id" "start → dispatch 위임 specs=${#ABS_SPECS[@]}"
@@ -305,6 +330,22 @@ echo "run-id: RUN-MOCK"
 EOF
   export DISPATCH_CMD="bash $TMP/m-dispatch.sh"
 
+  # spec-merge mock(성공): TRACE 기록 후 0 — start 배선 검증용(실질 머지는
+  # spec-merge.sh selftest 가 실git 으로 검증; 여기선 cmd_start 의 배선만 본다).
+  cat > "$TMP/m-sm-ok.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "spec-merge $*" >> "$TRACE"
+echo "spec-merge: mock 안착"
+EOF
+  # spec-merge mock(실패): TRACE 기록 후 비-0 — 머지 실패 시 dispatch 미시작 검증용.
+  cat > "$TMP/m-sm-fail.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "spec-merge $*" >> "$TRACE"
+echo "spec-merge: mock 비-ff 실패" >&2
+exit 1
+EOF
+  export FSD_SPEC_MERGE_CMD="bash $TMP/m-sm-ok.sh"
+
   # (a) intake --origin: origin 기록 + status 노출.
   local oid
   oid="$(cmd_intake --origin parent-task "$spec_clean" 2>/dev/null | sed -n 's/^task-id: //p')"
@@ -326,17 +367,35 @@ EOF
   grep -q "^needs-resume: .*SPEC-mark.md" "$TMP/start-mark.out" \
     && ok "마커 needs-resume 출력" || bad "마커 needs-resume 출력"
   grep -q "^dispatch start" "$TRACE" && bad "마커 SPEC dispatch 미위임" || ok "마커 SPEC dispatch 미위임"
+  # AC4: 마커 가드가 spec-merge 보다 먼저 — 마커 SPEC 은 타겟 브랜치에 안 올라간다.
+  grep -q "^spec-merge " "$TRACE" && bad "마커 SPEC spec-merge 미호출" || ok "마커 SPEC spec-merge 미호출(타겟 브랜치 미반영)"
   local mid; mid="$(derive_task_id "$(abspath "$spec_mark")")"
   [[ "$(get_state "$mid")" == "needs-clarification" ]] \
     && ok "마커 state=needs-clarification" || bad "마커 state=needs-clarification"
 
-  # (c) 마커 없는 SPEC: 정상 dispatch 회귀.
+  # (c) 마커 없는 SPEC: spec-merge 선행 후 정상 dispatch 회귀.
   : > "$TRACE"
   ( cmd_start "$spec_clean" ) > "$TMP/start-clean.out" 2>&1; rc=$?
   [[ "$rc" == "0" ]] && ok "마커없는 start 0 exit" || bad "마커없는 start 0 exit (rc=$rc)"
+  # AC1: dispatch 위임 전 spec-merge 가 task-id·SPEC 으로 호출됨(타겟 브랜치 선반영).
+  grep -q "^spec-merge .* .*SPEC-clean.md" "$TRACE" && ok "마커없는 SPEC spec-merge 선행" || bad "마커없는 SPEC spec-merge 선행"
   grep -q "^dispatch start" "$TRACE" && ok "마커없는 SPEC dispatch 위임" || bad "마커없는 SPEC dispatch 위임"
+  # 순서: spec-merge 가 dispatch 보다 먼저(같은 TRACE 내 행 순서).
+  [[ "$(grep -n '^spec-merge ' "$TRACE" | head -1 | cut -d: -f1)" -lt \
+     "$(grep -n '^dispatch start' "$TRACE" | head -1 | cut -d: -f1)" ]] \
+    && ok "spec-merge → dispatch 순서" || bad "spec-merge → dispatch 순서"
   grep -q "^run-id: RUN-MOCK" "$TMP/start-clean.out" && ok "마커없는 run-id 기록" || bad "마커없는 run-id 기록"
   [[ "$(get_state "$oid")" == "dispatched" ]] && ok "마커없는 state=dispatched" || bad "마커없는 state=dispatched"
+
+  # (d) spec-merge 실패: dispatch 미위임·비-0·state=spec-merge-failed (AC5).
+  : > "$TRACE"
+  ( FSD_SPEC_MERGE_CMD="bash $TMP/m-sm-fail.sh" cmd_start "$spec_reg" ) > "$TMP/start-fail.out" 2>&1; rc=$?
+  [[ "$rc" != "0" ]] && ok "spec-merge 실패 시 start 비-0" || bad "spec-merge 실패 시 start 비-0 (rc=$rc)"
+  grep -q "^spec-merge " "$TRACE" && ok "spec-merge 호출됨" || bad "spec-merge 호출됨"
+  grep -q "^dispatch start" "$TRACE" && bad "spec-merge 실패 시 dispatch 미위임" || ok "spec-merge 실패 시 dispatch 미위임"
+  grep -qi "dispatch 를 시작하지 않" "$TMP/start-fail.out" && ok "SPEC 미안착 메시지(dispatch 실패와 구분)" || bad "SPEC 미안착 메시지"
+  local fid; fid="$(derive_task_id "$(abspath "$spec_reg")")"
+  [[ "$(get_state "$fid")" == "spec-merge-failed" ]] && ok "state=spec-merge-failed" || bad "state=spec-merge-failed (got=$(get_state "$fid"))"
 
   echo "----"
   [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"

--- a/plugins/autopilot/skills/fsd/references/spec-merge.sh
+++ b/plugins/autopilot/skills/fsd/references/spec-merge.sh
@@ -68,7 +68,8 @@ sm_build_tree() {
     rel="${pair%%	*}"   # tab 구분
     abs="${pair#*	}"
     blob="$(git hash-object -w "$abs")" || { rc=1; break; }
-    GIT_INDEX_FILE="$idx" git update-index --add --cacheinfo "100644,$blob,$rel" || { rc=1; break; }
+    # 분리-인자 형식(쉼표 파싱 회피 — 경로에 쉼표가 있어도 안전).
+    GIT_INDEX_FILE="$idx" git update-index --add --cacheinfo 100644 "$blob" "$rel" || { rc=1; break; }
   done
   if [[ $rc -eq 0 ]]; then
     GIT_INDEX_FILE="$idx" git write-tree || rc=1

--- a/plugins/autopilot/skills/fsd/references/spec-merge.sh
+++ b/plugins/autopilot/skills/fsd/references/spec-merge.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# spec-merge.sh — fsd: dispatch 위임 직전 SPEC 을 타겟(기본) 통합 브랜치에 ff-merge 안착.
+#
+# 책임:
+#   - 레포의 기본 통합 브랜치를 감지(리터럴 main 하드코딩 금지).
+#   - 입력 SPEC 문서(들)를 그 타겟 브랜치 git 이력에 fast-forward 로 안착시키고
+#     원격(origin)에 반영한다 — dispatch 가 구현을 시작하기 전 의도(SPEC)가 통합
+#     브랜치 이력에 별도 commit 으로 남도록 보장한다.
+#   - 멱등: 같은 내용이 이미 타겟에 올라가 있으면 새 commit 없이 통과(no-op).
+#
+# 절차의 단일 출처:
+#   rules/engineering/branch-and-slug.md 의 "feat 브랜치 + commit" · "원격 동기화"
+#   절차의 **형태**(feat 브랜치 경유 · ff-only · force push 금지)를 소비한다.
+#   그 절차의 리터럴 `main` 은 감지된 기본 브랜치의 예시로 해석한다. 절차를 여기서
+#   중복 재정의하지 않는다.
+#
+# 불변식:
+#   - git 만 사용(forge CLI 호출 없음).
+#   - force push 금지. 비-ff·push 거부는 **오류**로 보고하고 비-0 으로 종료한다
+#     (호출자 fsd 는 이 비-0 을 dispatch 미시작 신호로 쓴다).
+#   - 워킹 트리를 건드리지 않는다(plumbing 으로 commit 생성; 체크아웃 juggling 없음).
+#
+# 사용:
+#   bash spec-merge.sh merge <task-id> <abs-spec...>
+#   bash spec-merge.sh detect-target
+#   bash spec-merge.sh selftest
+#
+# 환경 변수:
+#   DEFAULT_BRANCH   타겟 브랜치 강제 지정(감지보다 우선). dispatch 와 동일 어휘.
+#
+# bash 3.2+ 호환 (associative array 미사용).
+
+set -euo pipefail
+
+# ----- 타겟(기본 통합) 브랜치 감지 -----
+# 우선순위: DEFAULT_BRANCH env > origin/HEAD symbolic-ref > `remote show origin`
+#           HEAD branch > 로컬 main/master > 현재 브랜치. 리터럴 main 하드코딩 아님.
+sm_detect_target_branch() {
+  if [[ -n "${DEFAULT_BRANCH:-}" ]]; then
+    echo "$DEFAULT_BRANCH"; return 0
+  fi
+  local ref
+  ref="$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [[ -n "$ref" ]]; then
+    echo "${ref#refs/remotes/origin/}"; return 0
+  fi
+  ref="$(git remote show origin 2>/dev/null | sed -n 's/.*HEAD branch: //p' | head -1 || true)"
+  if [[ -n "$ref" && "$ref" != "(unknown)" ]]; then
+    echo "$ref"; return 0
+  fi
+  local b
+  for b in main master; do
+    if git show-ref --verify --quiet "refs/heads/$b"; then echo "$b"; return 0; fi
+  done
+  git rev-parse --abbrev-ref HEAD 2>/dev/null
+}
+
+# ----- 후보 tree 구성 -----
+# base tree 를 임시 인덱스에 읽어 SPEC 경로들을 갱신한 새 tree 해시를 출력.
+# 워킹 트리·현재 인덱스를 건드리지 않는다.
+sm_build_tree() {
+  local base="$1"; shift   # 나머지는 rel:abs 쌍을 "rel" + 별도 배열 대신, rel\tabs 인코딩
+  local idx; idx="$(mktemp)"
+  local rc=0
+  GIT_INDEX_FILE="$idx" git read-tree "$base" || rc=1
+  local pair rel abs blob
+  for pair in "$@"; do
+    rel="${pair%%	*}"   # tab 구분
+    abs="${pair#*	}"
+    blob="$(git hash-object -w "$abs")" || { rc=1; break; }
+    GIT_INDEX_FILE="$idx" git update-index --add --cacheinfo "100644,$blob,$rel" || { rc=1; break; }
+  done
+  if [[ $rc -eq 0 ]]; then
+    GIT_INDEX_FILE="$idx" git write-tree || rc=1
+  fi
+  rm -f "$idx"
+  return $rc
+}
+
+# ----- 핵심: SPEC 을 타겟 브랜치에 ff-merge -----
+merge_specs_to_target() {
+  local task_id="${1:-}"; shift || true
+  [[ -n "$task_id" ]] || { echo "spec-merge: task-id 필요" >&2; return 2; }
+  [[ $# -ge 1 ]] || { echo "spec-merge: SPEC 경로 필요" >&2; return 2; }
+
+  local root target
+  root="$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "spec-merge: git 저장소 아님" >&2; return 2; }
+  target="$(sm_detect_target_branch)"
+  [[ -n "$target" ]] || { echo "spec-merge: 타겟 브랜치 감지 실패 — SPEC 미안착, dispatch 미시작" >&2; return 1; }
+
+  local has_origin=0
+  git remote get-url origin >/dev/null 2>&1 && has_origin=1
+
+  local base
+  if [[ $has_origin -eq 1 ]]; then
+    if ! git fetch --quiet origin "$target" 2>/dev/null; then
+      echo "spec-merge: origin/$target fetch 실패 — SPEC 미안착, dispatch 미시작 (재시도 안내)" >&2
+      return 1
+    fi
+    base="origin/$target"
+  else
+    base="$target"
+  fi
+  if ! git rev-parse --verify --quiet "$base" >/dev/null 2>&1; then
+    echo "spec-merge: 타겟 브랜치 '$base' 가 없음 — SPEC 미안착, dispatch 미시작" >&2
+    return 1
+  fi
+  local base_sha base_tree
+  base_sha="$(git rev-parse "$base")"
+  base_tree="$(git rev-parse "$base^{tree}")"
+
+  # rel\tabs 쌍 구성(레포 루트 상대 경로만 허용).
+  local pairs=() s rel
+  for s in "$@"; do
+    case "$s" in
+      "$root"/*) rel="${s#"$root"/}" ;;
+      *) echo "spec-merge: SPEC 이 레포 루트 밖: $s — SPEC 미안착, dispatch 미시작" >&2; return 1 ;;
+    esac
+    [[ -f "$s" ]] || { echo "spec-merge: SPEC 파일 없음: $s" >&2; return 1; }
+    pairs+=("$rel	$s")
+  done
+
+  # 후보 tree → base tree 와 같으면 멱등 no-op.
+  local newtree
+  newtree="$(sm_build_tree "$base" "${pairs[@]}")" || { echo "spec-merge: tree 구성 실패" >&2; return 1; }
+  if [[ "$newtree" == "$base_tree" ]]; then
+    echo "spec-merge: SPEC 이미 타겟 브랜치($target)에 안착 — no-op (멱등)"
+    return 0
+  fi
+
+  # feat 브랜치 경유 commit (parent=base; ff-only 보장).
+  local feat_commit feat_branch
+  feat_commit="$(git commit-tree "$newtree" -p "$base_sha" \
+      -m "feat(spec): $task_id — SPEC 을 $target 에 선반영")" \
+    || { echo "spec-merge: commit-tree 실패 — SPEC 미안착" >&2; return 1; }
+  feat_branch="feat/$task_id"
+  git branch -f "$feat_branch" "$feat_commit" >/dev/null 2>&1 || true
+
+  local cleanup_feat='git branch -D "$feat_branch" >/dev/null 2>&1 || true'
+
+  # 로컬 타겟 브랜치 ff 안착 (force 금지).
+  local orig_branch local_sha
+  orig_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+  if git rev-parse --verify --quiet "refs/heads/$target" >/dev/null 2>&1; then
+    local_sha="$(git rev-parse "refs/heads/$target")"
+    if ! git merge-base --is-ancestor "$local_sha" "$feat_commit"; then
+      eval "$cleanup_feat"
+      echo "spec-merge: 로컬 $target 가 origin/$target 와 분기 — ff 불가. force 금지; 'git reset --hard origin/$target' 또는 PR 흐름으로 재시도. SPEC 미안착, dispatch 미시작." >&2
+      return 1
+    fi
+    if [[ "$orig_branch" == "$target" ]]; then
+      if ! git merge --ff-only "$feat_branch" >/dev/null 2>&1; then
+        eval "$cleanup_feat"
+        echo "spec-merge: 로컬 $target ff 머지 실패 — SPEC 미안착, dispatch 미시작." >&2
+        return 1
+      fi
+    else
+      git update-ref "refs/heads/$target" "$feat_commit" "$local_sha"
+    fi
+  else
+    # 로컬 타겟 브랜치 없음(base=origin/target) → 새로 생성.
+    git update-ref "refs/heads/$target" "$feat_commit"
+  fi
+
+  # 원격 반영 (force 금지).
+  if [[ $has_origin -eq 1 ]]; then
+    if ! git push --quiet origin "$target" 2>/dev/null; then
+      eval "$cleanup_feat"
+      echo "spec-merge: origin/$target push 거부 — 로컬 $target 는 ff 됨(원격 미반영). force 금지; 'git reset --hard origin/$target' 또는 PR 흐름으로 재시도. SPEC 원격 미안착, dispatch 미시작." >&2
+      return 1
+    fi
+  fi
+
+  eval "$cleanup_feat"
+  echo "spec-merge: SPEC ${#pairs[@]}건 타겟 브랜치($target) 안착 완료$([[ $has_origin -eq 1 ]] && echo ' + origin push')"
+  return 0
+}
+
+# ----- 자체 검증 (실제 git 저장소) -----
+sm_selftest() {
+  set +e
+  local TMP; TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' RETURN
+  local fail=0 rc
+  ok()  { echo "PASS  $1"; }
+  bad() { echo "FAIL  $1"; fail=1; }
+
+  # ---- S1: 타겟 브랜치 감지 (기본=trunk, main 하드코딩 아님) ----
+  local O1="$TMP/o1.git" R1="$TMP/r1"
+  git init -q --bare "$O1"
+  git init -q "$R1"
+  ( cd "$R1"
+    git config user.email t@t; git config user.name t
+    git checkout -q -b trunk
+    echo seed > seed.txt; git add seed.txt; git commit -q -m seed
+    git remote add origin "$O1"
+    git push -q origin trunk
+    git remote set-head origin trunk )
+  local det
+  det="$( cd "$R1" && unset DEFAULT_BRANCH && sm_detect_target_branch )"
+  [[ "$det" == "trunk" ]] && ok "S1 타겟 감지=trunk(비-main, 하드코딩 아님)" || bad "S1 타겟 감지 got=$det"
+
+  # ---- S2: ff-merge 성공 — SPEC 이 로컬 trunk·origin/trunk 에 안착 ----
+  ( cd "$R1"
+    mkdir -p docs/specs/x
+    printf '# X\n## 수용 기준\n1. A.\n' > docs/specs/x/SPEC.md
+    git checkout -q -b work )   # orig_branch != target (loop 워크트리 모사)
+  local spec2="$R1/docs/specs/x/SPEC.md"
+  ( cd "$R1" && unset DEFAULT_BRANCH && merge_specs_to_target "x-task" "$spec2" ) > "$TMP/s2.out" 2>&1
+  rc=$?
+  [[ $rc -eq 0 ]] && ok "S2 머지 0 exit" || { bad "S2 머지 rc=$rc"; cat "$TMP/s2.out"; }
+  ( cd "$R1" && git show "trunk:docs/specs/x/SPEC.md" 2>/dev/null | grep -q '# X' ) \
+    && ok "S2 SPEC 로컬 trunk 이력 안착(AC1)" || bad "S2 SPEC 로컬 trunk 안착"
+  ( cd "$R1" && git show "origin/trunk:docs/specs/x/SPEC.md" 2>/dev/null | grep -q '# X' ) \
+    && ok "S2 SPEC origin/trunk 안착(원격 반영)" || bad "S2 SPEC origin/trunk 안착"
+  # 워킹 트리 미교란: 여전히 work 브랜치
+  [[ "$( cd "$R1" && git rev-parse --abbrev-ref HEAD )" == "work" ]] \
+    && ok "S2 워킹 트리 미교란(현재 브랜치 유지)" || bad "S2 워킹 트리 교란됨"
+  # feat 브랜치 정리됨
+  ( cd "$R1" && ! git show-ref --verify --quiet refs/heads/feat/x-task ) \
+    && ok "S2 ephemeral feat 브랜치 정리" || bad "S2 feat 브랜치 잔존"
+
+  # ---- S3: 멱등 — 재실행 no-op, origin/trunk sha 불변 (AC3) ----
+  local before after
+  before="$( cd "$R1" && git rev-parse origin/trunk )"
+  ( cd "$R1" && unset DEFAULT_BRANCH && merge_specs_to_target "x-task" "$spec2" ) > "$TMP/s3.out" 2>&1
+  rc=$?
+  ( cd "$R1" && git fetch -q origin trunk )
+  after="$( cd "$R1" && git rev-parse origin/trunk )"
+  [[ $rc -eq 0 ]] && ok "S3 재실행 0 exit" || bad "S3 재실행 rc=$rc"
+  [[ "$before" == "$after" ]] && ok "S3 멱등 no-op(새 commit 없음)" || bad "S3 멱등 깨짐 $before→$after"
+  grep -q "no-op" "$TMP/s3.out" && ok "S3 no-op 메시지" || bad "S3 no-op 메시지"
+
+  # ---- S4: 비-ff(로컬 분기) → 실패·비-0·force 금지·원격 미반영 (AC5) ----
+  local O2="$TMP/o2.git" R2="$TMP/r2" R2b="$TMP/r2b"
+  git init -q --bare "$O2"
+  git init -q "$R2"
+  ( cd "$R2"
+    git config user.email t@t; git config user.name t
+    git checkout -q -b trunk
+    echo a > a.txt; git add a.txt; git commit -q -m A
+    git remote add origin "$O2"; git push -q origin trunk )
+  git -C "$O2" symbolic-ref HEAD refs/heads/trunk
+  git clone -q "$O2" "$R2b"
+  ( cd "$R2b"
+    git config user.email t@t; git config user.name t
+    echo c > c.txt; git add c.txt; git commit -q -m C; git push -q origin trunk )
+  ( cd "$R2"
+    git checkout -q trunk
+    echo b > b.txt; git add b.txt; git commit -q -m B   # 로컬 전용 분기
+    git checkout -q -b work
+    mkdir -p docs/specs/y; printf '# Y\n## 수용 기준\n1. B.\n' > docs/specs/y/SPEC.md )
+  ( cd "$R2" && DEFAULT_BRANCH=trunk merge_specs_to_target "y-task" "$R2/docs/specs/y/SPEC.md" ) > "$TMP/s4.out" 2>&1
+  rc=$?
+  [[ $rc -ne 0 ]] && ok "S4 비-ff 실패 비-0 종료(dispatch 미시작 신호)" || { bad "S4 비-ff 비-0 (rc=$rc)"; cat "$TMP/s4.out"; }
+  grep -qi "dispatch 미시작\|ff 불가\|분기" "$TMP/s4.out" \
+    && ok "S4 SPEC 미안착 메시지(원인 구분)" || bad "S4 메시지"
+  ( cd "$R2" && git fetch -q origin trunk )
+  ( cd "$R2" && ! git show "origin/trunk:docs/specs/y/SPEC.md" >/dev/null 2>&1 ) \
+    && ok "S4 SPEC origin 미반영(force 금지)" || bad "S4 SPEC origin 반영됨(force 의심)"
+  ( cd "$R2" && [[ "$(git rev-parse origin/trunk)" == "$( cd "$R2b" && git rev-parse origin/trunk 2>/dev/null || echo x )" ]] ) >/dev/null 2>&1
+
+  echo "----"
+  [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"
+  return $fail
+}
+
+# ----- 디스패처 -----
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  sub="${1:-}"; shift || true
+  case "$sub" in
+    merge)         merge_specs_to_target "$@" ;;
+    detect-target) sm_detect_target_branch ;;
+    selftest)      sm_selftest ;;
+    *) echo "usage: spec-merge.sh {merge <task-id> <spec...>|detect-target|selftest}" >&2; exit 1 ;;
+  esac
+fi


### PR DESCRIPTION
## 요약

`fsd start`가 SPEC을 `dispatch`에 위임하기 **직전에**, 입력 SPEC 문서를 task의 **타겟 통합 브랜치**(레포 기본 브랜치, `main` 하드코딩 아님)에 fast-forward로 안착시키는 전제조건을 추가합니다. 자연어 의도 진입(fsd가 spec 실행)·직접 SPEC 경로 intake 두 경우 모두 `start`를 거치므로 동일하게 적용되며, 이미 같은 내용이 안착해 있으면 새 commit 없이 통과하는 멱등 동작입니다.

SPEC: `docs/specs/2026-06-04-fsd-merges-spec-to-target-branch-before-dispatch/SPEC.md` (이미 main 선반영됨).

## 동기

fsd 자동 파이프라인이 SPEC을 떠서 곧바로 구현을 위임하면 의도(SPEC)가 통합 브랜치 이력에 남지 않아, 구현후 통합에서 의도와 구현이 한 덩어리로 엉켜 SPEC 선반영을 빠뜨리기 쉽습니다. dispatch 착수 전에 SPEC을 타겟 브랜치에 먼저 안착시켜 의도가 구현과 분리된 별도 머지로 항상 이력에 남도록 보장합니다.

## 변경

- **신규 `references/spec-merge.sh`**: SPEC을 감지된 기본 통합 브랜치에 ff-merge 안착시키는 모듈.
  - 타겟 브랜치 감지(`DEFAULT_BRANCH` env → `origin/HEAD` → `remote show` → 로컬 main/master → 현재 브랜치 — `main` 비하드코딩).
  - plumbing(`commit-tree`, parent=base)으로 워킹 트리·인덱스 미교란, ff-only 보장.
  - 멱등 no-op(후보 tree == base tree).
  - 비-ff·push 거부 등 실패 시 비-0 종료, **force push 금지**, "SPEC 미안착 ≠ dispatch 실패" 구분 메시지.
  - ephemeral feat 브랜치는 로컬 생성 후 정리.
  - 실-git selftest 4 시나리오(타겟 감지·안착·멱등·실패) **12/12 PASS**.
- **`fsd.sh cmd_start`**: 마커 가드 → spec-merge → dispatch 순서로 전제조건 배선(`FSD_SPEC_MERGE_CMD` 주입 가능). 실패 시 `state=spec-merge-failed`·dispatch 미시작·구분 메시지로 abort. 배선 selftest **21/21 PASS**.
- **`SKILL.md`**: 전제조건·실패 차단·타겟 감지·멱등·마커가드 우선순서·spec 불변식 문서화.
- **버전**: autopilot `0.25.0 → 0.26.0` (plugin.json SoT + 루트 marketplace.json 미러).

## 완료 조건 (SPEC AC1~AC6)

- AC1 dispatch 위임 전 SPEC commit이 타겟 브랜치 이력에 존재 ✅
- AC2 타겟 브랜치 `main` 하드코딩 금지 — 기본 브랜치 감지 ✅
- AC3 멱등 — 동일 내용 재-start 시 중복 commit 없음 ✅
- AC4 미해결 마커 가드가 머지보다 먼저 — 마커 SPEC은 타겟에 안 올라감 ✅
- AC5 머지/push 실패 시 dispatch 미시작·force 금지·메시지 구분 ✅
- AC6 spec 스킬 정의 파일 불변 ✅

## 검증

```
spec-merge.sh selftest: 12/12 ALL PASS (실 git)
fsd.sh selftest:        21/21 ALL PASS (배선)
```

## 리뷰 참고

- 단일출처 절차(`rules/engineering/branch-and-slug.md`)의 "feat 브랜치+commit"·"원격 동기화" **형태**(feat 경유·ff-only·force 금지)를 중복정의 없이 소비합니다.
- 워커 노트의 의심점 1건: ephemeral feat 브랜치를 원격에 push하지 않습니다(완료조건은 target commit+push만 요구한다는 해석, clutter 회피). 단일출처 절차와의 미세 드리프트라 리뷰 재확인을 권장합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
