### PR TITLE
fix(ci): codex 리뷰 인증 토큰 회전 만료를 write-back으로 자가 복구

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -319,8 +319,105 @@ jobs:
           include-hidden-files: true
           retention-days: 1
 
-  review:
+  # Codex ChatGPT auth uses ROTATING (single-use) refresh tokens: codex rotates the
+  # refresh token on each access-token refresh and writes the new pair into the
+  # run-local auth.json — which is discarded at job end, leaving the static
+  # CODEX_AUTH_JSON secret holding the OLD (now consumed) refresh token. After the
+  # access token later expires, the secret's refresh token is already dead → 401
+  # "refresh token was already used" → the review produces no chunk results → the
+  # merge job fails the check (false-green guard). This job closes that gap: it
+  # refreshes once, SINGLE-THREADED (global job concurrency), and writes the rotated
+  # auth.json BACK to the secret so the credential never permanently dies. `review`
+  # needs it so the refresh happens before (not concurrently with) the matrix, and
+  # the matrix reads the freshened secret instead of racing the same refresh token.
+  #
+  # Out-of-band prerequisites (code alone does NOT fix it):
+  #  - The REVIEW_APP_ID GitHub App must be granted repo "Secrets: Read and write";
+  #    the default GITHUB_TOKEN cannot write Actions secrets.
+  #  - The CODEX_AUTH_JSON secret must be RE-SEEDED once by hand (local `codex login`
+  #    → copy ~/.codex/auth.json into the secret) to bootstrap a live refresh token;
+  #    write-back can only keep an already-live token alive, not revive a dead one.
+  auth-refresh:
     needs: prep
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Global (run-spanning) group so concurrent runs never write the rotating
+    # secret at the same time. Distinct from the workflow-level per-PR group above.
+    concurrency:
+      group: codex-auth-writeback
+      cancel-in-progress: false
+    env:
+      REVIEW_APP_ID: ${{ secrets.REVIEW_APP_ID }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: ${{ env.REVIEW_APP_ID != '' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547
+        with:
+          app-id: ${{ secrets.REVIEW_APP_ID }}
+          private-key: ${{ secrets.REVIEW_APP_PRIVATE_KEY }}
+
+      - name: Bootstrap Codex auth.json
+        # Same seeding as the review job: secret → auth.json (chmod 600) in a
+        # dedicated codex-home, plus the placeholder server-info file the action's
+        # "Read server info" step expects. Empty secret fails fast.
+        env:
+          CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          if [ -z "$CODEX_AUTH_JSON" ]; then
+            echo "CODEX_AUTH_JSON secret is required for Codex ChatGPT authentication." >&2
+            exit 1
+          fi
+          umask 077
+          codex_home="$RUNNER_TEMP/codex-home"
+          mkdir -p "$codex_home"
+          printf '%s' "$CODEX_AUTH_JSON" > "$codex_home/auth.json"
+          chmod 600 "$codex_home/auth.json"
+          printf '{"port":1}' > "$codex_home/${GITHUB_RUN_ID}.json"
+          echo "CODEX_HOME_DIR=$codex_home" >> "$GITHUB_ENV"
+
+      - name: Refresh Codex token
+        # A trivial model call exercises auth; if the access token is expired codex
+        # refreshes it and rotates the refresh token into codex-home/auth.json.
+        # continue-on-error: a flaky/failed refresh must NOT block reviews — the
+        # matrix can still run on the existing secret, and the write-back step below
+        # no-ops when no fresh auth.json was produced.
+        id: refresh
+        continue-on-error: true
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1
+        with:
+          codex-version: '0.132.0'
+          codex-home: ${{ env.CODEX_HOME_DIR }}
+          sandbox: read-only
+          effort: low
+          prompt: 'Reply with: ok'
+          output-file: ${{ runner.temp }}/codex-refresh-out.txt
+
+      - name: Write rotated auth.json back to the secret
+        # Single writer (this job is globally serialized). Only writes when an App
+        # token with secrets:write is available AND the rotated auth.json actually
+        # differs from the current secret (skip no-op churn).
+        if: ${{ steps.app-token.outputs.token != '' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          OLD_AUTH: ${{ secrets.CODEX_AUTH_JSON }}
+        run: |
+          set -euo pipefail
+          new_auth="${CODEX_HOME_DIR}/auth.json"
+          if [ ! -s "$new_auth" ]; then
+            echo "No auth.json produced (refresh skipped/failed); nothing to write back."
+            exit 0
+          fi
+          if [ "$(cat "$new_auth")" = "$OLD_AUTH" ]; then
+            echo "auth.json unchanged (access token still valid); no write-back needed."
+            exit 0
+          fi
+          gh secret set CODEX_AUTH_JSON --repo "$GITHUB_REPOSITORY" --body "$(cat "$new_auth")"
+          echo "Rotated auth.json written back to CODEX_AUTH_JSON."
+
+  review:
+    needs: [prep, auth-refresh]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
## 문제

`Codex PR Review` 체크가 빨갛게 실패합니다(PR #380에서 관측). 실패 job 로그:
```
ERROR codex_login::auth::manager: Failed to refresh token: 401 ... refresh token was already used
failed to refresh available models: ... 401 ... token_expired
##[error]No chunk review results were produced; failing to avoid a false-green review.
```

## 근본 원인

`codex-review.yml`의 **Bootstrap Codex auth.json** 스텝은 정적 시크릿 `CODEX_AUTH_JSON`(ChatGPT 계정 auth.json)을 매 실행 auth.json으로 **재시드만** 합니다. 그런데 ChatGPT OAuth는 **회전형(1회용) refresh token**을 씁니다 — codex가 access token을 갱신하면 서버가 refresh token을 회전시켜 러너의 임시 auth.json에 새 토큰을 써넣고, 그 파일은 job 종료 시 버려집니다. 저장소 시크릿은 **옛(소비된) refresh token**을 계속 들고 있어, access token이 만료된 뒤 갱신을 시도하면 `already used` 401 → codex가 결과를 못 만들고 → merge job이 false-green 가드로 실패합니다.

즉 **회전 토큰을 정적 시크릿에 박아두고 회전된 토큰을 되돌려 쓰지(write-back) 않는 것**이 원인이며, 한 번 회전·만료되면 시크릿이 **영구히** 죽습니다.

## 수정

- **새 `auth-refresh` job** (`needs: prep`): 토큰을 **단일 스레드**(전역 job concurrency `codex-auth-writeback`, cancel 안 함)로 1회 갱신하고, 회전된 auth.json이 바뀌었으면 App 토큰으로 `CODEX_AUTH_JSON` 시크릿에 **write-back**합니다 → 회전 토큰을 잃지 않아 시크릿이 죽지 않습니다.
- **`review`**: `needs: prep` → `needs: [prep, auth-refresh]`. 갱신이 매트릭스보다 먼저 끝나, 매트릭스 chunk들이 같은 회전 토큰을 두고 경합하지 않고 신선해진 시크릿을 읽습니다.
- **refresh 스텝 `continue-on-error`**: 일시 장애가 리뷰를 막지 않습니다(매트릭스는 기존 시크릿으로 진행, write-back은 no-op).
- 최상위 **per-PR concurrency**(stale run 취소)는 그대로 두고, 시크릿 직렬화는 **job 레벨 전역 concurrency**로 분리했습니다.

## ⚠️ 코드만으로는 안 풀립니다 — 선행 조치 2가지

1. **App에 Secrets 쓰기 권한**: 기본 `GITHUB_TOKEN`은 Actions secret을 못 씁니다. write-back은 `REVIEW_APP_ID` GitHub App 토큰으로 하므로, 그 App에 저장소 **Secrets: Read and write** 권한을 부여(App 설정 → Repository permissions → 재설치/승인)해야 합니다.
2. **시크릿 1회 수동 재시드**: 지금 시크릿의 refresh token은 이미 소비돼 죽었습니다. write-back은 *살아있는* 토큰만 유지할 수 있으므로, 로컬에서 `codex login`(ChatGPT) → `~/.codex/auth.json`을 `CODEX_AUTH_JSON` 시크릿에 새로 저장해 **한 번** 부트스트랩해야 합니다. 이후부터 매 실행이 토큰을 갱신·write-back해 자가 지속됩니다.

## 정직한 한계

- **런 내 시크릿 전파**: 같은 워크플로 실행 안에서 `auth-refresh`가 갱신한 시크릿을 뒤따르는 `review` job이 즉시 읽는지는 GitHub 동작에 의존합니다. 전파가 안 되더라도 시크릿은 **다음 실행을 위해 신선하게 유지**되므로(영구 사망 → 최대 1회 일시 실패로 자가 치유) 현 상태보다 엄격히 개선입니다.
- **장기 무활동**: refresh token 절대 만료보다 오래 codex 리뷰가 한 번도 안 돌면 사이클이 끊겨 다시 수동 재시드가 필요합니다. 필요 시 keep-warm cron을 후속으로 추가할 수 있습니다(범위 밖).

## 검증

`.github/workflows/**`는 `paths-ignore`라 이 PR은 자기 자신에 codex 리뷰를 트리거하지 않습니다. 머지 후, 선행 조치 2가지를 마치고 임의 PR에 커밋을 푸시해 `Codex PR Review`가 401 없이 green인지 확인하세요(`gh pr checks <PR>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)