### PR TITLE
revert(ci): pull_request_review_thread 트리거 제거 (워크플로 startup_failure 복구)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,18 +11,12 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
-  pull_request_review_thread:
-    types: [resolved]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
   id-token: write
-
-concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
 
 # Phase 4 (Token Optimized Review): the single-job review is restructured into a
 # three-job pipeline so a large PR diff can be reviewed in token-bounded chunks
@@ -65,10 +59,6 @@ jobs:
           && github.event.review.user.login != 'github-actions[bot]'
           && github.event.review.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
-      || (github.event_name == 'pull_request_review_thread'
-          && github.event.pull_request.draft == false
-          && github.event.sender.type != 'Bot'
-          && github.event.sender.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -11,17 +11,11 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
-  pull_request_review_thread:
-    types: [resolved]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
-
-concurrency:
-  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
 
 # Phase 4 (Token Optimized Review): the single-job review is restructured into a
 # three-job pipeline so a large PR diff can be reviewed in token-bounded chunks
@@ -62,10 +56,6 @@ jobs:
           && github.event.review.user.login != 'github-actions[bot]'
           && github.event.review.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
-      || (github.event_name == 'pull_request_review_thread'
-          && github.event.pull_request.draft == false
-          && github.event.sender.type != 'Bot'
-          && github.event.sender.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:


### PR DESCRIPTION
## 긴급 — main 리뷰 워크플로 복구

#381 이 추가한 `pull_request_review_thread` 트리거는 **GitHub Actions 의 유효한 `on:` 트리거가 아니다**(웹훅 이벤트일 뿐, Actions "Events that trigger workflows" 목록에 없음). GitHub 이 이 미지원 이벤트 때문에 워크플로 파일을 거부하여 **codex/claude 리뷰 워크플로가 `startup_failure`** 가 되었고("This run likely failed because of a workflow file issue"), 결과적으로 **모든 트리거(pull_request 등)에서 리뷰가 실행되지 않는 상태**다.

## 변경
`#381` 전체(트리거 + concurrency + prep.if 게이트)를 pre-#381 상태로 되돌려 두 워크플로 파일을 정상 복구한다. (`yq` 로컬 검증은 구조만 보고 통과시켜 이 스키마 오류를 놓쳤다.)

## 근본 원인 / 후속
"스레드 resolve → 자동 재리뷰" 자체가 불가능 — GitHub Actions 에는 스레드 resolve 를 트리거하는 이벤트가 없다. "@멘션 없이 approve" 목표는 다른 접근(예: 멘션 게이트 완화, `pull_request_review[submitted]` 활용)으로 재설계해야 한다.

> 워크플로-only 변경이라 봇 리뷰가 안 붙습니다. **머지하면 즉시 복구됩니다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)