### PR TITLE
🤖 [자동 리뷰] mark-report 오형식 보고가 merged 로 승인되는 default-deny 구멍 수정

### DIFF
--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/review/flow 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 준비된 SPEC당 서브에이전트가 한 컨텍스트에서 구현(loop)·리뷰(review)·머지를 소유하는 모델 주도 오케스트레이션(dispatch는 의존성·웨이브·동시성·실패 격리만 총괄, 머지=done이면 의존자 해제; forge 백엔드 가용이면 PR 적대 리뷰→가용 토큰 ff-only 머지(분리 승인 신원 불필요), 미가용이면 로컬 적대 리뷰→ff-only 직접 머지; 대상 브랜치 --target-branch), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/dispatch/references/dispatch.sh
+++ b/plugins/autopilot/skills/dispatch/references/dispatch.sh
@@ -474,14 +474,22 @@ parse_report_result() {
   if command -v jq >/dev/null 2>&1; then
     # jq 가용: 유효 JSON 객체 + 최상위 result 가 문자열일 때만 채택. 그 외는 빈 값(deny).
     val="$(printf '%s' "$json" | jq -r 'if type=="object" and (.result|type)=="string" then .result else empty end' 2>/dev/null || true)"
-  else
-    # jq 부재일 때만 보수적 폴백: 입력이 JSON 객체 형태({...})일 때만 첫 "result":"<value>" 매치.
-    #   부분문자열 기반이라 완벽하진 않으나, 비-JSON 접두/접미 오형식은 객체-형태 가드로 걸러낸다.
-    local trimmed; trimmed="$(printf '%s' "$json" | tr -d '[:space:]')"
-    if [[ "$trimmed" == '{'*'}' ]]; then
-      val="$(printf '%s' "$json" | sed -n 's/.*"result"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
-    fi
+  elif command -v "${FLOW_PYTHON%% *}" >/dev/null 2>&1; then
+    # jq 부재: python3(이미 flow 드라이버 하드 의존성)로 엄격 파싱 — 유효 JSON 객체 + 최상위 result
+    #   가 문자열일 때만 채택. 부분문자열 매치 아님: trailing comma 는 파싱 실패로, 중첩 result 는
+    #   최상위 검사로 걸러져 default-deny 된다.
+    val="$(printf '%s' "$json" | ${FLOW_PYTHON} -c '
+import sys, json
+try:
+    o = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if isinstance(o, dict) and isinstance(o.get("result"), str):
+    sys.stdout.write(o["result"])
+' 2>/dev/null || true)"
   fi
+  # jq·python3 모두 부재면 val 은 빈 값(default-deny) — 검증 불가를 merged 로 승인하지 않는다.
+  #   sed 부분문자열 폴백은 trailing comma·중첩 result 오형식을 merged 로 승인할 수 있어 제거했다.
   echo "$val"
 }
 
@@ -1057,6 +1065,24 @@ cmd_selftest() {
   [[ "$o11" == "failed" && "$(run_state "$rd11e" feature-a.md)" == "failed" ]] \
     && ok "S11e mark-report: 오형식+merged 부분문자열 → default-deny failed" \
     || bad "S11e 오형식+부분문자열→failed got=[$o11]/$(run_state "$rd11e" feature-a.md)"
+  # S11f: 유효하지 않은 JSON(trailing comma) {"result":"merged",} → default-deny failed.
+  #   실제 JSON 파서(jq/python3)는 파싱 실패로 거부해야 한다(객체-형태 가드만으로는 새던 케이스).
+  rm -rf "$REPO/.dispatch"
+  local rid11f; rid11f="$( start_rid dsp bash "$DSP" start feature-a.md )"
+  local rd11f; rd11f="$(latest_run)"
+  o11="$(mkr "$rid11f" "$REPO/feature-a.md" '{"result":"merged",}')"
+  [[ "$o11" == "failed" && "$(run_state "$rd11f" feature-a.md)" == "failed" ]] \
+    && ok "S11f mark-report: trailing comma 오형식 → default-deny failed" \
+    || bad "S11f trailing comma→failed got=[$o11]/$(run_state "$rd11f" feature-a.md)"
+  # S11g: 최상위 result 부재·중첩 {"meta":{"result":"merged"}} → default-deny failed.
+  #   최상위 필드만 판독해야 한다(부분문자열·중첩 매치 금지).
+  rm -rf "$REPO/.dispatch"
+  local rid11g; rid11g="$( start_rid dsp bash "$DSP" start feature-a.md )"
+  local rd11g; rd11g="$(latest_run)"
+  o11="$(mkr "$rid11g" "$REPO/feature-a.md" '{"meta":{"result":"merged"}}')"
+  [[ "$o11" == "failed" && "$(run_state "$rd11g" feature-a.md)" == "failed" ]] \
+    && ok "S11g mark-report: 중첩 result(최상위 부재) → default-deny failed" \
+    || bad "S11g 중첩 result→failed got=[$o11]/$(run_state "$rd11g" feature-a.md)"
 
   echo "----"
   [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"

--- a/plugins/autopilot/skills/dispatch/references/dispatch.sh
+++ b/plugins/autopilot/skills/dispatch/references/dispatch.sh
@@ -463,17 +463,24 @@ cmd_mark() {
 }
 
 # parse_report_result <json> — 워커 구조화 보고 JSON 에서 result 값만 추출(없으면 빈 문자열).
-#   jq 가용 시 jq, 아니면 sed 폴백(deps 강결합 회피). 오형식·누락은 빈 문자열을 반환해
-#   호출처(cmd_mark_report)가 default-deny 하게 한다.
+#   default-deny: 유효한 JSON 객체이고 최상위 result 가 문자열일 때만 그 값을 채택하고,
+#   파싱 실패·result 부재·비문자열은 빈 문자열을 반환해 호출처(cmd_mark_report)가 deny→failed 하게 한다.
+#   jq 가용 시 jq 가 단일 판정자다 — 파싱 실패해도 sed 부분문자열 폴백을 타지 않는다(거짓 성공 금지).
+#   sed 폴백은 jq 자체가 부재할 때만, 그것도 입력이 JSON 객체 형태일 때만 실행하는 보수적 폴백이다
+#   (오형식 부분문자열을 merged 로 승인하지 않는다).
 parse_report_result() {
   local json="$1" val=""
   [[ -n "$json" ]] || { echo ""; return; }
   if command -v jq >/dev/null 2>&1; then
-    val="$(printf '%s' "$json" | jq -r '.result // empty' 2>/dev/null || true)"
-  fi
-  if [[ -z "$val" ]]; then
-    # 폴백: 첫 "result": "<value>" 매치.
-    val="$(printf '%s' "$json" | sed -n 's/.*"result"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+    # jq 가용: 유효 JSON 객체 + 최상위 result 가 문자열일 때만 채택. 그 외는 빈 값(deny).
+    val="$(printf '%s' "$json" | jq -r 'if type=="object" and (.result|type)=="string" then .result else empty end' 2>/dev/null || true)"
+  else
+    # jq 부재일 때만 보수적 폴백: 입력이 JSON 객체 형태({...})일 때만 첫 "result":"<value>" 매치.
+    #   부분문자열 기반이라 완벽하진 않으나, 비-JSON 접두/접미 오형식은 객체-형태 가드로 걸러낸다.
+    local trimmed; trimmed="$(printf '%s' "$json" | tr -d '[:space:]')"
+    if [[ "$trimmed" == '{'*'}' ]]; then
+      val="$(printf '%s' "$json" | sed -n 's/.*"result"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+    fi
   fi
   echo "$val"
 }
@@ -1041,6 +1048,15 @@ cmd_selftest() {
   [[ "$o11" == "failed" && "$(run_state "$rd11d" feature-a.md)" == "failed" ]] \
     && ok "S11d mark-report: result!=merged → failed" \
     || bad "S11d non-merged→failed got=[$o11]/$(run_state "$rd11d" feature-a.md)"
+  # S11e: 비-JSON 이지만 "result":"merged" 부분문자열 포함 → default-deny failed.
+  #   jq 가용 시 jq 파싱 실패는 sed 부분문자열 폴백을 타면 안 된다(거짓 성공 금지: 완료 조건 1·3).
+  rm -rf "$REPO/.dispatch"
+  local rid11e; rid11e="$( start_rid dsp bash "$DSP" start feature-a.md )"
+  local rd11e; rd11e="$(latest_run)"
+  o11="$(mkr "$rid11e" "$REPO/feature-a.md" 'not-json {"result":"merged"}')"
+  [[ "$o11" == "failed" && "$(run_state "$rd11e" feature-a.md)" == "failed" ]] \
+    && ok "S11e mark-report: 오형식+merged 부분문자열 → default-deny failed" \
+    || bad "S11e 오형식+부분문자열→failed got=[$o11]/$(run_state "$rd11e" feature-a.md)"
 
   echo "----"
   [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"


### PR DESCRIPTION
🤖 이 PR 은 dispatch 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

SPEC: /workspace/claude-plugins/.claude/worktrees/autopilot-repair-skill-spec/docs/specs/2026-06-14-mark-report-malformed-default-deny/SPEC.md
dispatch-run: 20260614T005411-4f801b2

## 요약


dispatch 의 머지 정합 게이트(`dispatch.sh` 의 `cmd_mark_report` / `parse_report_result`)가 **오형식·비-JSON 보고를 `merged` 로 오추출하지 않도록** default-deny 를 강화한다. 유효한 JSON 이고 최상위 `result` 가 문자열일 때만 그 값을 채택하고, 그 외(파싱 실패·`result` 부재·비문자열)는 빈 값(=deny → failed)으로 처리한다. 기존 selftest 가 놓친 "비-JSON 인데 `result":"merged" 부분문자열을 포함" 케이스를 회귀 가드로 추가한다.
