### PR TITLE
feat(ci): workflow_dispatch 로 멘션 없이 재리뷰 트리거 (resolve→재리뷰 순차)

### DIFF
--- a/.github/scripts/dispatch-rereview.sh
+++ b/.github/scripts/dispatch-rereview.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Trigger a fresh Codex + Claude PR review via workflow_dispatch.
+#
+# Use as the sequential step after resolving review threads (resolve →
+# re-review): a maintainer/flow resolves the threads it considers addressed,
+# then runs this to re-review WITHOUT an @codex/@claude mention. The review
+# only APPROVEs if that fresh run finds zero findings (model still decides).
+#
+# This script deliberately does NOT resolve threads — resolution is a human
+# judgement (findings actually addressed); auto-resolving would forge approval.
+#
+# Requires: gh (authenticated, repo write access — workflow_dispatch is gated to
+# write access by GitHub). The review workflows must be on the default branch.
+#
+#   .github/scripts/dispatch-rereview.sh <pr-number>
+set -euo pipefail
+
+PR="${1:?usage: dispatch-rereview.sh <pr-number>}"
+
+gh workflow run "Codex PR Review" -f pr="$PR"
+gh workflow run "Claude PR Review" -f pr="$PR"
+
+echo "dispatched Codex + Claude re-review for PR #$PR"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,6 +11,12 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to (re-)review'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -59,6 +65,7 @@ jobs:
           && github.event.review.user.login != 'github-actions[bot]'
           && github.event.review.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -87,6 +94,17 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: context.payload.issue.number,
+              });
+              pr = response.data;
+            }
+
+            // workflow_dispatch: no PR in the payload — fetch by the `pr` input
+            // (used for the resolve→re-review sequential trigger).
+            if (!pr && context.eventName === 'workflow_dispatch' && context.payload.inputs?.pr) {
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(context.payload.inputs.pr),
               });
               pr = response.data;
             }

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -11,6 +11,12 @@ on:
     types: [created]
   pull_request_review:
     types: [submitted]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to (re-)review'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -56,6 +62,7 @@ jobs:
           && github.event.review.user.login != 'github-actions[bot]'
           && github.event.review.user.type != 'Bot'
           && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -82,6 +89,17 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: context.payload.issue.number,
+              });
+              pr = response.data;
+            }
+
+            // workflow_dispatch: no PR in the payload — fetch by the `pr` input
+            // (used for the resolve→re-review sequential trigger).
+            if (!pr && context.eventName === 'workflow_dispatch' && context.payload.inputs?.pr) {
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(context.payload.inputs.pr),
               });
               pr = response.data;
             }


### PR DESCRIPTION
## 무엇
codex/claude 리뷰 워크플로에 **`workflow_dispatch`(+`pr` 입력)** 트리거를 추가한다. GitHub Actions 에는 "스레드 resolve" 트리거가 없으므로(이전 `pull_request_review_thread` 시도는 유효 트리거가 아니라 startup_failure 였음), **resolve 를 처리하는 흐름이 그 다음 순차 단계로 재리뷰를 직접 디스패치**하게 한다 — `@codex`/`@claude` 멘션 없이.

## 변경
- `on:` 에 `workflow_dispatch: inputs: { pr }` 추가(유효 Actions 트리거).
- `prep.if:` 에 `|| github.event_name == 'workflow_dispatch'` (GitHub 이 workflow_dispatch 를 **write 권한자로 제한**하므로 추가 게이트 불필요).
- "Resolve pull request context" 스텝: payload 에 PR 이 없을 때(`workflow_dispatch`) **입력 `pr` 로 PR 을 조회**해 이후 단계가 그대로 동작.
- `.github/scripts/dispatch-rereview.sh <pr>`: `gh workflow run` 으로 두 리뷰를 디스패치하는 **순차 호출 헬퍼**. 스레드 자동 resolve 는 하지 않는다(resolve 는 findings 가 실제로 해소됐다는 사람 판단 — 자동 resolve 는 거짓 승인이 됨).

## 사용 (resolve→재리뷰 순차)
```
# (사람/흐름이 해소된 스레드를 resolve 한 뒤)
.github/scripts/dispatch-rereview.sh <pr-number>
# 또는 직접:
gh workflow run "Codex PR Review"  -f pr=<n>
gh workflow run "Claude PR Review" -f pr=<n>
```
재리뷰가 `findings===0` 이면 봇이 APPROVE(모델이 verdict 판정 — 디스패치가 approve 를 강제하지 않음).

## 안전성 / 비고
- `workflow_dispatch` 는 **유효한 Actions 트리거**라 startup_failure 가 발생하지 않는다(yq 검증 통과). 직전 startup_failure 의 원인(`pull_request_review_thread` 미지원)을 피한다.
- workflow_dispatch 는 기본 브랜치(main)에 트리거가 올라간 뒤에야 디스패치 가능 — **머지 후** `gh workflow run` 으로 동작 검증.
- 워크플로-only 변경이라 봇 자동 리뷰는 안 붙는다(paths-ignore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)