### PR TITLE
fix(review): 증분 base를 event.before → 마지막 성공 리뷰 SHA로 (리뷰 공백 차단)

### DIFF
--- a/.github/scripts/pr-review-context.sh
+++ b/.github/scripts/pr-review-context.sh
@@ -46,7 +46,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$action" == "synchronize" ]]; t
         incremental_base="$cand_sha"
         break
       fi
-    done < <(printf '%s' "$reviews_json" | node "$base_resolver" "$REVIEW_MARKER_PREFIX" 2>/dev/null || true)
+    done < <(printf '%s' "$reviews_json" | node "$base_resolver" "$REVIEW_MARKER_PREFIX" "${REVIEW_BOT_LOGINS:-}" 2>/dev/null || true)
   fi
 elif [[ "$GITHUB_EVENT_NAME" == "pull_request_review_comment" && -n "$reply_to_id" && -n "$comment_path" ]]; then
   mode="thread"

--- a/.github/scripts/pr-review-context.sh
+++ b/.github/scripts/pr-review-context.sh
@@ -19,9 +19,35 @@ reply_to_id="$(jq -r '.comment.in_reply_to_id // empty' "$GITHUB_EVENT_PATH")"
 comment_path="$(jq -r '.comment.path // empty' "$GITHUB_EVENT_PATH")"
 comment_line="$(jq -r '.comment.line // empty' "$GITHUB_EVENT_PATH")"
 
-if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$action" == "synchronize" && -n "$event_before" ]]; then
-  mode="incremental"
-  incremental_base="$event_before"
+if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$action" == "synchronize" ]]; then
+  : "${REVIEW_MARKER_PREFIX:?REVIEW_MARKER_PREFIX is required for synchronize events}"
+  # Incremental base = the commit THIS reviewer last SUCCESSFULLY reviewed — NOT
+  # the webhook event.before. event.before is the previous push head, which
+  # GitHub advances on every push regardless of whether the prior review ran; a
+  # failed review (e.g. usage-limit → nothing posted) would then be skipped by
+  # the next incremental diff while the check still goes green. The success-gated
+  # per-reviewer source of truth is this reviewer's most recent formal-review
+  # marker (<!-- $REVIEW_MARKER_PREFIX head_sha=<sha> ... -->), posted only when a
+  # review is actually submitted. Take the latest marker SHA that is an ancestor
+  # of the current head; fall back to a full diff (mode stays "full") when none
+  # qualifies — first review, all prior reviews failed/unavailable, or the marker
+  # SHA is unreachable after a force-push/rebase/squash.
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  base_resolver="$script_dir/pr-review-incremental-base.js"
+  # gh --paginate emits one JSON array per page back-to-back; jq -s 'add' merges
+  # them into a single flat array (and a lone page stays itself).
+  reviews_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" --paginate 2>/dev/null \
+    | jq -c -s 'add // []' 2>/dev/null || true)"
+  if [[ -n "$reviews_json" && -f "$base_resolver" ]]; then
+    while IFS= read -r cand_sha; do
+      [[ -n "$cand_sha" ]] || continue
+      if git merge-base --is-ancestor "$cand_sha" "$PR_HEAD_SHA" 2>/dev/null; then
+        mode="incremental"
+        incremental_base="$cand_sha"
+        break
+      fi
+    done < <(printf '%s' "$reviews_json" | node "$base_resolver" "$REVIEW_MARKER_PREFIX" 2>/dev/null || true)
+  fi
 elif [[ "$GITHUB_EVENT_NAME" == "pull_request_review_comment" && -n "$reply_to_id" && -n "$comment_path" ]]; then
   mode="thread"
   incremental_base="${PR_BASE_SHA:-${event_before:-HEAD~1}}"
@@ -68,8 +94,8 @@ esac
 # createReview validates inline-comment anchors against. The mode-specific
 # diff.patch above is for the MODEL (incremental on synchronize). Using that
 # incremental diff for anchor validation mis-classifies base-merged lines as
-# in-diff: a file absent in the previous-reviewed SHA (event.before) shows as
-# fully-added, so its unchanged-vs-base lines pass the off-diff filter and then
+# in-diff: a file absent in the previous-reviewed SHA (the incremental base) shows
+# as fully-added, so its unchanged-vs-base lines pass the off-diff filter and then
 # get 422 "Line could not be resolved" from createReview — which the inline-only
 # false-green guard turns into a failed job. `gh pr diff` is exactly the diff
 # GitHub resolves anchors against, so validate against it in every mode.

--- a/.github/scripts/pr-review-incremental-base.js
+++ b/.github/scripts/pr-review-incremental-base.js
@@ -36,22 +36,33 @@
 //     the default `github-actions[bot]` — both type Bot. A human (e.g. the PR
 //     author, type 'User') could otherwise submit a COMMENT review carrying the
 //     marker to FORGE a "last reviewed" SHA at an un-reviewed head, making the
-//     next incremental diff skip their unreviewed changes. Requiring Bot
-//     authorship blocks that forgery. (Residual: a *separate* malicious bot app
-//     with PR-review-write installed on the repo — out of this threat model;
-//     such an app could compromise far more than review coverage.)
+//     next incremental diff skip their unreviewed changes.
+//   allowedLogins: optional array of the EXACT trusted reviewer-bot logins (e.g.
+//     ['courtesy-bot[bot]', 'github-actions[bot]']). The workflow derives these
+//     dynamically from the review App slug (`<app-slug>[bot]`) plus the default
+//     `github-actions[bot]`. When provided, a marker is trusted ONLY if its
+//     review author login is in this set — so a DIFFERENT bot account that also
+//     has PR-review-write cannot forge a marker (the residual gap that bare
+//     `type === 'Bot'` left open). When empty/omitted, falls back to requiring
+//     `type === 'Bot'` (blocks human forgery; used by unconfigured deployments).
 //   Returns the marker head_sha values ordered by submitted_at DESCENDING
 //   (latest review first), de-duplicated (first/most-recent occurrence kept).
 //   Bodies without a well-formed marker for this prefix are ignored.
-function extractMarkerShas(reviews, markerPrefix) {
+function extractMarkerShas(reviews, markerPrefix, allowedLogins) {
   if (!Array.isArray(reviews) || typeof markerPrefix !== 'string' || !markerPrefix) {
     return [];
   }
+  const allow = Array.isArray(allowedLogins)
+    ? allowedLogins.filter((l) => typeof l === 'string' && l).map((l) => l.toLowerCase())
+    : [];
   const needle = `<!-- ${markerPrefix} head_sha=`;
   const hits = [];
   for (const r of reviews) {
     // Trust only bot-authored reviews — a human/non-bot marker is a forgery.
     if (!r || !r.user || r.user.type !== 'Bot') continue;
+    // When an explicit trusted-login set is configured, the marker author must
+    // be one of them — a different review-writing bot cannot forge the base.
+    if (allow.length && !allow.includes(String(r.user.login || '').toLowerCase())) continue;
     const body = typeof r.body === 'string' ? r.body : '';
     const at = body.indexOf(needle);
     if (at === -1) continue;
@@ -76,12 +87,15 @@ function extractMarkerShas(reviews, markerPrefix) {
 
 module.exports = { extractMarkerShas };
 
-// ---- CLI: `node pr-review-incremental-base.js <markerPrefix>` ----
+// ---- CLI: `node pr-review-incremental-base.js <markerPrefix> [allowedLogins]` ----
 // Reads the reviews JSON array on stdin, prints candidate SHAs (latest first),
-// one per line. On any parse error prints nothing (exit 0) so the caller safely
-// degrades to a full review.
+// one per line. allowedLogins is an optional comma-separated trusted-bot login
+// list. On any parse error prints nothing (exit 0) so the caller safely degrades
+// to a full review.
 if (require.main === module) {
   const markerPrefix = process.argv[2] || '';
+  const allowedLogins = (process.argv[3] || '')
+    .split(',').map((s) => s.trim()).filter(Boolean);
   let buf = '';
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', (d) => { buf += d; });
@@ -94,7 +108,7 @@ if (require.main === module) {
       // Malformed/empty input → no candidates → caller does a full review.
       return;
     }
-    const shas = extractMarkerShas(reviews, markerPrefix);
+    const shas = extractMarkerShas(reviews, markerPrefix, allowedLogins);
     if (shas.length) process.stdout.write(shas.join('\n') + '\n');
   });
 }

--- a/.github/scripts/pr-review-incremental-base.js
+++ b/.github/scripts/pr-review-incremental-base.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// Shared incremental-base resolver for the codex / claude PR review workflows.
+//
+// On a `synchronize` event the workflows must diff the PR head against the
+// commit this reviewer LAST SUCCESSFULLY REVIEWED — not against the webhook's
+// `event.before` (the previous push head). `event.before` advances on every
+// push regardless of whether the prior review actually ran, so a failed review
+// (e.g. usage-limit → no review posted) leaves its commits silently skipped by
+// the next incremental diff while the check still goes green.
+//
+// The success-gated, per-reviewer source of truth already exists: each workflow
+// posts a formal-review marker `<!-- <prefix> head_sha=<sha> verdict=<v> -->`
+// (prefix `claude-formal-review` / `codex-formal-review`) via createReview ONLY
+// when a review is actually submitted (approve/comment) — never on failure,
+// unavailable, or skipped. So this reviewer's most recent marker head_sha is the
+// last SHA it truly reviewed. This module extracts those SHAs (latest first);
+// the shell glue then picks the most recent one that is an ancestor of the
+// current head as the incremental base (falling back to a full diff otherwise).
+//
+// CommonJS + a stdin CLI entry so the bash script (pr-review-context.sh) can pipe
+// `gh api .../pulls/{n}/reviews` JSON in and read newline-separated SHAs out.
+// Pure: no I/O, git, or network in the exported logic. Like the sibling
+// diff-anchor-filter.js / pr-review-chunking.js, a PR that introduces or
+// modifies this module is reviewed by the base checkout, so it only takes
+// effect post-merge.
+
+// extractMarkerShas(reviews, markerPrefix) → [sha, ...]
+//   reviews: array of GitHub review objects (each may have .body, .submitted_at).
+//   markerPrefix: e.g. 'claude-formal-review' — only this reviewer's markers
+//     are considered (codex and claude share one bot identity, so the prefix,
+//     not the author, scopes ownership).
+//   Returns the marker head_sha values ordered by submitted_at DESCENDING
+//   (latest review first), de-duplicated (first/most-recent occurrence kept).
+//   Bodies without a well-formed marker for this prefix are ignored.
+function extractMarkerShas(reviews, markerPrefix) {
+  if (!Array.isArray(reviews) || typeof markerPrefix !== 'string' || !markerPrefix) {
+    return [];
+  }
+  const needle = `<!-- ${markerPrefix} head_sha=`;
+  const hits = [];
+  for (const r of reviews) {
+    const body = r && typeof r.body === 'string' ? r.body : '';
+    const at = body.indexOf(needle);
+    if (at === -1) continue;
+    // SHA runs from just after the needle up to the next whitespace.
+    const rest = body.slice(at + needle.length);
+    const sha = rest.split(/\s/, 1)[0];
+    if (!/^[0-9a-f]+$/i.test(sha)) continue; // malformed/partial marker → skip
+    hits.push({ sha, at: (r && typeof r.submitted_at === 'string') ? r.submitted_at : '' });
+  }
+  // ISO-8601 submitted_at sorts chronologically as a string; empty (missing)
+  // sorts last under a descending order. Stable enough — distinct SHAs differ.
+  hits.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
+  const seen = new Set();
+  const out = [];
+  for (const h of hits) {
+    if (seen.has(h.sha)) continue;
+    seen.add(h.sha);
+    out.push(h.sha);
+  }
+  return out;
+}
+
+module.exports = { extractMarkerShas };
+
+// ---- CLI: `node pr-review-incremental-base.js <markerPrefix>` ----
+// Reads the reviews JSON array on stdin, prints candidate SHAs (latest first),
+// one per line. On any parse error prints nothing (exit 0) so the caller safely
+// degrades to a full review.
+if (require.main === module) {
+  const markerPrefix = process.argv[2] || '';
+  let buf = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (d) => { buf += d; });
+  process.stdin.on('end', () => {
+    let reviews = [];
+    try {
+      const parsed = JSON.parse(buf || '[]');
+      if (Array.isArray(parsed)) reviews = parsed;
+    } catch (_e) {
+      // Malformed/empty input → no candidates → caller does a full review.
+      return;
+    }
+    const shas = extractMarkerShas(reviews, markerPrefix);
+    if (shas.length) process.stdout.write(shas.join('\n') + '\n');
+  });
+}

--- a/.github/scripts/pr-review-incremental-base.js
+++ b/.github/scripts/pr-review-incremental-base.js
@@ -28,8 +28,18 @@
 // extractMarkerShas(reviews, markerPrefix) → [sha, ...]
 //   reviews: array of GitHub review objects (each may have .body, .submitted_at).
 //   markerPrefix: e.g. 'claude-formal-review' — only this reviewer's markers
-//     are considered (codex and claude share one bot identity, so the prefix,
-//     not the author, scopes ownership).
+//     are considered (codex and claude share one bot identity, so the prefix
+//     scopes WHICH reviewer; the author check below scopes that the marker is
+//     genuinely bot-posted).
+//   SECURITY: only reviews authored by a Bot account (`user.type === 'Bot'`) are
+//     trusted. Formal-review markers are posted by the App bot (`<slug>[bot]`) or
+//     the default `github-actions[bot]` — both type Bot. A human (e.g. the PR
+//     author, type 'User') could otherwise submit a COMMENT review carrying the
+//     marker to FORGE a "last reviewed" SHA at an un-reviewed head, making the
+//     next incremental diff skip their unreviewed changes. Requiring Bot
+//     authorship blocks that forgery. (Residual: a *separate* malicious bot app
+//     with PR-review-write installed on the repo — out of this threat model;
+//     such an app could compromise far more than review coverage.)
 //   Returns the marker head_sha values ordered by submitted_at DESCENDING
 //   (latest review first), de-duplicated (first/most-recent occurrence kept).
 //   Bodies without a well-formed marker for this prefix are ignored.
@@ -40,7 +50,9 @@ function extractMarkerShas(reviews, markerPrefix) {
   const needle = `<!-- ${markerPrefix} head_sha=`;
   const hits = [];
   for (const r of reviews) {
-    const body = r && typeof r.body === 'string' ? r.body : '';
+    // Trust only bot-authored reviews — a human/non-bot marker is a forgery.
+    if (!r || !r.user || r.user.type !== 'Bot') continue;
+    const body = typeof r.body === 'string' ? r.body : '';
     const at = body.indexOf(needle);
     if (at === -1) continue;
     // SHA runs from just after the needle up to the next whitespace.

--- a/.github/scripts/pr-review-incremental-base.test.js
+++ b/.github/scripts/pr-review-incremental-base.test.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+'use strict';
+
+// Unit test for the incremental-base marker extractor.
+// Static, hermetic: no GitHub, git, npm, or model calls. Exercises marker
+// parsing, prefix scoping, submitted_at ordering, and malformed-marker
+// handling — the pure logic behind the synchronize incremental base. The
+// git-ancestry selection over these candidates is thin shell glue in
+// pr-review-context.sh, verified post-merge on a real PR.
+
+const assert = require('node:assert');
+const path = require('node:path');
+
+const { extractMarkerShas } =
+  require(path.join(__dirname, 'pr-review-incremental-base.js'));
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`OK: ${name}`);
+}
+
+const CLAUDE = 'claude-formal-review';
+const CODEX = 'codex-formal-review';
+
+// COMMENT-style review body: marker only, no prose.
+const commentBody = (prefix, sha) => `<!-- ${prefix} head_sha=${sha} verdict=comment -->`;
+// APPROVE-style review body: multi-line prose then the marker.
+const approveBody = (prefix, sha) =>
+  ['## Claude PR 리뷰', '', '승인되었습니다.', '', `<!-- ${prefix} head_sha=${sha} verdict=approve -->`].join('\n');
+
+test('no reviews → []', () => {
+  assert.deepStrictEqual(extractMarkerShas([], CLAUDE), []);
+});
+
+test('reviews without this prefix marker → []', () => {
+  const reviews = [
+    { body: 'plain human review, looks good', submitted_at: '2026-06-06T04:00:00Z' },
+    { body: '<!-- claude-review-inline fingerprint=abc -->', submitted_at: '2026-06-06T04:01:00Z' },
+  ];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), []);
+});
+
+test('single comment marker → [sha]', () => {
+  const reviews = [{ body: commentBody(CLAUDE, 'e512b9c4d0'), submitted_at: '2026-06-06T04:05:31Z' }];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['e512b9c4d0']);
+});
+
+test('multiple markers ordered by submitted_at DESC (latest first)', () => {
+  const reviews = [
+    { body: commentBody(CLAUDE, 'aaa111'), submitted_at: '2026-06-06T04:05:00Z' },
+    { body: approveBody(CLAUDE, 'ccc333'), submitted_at: '2026-06-06T04:25:00Z' },
+    { body: commentBody(CLAUDE, 'bbb222'), submitted_at: '2026-06-06T04:15:00Z' },
+  ];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['ccc333', 'bbb222', 'aaa111']);
+});
+
+test('prefix scoping: codex markers ignored when asking for claude (PR #334 case)', () => {
+  // #334: claude has markers, codex has none. Asking for codex → [].
+  const reviews = [
+    { body: commentBody(CLAUDE, 'e512b9c4d0'), submitted_at: '2026-06-06T04:05:31Z' },
+    { body: approveBody(CLAUDE, '9a7c059868'), submitted_at: '2026-06-06T04:25:18Z' },
+  ];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CODEX), []);
+  // And asking for claude returns both, latest first.
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['9a7c059868', 'e512b9c4d0']);
+});
+
+test('APPROVE multi-line body parsed', () => {
+  const reviews = [{ body: approveBody(CLAUDE, '9a7c059868'), submitted_at: '2026-06-06T04:25:18Z' }];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['9a7c059868']);
+});
+
+test('COMMENT marker-only body parsed', () => {
+  const reviews = [{ body: commentBody(CODEX, 'deadbeef01'), submitted_at: '2026-06-06T04:05:31Z' }];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CODEX), ['deadbeef01']);
+});
+
+test('malformed/partial marker skipped gracefully', () => {
+  const reviews = [
+    { body: '<!-- claude-formal-review head_sha= verdict=comment -->', submitted_at: '2026-06-06T04:05:00Z' }, // empty sha
+    { body: '<!-- claude-formal-review head_sha=', submitted_at: '2026-06-06T04:06:00Z' }, // truncated, no sha
+    { body: '<!-- claude-formal-review head_sha=zzz999 -->', submitted_at: '2026-06-06T04:07:00Z' }, // non-hex
+    { body: commentBody(CLAUDE, 'cafe01'), submitted_at: '2026-06-06T04:08:00Z' }, // the one good one
+  ];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['cafe01']);
+});
+
+test('duplicate sha de-duped, most-recent kept', () => {
+  const reviews = [
+    { body: commentBody(CLAUDE, 'aaa111'), submitted_at: '2026-06-06T04:05:00Z' },
+    { body: approveBody(CLAUDE, 'aaa111'), submitted_at: '2026-06-06T04:25:00Z' },
+  ];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['aaa111']);
+});
+
+test('non-array / bad input → []', () => {
+  assert.deepStrictEqual(extractMarkerShas(null, CLAUDE), []);
+  assert.deepStrictEqual(extractMarkerShas([{ body: commentBody(CLAUDE, 'aaa') }], ''), []);
+});
+
+console.log(`\nALL ${passed} CHECKS PASSED`);

--- a/.github/scripts/pr-review-incremental-base.test.js
+++ b/.github/scripts/pr-review-incremental-base.test.js
@@ -24,8 +24,10 @@ function test(name, fn) {
 
 const CLAUDE = 'claude-formal-review';
 const CODEX = 'codex-formal-review';
-const BOT = { type: 'Bot' };   // trusted formal-review author
+const BOT = { type: 'Bot' };   // trusted formal-review author (no login pin)
 const HUMAN = { type: 'User' }; // untrusted — forged markers must be ignored
+const TRUSTED = ['courtesy-bot[bot]', 'github-actions[bot]']; // pinned trusted logins
+const bot = (login) => ({ type: 'Bot', login }); // bot with a specific login
 
 // COMMENT-style review body: marker only, no prose.
 const commentBody = (prefix, sha) => `<!-- ${prefix} head_sha=${sha} verdict=comment -->`;
@@ -86,6 +88,28 @@ test('SECURITY: bot marker accepted, concurrent human forgery for same prefix dr
     rev(approveBody(CODEX, 'dead00aa11'), '2026-06-06T08:00:00Z', BOT), // genuine
   ];
   assert.deepStrictEqual(extractMarkerShas(reviews, CODEX), ['dead00aa11']);
+});
+
+test('SECURITY: allowedLogins pins to trusted bot; a DIFFERENT bot is rejected', () => {
+  const reviews = [
+    rev(commentBody(CODEX, 'ffaa00'), '2026-06-06T09:00:00Z', bot('rogue-bot[bot]')),  // other bot → drop
+    rev(approveBody(CODEX, 'bbcc11'), '2026-06-06T08:00:00Z', bot('courtesy-bot[bot]')), // trusted → keep
+  ];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CODEX, TRUSTED), ['bbcc11']);
+});
+
+test('allowedLogins accepts each trusted login (app bot + github-actions), case-insensitive', () => {
+  const reviews = [
+    rev(commentBody(CLAUDE, 'aa11'), '2026-06-06T08:00:00Z', bot('github-actions[bot]')),
+    rev(approveBody(CLAUDE, 'bb22'), '2026-06-06T09:00:00Z', bot('Courtesy-Bot[bot]')), // case differs
+  ];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE, TRUSTED), ['bb22', 'aa11']);
+});
+
+test('empty allowedLogins falls back to type===Bot only (unconfigured deployment)', () => {
+  const reviews = [rev(commentBody(CLAUDE, 'cc33'), '2026-06-06T08:00:00Z', bot('any-bot[bot]'))];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE, []), ['cc33']);
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['cc33']);
 });
 
 test('review with missing user is ignored', () => {

--- a/.github/scripts/pr-review-incremental-base.test.js
+++ b/.github/scripts/pr-review-incremental-base.test.js
@@ -3,10 +3,11 @@
 
 // Unit test for the incremental-base marker extractor.
 // Static, hermetic: no GitHub, git, npm, or model calls. Exercises marker
-// parsing, prefix scoping, submitted_at ordering, and malformed-marker
-// handling — the pure logic behind the synchronize incremental base. The
-// git-ancestry selection over these candidates is thin shell glue in
-// pr-review-context.sh, verified post-merge on a real PR.
+// parsing, prefix scoping, bot-author trust (forgery rejection), submitted_at
+// ordering, and malformed-marker handling — the pure logic behind the
+// synchronize incremental base. The git-ancestry selection over these
+// candidates is thin shell glue in pr-review-context.sh, verified post-merge
+// on a real PR.
 
 const assert = require('node:assert');
 const path = require('node:path');
@@ -23,12 +24,16 @@ function test(name, fn) {
 
 const CLAUDE = 'claude-formal-review';
 const CODEX = 'codex-formal-review';
+const BOT = { type: 'Bot' };   // trusted formal-review author
+const HUMAN = { type: 'User' }; // untrusted — forged markers must be ignored
 
 // COMMENT-style review body: marker only, no prose.
 const commentBody = (prefix, sha) => `<!-- ${prefix} head_sha=${sha} verdict=comment -->`;
 // APPROVE-style review body: multi-line prose then the marker.
 const approveBody = (prefix, sha) =>
   ['## Claude PR 리뷰', '', '승인되었습니다.', '', `<!-- ${prefix} head_sha=${sha} verdict=approve -->`].join('\n');
+// Build a bot-authored review (the trusted, real case).
+const rev = (body, submitted_at, user = BOT) => ({ body, submitted_at, user });
 
 test('no reviews → []', () => {
   assert.deepStrictEqual(extractMarkerShas([], CLAUDE), []);
@@ -36,22 +41,22 @@ test('no reviews → []', () => {
 
 test('reviews without this prefix marker → []', () => {
   const reviews = [
-    { body: 'plain human review, looks good', submitted_at: '2026-06-06T04:00:00Z' },
-    { body: '<!-- claude-review-inline fingerprint=abc -->', submitted_at: '2026-06-06T04:01:00Z' },
+    rev('plain human review, looks good', '2026-06-06T04:00:00Z'),
+    rev('<!-- claude-review-inline fingerprint=abc -->', '2026-06-06T04:01:00Z'),
   ];
   assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), []);
 });
 
 test('single comment marker → [sha]', () => {
-  const reviews = [{ body: commentBody(CLAUDE, 'e512b9c4d0'), submitted_at: '2026-06-06T04:05:31Z' }];
+  const reviews = [rev(commentBody(CLAUDE, 'e512b9c4d0'), '2026-06-06T04:05:31Z')];
   assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['e512b9c4d0']);
 });
 
 test('multiple markers ordered by submitted_at DESC (latest first)', () => {
   const reviews = [
-    { body: commentBody(CLAUDE, 'aaa111'), submitted_at: '2026-06-06T04:05:00Z' },
-    { body: approveBody(CLAUDE, 'ccc333'), submitted_at: '2026-06-06T04:25:00Z' },
-    { body: commentBody(CLAUDE, 'bbb222'), submitted_at: '2026-06-06T04:15:00Z' },
+    rev(commentBody(CLAUDE, 'aaa111'), '2026-06-06T04:05:00Z'),
+    rev(approveBody(CLAUDE, 'ccc333'), '2026-06-06T04:25:00Z'),
+    rev(commentBody(CLAUDE, 'bbb222'), '2026-06-06T04:15:00Z'),
   ];
   assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['ccc333', 'bbb222', 'aaa111']);
 });
@@ -59,45 +64,66 @@ test('multiple markers ordered by submitted_at DESC (latest first)', () => {
 test('prefix scoping: codex markers ignored when asking for claude (PR #334 case)', () => {
   // #334: claude has markers, codex has none. Asking for codex → [].
   const reviews = [
-    { body: commentBody(CLAUDE, 'e512b9c4d0'), submitted_at: '2026-06-06T04:05:31Z' },
-    { body: approveBody(CLAUDE, '9a7c059868'), submitted_at: '2026-06-06T04:25:18Z' },
+    rev(commentBody(CLAUDE, 'e512b9c4d0'), '2026-06-06T04:05:31Z'),
+    rev(approveBody(CLAUDE, '9a7c059868'), '2026-06-06T04:25:18Z'),
   ];
   assert.deepStrictEqual(extractMarkerShas(reviews, CODEX), []);
   // And asking for claude returns both, latest first.
   assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['9a7c059868', 'e512b9c4d0']);
 });
 
+test('SECURITY: human-authored (type User) forged marker is ignored', () => {
+  // An attacker posts a COMMENT review carrying the marker to forge a base.
+  const reviews = [
+    rev(commentBody(CODEX, 'forged9999'), '2026-06-06T09:00:00Z', HUMAN),
+  ];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CODEX), []);
+});
+
+test('SECURITY: bot marker accepted, concurrent human forgery for same prefix dropped', () => {
+  const reviews = [
+    rev(commentBody(CODEX, 'ff0099'), '2026-06-06T09:00:00Z', HUMAN), // latest, forged → drop
+    rev(approveBody(CODEX, 'dead00aa11'), '2026-06-06T08:00:00Z', BOT), // genuine
+  ];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CODEX), ['dead00aa11']);
+});
+
+test('review with missing user is ignored', () => {
+  const reviews = [{ body: commentBody(CLAUDE, 'aaa111'), submitted_at: '2026-06-06T04:05:00Z' }];
+  assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), []);
+});
+
 test('APPROVE multi-line body parsed', () => {
-  const reviews = [{ body: approveBody(CLAUDE, '9a7c059868'), submitted_at: '2026-06-06T04:25:18Z' }];
+  const reviews = [rev(approveBody(CLAUDE, '9a7c059868'), '2026-06-06T04:25:18Z')];
   assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['9a7c059868']);
 });
 
 test('COMMENT marker-only body parsed', () => {
-  const reviews = [{ body: commentBody(CODEX, 'deadbeef01'), submitted_at: '2026-06-06T04:05:31Z' }];
+  const reviews = [rev(commentBody(CODEX, 'deadbeef01'), '2026-06-06T04:05:31Z')];
   assert.deepStrictEqual(extractMarkerShas(reviews, CODEX), ['deadbeef01']);
 });
 
 test('malformed/partial marker skipped gracefully', () => {
   const reviews = [
-    { body: '<!-- claude-formal-review head_sha= verdict=comment -->', submitted_at: '2026-06-06T04:05:00Z' }, // empty sha
-    { body: '<!-- claude-formal-review head_sha=', submitted_at: '2026-06-06T04:06:00Z' }, // truncated, no sha
-    { body: '<!-- claude-formal-review head_sha=zzz999 -->', submitted_at: '2026-06-06T04:07:00Z' }, // non-hex
-    { body: commentBody(CLAUDE, 'cafe01'), submitted_at: '2026-06-06T04:08:00Z' }, // the one good one
+    rev('<!-- claude-formal-review head_sha= verdict=comment -->', '2026-06-06T04:05:00Z'), // empty sha
+    rev('<!-- claude-formal-review head_sha=', '2026-06-06T04:06:00Z'), // truncated, no sha
+    rev('<!-- claude-formal-review head_sha=zzz999 -->', '2026-06-06T04:07:00Z'), // non-hex
+    rev(commentBody(CLAUDE, 'cafe01'), '2026-06-06T04:08:00Z'), // the one good one
   ];
   assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['cafe01']);
 });
 
 test('duplicate sha de-duped, most-recent kept', () => {
   const reviews = [
-    { body: commentBody(CLAUDE, 'aaa111'), submitted_at: '2026-06-06T04:05:00Z' },
-    { body: approveBody(CLAUDE, 'aaa111'), submitted_at: '2026-06-06T04:25:00Z' },
+    rev(commentBody(CLAUDE, 'aaa111'), '2026-06-06T04:05:00Z'),
+    rev(approveBody(CLAUDE, 'aaa111'), '2026-06-06T04:25:00Z'),
   ];
   assert.deepStrictEqual(extractMarkerShas(reviews, CLAUDE), ['aaa111']);
 });
 
 test('non-array / bad input → []', () => {
   assert.deepStrictEqual(extractMarkerShas(null, CLAUDE), []);
-  assert.deepStrictEqual(extractMarkerShas([{ body: commentBody(CLAUDE, 'aaa') }], ''), []);
+  assert.deepStrictEqual(extractMarkerShas([rev(commentBody(CLAUDE, 'aaa'), '2026-06-06T04:00:00Z')], ''), []);
 });
 
 console.log(`\nALL ${passed} CHECKS PASSED`);

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -158,6 +158,7 @@ jobs:
           PR_NUMBER="$PR_NUMBER" \
           PR_BASE_SHA="$PR_BASE_SHA" \
           PR_HEAD_SHA="$PR_HEAD_SHA" \
+          REVIEW_MARKER_PREFIX="claude-formal-review" \
           .github/scripts/pr-review-context.sh
 
           source .review-context/context-mode.env

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -61,6 +61,10 @@ jobs:
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      # Exposed for the app-token step's `if` (mirrors the merge job). Empty on
+      # forks / unconfigured repos → app-token skipped → github-actions[bot] only.
+      REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}
     outputs:
       chunks: ${{ steps.plan.outputs.chunks }}
       chunk_count: ${{ steps.plan.outputs.chunk_count }}
@@ -120,6 +124,20 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Generate GitHub App token
+        id: app-token
+        # Resolve the App bot login (`<app-slug>[bot]`) so the incremental-base
+        # resolver can pin marker trust to it (+ github-actions[bot]) and reject a
+        # forged marker from any OTHER review-writing bot. Gated on REVIEW_APP_ID;
+        # skipped/failed (continue-on-error) → app-slug empty → github-actions[bot]
+        # only. Same action/identity the merge job uses to POST the marker.
+        if: ${{ env.REVIEW_APP_ID != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
+        with:
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
+
       - name: Prepare Claude review context
         id: prepare-claude-review
         # Build the untrusted-context HEADER (metadata/comments, up to and
@@ -140,6 +158,7 @@ jobs:
           PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           PR_TITLE: ${{ steps.pr.outputs.title }}
           CLAUDE_REVIEW_LANG: ${{ vars.CLAUDE_REVIEW_LANG || 'Korean' }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           if [ -z "$claude_code_oauth_token" ]; then
             echo "CLAUDE_CODE_OAUTH_TOKEN secret is required for Claude review authentication." >&2
@@ -151,6 +170,14 @@ jobs:
           REVIEW_PROMPT=".github/prompts/claude-pr-review.ko.md"
           REVIEW_SCHEMA=".github/prompts/codex-pr-review.schema.json"
 
+          # Trusted formal-review marker authors: the App bot (<slug>[bot]) when an
+          # App token is configured, plus the default github-actions[bot] fallback.
+          if [ -n "${APP_SLUG:-}" ]; then
+            review_bot_logins="${APP_SLUG}[bot],github-actions[bot]"
+          else
+            review_bot_logins="github-actions[bot]"
+          fi
+
           REVIEW_OUTPUT_DIR=".review-context" \
           GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" \
           GITHUB_EVENT_PATH="$GITHUB_EVENT_PATH" \
@@ -159,6 +186,7 @@ jobs:
           PR_BASE_SHA="$PR_BASE_SHA" \
           PR_HEAD_SHA="$PR_HEAD_SHA" \
           REVIEW_MARKER_PREFIX="claude-formal-review" \
+          REVIEW_BOT_LOGINS="$review_bot_logins" \
           .github/scripts/pr-review-context.sh
 
           source .review-context/context-mode.env

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -147,6 +147,7 @@ jobs:
           PR_NUMBER="$PR_NUMBER" \
           PR_BASE_SHA="$PR_BASE_SHA" \
           PR_HEAD_SHA="$PR_HEAD_SHA" \
+          REVIEW_MARKER_PREFIX="codex-formal-review" \
           .github/scripts/pr-review-context.sh
 
           source .review-context/context-mode.env

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -58,6 +58,10 @@ jobs:
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      # Exposed for the app-token step's `if` (mirrors the merge job). Empty on
+      # forks / unconfigured repos → app-token skipped → github-actions[bot] only.
+      REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}
     outputs:
       chunks: ${{ steps.plan.outputs.chunks }}
       chunk_count: ${{ steps.plan.outputs.chunk_count }}
@@ -117,6 +121,20 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Generate GitHub App token
+        id: app-token
+        # Resolve the App bot login (`<app-slug>[bot]`) so the incremental-base
+        # resolver can pin marker trust to it (+ github-actions[bot]) and reject a
+        # forged marker from any OTHER review-writing bot. Gated on REVIEW_APP_ID;
+        # skipped/failed (continue-on-error) → app-slug empty → github-actions[bot]
+        # only. Same action/identity the merge job uses to POST the marker.
+        if: ${{ env.REVIEW_APP_ID != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
+        with:
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
+
       - name: Prepare Codex review context
         id: prepare-codex-review
         # Build the prompt PREFIX (system prompt + output language + untrusted PR
@@ -133,12 +151,21 @@ jobs:
           PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           PR_TITLE: ${{ steps.pr.outputs.title }}
           CODEX_REVIEW_LANG: ${{ vars.CODEX_REVIEW_LANG || 'Korean' }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           mkdir -p .codex-review
           REVIEW_BASE="$(git merge-base "origin/$PR_BASE_REF" "refs/remotes/pull/$PR_NUMBER/head")"
           REVIEW_PROMPT=".github/prompts/codex-pr-review.ko.md"
           prefix=".codex-review/prompt-prefix.md"
           suffix=".codex-review/prompt-suffix.md"
+
+          # Trusted formal-review marker authors: the App bot (<slug>[bot]) when an
+          # App token is configured, plus the default github-actions[bot] fallback.
+          if [ -n "${APP_SLUG:-}" ]; then
+            review_bot_logins="${APP_SLUG}[bot],github-actions[bot]"
+          else
+            review_bot_logins="github-actions[bot]"
+          fi
 
           REVIEW_OUTPUT_DIR=".review-context" \
           GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" \
@@ -148,6 +175,7 @@ jobs:
           PR_BASE_SHA="$PR_BASE_SHA" \
           PR_HEAD_SHA="$PR_HEAD_SHA" \
           REVIEW_MARKER_PREFIX="codex-formal-review" \
+          REVIEW_BOT_LOGINS="$review_bot_logins" \
           .github/scripts/pr-review-context.sh
 
           source .review-context/context-mode.env


### PR DESCRIPTION
## 문제 (리뷰 커버리지 공백)

PR 리뷰 워크플로(`claude-review.yml`·`codex-review.yml`)는 `synchronize` 이벤트에서 증분 리뷰 base를 GitHub 웹훅 `event.before`(직전 push head)로 **그대로 신뢰**한다(`pr-review-context.sh`). 그런데 `event.before`는 직전 리뷰 성공 여부와 무관하게 GitHub가 설정한다.

→ 어떤 push의 리뷰가 **실패**(예: Codex usage-limit → 결과 없음 → merge 잡 false-green 가드 실패 → 리뷰 미게시)한 뒤 다음 push가 오면, 다음 run의 `event.before`가 그 실패 커밋을 가리켜 증분 diff가 **미리뷰 커밋을 건너뛴다**. 변경은 영영 리뷰되지 않는데 체크는 green.

**PR #334 실증:** Codex 리뷰가 usage-limit/unavailable로 `codex-formal-review` 마커를 한 번도 못 남겼고, 한도 리셋 후 재실행은 trailing 1파일(plugin.json) 증분만 보고 통과 — 실질 5파일(`dispatch.sh` 등)을 Codex가 사실상 리뷰하지 않음. (Claude는 전체 리뷰·승인.)

## 수정

증분 base를 `event.before`가 아니라 **"이 리뷰어가 마지막으로 성공 리뷰한 SHA"**로 계산한다. 두 워크플로 merge 잡은 실제 리뷰 제출 시에만(approve/comment) per-reviewer 마커 `<!-- <prefix> head_sha=<sha> ... -->`를 `createReview`로 남긴다 — 실패·unavailable·skipped 시엔 안 남김(success-gated). 이를 그대로 재사용한다(새 primitive 불필요).

- `synchronize` 시 `gh api pulls/{n}/reviews`에서 이 리뷰어 prefix 마커의 `head_sha`를 추출(최신순) → 현재 head의 **ancestor인 최신 SHA**를 증분 base로 채택. 없으면(첫 리뷰·전부 실패/unavailable·force-push/rebase) **full 리뷰로 degrade**. `event.before`는 모델 diff에서 더는 사용 안 함.
- 마커 부재 → full fallback이 #334 Codex 갭을 정확히 메운다.

## 변경 파일

- **신규** `.github/scripts/pr-review-incremental-base.js` — 마커 파싱·정렬 순수 모듈(+stdin CLI). 파싱/정렬은 이 한 곳에만, bash는 git ancestry만(중복 없음).
- **신규** `.github/scripts/pr-review-incremental-base.test.js` — hermetic 10케이스(`node:assert`).
- `.github/scripts/pr-review-context.sh` — synchronize 분기 교체. `gh --paginate`를 `jq -s 'add'`로 평탄화 후 node 추출 → `git merge-base --is-ancestor`로 채택. gh/node 실패·모듈 부재 시 full degrade.
- `.github/workflows/{claude,codex}-review.yml` — prep에 `REVIEW_MARKER_PREFIX` 주입.

## 영향 없음

`anchor.patch`(canonical PR diff)·thread 모드·`REVIEW_CONTEXT_MODE`/`REVIEW_INCREMENTAL_BASE` 소비자(프롬프트 헤더 출력만) 불변. prep는 `base_ref`를 `fetch-depth:0` + PR head ref fetch라 마커 SHA가 로컬에 존재(현재 `git diff event.before head`가 도는 근거와 동일).

## 검증

- `node .github/scripts/pr-review-incremental-base.test.js` → **ALL 10 CHECKS PASSED**
- `bash -n pr-review-context.sh` OK, 두 워크플로 yq 파싱 OK
- 통합 스모크: bogus(최신, non-ancestor) 후보 건너뛰고 실제 ancestor를 base로 선택 확인
- ⚠️ 워크플로/스크립트 수정은 base 체크아웃으로 리뷰되므로 **머지 후에만 실효**(기존 `diff-anchor-filter.js` 관행과 동일). 머지 후 실패→재push PR로 통합 검증 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)