### PR TITLE
feat(ci): 리뷰 스레드 resolve 시 자동 재리뷰 트리거(@멘션 불필요)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,12 +11,18 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
+  pull_request_review_thread:
+    types: [resolved]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
   id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
 
 # Phase 4 (Token Optimized Review): the single-job review is restructured into a
 # three-job pipeline so a large PR diff can be reviewed in token-bounded chunks
@@ -59,6 +65,10 @@ jobs:
           && github.event.review.user.login != 'github-actions[bot]'
           && github.event.review.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
+      || (github.event_name == 'pull_request_review_thread'
+          && github.event.pull_request.draft == false
+          && github.event.sender.type != 'Bot'
+          && github.event.sender.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -11,11 +11,17 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
+  pull_request_review_thread:
+    types: [resolved]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
 
 # Phase 4 (Token Optimized Review): the single-job review is restructured into a
 # three-job pipeline so a large PR diff can be reviewed in token-bounded chunks
@@ -56,6 +62,10 @@ jobs:
           && github.event.review.user.login != 'github-actions[bot]'
           && github.event.review.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
+      || (github.event_name == 'pull_request_review_thread'
+          && github.event.pull_request.draft == false
+          && github.event.sender.type != 'Bot'
+          && github.event.sender.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:


### PR DESCRIPTION
## 무엇
Codex/Claude PR 리뷰 워크플로에 **`pull_request_review_thread[resolved]` 트리거**를 추가해, 메인테이너가 봇 인라인 리뷰 스레드를 resolve하면 `@codex`/`@claude` 멘션 없이 **자동 재리뷰**가 돌게 한다. 그 재리뷰가 `findings===0`이면 봇이 APPROVE를 게시한다.

## 왜
기존 자동(멘션 불필요) 트리거는 `pull_request`(push)뿐이라, 새 커밋 없이 스레드만 resolve하면 재리뷰가 돌지 않아 approve가 갱신되지 않았다. approve는 run마다 `findings===0`일 때만 나오므로, resolve 후 재리뷰를 자동으로 돌릴 트리거가 필요했다. **모델이 여전히 verdict를 판정**하므로 resolve가 approve를 강제하지 않고 리뷰 품질 게이트는 유지된다.

## 변경 (codex/claude 대칭)
- `on:` 에 `pull_request_review_thread: types: [resolved]` 추가.
- `prep.if:` 에 게이트 추가: `event_name == 'pull_request_review_thread' && pull_request.draft == false && sender.type != 'Bot' && sender.login != 'github-actions[bot]'`.
- `concurrency:` (PR 단위, cancel-in-progress) 추가.

## 안전성
- **자기 트리거 무한루프 차단**: merge job이 매 run마다 자기 스레드를 봇 신원(`<slug>[bot]`/`github-actions[bot]`, 둘 다 type=Bot)으로 resolve한다. `sender.type != 'Bot'` 게이트가 그 봇 resolve 이벤트를 걸러 재트리거를 막는다.
- **신뢰 모델**: `pull_request_review_thread` 페이로드의 sender에는 author_association이 없으나, 스레드 resolve는 **write 권한**을 요구한다 → 비-Bot resolver는 정의상 신뢰 가능한 협력자(기존 `pull_request` 트리거가 비-draft push를 association 체크 없이 리뷰하는 것과 동일 신뢰 수준).
- **idempotency**: 같은 head SHA에서 동일 verdict 마커가 있으면 중복 제출 skip(기존 로직 불변).
- verdict 도출·approve 제출·App 토큰·self thread-resolve 로직은 **건드리지 않음**.

## 트레이드오프
`concurrency: cancel-in-progress`는 기존 push 리뷰를 PR 단위 latest-wins로 만든다(취소된 run은 후속 run이 같은 SHA로 대체, idempotency가 중복 방지). resolve 다발 시 N개 풀 모델 리뷰가 도는 비용을 막는 게 목적.

## 검증
1. 봇 스레드 resolve(멤버 계정) → `pull_request_review_thread` run 시작·prep skip 아님.
2. merge job의 봇 self-resolve 후 새 run 미생성(루프 차단).
3. 깨끗한 PR 스레드 resolve → findings=0 → APPROVE 게시.
4. 같은 SHA 중복 resolve → idempotency skip.
5. 연속 resolve → concurrency로 1개만 완료.

> 첫 run에서 `github.event.sender.type`(='Bot'/'User')·`pull_request.number/.draft` 페이로드 값 확인 권장(저위험).

🤖 Generated with [Claude Code](https://claude.com/claude-code)