### PR TITLE
feat(dispatch): 신규 생성 PR 에 자동 리뷰 표시 추가

### DIFF
--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.38.1",
+  "version": "0.39.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/review 4-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 준비된 SPEC당 서브에이전트가 한 컨텍스트에서 구현(loop)·리뷰(review)·머지를 소유하는 모델 주도 오케스트레이션(dispatch는 의존성·웨이브·동시성·실패 격리만 총괄, 머지=done이면 의존자 해제; forge 백엔드 가용이면 PR 적대 리뷰→가용 토큰 ff-only 머지(분리 승인 신원 불필요), 미가용이면 로컬 적대 리뷰→ff-only 직접 머지; 대상 브랜치 --target-branch), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/dispatch/references/integration.sh
+++ b/plugins/autopilot/skills/dispatch/references/integration.sh
@@ -290,10 +290,12 @@ in_spec_issue() {
 }
 
 # in_pr_body <spec_path> <run-id> — 구조화 PR 본문(결정적) stdout.
-#   추적성(SPEC 경로) + 실행 컨텍스트(dispatch run-id) + 조건부 이슈 cross-reference(Refs #n,
-#   rules/context.md 형식) + 요약(SPEC 의도 섹션, 없으면 생략).
+#   자동 리뷰 식별 줄(dispatch 자동 생성·자동 적대 리뷰) + 추적성(SPEC 경로) + 실행 컨텍스트
+#   (dispatch run-id) + 조건부 이슈 cross-reference(Refs #n, rules/context.md 형식) + 요약
+#   (SPEC 의도 섹션, 없으면 생략).
 in_pr_body() {
   local spec="$1" rid="$2"
+  printf '🤖 이 PR 은 dispatch 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.\n\n'
   printf 'SPEC: %s\n' "$spec"
   printf 'dispatch-run: %s\n' "$rid"
   local issue; issue="$(in_spec_issue "$spec")"
@@ -305,6 +307,8 @@ in_pr_body() {
 }
 
 # in_ensure_pr <branch> <title> <spec> <run-id> — open PR 재사용 또는 신규 생성. PR 번호 echo.
+#   신규 생성 PR 에만 자동 리뷰 표시를 단다(제목 '🤖 [자동 리뷰]' 접두 + 본문 식별 줄(in_pr_body)) —
+#   open PR 재사용(조기 반환) 경로는 기존 PR 제목·본문을 건드리지 않는다(수정 호출 없음).
 #   본문은 임시 파일 + --body-file 로 전달해 셸 인용·줄바꿈 손상 없이 멀티라인을 보존한다.
 in_ensure_pr() {
   local branch="$1" title="$2" spec="$3" rid="$4" n
@@ -314,7 +318,7 @@ in_ensure_pr() {
   in_pr_body "$spec" "$rid" > "$bodyf"
   # shellcheck disable=SC2086
   $FORGE_CMD pr create --head "$branch" --base "$DEFAULT_BRANCH" \
-    --title "$title" --body-file "$bodyf" \
+    --title "🤖 [자동 리뷰] $title" --body-file "$bodyf" \
     >/dev/null 2>&1 || { rm -f "$bodyf"; in_die "PR 생성 실패: $branch"; return 1; }
   rm -f "$bodyf"
   in_existing_open_pr "$branch"
@@ -581,6 +585,11 @@ in_selftest() {
   grep -q 'feat/20260604T000000-abc1234-x' "$PUSHLOG" && ok "AC2 작업 브랜치 push" || bad "AC2 작업 브랜치 push"
   grep -q 'pr create' "$PRLOG" && ok "AC2 PR 생성" || bad "AC2 PR 생성"
   grep -q 'rebase' "$GITLOG" && ok "AC2 base sync rebase" || bad "AC2 base sync rebase"
+  # ---- AC: 신규 생성 PR 의 자동 리뷰 표시(제목 접두 태그 + 본문 식별 줄) ----
+  grep -Fq -- '--title 🤖 [자동 리뷰] ' "$PRLOG" \
+    && ok "AC 신규 PR 제목 자동 리뷰 접두 태그" || bad "AC 신규 PR 제목 자동 리뷰 접두 태그"
+  grep -Fq '자동 적대 리뷰' "$PRBODY" \
+    && ok "AC 신규 PR 본문 자동 리뷰 식별 줄" || bad "AC 신규 PR 본문 자동 리뷰 식별 줄"
 
   # ---- AC: open PR 존재 → 재사용(새 PR 미생성) + 기존 브랜치 rebase 재작성 안 함 ----
   #   (Codex blocking 회귀 가드: base 전진+원격 브랜치 존재 시 rebase 는 non-ff push 를 부른다.)


### PR DESCRIPTION
## 무엇
dispatch 가 forge 경로에서 **새로 생성**하는 PR 의 제목·본문에 자동(적대) 리뷰 표시를 추가한다.
- 제목: `🤖 [자동 리뷰] <원래 제목>` 접두 태그
- 본문: 기존 통합 문구 유지 + "이 PR 은 dispatch 가 자동 생성했으며 자동 적대 리뷰를 거칩니다." 식별 줄
- open PR 재사용(조기 반환) 경로는 제목·본문 수정 호출 없이 보존
- `integration.sh selftest` 에 신규 PR 표시 단언 3개 추가 (ALL PASS)
- plugins 워치 변경에 따라 plugin.json 0.38.0 → 0.39.0 (MINOR)

## SPEC
`docs/specs/2026-06-08-dispatch-pr-auto-review-marker/SPEC.md` (autopilot:spec → dispatch 로 구현)

🤖 Generated with [Claude Code](https://claude.com/claude-code)