### PR TITLE
refactor(dispatch): 서브에이전트 지침 중복 제거·토큰 최적화 (#348)

### DIFF
--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/review 4-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 준비된 SPEC당 서브에이전트가 한 컨텍스트에서 구현(loop)·리뷰(review)·머지를 소유하는 모델 주도 오케스트레이션(dispatch는 의존성·웨이브·동시성·실패 격리만 총괄, 머지=done이면 의존자 해제; forge 백엔드 가용이면 PR 적대 리뷰→가용 토큰 ff-only 머지(분리 승인 신원 불필요), 미가용이면 로컬 적대 리뷰→ff-only 직접 머지; 대상 브랜치 --target-branch), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch
-description: "하나 이상의 SPEC 파일을 구현·머지 단계로 넘기고 싶을 때 사용 — depends_on 준비도를 풀어 **준비된 SPEC마다 서브에이전트를 1개 띄우는 모델 주도 오케스트레이터**. 각 SPEC 서브에이전트는 자기 컨텍스트에서 loop(구현)·review(리뷰)를 승인까지 반복하고 대상 브랜치로 직접 머지한다(forge 백엔드 가용이면 PR 적대 리뷰→가용 토큰 ff-only 머지(분리 승인 신원 불필요), 미가용이면 로컬 적대 리뷰 게이트→ff-only 직접 머지). dispatch 는 의존성·웨이브·동시성·실패 격리만 총괄하고, 머지(=done)되면 의존자를 해제한다. 대상 브랜치는 --target-branch 로 지정(기본: 기본 브랜치). 호출 'Skill(skill=\"dispatch\", args=\"<subcommand> [<args>]\")' (start/list/status/stop/watch)."
+description: "하나 이상의 SPEC 파일을 구현·머지 단계로 넘기고 싶을 때 사용 — depends_on 준비도를 풀어 **준비된 SPEC마다 서브에이전트를 1개 띄우는 모델 주도 오케스트레이터**. 각 서브에이전트가 자기 컨텍스트에서 그 SPEC 의 구현→리뷰→머지를 소유하고, dispatch 는 의존성·동시성·실패 격리만 총괄해 머지(=done)되면 의존자를 해제한다. 호출 'Skill(skill=\"dispatch\", args=\"<subcommand> [<args>]\")' (start/list/status/stop/watch)."
 allowed-tools:
   - Read
   - Bash(bash * dispatch.sh start:*)
@@ -32,16 +32,14 @@ allowed-tools:
 
 ## 서브에이전트 위임 — 준비된 SPEC당 1개
 
-dispatch 는 준비된(모든 dep 이 done) SPEC마다 서브에이전트를 **정확히 1개** 띄우고, 그 서브에이전트가 자기 컨텍스트에서 그 SPEC 의 구현→리뷰→재구현→머지를 닫는다. 서브에이전트 절차의 단일 출처는 **`references/spec-subagent.md`**(완료 조건 2–8)다. dispatch 는 그 내부를 들여다보지 않고 결과(머지됨/비완료)만 받아, 머지를 보고한 SPEC 을 `done`(="대상 브랜치에 머지됨")으로 전이하고 의존자를 해제한다.
+준비된(모든 dep 이 done) SPEC마다 서브에이전트를 **정확히 1개** 띄우고, 그 서브에이전트가 한 컨텍스트에서 그 SPEC 의 구현→리뷰→재구현→머지를 닫는다. **서브에이전트 절차의 단일 출처는 `references/spec-subagent.md`**(완료 조건 2–8: loop/review 블랙박스 호출·forge/direct 서브모드·무한루프 가드·approve 후 머지 게이트·force 금지·동시 머지 직렬화·에스컬레이션). dispatch 는 그 내부를 들여다보지 않고 결과(머지됨/비완료)만 받는다.
 
-- **dispatch 의 책임(결정적)**: depends_on 준비도 스케줄링·동시성 상한·서브에이전트 spawn/reap·done(=대상 브랜치에 머지됨)이면 의존자 해제·실패 이행 격리. 이 부분은 결정적 헬퍼(`dispatch.sh`)로 분리되어 selftest 로 검증된다(서브에이전트 spawn 은 Agent 도구를 쓰는 살아있는 에이전트 컨텍스트가 수행 — bash 무인 파이프라인이 아님).
-- **서브에이전트의 책임(모델 주도)**: 한 컨텍스트에서 `loop`(구현)·`review`(리뷰)를 **공개 스킬 인터페이스로** 호출하고(별도 추가 서브에이전트로 나누지 않음), `request_changes` 면 같은 작업 브랜치(`feat/<run-id>-<slug>`) 위에서 재구현→재리뷰를 `approve` 까지 반복(무한루프 가드 안), `approve` 후 대상 브랜치로 머지, dispatch 에 보고. 상세는 `references/spec-subagent.md`.
-- **대상 브랜치**: `--target-branch <branch>` 로 지정(미지정 시 기본 브랜치 `main` 또는 주입된 `DEFAULT_BRANCH`). run 전역으로 결정돼 모든 서브에이전트의 base 동기화·리뷰 대상·ff 머지에 일관 적용되며, run-dir 마커(`TARGET_BRANCH`)로 영속해 `--resume` 에서 sticky 하다(재개 시 마커가 현재 env·플래그보다 우선).
-- **서브모드(forge / direct)**: 서브에이전트가 리뷰·머지 대상을 정한다 — **forge CLI(백엔드)가 사용 가능하면** **forge**(작업 브랜치 push→같은 head PR 재사용/생성→PR 적대 리뷰→가용 토큰 ff 머지), 아니면 **direct**(PR·원격 push 없이 작업 브랜치 변경 base..head 를 로컬 적대 리뷰→ff 직접 머지). **분리 승인 신원(`APPROVER`)은 요구하지 않는다** — forge 백엔드가 있으면 approver 구성과 무관하게 forge 경로를 쓰고 머지는 가용 토큰으로 한다. 두 서브모드 모두 적대 리뷰·버전 범프 게이트·fast-forward 전용 머지를 통과한다.
-- **머지 게이트(done=머지)**: 서브에이전트가 머지를 보고한 SPEC 만 `done` 으로 전이한다. 따라서 **의존자는 의존성이 대상 브랜치에 머지된 뒤에만** 실행 큐에 풀리고, 갱신된 대상 브랜치 위에서 분기한다. 서브에이전트가 비완료(가드 소진·loop/review `unavailable`·충돌 해결 불가)로 끝나면 거짓 green 대신 에스컬레이션하고, 그 SPEC 은 `failed` 이며 그 **이행적 의존자만** `skipped` 된다. 무관한 가지는 계속 진행한다.
-- **무한루프 가드·안전 강등(결정적 헬퍼)**: 재구현→재리뷰 반복은 결정적 가드(라운드 상한 기본 3·무진전·동일 지적 핑퐁 — `review-loop.sh` 헬퍼가 판정, selftest 검증)에 걸리면 머지 없이 에스컬레이션한다. 버전 범프 게이트(`plugins/` 변경 시 `plugin.json` 범프 강제)·ff-only 머지(`merge.sh` 헬퍼, selftest 검증)를 통과하지 못하면 안전 강등한다(머지는 분리 승인 신원 없이 가용 토큰으로 수행).
-- **동시 머지 직렬화**: 여러 서브에이전트가 같은 대상 브랜치로 머지할 때 **전역 락·dispatch 머지 순번 통제 없이** git 자체 메커니즘이 직렬성을 제공한다. 한 머지가 대상 브랜치를 전진시켜 다른 서브에이전트의 머지가 더 이상 fast-forward 가 아니게 되면, 그 서브에이전트는 갱신된 대상 브랜치에 동기화·충돌 해결 후 머지한다. **어떤 경로(forge·direct)에서도 force(push·merge·rebase)를 쓰지 않는다.**
-- **주입 가능한 인터페이스(mock 검증)**: 결정적 헬퍼의 외부 인터페이스(`LOOP_CMD` `GIT_CMD` `FORGE_CMD`(기본 gh) `FORGE_BIN`(서브모드 판정용 forge CLI) `DEFAULT_BRANCH`(대상 브랜치) `REVIEW_ROUNDS_MAX`(3) `WATCH_DIRS`(plugins/) `REVIEW_PRODUCE_CMD` 등)는 주입 가능해 실제 PR·머지 없이 mock 으로 독립 검증된다.
+dispatch 자신의 책임은 **결정적 오케스트레이션**뿐이며 `dispatch.sh` 헬퍼로 분리되어 selftest 로 검증된다:
+
+- **준비도·격리**: depends_on 준비도 스케줄링·동시성 상한·서브에이전트 spawn/reap·실패 이행 격리(spawn 은 Agent 도구를 쓰는 살아있는 컨텍스트가 수행 — bash 무인 파이프라인 아님).
+- **머지=done 전이**: 서브에이전트가 머지를 보고한 SPEC 만 `done`(=대상 브랜치 머지됨)으로 전이해 의존자를 해제하므로, 의존자는 의존성이 머지된 뒤에야 갱신된 대상 브랜치 위에서 분기한다. 비완료 보고는 `failed` 로 두고 **그 이행적 의존자만** `skipped`(독립 가지는 계속).
+- **대상 브랜치**: `--target-branch <branch>`(미지정 시 기본 브랜치 또는 주입된 `DEFAULT_BRANCH`). run 전역으로 결정돼 모든 서브에이전트의 base 동기화·리뷰·ff 머지에 일관 적용되고, run-dir 마커(`TARGET_BRANCH`)로 영속해 `--resume` 에서 sticky 하다(마커가 현재 env·플래그보다 우선).
+- **주입 가능 인터페이스(mock 검증)**: 결정적 헬퍼의 외부 인터페이스(`LOOP_CMD`·`GIT_CMD`·`FORGE_CMD`(기본 gh)·`FORGE_BIN`(서브모드 판정)·`DEFAULT_BRANCH`·`REVIEW_ROUNDS_MAX`(3)·`WATCH_DIRS`(plugins/) 등)는 주입 가능해 실제 PR·머지 없이 mock 으로 독립 검증된다.
 
 ## Subcommands
 
@@ -89,13 +87,10 @@ per-SPEC 상태를 주기적으로 refresh 하며, 모든 child 가 terminal(`do
 ## 의존성
 
 - **결정적 헬퍼(`dispatch.sh`)**: `git`, `bash` 3.2+, `sha256sum` 또는 `shasum`, `yq`(mikefarah). `yq` 는 SPEC frontmatter 의 `depends_on` 파싱(DAG 구성)에 쓰며 `start` 가 요구한다(없으면 awk 폴백이 있으나 신·구 레이아웃·인라인/블록 형식의 견고한 파싱을 위해 명시 요구). `ready`/`mark`/`status`/`stop`/`watch` 는 결정적 상태 헬퍼로 yq 비의존.
-- **서브에이전트가 호출하는 스킬**: `autopilot:loop`(구현)·`autopilot:review`(리뷰; 판정 JSON 파싱에 `jq`). **forge 서브모드**는 추가로 forge CLI(`gh`, 주입 가능)를 쓴다(PR 적대 리뷰·가용 토큰 머지 — 분리 승인 신원 불필요). **direct 서브모드**(forge 백엔드 미가용)는 forge CLI·원격 push 없이 작업 브랜치 변경(base..head)을 로컬 적대 리뷰한다. 서브에이전트는 loop 종료를 그 공개 구조화 상태(`loop status --json`)로만 판정한다.
+- **서브에이전트가 호출하는 스킬·도구**: `autopilot:loop`·`autopilot:review`(판정 JSON 파싱에 `jq`). forge 서브모드는 추가로 forge CLI(`gh`, 주입 가능)를 쓰고, direct 서브모드는 forge CLI·원격 push 가 필요 없다. 서브모드 절차는 `references/spec-subagent.md`.
 
 ## 규칙
 
-- 자체 작성·갱신하는 영역은 `<project_root>/.dispatch/runs/<run-id>/` 디렉토리 안의 파일들(SPEC 델타·백로그·통합 상태 포함)과 본 스킬의 정의 파일뿐이다. 작업 브랜치·PR·머지 같은 forge 부수효과를 제외하면 이 외 경로를 만들지 않는다.
-- 서브에이전트는 `loop`·`review` 를 공개 스킬 인터페이스로만 호출하고, 그들의 내부 워크트리·신호 파일·하니스를 직접 들여다보지 않는다(블랙박스 경계). dispatch 는 서브에이전트의 결과 보고만 받는다.
-- **통합·머지 소유권**: 통합·리뷰·머지는 **SPEC 서브에이전트가 SPEC당 한 컨텍스트에서 소유**한다(`references/spec-subagent.md`). dispatch 는 의존성·웨이브·동시성·실패 격리만 총괄하고, 서브에이전트가 머지(=done)를 보고하면 의존자를 해제한다 — dispatch 는 통합·리뷰·머지를 bash 드레인 파이프라인으로 직접 수행하지 않는다. 결정적 부분(DAG 준비도·동시성·라운드 상한·무진전·핑퐁·버전 범프 게이트·ff 머지 메커니즘)은 헬퍼로 분리되어 주입 가능한 인터페이스로 mock·selftest 검증되며, force 는 어떤 경로(forge·direct)에서도 쓰지 않는다.
+- 자체 작성·갱신 영역은 `<project_root>/.dispatch/runs/<run-id>/` 안의 파일들(SPEC 델타·백로그·통합 상태 포함)과 본 스킬 정의 파일뿐이다. 작업 브랜치·PR·머지 같은 forge 부수효과를 제외하면 이 외 경로를 만들지 않으며, run 디렉토리는 git 추적에서 제외한다(`.gitignore` 권장).
+- **통합·리뷰·머지 소유권은 SPEC 서브에이전트**(SPEC당 한 컨텍스트, `references/spec-subagent.md`)에 있다 — dispatch 는 의존성·동시성·실패 격리만 총괄하고, 통합·리뷰·머지를 bash 드레인 파이프라인으로 직접 수행하지 않는다.
 - 분해(여러 SPEC 작성) 책임은 SPEC 작성 도구(`autopilot:spec` 등)에 있고, dispatch 는 이미 만들어진 SPEC 들만 받는다.
-- loop 의 종료 의도(완료/차단)는 자율 실행기가 신호로 표현하고, **서브에이전트**는 그 공개 인터페이스가 제공하는 **구조화된 상태**(`loop.sh status --json` 의 `.state`·`.signals[]`)로만 읽는다 — 표 컬럼 위치·부분 문자열 일치에 의존하지 않는다. `signals` 의 의미(`DONE`/`BLOCKED`)는 워커 컨벤션이며 정확 일치 멤버십으로 판정한다. dispatch 는 서브에이전트의 결과(머지됨/비완료) 보고만 구조화로 받는다.
-- run 디렉토리는 git 추적에서 제외한다(`.gitignore` 처리 권장).

--- a/plugins/autopilot/skills/dispatch/references/spec-subagent.md
+++ b/plugins/autopilot/skills/dispatch/references/spec-subagent.md
@@ -1,89 +1,47 @@
 # SPEC 서브에이전트 계약 (per-SPEC implement·review·merge owner)
 
-`dispatch` 가 준비된(모든 `depends_on` 이 `done`) SPEC마다 **정확히 1개** 띄우는 서브에이전트의
-절차 계약이다. 한 서브에이전트는 **한 컨텍스트에서 그 SPEC 의 전 생애**(구현→리뷰→재구현→
-머지→보고)를 소유한다. dispatch 는 이 절차의 내부를 들여다보지 않고 결과(머지됨/비완료)만 받는다.
+`dispatch` 가 준비된(모든 `depends_on` 이 `done`) SPEC마다 **정확히 1개** 띄우는 서브에이전트의 절차 계약. 한 서브에이전트가 **한 컨텍스트에서** 그 SPEC 의 전 생애(구현→리뷰→재구현→머지→보고)를 소유한다. 이 문서가 완료 조건 2–8 의 단일 출처다 — dispatch 의 결정적 책임(DAG 준비도·동시성·spawn/reap·done 시 의존자 해제·실패 이행 격리)은 `SKILL.md`·`dispatch.sh` 가 소유한다.
 
-이 문서는 완료 조건 2–8 의 단일 출처다. dispatch 의 결정적 책임(DAG 준비도·동시성·spawn/reap·
-done 시 의존자 해제·실패 이행 격리)은 SKILL.md 와 `dispatch.sh` 가 소유한다.
+## 입력 (dispatch → 서브에이전트, 계약 경계)
 
-## dispatch 가 서브에이전트에 넘기는 입력 (계약 경계)
-
-- `spec` — 구현할 SPEC 파일 경로(준비됨이 보장된 상태로 위임).
-- `target-branch` — 머지·동기화 대상 브랜치(run 전역, dispatch 가 일관 주입).
+- `spec` — SPEC 파일 경로(준비 보장).
+- `target-branch` — 머지·동기화 대상(run 전역 주입).
 - `run-dir`·`key` — 통합 상태(branch/pr/head/review-round/verdict/phase) 영속 위치(결정적 헬퍼 공유).
 
-서브에이전트는 이 입력만으로 자기 컨텍스트에서 전 생애를 닫고, 종료 시 **머지됨(done)** 또는
-**비완료(escalated/blocked)** 를 dispatch 에 보고한다.
+이 입력만으로 전 생애를 닫고, 종료 시 **머지됨(done)** 또는 **비완료(escalated/blocked)** 를 보고한다.
 
 ## 절차
 
-### 1. 구현 — `loop` 스킬 (완료 조건 2)
+**불변 경계(전 단계 공통)**: `loop`·`review` 는 **공개 스킬 인터페이스로만** 호출하고 내부 신호 파일·워크트리·하니스는 들여다보지 않는다(블랙박스). 구현·리뷰를 별도 서브에이전트로 나누지 않는다. 어느 단계든 `unavailable`·판정 불가·해결 불가는 거짓 green 대신 **에스컬레이션**한다.
 
-서브에이전트는 `Skill(skill="loop", ...)` **공개 인터페이스로** 그 SPEC 을 격리 작업 브랜치
-(`feat/<run-id>-<slug>`) 위에서 구현한다. loop 의 내부 신호 파일·워크트리·하니스를 직접 들여다보지
-않는다(블랙박스 경계). 구현·리뷰를 위해 **별도의 추가 서브에이전트로 나누지 않는다** — 한 컨텍스트가
-loop·review 를 직접 호출한다.
+### 1. 구현 — `loop` (완료 조건 2)
 
-- loop 이 `unavailable`/실패/판정 불가로 끝나면 거짓 머지 대신 그 SPEC 을 **에스컬레이션**한다(완료 조건 8).
-- loop 의 종료 의도(DONE/BLOCKED)는 그 공개 구조화 상태(`loop status --json` 의 `.state`·`.signals[]`)로만 읽는다.
-  `spec-gap`/하드 BLOCKED 는 머지 없이 비완료 종착(스펙 보강 재개 안내 / 사람 에스컬레이션).
+- `Skill(skill="loop", ...)` 로 격리 작업 브랜치 `feat/<run-id>-<slug>` 위에서 구현.
+- 종료 의도는 공개 구조화 상태(`loop status --json` 의 `.state`·`.signals[]`)로만 판정. `spec-gap`/하드 BLOCKED 는 머지 없이 종착(스펙 보강 재개 안내 / 사람 에스컬레이션).
 
-### 2. 리뷰 — `review` 스킬 (완료 조건 2)
+### 2. 리뷰 — `review` (완료 조건 2)
 
-구현이 DONE 이면 `Skill(skill="review", ...)` **공개 인터페이스로** 변경을 다관점 적대 리뷰해
-머신리더블 단일 판정(`approve`/`request_changes`/`unavailable`)을 받는다.
+- 구현 DONE 이면 `Skill(skill="review", ...)` 로 다관점 적대 리뷰 → 머신리더블 단일 판정(`approve`/`request_changes`/`unavailable`).
+- **리뷰 대상은 서브모드로 갈린다**(forge CLI 가용 여부로 판정):
+  - **forge**: 작업 브랜치 push → 같은 head 의 open PR 재사용/생성 → **PR 대상** 리뷰. 분리 승인 신원(approver) 불요.
+  - **direct**(forge 미가용): 원격 push·PR 없이 **작업 브랜치 변경(base..head)** 로컬 적대 리뷰.
 
-- **리뷰 대상은 통합 서브모드로 갈린다**(forge 백엔드 가용 여부로 판정):
-  - **forge**(forge CLI 사용 가능): 작업 브랜치를 push 하고 같은 head 의 open PR 을 재사용/생성해
-    **PR 을 대상으로** 리뷰. 분리 승인 신원(approver) 구성은 요구하지 않는다.
-  - **direct**(forge 백엔드 미가용): 원격 push·PR 없이 **작업 브랜치 변경(base..head)** 을 대상으로 로컬 적대 리뷰.
-- 판정이 `unavailable`(리뷰 producer 실패·판정 불가)이면 거짓 승인 대신 **에스컬레이션**한다(완료 조건 8).
+### 3. 반복 — request_changes (완료 조건 3·4)
 
-### 3. 반복 — request_changes → 재구현→재리뷰 (완료 조건 3·4)
-
-판정이 `request_changes` 면 그 지적(`must_adopt`)을 반영해 **같은 작업 브랜치 위에서** 다시 `loop`
-으로 재구현하고 다시 `review` 하기를 `approve` 판정이 날 때까지 반복한다(새 작업 브랜치/새 PR 미생성).
-
-반복은 **무한루프 가드**(결정적 헬퍼가 판정 — 라운드 상한 기본 3·무진전·동일 지적 핑퐁)에 걸리면
-**머지 없이 종료(에스컬레이션)** 한다(완료 조건 4). 이 가드 판정 로직은 `review-loop.sh` 의 결정적
-헬퍼에 있고 selftest 로 검증된다(서브에이전트는 그 판정을 호출해 반복을 멈춘다 — 라운드 카운트·
-직전 지적 집합은 `run-dir` 키로 영속). 한 SPEC 이 가드로 종료돼도 **무관한 SPEC 가지는 계속 진행**한다
-(그 격리는 dispatch 의 실패 이행 격리가 보장).
+- `request_changes` 면 지적(`must_adopt`)을 반영해 **같은 작업 브랜치 위에서** 재구현→재리뷰를 `approve` 까지 반복(새 브랜치/새 PR 미생성).
+- **무한루프 가드**(`review-loop.sh` 결정적 판정, selftest 검증 — 라운드 상한 기본 3·무진전·동일 지적 핑퐁)에 걸리면 **머지 없이 에스컬레이션**. 라운드 카운트·직전 지적 집합은 `run-dir` 키로 영속. 가드 종료는 그 SPEC 만 끝내고 무관한 가지는 계속 진행한다.
 
 ### 4. 머지 — approve 후에만 (완료 조건 5·6·7)
 
-`approve` 판정 **이후에만** 대상 브랜치로 머지한다. 머지는 **결정적 게이트**(`merge.sh`)를 통과한다:
+`approve` **이후에만** 대상 브랜치로 머지하며 결정적 게이트(`merge.sh`)를 통과한다:
 
-1. **버전 범프 게이트** — `plugins/` 변경이면 `plugin.json` SemVer 범프를 강제(완료 조건 11 의 일부).
-2. **머지(분리 승인 신원 불필요)** — 머지는 **가용한 forge 토큰**(예: gh 인증)으로 수행한다. 별도의
-   분리 승인 신원(`APPROVER`)의 정식 APPROVED 리뷰를 머지 전제로 두지 않는다 — 리뷰 수렴(`approve`)
-   판정은 위 적대 리뷰가 이미 책임졌고, 머지 단계는 버전·ff 게이트만 더한다. forge 서브모드는 통합이
-   PR 을 통하며(작업 브랜치 push→PR), direct 서브모드는 PR 없이 로컬 작업 브랜치를 머지한다. 두 경로
-   모두 버전·ff 게이트는 동일 적용.
-3. **fast-forward 전용 머지** — `git merge --ff-only`. **force push·force merge·force rebase 를 어떤
-   경로에서도 쓰지 않는다**(완료 조건 6).
+1. **버전 범프** — `plugins/` 변경이면 `plugin.json` SemVer 범프 강제.
+2. **머지(분리 승인 신원 불요)** — 가용 forge 토큰(예: gh 인증)으로 수행. approve 판정은 위 적대 리뷰가 이미 책임졌고 이 단계는 버전·ff 게이트만 더한다. forge=PR 경유, direct=로컬 작업 브랜치 머지, 게이트는 동일.
+3. **fast-forward 전용** — `git merge --ff-only`. **force push/merge/rebase 를 어떤 경로에서도 쓰지 않는다.**
 
-#### 동시 머지의 git 직렬화 (완료 조건 6)
-
-여러 서브에이전트가 같은 대상 브랜치로 동시에 머지할 때 **전역 락이나 dispatch 의 머지 순번 통제 없이**
-git 자체 메커니즘이 직렬성을 제공한다. 한 서브에이전트의 머지가 대상 브랜치를 전진시켜 다른
-서브에이전트의 머지가 더 이상 fast-forward 가 아니게 되면, 그 서브에이전트는 **갱신된 대상 브랜치에
-동기화(non-force rebase/merge)하고 충돌을 해결한 뒤** 다시 ff 머지한다. 해결 불가면 거짓 green 대신
-에스컬레이션한다. 누가 먼저 머지하든 결과는 같다.
+**동시 머지 직렬화**: 전역 락·dispatch 머지 순번 통제 없이 git 자체가 직렬성을 제공한다. 한 머지가 대상 브랜치를 전진시켜 ff 가 깨지면, 갱신된 대상에 **non-force 동기화**(rebase/merge)·충돌 해결 후 다시 ff 머지한다. 해결 불가면 에스컬레이션. 누가 먼저 머지하든 결과는 같다.
 
 ### 5. 보고 (완료 조건 5)
 
-- **머지 완료** → dispatch 에 done 보고. dispatch 가 그 SPEC 을 `done`(=대상 브랜치에 머지됨)으로
-  전이하고 의존자를 해제한다. 의존자는 **갱신된 대상 브랜치 위에서** 분기한다.
-- **비완료**(가드 소진·loop/review unavailable·승인 불가·충돌 해결 불가) → 에스컬레이션 보고.
-  dispatch 가 그 SPEC 을 `failed` 로 두고 **그 이행적 의존자만** `skipped` 한다(독립 가지는 계속).
-
-## 안전 불변식 (요약)
-
-- approve 없이 머지 없음. 적대 리뷰가 approve 판정을 낸 이후에만 머지(완료 조건 5).
-- 거짓 green 금지: loop/review unavailable·충돌 해결 불가 → 에스컬레이션(완료 조건 7·8).
-- force 금지: 어떤 경로에서도 force push/merge/rebase 미사용(완료 조건 6).
-- 블랙박스 경계: loop·review 는 공개 스킬 인터페이스로만 호출, 내부 신호 파일·워크트리 미열람.
-- 결정적 가드·게이트(라운드 상한·무진전·핑퐁·버전 범프·ff 머지)는 헬퍼가 판정하며 selftest 로 검증된다.
-</content>
+- **머지 완료** → done 보고. dispatch 가 `done`(=대상 브랜치 머지됨)으로 전이하고 의존자를 **갱신된 대상 브랜치 위에서** 해제.
+- **비완료**(가드 소진·unavailable·승인 불가·충돌 해결 불가) → 에스컬레이션. dispatch 가 `failed` 로 두고 **그 이행적 의존자만** `skipped`(독립 가지는 계속).


### PR DESCRIPTION
## 목표
`dispatch` 스킬의 서브에이전트 지침에서 파일 간/파일 내 중복 산문을 제거해 토큰을 줄인다. 동작·계약·안전 불변식은 그대로 유지하는 순수 문서 리팩토링.

Closes #348

## 변경
- **`references/spec-subagent.md`**(단일 출처): 입력 계약·절차를 산문→블릿로 압축. 중복되던 "안전 불변식(요약)" 절을 절차에 인라인 흡수해 중복 0. 헬퍼 참조(`review-loop.sh`·`merge.sh`) 링크 유지. 6819→4327자 (-37%).
- **`SKILL.md`**: "서브에이전트 위임"·"규칙" 절에서 서브에이전트 내부 절차(forge/direct·머지 3게이트·동시 머지 직렬화·무한루프 가드) 재설명을 제거하고 `spec-subagent.md` 포인터로 위임. dispatch 고유의 결정적 책임(준비도·동시성·spawn/reap·의존자 해제·실패 격리·target-branch·주입 인터페이스)만 남김. 15645→11359자 (-27%).
- **frontmatter `description`**: 스킬 선택 트리거 신호(언제 쓰는가 + 한 줄 정체성 + 호출/서브커맨드)만 남기고 내부 구현 메커니즘(ff-only 머지·PR 적대 리뷰·분리 승인 신원 등) 제거.
- **`plugin.json`**: `plugins/` 워치 디렉토리 변경 → 0.31.0 → 0.31.1 (문서 전용 PATCH).

**총 토큰: 22,464 → 15,686자 (-6,778, -30%)**

## 보존한 불변식 (change-adoption.md — 중복만 제거, 의미 유지)
각 키워드 최소 1회 잔존 grep 확인: approve前 no merge / no force / 블랙박스 경계 / unavailable→에스컬레이션 / 버전 범프·ff-only 게이트 / 결정적 가드 selftest. 모든 헬퍼·파일 참조 링크 유효(끊긴 참조 0).

## 검증
- 참조 무결성: 6개 헬퍼 참조 전부 실재 — OK.
- 불변식 키워드 잔존: ff-only=2, force=3, approve=7, 블랙박스=3, unavailable=3, 에스컬레이션=6, 버전 범프=2.
- `bash references/dispatch.sh selftest` → **ALL PASS** (22 케이스).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
