### PR TITLE
🤖 [자동 리뷰] dispatch flow 워커가 헤드리스 환경에서 loop 을 고아로 만드는 버그 수정

### DIFF
--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/review/flow 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 준비된 SPEC당 서브에이전트가 한 컨텍스트에서 구현(loop)·리뷰(review)·머지를 소유하는 모델 주도 오케스트레이션(dispatch는 의존성·웨이브·동시성·실패 격리만 총괄, 머지=done이면 의존자 해제; forge 백엔드 가용이면 PR 적대 리뷰→가용 토큰 ff-only 머지(분리 승인 신원 불필요), 미가용이면 로컬 적대 리뷰→ff-only 직접 머지; 대상 브랜치 --target-branch), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/dispatch/SKILL.md
+++ b/plugins/autopilot/skills/dispatch/SKILL.md
@@ -36,7 +36,7 @@ allowed-tools:
 
 준비된(모든 dep 이 done) SPEC마다 서브에이전트를 **정확히 1개** 띄우고, 그 서브에이전트가 한 컨텍스트에서 그 SPEC 의 구현→리뷰→재구현→머지를 닫는다. **서브에이전트 절차의 단일 출처는 `references/subagent-prompt.md`**(loop/review 블랙박스 호출·forge/direct 서브모드·무한루프 가드·approve 후 머지 게이트·에스컬레이션) — dispatch 가 워커 spawn 프롬프트에 그 전문을 embed 한다. dispatch 는 그 내부를 들여다보지 않고 결과(머지됨/비완료)만 받는다.
 
-- **워커 spawn 은 flow 서브프로세스 에이전트 + 계약 프롬프트 embed**: 준비된 SPEC 의 워커는 **`flow` 의 에이전트 노드(`wf.agent` + `SubprocessAgentCaller`)로 띄우되, 워커 절차 계약 전문(`references/subagent-prompt.md`)을 spawn 프롬프트에 그대로 embed** 한다. flow 의 서브프로세스 caller(기본 `claude --print`, caller argv 주입으로 벤더 중립)가 워커를 **독립 서브프로세스**로 실행하므로, 워커는 자기 실행 환경에서 `autopilot:loop`·결정적 헬퍼를 호출해 구현→리뷰→머지를 완수한다. spawn 시 입력으로 `spec`·`target-branch`·`run-dir`·`key` 를 넘긴다. (인세션 Agent 도구의 부모 권한 상속 전제 대신 flow 서브프로세스 워커 모델이며 — 워커의 권한·스킬 가용성은 flow agent caller 설정·벤더 CLI 실행 환경에 의존한다. dispatch 는 그 결과·격리를 관찰해 보완한다.)
+- **워커 spawn 은 flow 서브프로세스 에이전트 + 계약 프롬프트 embed**: 준비된 SPEC 의 워커는 **`flow` 의 에이전트 노드(`wf.agent` + `SubprocessAgentCaller`)로 띄우되, 워커 절차 계약 전문(`references/subagent-prompt.md`)을 spawn 프롬프트에 그대로 embed** 한다. flow 의 서브프로세스 caller(기본 `claude --print`, caller argv 주입으로 벤더 중립)가 워커를 **독립 서브프로세스**로 실행하므로, 워커는 자기 실행 환경에서 loop 드라이버(`bash …/loop/references/loop.sh start <spec>`)·결정적 헬퍼를 구동해 구현→리뷰→머지를 완수한다. **헤드리스 동기 완주 강제**: 임베드한 계약은 구현 단계를 **포그라운드(`run_in_background` 금지) 직접 동기 구동**으로 규정한다 — 비대화형 일회성(`--print`) 워커에는 백그라운드 완료를 알릴 후속 턴이 없으므로, 워커가 loop 을 백그라운드로 띄우고 알림을 기다리며 턴을 끝내면 loop 이 고아로 kill 된다. 따라서 워커는 자기 **단일 호출 안에서** loop 을 종료 상태(DONE/BLOCKED)까지 동기로 완주한 **뒤** 통합·리뷰·머지로 진행한다. spawn 시 입력으로 `spec`·`target-branch`·`run-dir`·`key` 를 넘긴다. (인세션 Agent 도구의 부모 권한 상속 전제 대신 flow 서브프로세스 워커 모델이며 — 워커의 권한·스킬 가용성은 flow agent caller 설정·벤더 CLI 실행 환경에 의존한다. dispatch 는 그 결과·격리를 관찰해 보완한다.)
 
 - **서브프로세스 워커 진행 모니터 자동 설치**: 워커를 **flow 서브프로세스 에이전트로 띄울 때**, dispatch 는 그 워커의 진행을 **워커가 남기는 디스크 아티팩트**(구현 스킬 `autopilot:loop` 의 status/signals, 작업 브랜치 커밋, PR·리뷰 판정, dispatch SPEC state)에 기반해 관찰하는 **진행 모니터를 자동으로 설치**한다. 가용한 환경 수단(예: 주기 폴링 메커니즘)으로 설치하되 **특정 모니터링 하니스 도구에 하드 종속하지 않는다**.
   - **read-only 관찰(블랙박스 보존)**: 모니터는 디스크 아티팩트를 **읽기만** 하며 워커·loop 워크트리·신호·하니스를 변경하지 않는다. 관찰 상태가 **바뀔 때만** 진행을 표면화하고(변화 없는 동안 중복 방출하지 않음), 워커가 **산출 없이 죽거나 정지한 경우·조용한 실패**가 드러나게 한다.
@@ -46,7 +46,7 @@ allowed-tools:
 dispatch 자신의 책임은 **결정적 오케스트레이션**뿐이며 `dispatch.sh` 헬퍼로 분리되어 selftest 로 검증된다:
 
 - **준비도·격리**: depends_on 준비도 스케줄링·동시성 상한·서브에이전트 spawn/reap·실패 이행 격리(spawn 은 `flow` 의 서브프로세스 에이전트 caller 가 수행 — bash 무인 드레인 파이프라인 아님).
-- **머지=done 전이**: 서브에이전트가 머지를 보고한 SPEC 만 `done`(=대상 브랜치 머지됨)으로 전이해 의존자를 해제하므로, 의존자는 의존성이 머지된 뒤에야 갱신된 대상 브랜치 위에서 분기한다. 비완료 보고는 `failed` 로 두고 **그 이행적 의존자만** `skipped`(독립 가지는 계속).
+- **머지=done 전이(머지 정합 — 거짓 성공 금지)**: done 전이는 **오직 서브에이전트의 구조화 머지 보고**(`result=merged`)에만 의존한다(`dispatch.sh mark-report` 가 그 보고를 받아 `merged` 일 때만 done, 그 외는 default-deny failed). fan-out 을 구동하는 flow 의 `ok:true`(=flow 실행이 내부 오류 없이 끝남)는 **머지 성공이 아니므로 done 판정에 쓰지 않는다** — 머지 없이 끝난(고아·에스컬레이션·실패) 워커가 성공처럼 보이는 거짓 성공을 막는다. done 된 SPEC 만 의존자를 해제하므로, 의존자는 의존성이 머지된 뒤에야 갱신된 대상 브랜치 위에서 분기한다. 비완료 보고는 `failed` 로 두고 **그 이행적 의존자만** `skipped`(독립 가지는 계속).
 - **대상 브랜치**: `--target-branch <branch>`(미지정 시 기본 브랜치 또는 주입된 `DEFAULT_BRANCH`). run 전역으로 결정돼 모든 서브에이전트의 base 동기화·리뷰·ff 머지에 일관 적용되고, run-dir 마커(`TARGET_BRANCH`)로 영속해 `--resume` 에서 sticky 하다(마커가 현재 env·플래그보다 우선).
 - **주입 가능 인터페이스(mock 검증)**: 결정적 헬퍼의 외부 인터페이스(`LOOP_CMD`·`GIT_CMD`·`FORGE_CMD`(기본 gh)·`FORGE_BIN`(서브모드 판정)·`DEFAULT_BRANCH`·`REVIEW_ROUNDS_MAX`(3)·`WATCH_DIRS`(plugins/) 등)는 주입 가능해 실제 PR·머지 없이 mock 으로 독립 검증된다.
 
@@ -55,7 +55,7 @@ dispatch 자신의 책임은 **결정적 오케스트레이션**뿐이며 `dispa
 fan-out 단계(준비된 SPEC마다 워커 1개 진행)는 **단일 `flow` 드라이버**로 구동된다 — `flow` 스킬의 **공개 계약**(`bash plugins/autopilot/skills/flow/references/flow.sh run <정의 파일>` → 단일 JSON)을 통해 임의 `depends_on` DAG를 **스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume·결과 전달**로 실행한다. flow 엔진 내부는 **블랙박스**로 두고 입력→JSON 출력 계약으로만 호출한다. 드라이버 선택·자동 감지·운영자 override·안전 강등 사슬은 없으며, 호출자에게 노출된 **시작 인터페이스는 변하지 않는다**(flow 통합은 dispatch 내부에서 일어난다). dispatch 의 결정적 코어(준비도·상태 전이·skip 전파·워커 계약·머지/리뷰 게이트)는 그대로 보존하고, fan-out 을 무엇으로 구동하느냐만 flow 로 통합한다.
 
 - **flow 호출 경로**: `dispatch.sh start` 로 run·DAG·markers·pending 상태를 셋업한 뒤, 오케스트레이터가 준비된 SPEC 들을 flow **워크플로 정의**(각 노드의 `depends_on` 이 모두 충족되는 즉시 워커 실행, SPEC당 워커 1개)로 표현하고 `flow run` 으로 실행한다. 한 SPEC 의 dep 이 모두 done 이면 **같은 그래프의 더 느린 무관한 SPEC 이 진행 중이어도** 기다리지 않고 그 워커가 시작된다(런타임 스트리밍). 동시성 상한은 flow 정의의 `CONCURRENCY` 로 주되 그 값은 `dispatch.sh concurrency <run-id>` 가 산출한다(`0`=무제한을 SPEC 수로 결정적 변환 — 단일 출처). **fan-out 항목이 하나(N=1)여도 같은 flow 경로로 구동**한다.
-- **워커 노드 = flow 서브프로세스 에이전트**: 각 SPEC 워커는 flow 의 에이전트 노드(`wf.agent` + `SubprocessAgentCaller`)로 spawn 하고, spawn 프롬프트에 **워커 계약 전문(`references/subagent-prompt.md`)을 embed** 하며 `spec`·`target-branch`·`run-dir`·`key` 를 입력으로 넘긴다. caller argv 는 주입 가능하며 기본은 Claude(`claude --print`) — 특정 벤더 CLI 에 하드 종속하지 않는다(멀티벤더). 워커가 머지를 보고하면 `dispatch.sh mark done`, 비완료면 `mark failed` 후 `ready` 재평가로 의존자를 해제한다.
+- **워커 노드 = flow 서브프로세스 에이전트**: 각 SPEC 워커는 flow 의 에이전트 노드(`wf.agent` + `SubprocessAgentCaller`)로 spawn 하고, spawn 프롬프트에 **워커 계약 전문(`references/subagent-prompt.md`)을 embed** 하며 `spec`·`target-branch`·`run-dir`·`key` 를 입력으로 넘긴다. caller argv 는 주입 가능하며 기본은 Claude(`claude --print`) — 특정 벤더 CLI 에 하드 종속하지 않는다(멀티벤더). 워커가 종료 보고를 내면 그 구조화 보고를 `dispatch.sh mark-report <run-id> <spec>` 로 받아 머지 정합으로 전이한다(`result=merged`→done, 그 외→failed; flow 의 `ok:true` 는 머지 성공으로 해석하지 않음) 후 `ready` 재평가로 의존자를 해제한다.
   - **워커 권한(서브프로세스는 부모 권한 비상속)**: 인세션 Agent 와 달리 flow 서브프로세스 워커는 **부모 세션의 런타임 권한 grant 를 상속하지 않는다**. 워커 계약(`references/subagent-prompt.md`)이 요구하는 명령 표면을 비대화형 `--print` 으로 무인 실행해야 하므로, caller 는 **격리 워크트리 전제로 `--dangerously-skip-permissions`** 를 기본으로 한다 — 더 좁은 정책이 필요하면 `--allowedTools`/프로젝트 settings allow 로 대체한다.
 - **`python3` hard-abort(폴백 없음)**: flow 는 `python3` 3.9+ 표준 라이브러리로 동작한다. **`python3` 3.9+ 가 사용 불가이면** dispatch 는 다른 드라이버로 강등하지 않고 **명확한 오류로 즉시 중단**한다(비-0 종료). 강등 사슬 자체를 두지 않는 것이 이 통합의 핵심이다(`dispatch.sh` 의 `require_python3` 가 `start` 진입부에서 강제).
 - **관찰**: 단일 드라이버이므로 `dispatch driver <run-id>` 와 `dispatch status` 의 `driver:` 라인은 항상 `flow` 를 일관되게 보고한다.
@@ -113,7 +113,7 @@ per-SPEC 상태를 주기적으로 refresh 하며, 모든 child 가 terminal(`do
 
 | 파일 | 역할 |
 |---|---|
-| `dispatch.sh` | run-id 디렉토리·의존 인덱스·준비도 스케줄링·동시성·`python3` 전제 강제(단일 flow 드라이버)·구조화 종료 판정(결정적 오케스트레이션 헬퍼) |
+| `dispatch.sh` | run-id 디렉토리·의존 인덱스·준비도 스케줄링·동시성·`python3` 전제 강제(단일 flow 드라이버)·머지 정합 보고 게이트(`mark-report`: `result=merged`만 done, 그 외 default-deny failed — flow `ok:true`≠머지)·구조화 종료 판정(결정적 오케스트레이션 헬퍼) |
 | `subagent-prompt.md` | **per-SPEC 워커 지침(계약)** — dispatch 가 flow 서브프로세스 에이전트 spawn 프롬프트에 embed(구현=autopilot:loop·통합/리뷰/머지=헬퍼 구동·approve 후 머지·구조화 보고) |
 | `lib-integration.sh` | per-SPEC 통합 상태 헬퍼(run-dir + 키: branch/pr/head/review-round/verdict/phase) — 서브에이전트 공유 |
 | `integration.sh` | base sync → push → PR 생성/재사용(forge) / PR 없이 작업 브랜치 식별(direct) + 실패-경로 조건부 워크트리 정리(`cleanup-on-fail`: 원격 보존 시 loop cleanup 위임·미보존 시 보존) — 서브에이전트 호출 헬퍼 |

--- a/plugins/autopilot/skills/dispatch/references/dispatch.sh
+++ b/plugins/autopilot/skills/dispatch/references/dispatch.sh
@@ -462,6 +462,48 @@ cmd_mark() {
   fi
 }
 
+# parse_report_result <json> — 워커 구조화 보고 JSON 에서 result 값만 추출(없으면 빈 문자열).
+#   jq 가용 시 jq, 아니면 sed 폴백(deps 강결합 회피). 오형식·누락은 빈 문자열을 반환해
+#   호출처(cmd_mark_report)가 default-deny 하게 한다.
+parse_report_result() {
+  local json="$1" val=""
+  [[ -n "$json" ]] || { echo ""; return; }
+  if command -v jq >/dev/null 2>&1; then
+    val="$(printf '%s' "$json" | jq -r '.result // empty' 2>/dev/null || true)"
+  fi
+  if [[ -z "$val" ]]; then
+    # 폴백: 첫 "result": "<value>" 매치.
+    val="$(printf '%s' "$json" | sed -n 's/.*"result"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+  fi
+  echo "$val"
+}
+
+# cmd_mark_report <run-id> <spec> [report-json] — 워커 구조화 보고 → 종료 전이(머지 정합 게이트).
+#   워커의 마지막 보고 JSON(형식: references/subagent-prompt.md 보고 절)을 받아 result 필드만으로
+#   결정적으로 전이한다: result=="merged" 일 때만 done(=의존자 해제), 그 외(escalated/누락/오형식)는
+#   default-deny 로 failed + 이행적 skip 전파. flow 의 ok:true(=flow 실행이 내부 오류 없이 끝남)는
+#   머지 성공이 아니므로 이 판정에 절대 쓰지 않는다 — 머지된 사실은 오직 워커의 구조화 머지 보고
+#   (result=merged)로만 표면화한다(거짓 성공 금지: 완료 조건 3·5). 결정된 상태를 stdout 으로 출력.
+#   보고 본문은 3번째 인자로 주거나 stdin 으로 흘려 넣는다.
+cmd_mark_report() {
+  require_git_root
+  local rid="${1:-}" spec="${2:-}" report="${3:-}"
+  [[ -n "$rid" && -n "$spec" ]] || die "사용: $0 mark-report <run-id> <spec> [report-json]  (보고는 인자 또는 stdin)"
+  if [[ -z "$report" ]] && [[ ! -t 0 ]]; then report="$(cat)"; fi
+  local result; result="$(parse_report_result "$report")"
+  local st
+  if [[ "$result" == "merged" ]]; then st="done"; else st="failed"; fi
+  local RD; local -a SP=() DEP_IDX=()
+  load_run "$rid"
+  local ap; ap="$(abspath "$spec")"
+  set_state "$RD" "$ap" "$st"
+  log_event "$RD" "mark-report $(spec_slug "$ap") result=${result:-<none>} → $st (done=머지됨; flow ok:true 무관)"
+  if [[ "$st" == "failed" ]]; then
+    propagate_skips "$RD" "${SP[@]}"
+  fi
+  echo "$st"
+}
+
 # ----- subcommand: start -----
 
 cmd_start() {
@@ -760,6 +802,8 @@ cmd_sweep() {
 #     S8 watch(읽기 전용 폴러)·stop(running→failed + 이행적 skip).
 #     S9 단일 flow 드라이버: 구 override·강등 신호가 동작을 가르지 않고 DRIVER 마커 부재.
 #     S10 관찰 진입점 일관 flow + python3 미가용 hard-abort(폴백 없음).
+#     S11 머지 정합 보고 게이트(mark-report): result=merged 만 done, 그 외(escalated/오형식/
+#         누락)는 default-deny failed+이행적 skip — flow ok:true 를 머지 성공으로 오인하지 않음.
 # =====================================================================
 cmd_selftest() {
   local TMP; TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' RETURN
@@ -790,6 +834,7 @@ cmd_selftest() {
   dsp() { env DISPATCH_POLL_SECONDS=0 DISPATCH_WAVE_TIMEOUT_SECONDS=120 "$@"; }
   rdy() { ( cd "$REPO" && dsp bash "$DSP" ready "$@" 2>/dev/null ); }
   mk() { ( cd "$REPO" && dsp bash "$DSP" mark "$@" ) >/dev/null 2>&1; }
+  mkr() { ( cd "$REPO" && dsp bash "$DSP" mark-report "$@" 2>/dev/null ); }
 
   # ---- S1: start = 셋업 전용 (스스로 done 으로 드라이브하지 않음) + 마커 ----
   rm -rf "$REPO/.dispatch"
@@ -956,6 +1001,47 @@ cmd_selftest() {
   local rc10=0; ( cd "$REPO" && dsp env FLOW_PYTHON=__nopython__ bash "$DSP" start feature-a.md ) >/dev/null 2>&1 || rc10=$?
   [[ "$rc10" -ne 0 ]] && ok "S10 python3 미가용 → hard-abort(비-0, 강등 없음)" || bad "S10 python3 hard-abort got=$rc10"
 
+  # ---- S11: 머지 정합 보고 게이트(mark-report) — 거짓 성공 금지 ----
+  # 워커 구조화 보고의 result 만으로 종료 전이를 결정한다(완료 조건 3·5). allowlist=merged 만
+  # done, 그 외(escalated/누락/오형식)는 default-deny → failed(+이행적 skip). flow 의 ok:true
+  # (=내부 오류 없이 실행 완료)를 머지 성공으로 해석하지 않는다(거짓 성공 금지).
+  local o11
+  # S11a: result=merged → done.
+  rm -rf "$REPO/.dispatch"
+  local rid11a; rid11a="$( start_rid dsp bash "$DSP" start feature-a.md )"
+  local rd11a; rd11a="$(latest_run)"
+  o11="$(mkr "$rid11a" "$REPO/feature-a.md" '{"key":"a","result":"merged","detail":"x"}')"
+  [[ "$o11" == "done" && "$(run_state "$rd11a" feature-a.md)" == "done" ]] \
+    && ok "S11a mark-report: result=merged → done" \
+    || bad "S11a merged→done got=[$o11]/$(run_state "$rd11a" feature-a.md)"
+  # S11b: result=escalated → failed + dep B 이행적 skipped.
+  rm -rf "$REPO/.dispatch"
+  local rid11b; rid11b="$( start_rid dsp bash "$DSP" start feature-a.md feature-b.md )"
+  local rd11b; rd11b="$(latest_run)"
+  o11="$(mkr "$rid11b" "$REPO/feature-a.md" '{"key":"a","result":"escalated","detail":"no merge"}')"
+  [[ "$o11" == "failed" && "$(run_state "$rd11b" feature-a.md)" == "failed" ]] \
+    && ok "S11b mark-report: result=escalated → failed(머지 없음=성공 아님)" \
+    || bad "S11b escalated→failed got=[$o11]/$(run_state "$rd11b" feature-a.md)"
+  [[ "$(run_state "$rd11b" feature-b.md)" == "skipped" ]] \
+    && ok "S11b escalated: dep B 이행적 skipped(독립 가지만 차단)" \
+    || bad "S11b B skipped got=$(run_state "$rd11b" feature-b.md)"
+  # S11c: 오형식/비-JSON 보고 → default-deny failed.
+  rm -rf "$REPO/.dispatch"
+  local rid11c; rid11c="$( start_rid dsp bash "$DSP" start feature-a.md )"
+  local rd11c; rd11c="$(latest_run)"
+  o11="$(mkr "$rid11c" "$REPO/feature-a.md" 'not-json-garbage')"
+  [[ "$o11" == "failed" && "$(run_state "$rd11c" feature-a.md)" == "failed" ]] \
+    && ok "S11c mark-report: 오형식 보고 → default-deny failed" \
+    || bad "S11c 오형식→failed got=[$o11]/$(run_state "$rd11c" feature-a.md)"
+  # S11d: result 가 merged 가 아닌 임의 값 → failed(allowlist=merged only).
+  rm -rf "$REPO/.dispatch"
+  local rid11d; rid11d="$( start_rid dsp bash "$DSP" start feature-a.md )"
+  local rd11d; rd11d="$(latest_run)"
+  o11="$(mkr "$rid11d" "$REPO/feature-a.md" '{"result":"running"}')"
+  [[ "$o11" == "failed" && "$(run_state "$rd11d" feature-a.md)" == "failed" ]] \
+    && ok "S11d mark-report: result!=merged → failed" \
+    || bad "S11d non-merged→failed got=[$o11]/$(run_state "$rd11d" feature-a.md)"
+
   echo "----"
   [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"
   return $fail
@@ -984,6 +1070,12 @@ Subcommands:
   mark <run-id> <running|done|failed> <spec>
         SPEC 상태 전이(결정적). running=spawn 직전, done=서브에이전트 머지 보고(=의존자 해제),
         failed=비완료 보고 → 이행적 의존자만 skipped 전파.
+  mark-report <run-id> <spec> [report-json]
+        워커 구조화 보고(references/subagent-prompt.md 보고 형식)를 받아 머지 정합으로 종료 전이를
+        결정한다(거짓 성공 금지). result=="merged" 일 때만 done(=의존자 해제), 그 외(escalated/
+        누락/오형식)는 default-deny → failed + 이행적 skip. flow 의 ok:true 를 머지 성공으로
+        해석하지 않는다 — 머지된 사실은 오직 워커의 result=merged 로만 표면화. 결정 상태를 출력.
+        보고는 인자 또는 stdin.
   list
         모든 run-id 와 진행 요약.
   status <run-id>
@@ -1022,6 +1114,7 @@ case "$SUB" in
   start)  cmd_start  "$@" ;;
   ready)  cmd_ready  "$@" ;;
   mark)   cmd_mark   "$@" ;;
+  mark-report) cmd_mark_report "$@" ;;
   list)   cmd_list  ;;
   status) cmd_status "$@" ;;
   driver) cmd_driver "$@" ;;

--- a/plugins/autopilot/skills/dispatch/references/subagent-prompt.md
+++ b/plugins/autopilot/skills/dispatch/references/subagent-prompt.md
@@ -12,20 +12,24 @@ dispatch 가 준비된(모든 `depends_on` 이 `done`) SPEC마다 띄우는 per-
 
 ## 절대 규칙 (위반 금지 — 어기느니 멈추고 에스컬레이션)
 
-1. **구현은 오직 격리 구현 스킬로**: 구현은 **반드시 `Skill(skill="autopilot:loop", args="start <spec>")`** 로 한다.
-   - **포그라운드(블로킹) 단일 실행**: 이 호출은 loop 의 이터레이션 루프가 끝날 때까지 블로킹한다(loop SKILL.md
-     가 정의). 너는 그 실행이 **반환될 때까지 자기 턴을 끝내지 않는다**. 같은 호출을 **백그라운드 프로세스로
-     띄우거나**(비동기 실행) 완료를 **기다리며 yield·턴 종료**하지 **마라**. 근거: 백그라운드로 띄우면 **워커
-     턴이 끝나는 순간 그 실행이 kill 되어 산출 없이 실패**한다(관측된 회귀). 포그라운드 실행이 **반환된 뒤에야**
-     종료를 판정한다.
+1. **구현은 오직 격리 구현 드라이버를 포그라운드 동기로 직접 구동**: 구현은 **반드시 loop 드라이버를
+   포그라운드(동기) 블로킹 Bash 호출로 직접 구동**한다 —
+   `bash "$(git rev-parse --show-toplevel)/plugins/autopilot/skills/loop/references/loop.sh" start <spec>`.
+   - **포그라운드(블로킹) 단일 실행 — `run_in_background` 금지**: 이 호출은 loop 의 이터레이션 루프가 끝날
+     때까지 블로킹한다(loop SKILL.md 가 정의: `loop.sh start` 가 포그라운드 동기 진입점). 이 Bash 호출을
+     **`run_in_background:true` 로 띄우지 마라**. 너는 그 호출이 **반환될 때까지 자기 턴을 끝내지 않는다**.
+     실행을 **백그라운드로 띄운 뒤 "하니스가 완료를 알려줄 것"이라며 턴을 종료**하지 **마라**. 근거:
+     비대화형 일회성(`claude --print`) 워커에는 **완료를 알려 줄 후속 턴이 없어**, 백그라운드로 띄우면 **워커
+     턴이 끝나는 순간 그 실행이 kill 되어 산출(커밋·PR·머지) 없이 고아로 실패**한다(관측된 회귀). 포그라운드
+     실행이 **반환된 뒤에야** 종료를 판정한다.
    - **일반 원칙(임의 장시간 구동)**: 위는 loop 을 중심 사례로 하되, 네가 **직접 구동하는 임의의 장시간
      스킬·구동**에 똑같이 적용된다 — 직접 구동하는 것은 포그라운드 블로킹으로 돌리고 반환까지 턴을 유지한다.
      단 이는 **호출 세션이 너의 진행을 비차단으로 관찰**하는 정당한 행위(디스크 아티팩트 폴링·진행 모니터)를
      금지하지 않는다. 금지 대상은 **네가 네 실행을 백그라운드로 띄워 산출 전에 턴을 끝내는 것**이다.
-   - 대상 파일을 **직접 편집하지 않는다**. `git checkout -b`/`git commit` 등으로 **직접 구현하지 않는다**.
-   - `loop.sh`를 Bash로 **직접 구동하지 않는다** — 반드시 loop **스킬**을 호출한다. loop이 전용 격리
-     워크트리(`<spec_dir>/.worktree`)를 만들고 소유한다. 너의 cwd 워크트리를 점유하지 마라.
-   - loop 종료는 포그라운드 실행이 **반환된 뒤** 공개 구조화 상태(`autopilot:loop status --json`의
+   - 대상 파일을 **직접 편집하지 않는다**. `git checkout -b`/`git commit` 등으로 **직접 구현하지 않는다** —
+     구현은 위 loop 드라이버가 소유한다. loop 이 전용 격리 워크트리(`<spec_dir>/.worktree`)를 만들고
+     소유한다. 너의 cwd 워크트리를 점유하지 마라.
+   - loop 종료는 포그라운드 실행이 **반환된 뒤** loop 공개 구조화 상태(`loop.sh status --json`의
      `.state`·`.signals[]`)로만 판정한다 — **시작과 동시에 비동기 폴링으로 오인하지 마라**(반환이 먼저다).
 
 2. **통합·리뷰·머지는 오직 결정적 헬퍼로**: 다음 헬퍼를 구동한다(경로는 dispatch references/):
@@ -82,7 +86,7 @@ dispatch 가 준비된(모든 `depends_on` 이 `done`) SPEC마다 띄우는 per-
 5. **블랙박스 경계**: `autopilot:loop`·`autopilot:review`의 내부 신호 파일·워크트리·하니스를 들여다보거나 건드리지 않는다.
 
 ## 절차 요약
-1. `Skill(skill="autopilot:loop", args="start <spec>")` — **포그라운드 블로킹 실행**(반환까지 턴 유지), 반환된 뒤 DONE 판정(`autopilot:loop status --json`).
+1. `bash "$(git rev-parse --show-toplevel)/plugins/autopilot/skills/loop/references/loop.sh" start <spec>` — **포그라운드 블로킹 직접 구동**(`run_in_background` 금지, 반환까지 턴 유지·알림 대기 금지), 반환된 뒤 DONE 판정(`loop.sh status --json`).
 2. 서브모드 판정 → `integration.sh integrate|integrate-direct`.
 3. `review-loop.sh run|run-direct` → 승인 게이트(forge=호스팅 리뷰 **비동기 대기**·pending=transient·**자기승인 금지**·PR APPROVED, direct=로컬 review approve). `request_changes`면 재구현 반복(가드).
 4. 승인 후 `merge.sh finish`(버전 범프·승인 게이트·**머지 확정 후 작업 브랜치 정리**). **타겟 전진 충돌·ff 실패는
@@ -95,4 +99,8 @@ dispatch 가 준비된(모든 `depends_on` 이 `done`) SPEC마다 띄우는 per-
 ## 보고 (너의 마지막 메시지 = 반환값, 사람 대상 산문 아님)
 정확히 아래 JSON 한 개:
 `{"key":"<key>","result":"merged"|"escalated","target_branch":"<branch>","work_branch":"<branch-or-null>","pr":"<url-or-null>","detail":"<한 줄>"}`
-`result="merged"`는 실제로 대상 브랜치에 머지된 경우만. 그 외는 `escalated`(사유를 detail에).
+`result="merged"`는 **실제로 대상 브랜치에 머지된 경우만**. 그 외는 모두 `escalated`(사유를 detail에) —
+loop 이 고아·미완(DONE 미도달)으로 끝났거나, 통합·리뷰·머지가 승인 없이 멈췄거나, 환경이 loop 을 동기
+완주시키지 못한 경우를 포함한다. dispatch 는 이 보고를 `dispatch.sh mark-report` 로 받아 **`result=merged`
+일 때만 done(=의존자 해제)** 으로 전이하고, 그 외는 failed 로 둔다(이행적 의존자만 차단). 머지하지 않았는데
+`merged` 로 보고하지 마라 — 거짓 성공은 금지다.


### PR DESCRIPTION
🤖 이 PR 은 dispatch 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

SPEC: /workspace/claude-plugins/.claude/worktrees/autopilot-repair-skill-spec/docs/specs/2026-06-13-dispatch-flow-worker-loop-orphan/SPEC.md
dispatch-run: 20260614T002453-57393e7

## 요약


dispatch 의 **단일 flow 드라이버**가 비대화형 헤드리스 워커(예: `claude --print`) 서브프로세스로 per-SPEC 워커를 띄울 때, 그 워커가 구현 단계(`autopilot:loop`)를 **자기 단일 호출 안에서 종료 상태까지 동기로 완주**하도록 보장한다. 워커가 loop 을 백그라운드로 띄우고 외부 알림을 기다리며 턴을 끝내 loop 이 고아로 죽는 회귀를 없앤다.

더불어, dispatch fan-out 의 성공 보고가 **실제 머지(=done) 여부에 정합**하도록 한다 — 워커가 머지 없이 끝났는데도 fan-out 결과가 성공처럼 보이는 거짓 성공을 막는다.

이 변경은 dispatch 의 워커 계약(`references/subagent-prompt.md`)과 그 계약을 flow 서브프로세스 에이전트에 싣는 dispatch 의 fan-out 경로에 한정한다. loop 엔진·flow 엔진의 내부 동작은 바꾸지 않는다(블랙박스 경계 보존).
