### PR TITLE
🤖 [자동 리뷰] 머지 승인 게이트가 미해결 [blocking] 인라인 리뷰 지적을 차단하지 않는 갭 수정

### DIFF
--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/loop/dispatch/review/flow 5-skill family — spec으로 SPEC 작성, loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 준비된 SPEC당 서브에이전트가 한 컨텍스트에서 구현(loop)·리뷰(review)·머지를 소유하는 모델 주도 오케스트레이션(dispatch는 의존성·웨이브·동시성·실패 격리만 총괄, 머지=done이면 의존자 해제; forge 백엔드 가용이면 PR 적대 리뷰→가용 토큰 ff-only 머지(분리 승인 신원 불필요), 미가용이면 로컬 적대 리뷰→ff-only 직접 머지; 대상 브랜치 --target-branch), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/dispatch/references/merge.sh
+++ b/plugins/autopilot/skills/dispatch/references/merge.sh
@@ -58,28 +58,72 @@ mg_die() { echo "merge: $*" >&2; return 1; }
 #       남긴 본문 마커 `<!-- <prefix> head_sha=<sha> verdict=approve -->`(prefix=*-formal-review).
 # 신뢰 봇 로그인(App bot / github-actions[bot])만 마커를 신뢰한다(위조 마커 거부).
 REVIEW_BOT_LOGINS_RE="${REVIEW_BOT_LOGINS_RE:-(\[bot\]$|^github-actions$|courtesy-bot)}"
+# 차단성 인라인 태그(리터럴 부분문자열) — 리뷰 워크플로 본문 `**[<severity>/<conf>] title**` 형식
+# (.github/workflows/{codex,claude}-review.yml). `[blocking` 는 `[non_blocking` 을 매치하지 않음.
+# 봇 컨벤션 결합을 끊기 위해 주입 가능 변수로 둔다(awk index() 리터럴 매치 → awk별 escape 비의존).
+BLOCKING_TAG="${BLOCKING_TAG:-[blocking}"
+
+# mg_blocking_inline_gate <pr> <head> — 현재 head 에 신뢰봇이 남긴 미해결 [blocking] 인라인이
+#   하나라도 있으면 1(차단), 없으면 0(통과). "현재 head 대응" = 코멘트 commit_id==head(결정적;
+#   재푸시로 head 가 바뀌면 outdated 지적은 자동 해소). head 미확정·조회 실패는 보수적 차단
+#   (default-deny)하고 사유를 stderr 로 표면화(거짓 승인 금지).
+mg_blocking_inline_gate() {
+  local pr="$1" head="$2" out rc
+  if [[ -z "$head" ]]; then
+    echo "merge: 승인 차단 — 현재 head 미확정으로 [blocking] 인라인 검증 불가(default-deny)" >&2
+    return 1
+  fi
+  # 인라인 리뷰 코멘트: login\tcommit_id\tbody(코멘트당 1줄, 본문 개행·탭은 공백화).
+  # shellcheck disable=SC2086
+  out="$($FORGE_CMD api "repos/{owner}/{repo}/pulls/$pr/comments" --paginate \
+        --jq '.[] | (.user.login // "")+"\t"+(.commit_id // "")+"\t"+((.body // "")|gsub("[\n\t]";" "))' 2>/dev/null)"
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo "merge: 승인 차단 — 인라인 리뷰 조회 실패(rc=$rc), [blocking] 검증 불가(default-deny)" >&2
+    return 1
+  fi
+  # 현재 head 대응(field2 정확일치) + [blocking] 태그(field3 리터럴 index) 줄의 login(field1)을
+  #   추려, 신뢰봇 정규식으로 grep(앵커가 login 단독에 올바로 걸림; awk 정규식 escape 비의존).
+  #   하나라도 있으면 차단.
+  if printf '%s\n' "$out" \
+       | awk -F'\t' -v h="$head" -v tag="$BLOCKING_TAG" '$2==h && index($3,tag)>0 {print $1}' \
+       | grep -qE "$REVIEW_BOT_LOGINS_RE"; then
+    echo "merge: 승인 차단 — 신뢰봇이 현재 head($head)에 남긴 미해결 [blocking] 인라인 존재" >&2
+    return 1
+  fi
+  return 0
+}
+
 # mg_approval_gh <pr> — 승인이면 "APPROVED" 출력(없으면 빈 값). 주입 가능(MERGE_APPROVAL_CMD).
+#   승인 신호(reviewDecision==APPROVED 또는 현재 head verdict=approve 마커)가 있어도, 현재 head 의
+#   신뢰봇 미해결 [blocking] 인라인이 있으면 승인을 가린다(가산 차단, PR #385 회귀 가드).
 mg_approval_gh() {
-  local pr="$1" decision head
+  local pr="$1" decision head approved=""
   # shellcheck disable=SC2086
   decision="$($FORGE_CMD pr view "$pr" --json reviewDecision --jq '.reviewDecision' 2>/dev/null)"
-  if [[ "$decision" == "APPROVED" ]]; then echo "APPROVED"; return 0; fi
-  # 강등 승인: 신뢰 봇이 현재 head 에 남긴 verdict=approve 마커.
   # shellcheck disable=SC2086
   head="$($FORGE_CMD pr view "$pr" --json headRefOid --jq '.headRefOid' 2>/dev/null)"
-  [[ -n "$head" ]] || return 0
+  if [[ "$decision" == "APPROVED" ]]; then
+    approved=1
+  # 강등 승인: 신뢰 봇이 현재 head 에 남긴 verdict=approve 마커.
   # shellcheck disable=SC2086
-  if $FORGE_CMD pr view "$pr" --json reviews \
+  elif [[ -n "$head" ]] && $FORGE_CMD pr view "$pr" --json reviews \
         --jq '.reviews[] | (.author.login // "") + "\t" + (.body // "")' 2>/dev/null \
        | grep -E "$REVIEW_BOT_LOGINS_RE" \
        | grep -qE "head_sha=${head}[^>]*verdict=approve"; then
-    echo "APPROVED"
+    approved=1
   fi
+  [[ -n "$approved" ]] || return 0
+  # 승인 신호가 있어도 현재 head 의 신뢰봇 [blocking] 인라인이 가린다(차단되면 APPROVED 미출력).
+  mg_blocking_inline_gate "$pr" "$head" || return 0
+  echo "APPROVED"
 }
 # mg_approval_gate <pr> — forge PR 의 호스팅 리뷰가 APPROVED 면 0, 아니면 1(차단).
+#   stderr 는 의도적으로 통과시킨다 — default-deny([blocking] 검출·인라인 조회 실패) 사유가
+#   거짓 승인 없이 관찰 가능하도록(AC5). stdout 만 캡처하므로 판정에는 영향 없다.
 mg_approval_gate() {
   local decision
-  decision="$($MERGE_APPROVAL_CMD "$1" 2>/dev/null | tr -d '[:space:]')"
+  decision="$($MERGE_APPROVAL_CMD "$1" | tr -d '[:space:]')"
   [[ "$decision" == "APPROVED" ]]
 }
 
@@ -605,6 +649,72 @@ BR
   case "$swerr" in *WARN*) ok "sweep 부분 실패 WARN 표면화";; *) bad "sweep 부분 실패 WARN 표면화(조용한 실패 금지)";; esac
   # force 미사용(sweep 경로).
   if grep -qiE 'force|(^| )-f( |$)' "$trace"; then bad "sweep force 미사용"; else ok "sweep force 미사용"; fi
+
+  # =====================================================================
+  # 승인 게이트 ── 현재 head 의 신뢰봇 미해결 [blocking] 인라인이 approve 를 가린다(PR #385).
+  #   mg_approval_gh 를 직접 호출(merge_finish 경로는 MERGE_APPROVAL_CMD 가 mock 이라
+  #   gh-경로를 안 탐). FORGE_CMD 를 시나리오 변수로 구동하는 mock 으로 치환.
+  # =====================================================================
+  # mock gh: pr view --json {reviewDecision|headRefOid|reviews}, api .../comments 를
+  #   이미 --jq 적용된 형태로 시뮬(SC_* 변수). api 실패는 SC_API_FAIL=1.
+  mock_forge_gh() {
+    case "$1" in
+      pr)
+        case "$*" in
+          *"--json reviewDecision"*) printf '%s\n' "${SC_DECISION:-}" ;;
+          *"--json headRefOid"*)     printf '%s\n' "${SC_HEAD:-}" ;;
+          *"--json reviews"*)        printf '%b' "${SC_REVIEWS:-}" ;;  # login\tbody 줄들
+        esac ;;
+      api)
+        [[ "${SC_API_FAIL:-}" == "1" ]] && return 1
+        printf '%b' "${SC_COMMENTS:-}" ;;  # login\tcommit_id\tbody 줄들
+    esac
+    return 0
+  }
+  # ag — mg_approval_gh 출력(APPROVED/빈값). 시나리오 SC_* 는 호출부 env-prefix 로 주입하되
+  #   반드시 substitution 안에서 prefix 해야 ag 환경에 도달한다(밖에 두면 chk 에만 걸림).
+  ag() { FORGE_CMD=mock_forge_gh mg_approval_gh "${1:-700}" 2>/dev/null | tr -d '[:space:]'; }
+  local H="headSHA1"
+  # 마커 경로 grep 은 login\tbody 줄에 앵커 정규식을 적용 → 비앵커 매치되는 courtesy-bot 사용.
+  local MARK="courtesy-bot\t<!-- claude-formal-review head_sha=$H verdict=approve -->\n"
+  local BLK="github-actions[bot]\t$H\t**[blocking/98] 차단 지적** 본문\n"
+  local OK_C="github-actions[bot]\t$H\t**[non_blocking/85] 정보성** 본문\n"
+
+  # AC2: APPROVED 인데 현재 head 신뢰봇 [blocking] 인라인 → 승인 아님(차단).
+  chk "AC2 approved+head [blocking] → 차단(빈값)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_COMMENTS="$BLK" ag)" ""
+  # AC1: blocking 없음 + APPROVED → APPROVED 통과.
+  chk "AC1 approved+blocking없음 → APPROVED" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_COMMENTS="$OK_C" ag)" "APPROVED"
+  # AC3: 비신뢰 작성자 [blocking] + APPROVED → 차단 근거 아님(통과).
+  chk "AC3 비신뢰봇 [blocking] → 차단 안 함(APPROVED)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_COMMENTS="random-human\t$H\t**[blocking/98] 위조**\n" ag)" "APPROVED"
+  # AC3: outdated(이전 head) [blocking] + APPROVED → 차단 근거 아님(통과).
+  chk "AC3 outdated [blocking] → 차단 안 함(APPROVED)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_COMMENTS="github-actions[bot]\toldSHA\t**[blocking/98] 이전**\n" ag)" "APPROVED"
+  # AC2: 강등 승인 마커(verdict=approve) + head [blocking] → 차단.
+  chk "AC2 마커승인+head [blocking] → 차단(빈값)" \
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK" SC_COMMENTS="$BLK" ag)" ""
+  # 강등 승인 마커 + blocking 없음 → APPROVED.
+  chk "마커승인+blocking없음 → APPROVED" \
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK" SC_COMMENTS="$OK_C" ag)" "APPROVED"
+  # AC5: 인라인 조회 실패 + APPROVED → default-deny(차단).
+  chk "AC5 인라인 조회 실패 → default-deny(차단)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_API_FAIL=1 ag)" ""
+  # AC5: head 미확정 + APPROVED → default-deny(차단).
+  chk "AC5 head 미확정 → default-deny(차단)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="" SC_COMMENTS="$OK_C" ag)" ""
+  # AC5: 조회 실패 시 stderr 표면화(거짓 승인 금지).
+  ( SC_DECISION=APPROVED SC_HEAD=$H SC_API_FAIL=1 FORGE_CMD=mock_forge_gh mg_approval_gh 708 ) \
+    2>"$TMP/ag_err" >/dev/null
+  case "$(cat "$TMP/ag_err" 2>/dev/null)" in *차단*|*default-deny*) ok "AC5 조회 실패 stderr 표면화";; *) bad "AC5 조회 실패 stderr 표면화";; esac
+  # AC5 Wired: 전체 게이트(mg_approval_gate→mg_approval_gh)에서 default-deny 사유가 stderr 로 살아남고
+  #   판정은 차단(rc=1)임. mg_approval_gate 의 stderr 미차단이 관찰성을 보존하는지 검증.
+  ( SC_DECISION=APPROVED SC_HEAD=$H SC_API_FAIL=1 \
+    FORGE_CMD=mock_forge_gh MERGE_APPROVAL_CMD=mg_approval_gh mg_approval_gate 709 ) \
+    2>"$TMP/gate_err"; rc=$?
+  chk "AC5 게이트 default-deny 차단(rc=1)" "$rc" "1"
+  case "$(cat "$TMP/gate_err" 2>/dev/null)" in *차단*|*default-deny*) ok "AC5 게이트 stderr 사유 보존(Wired)";; *) bad "AC5 게이트 stderr 사유 보존(Wired)";; esac
 
   echo "----"
   [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"

--- a/plugins/autopilot/skills/dispatch/references/merge.sh
+++ b/plugins/autopilot/skills/dispatch/references/merge.sh
@@ -83,12 +83,19 @@ mg_blocking_inline_gate() {
     echo "merge: 승인 차단 — repo owner/name 미확정으로 [blocking] 검증 불가(default-deny)" >&2
     return 1
   fi
+  # 모든 reviewThreads 페이지를 --paginate(pageInfo+after:$endCursor)로 따라간다 — 100개 초과
+  #   스레드의 [blocking]을 놓치지 않게. comments 는 단일 스레드 기준 충분한 first:100(한 라인
+  #   대화가 100개 초과는 비현실적). gh 출력은 페이지별 JSON 의 연결 스트림이고, 아래 jq 가 그
+  #   스트림 전체를 처리한다(mock 도 다중-페이지 JSON 을 연결해 돌려줘 결정적 검증).
   # shellcheck disable=SC2086
-  raw="$($FORGE_CMD api graphql -F owner="$owner" -F name="$name" -F pr="$pr" -f query='
-query($owner:String!,$name:String!,$pr:Int!){
+  raw="$($FORGE_CMD api graphql --paginate -F owner="$owner" -F name="$name" -F pr="$pr" -f query='
+query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
   repository(owner:$owner,name:$name){
     pullRequest(number:$pr){
-      reviewThreads(first:100){nodes{isResolved comments(first:50){nodes{author{login} commit{oid} body}}}}
+      reviewThreads(first:100, after:$endCursor){
+        pageInfo{hasNextPage endCursor}
+        nodes{isResolved comments(first:100){nodes{author{login} commit{oid} body}}}
+      }
     }}}' 2>/dev/null)"
   if [[ $? -ne 0 || -z "$raw" ]]; then
     echo "merge: 승인 차단 — 리뷰 스레드 조회 실패, [blocking] 검증 불가(default-deny)" >&2
@@ -709,6 +716,9 @@ BR
   # isResolved: resolve 된 스레드의 [blocking] → 차단 안 함(APPROVED) — resolve→재리뷰 데드락 방지.
   chk "resolved 스레드 [blocking] → 차단 안 함(APPROVED)" \
     "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$(thr true "github-actions[bot]" "$H" "**[blocking/98] 해결됨**")" ag)" "APPROVED"
+  # 페이지네이션: 2페이지 연결 JSON 중 2페이지에 head [blocking] → 차단(--paginate 전 페이지 처리).
+  chk "pagination: 2페이지의 [blocking] → 차단(빈값)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$(thr false "github-actions[bot]" "$H" "**[non_blocking/80] 1p**")$(thr false "github-actions[bot]" "$H" "**[blocking/98] 2p**")" ag)" ""
   # AC3: 비신뢰 작성자 [blocking] + APPROVED → 차단 근거 아님(통과).
   chk "AC3 비신뢰봇 [blocking] → 차단 안 함(APPROVED)" \
     "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$(thr false "random-human" "$H" "**[blocking/98] 위조**")" ag)" "APPROVED"

--- a/plugins/autopilot/skills/dispatch/references/merge.sh
+++ b/plugins/autopilot/skills/dispatch/references/merge.sh
@@ -63,28 +63,45 @@ REVIEW_BOT_LOGINS_RE="${REVIEW_BOT_LOGINS_RE:-(\[bot\]$|^github-actions$|courtes
 # 봇 컨벤션 결합을 끊기 위해 주입 가능 변수로 둔다(awk index() 리터럴 매치 → awk별 escape 비의존).
 BLOCKING_TAG="${BLOCKING_TAG:-[blocking}"
 
-# mg_blocking_inline_gate <pr> <head> — 현재 head 에 신뢰봇이 남긴 미해결 [blocking] 인라인이
-#   하나라도 있으면 1(차단), 없으면 0(통과). "현재 head 대응" = 코멘트 commit_id==head(결정적;
-#   재푸시로 head 가 바뀌면 outdated 지적은 자동 해소). head 미확정·조회 실패는 보수적 차단
-#   (default-deny)하고 사유를 stderr 로 표면화(거짓 승인 금지).
+# mg_blocking_inline_gate <pr> <head> — 현재 head 에 신뢰봇이 남긴 **미해결** [blocking] 인라인이
+#   하나라도 있으면 1(차단), 없으면 0(통과).
+#   - 미해결 판정: 리뷰 스레드 isResolved(GraphQL). resolve 된 스레드는 제외 → resolve→재리뷰
+#     워크플로 데드락 방지(commit_id 일치만으로 영구 차단하지 않음).
+#   - 현재 head 대응: 코멘트 commit.oid==head(재푸시로 head 가 바뀌면 outdated 는 자동 해소).
+#   - owner/name·head 미확정·조회/파싱 실패는 보수적 차단(default-deny)하고 사유를 stderr 로 표면화.
+#   - GraphQL raw JSON 을 받아 실제 jq 로 필터 → isResolved 필터를 mock(raw 반환)으로 결정적 검증.
 mg_blocking_inline_gate() {
-  local pr="$1" head="$2" out rc
+  local pr="$1" head="$2" on owner name raw out
   if [[ -z "$head" ]]; then
     echo "merge: 승인 차단 — 현재 head 미확정으로 [blocking] 인라인 검증 불가(default-deny)" >&2
     return 1
   fi
-  # 인라인 리뷰 코멘트: login\tcommit_id\tbody(코멘트당 1줄, 본문 개행·탭은 공백화).
   # shellcheck disable=SC2086
-  out="$($FORGE_CMD api "repos/{owner}/{repo}/pulls/$pr/comments" --paginate \
-        --jq '.[] | (.user.login // "")+"\t"+(.commit_id // "")+"\t"+((.body // "")|gsub("[\n\t]";" "))' 2>/dev/null)"
-  rc=$?
-  if [[ $rc -ne 0 ]]; then
-    echo "merge: 승인 차단 — 인라인 리뷰 조회 실패(rc=$rc), [blocking] 검증 불가(default-deny)" >&2
+  on="$($FORGE_CMD repo view --json owner,name --jq '.owner.login+" "+.name' 2>/dev/null)" || on=""
+  owner="${on%% *}"; name="${on##* }"
+  if [[ -z "$owner" || -z "$name" ]]; then
+    echo "merge: 승인 차단 — repo owner/name 미확정으로 [blocking] 검증 불가(default-deny)" >&2
     return 1
   fi
-  # 현재 head 대응(field2 정확일치) + [blocking] 태그(field3 리터럴 index) 줄의 login(field1)을
-  #   추려, 신뢰봇 정규식으로 grep(앵커가 login 단독에 올바로 걸림; awk 정규식 escape 비의존).
-  #   하나라도 있으면 차단.
+  # shellcheck disable=SC2086
+  raw="$($FORGE_CMD api graphql -F owner="$owner" -F name="$name" -F pr="$pr" -f query='
+query($owner:String!,$name:String!,$pr:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$pr){
+      reviewThreads(first:100){nodes{isResolved comments(first:50){nodes{author{login} commit{oid} body}}}}
+    }}}' 2>/dev/null)"
+  if [[ $? -ne 0 || -z "$raw" ]]; then
+    echo "merge: 승인 차단 — 리뷰 스레드 조회 실패, [blocking] 검증 불가(default-deny)" >&2
+    return 1
+  fi
+  # 미해결(isResolved=false) 스레드의 코멘트만: login\tcommit_oid\tbody.
+  out="$(printf '%s' "$raw" | jq -r '
+        .data.repository.pullRequest.reviewThreads.nodes[]
+        | select(.isResolved==false)
+        | .comments.nodes[]
+        | (.author.login // "")+"\t"+(.commit.oid // "")+"\t"+((.body // "")|gsub("[\n\t]";" "))' 2>/dev/null)" \
+    || { echo "merge: 승인 차단 — 리뷰 스레드 파싱 실패(default-deny)" >&2; return 1; }
+  # 미해결 + 현재 head 대응(field2==head) + [blocking] 태그(field3 리터럴) 줄의 login 을 신뢰봇 grep.
   if printf '%s\n' "$out" \
        | awk -F'\t' -v h="$head" -v tag="$BLOCKING_TAG" '$2==h && index($3,tag)>0 {print $1}' \
        | grep -qE "$REVIEW_BOT_LOGINS_RE"; then
@@ -655,8 +672,8 @@ BR
   #   mg_approval_gh 를 직접 호출(merge_finish 경로는 MERGE_APPROVAL_CMD 가 mock 이라
   #   gh-경로를 안 탐). FORGE_CMD 를 시나리오 변수로 구동하는 mock 으로 치환.
   # =====================================================================
-  # mock gh: pr view --json {reviewDecision|headRefOid|reviews}, api .../comments 를
-  #   이미 --jq 적용된 형태로 시뮬(SC_* 변수). api 실패는 SC_API_FAIL=1.
+  # mock gh: pr view --json {reviewDecision|headRefOid|reviews}, repo view(--jq → "owner name"),
+  #   api graphql(리뷰 스레드 raw JSON). graphql 조회 실패는 SC_API_FAIL=1.
   mock_forge_gh() {
     case "$1" in
       pr)
@@ -665,45 +682,51 @@ BR
           *"--json headRefOid"*)     printf '%s\n' "${SC_HEAD:-}" ;;
           *"--json reviews"*)        printf '%b' "${SC_REVIEWS:-}" ;;  # login\tbody 줄들
         esac ;;
+      repo) printf '%s %s\n' "${SC_OWNER:-o}" "${SC_NAME:-n}" ;;
       api)
         [[ "${SC_API_FAIL:-}" == "1" ]] && return 1
-        printf '%b' "${SC_COMMENTS:-}" ;;  # login\tcommit_id\tbody 줄들
+        printf '%s' "${SC_THREADS:-}" ;;  # 리뷰 스레드 raw GraphQL JSON(게이트 내부 jq 가 필터)
     esac
     return 0
   }
+  # thr <isResolved> <login> <oid> <body> — 단일 리뷰 스레드 raw GraphQL JSON 빌더.
+  thr() { printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":%s,"comments":{"nodes":[{"author":{"login":"%s"},"commit":{"oid":"%s"},"body":"%s"}]}}]}}}}}' "$1" "$2" "$3" "$4"; }
   # ag — mg_approval_gh 출력(APPROVED/빈값). 시나리오 SC_* 는 호출부 env-prefix 로 주입하되
   #   반드시 substitution 안에서 prefix 해야 ag 환경에 도달한다(밖에 두면 chk 에만 걸림).
   ag() { FORGE_CMD=mock_forge_gh mg_approval_gh "${1:-700}" 2>/dev/null | tr -d '[:space:]'; }
   local H="headSHA1"
   # 마커 경로 grep 은 login\tbody 줄에 앵커 정규식을 적용 → 비앵커 매치되는 courtesy-bot 사용.
   local MARK="courtesy-bot\t<!-- claude-formal-review head_sha=$H verdict=approve -->\n"
-  local BLK="github-actions[bot]\t$H\t**[blocking/98] 차단 지적** 본문\n"
-  local OK_C="github-actions[bot]\t$H\t**[non_blocking/85] 정보성** 본문\n"
+  local BLK; BLK="$(thr false "github-actions[bot]" "$H" "**[blocking/98] 차단 지적**")"
+  local OK_C; OK_C="$(thr false "github-actions[bot]" "$H" "**[non_blocking/85] 정보성**")"
 
-  # AC2: APPROVED 인데 현재 head 신뢰봇 [blocking] 인라인 → 승인 아님(차단).
+  # AC2: APPROVED 인데 현재 head 신뢰봇 미해결 [blocking] → 승인 아님(차단).
   chk "AC2 approved+head [blocking] → 차단(빈값)" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_COMMENTS="$BLK" ag)" ""
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$BLK" ag)" ""
   # AC1: blocking 없음 + APPROVED → APPROVED 통과.
   chk "AC1 approved+blocking없음 → APPROVED" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_COMMENTS="$OK_C" ag)" "APPROVED"
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$OK_C" ag)" "APPROVED"
+  # isResolved: resolve 된 스레드의 [blocking] → 차단 안 함(APPROVED) — resolve→재리뷰 데드락 방지.
+  chk "resolved 스레드 [blocking] → 차단 안 함(APPROVED)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$(thr true "github-actions[bot]" "$H" "**[blocking/98] 해결됨**")" ag)" "APPROVED"
   # AC3: 비신뢰 작성자 [blocking] + APPROVED → 차단 근거 아님(통과).
   chk "AC3 비신뢰봇 [blocking] → 차단 안 함(APPROVED)" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_COMMENTS="random-human\t$H\t**[blocking/98] 위조**\n" ag)" "APPROVED"
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$(thr false "random-human" "$H" "**[blocking/98] 위조**")" ag)" "APPROVED"
   # AC3: outdated(이전 head) [blocking] + APPROVED → 차단 근거 아님(통과).
   chk "AC3 outdated [blocking] → 차단 안 함(APPROVED)" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_COMMENTS="github-actions[bot]\toldSHA\t**[blocking/98] 이전**\n" ag)" "APPROVED"
-  # AC2: 강등 승인 마커(verdict=approve) + head [blocking] → 차단.
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$(thr false "github-actions[bot]" "oldSHA" "**[blocking/98] 이전**")" ag)" "APPROVED"
+  # AC2: 강등 승인 마커(verdict=approve) + head 미해결 [blocking] → 차단.
   chk "AC2 마커승인+head [blocking] → 차단(빈값)" \
-    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK" SC_COMMENTS="$BLK" ag)" ""
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK" SC_THREADS="$BLK" ag)" ""
   # 강등 승인 마커 + blocking 없음 → APPROVED.
   chk "마커승인+blocking없음 → APPROVED" \
-    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK" SC_COMMENTS="$OK_C" ag)" "APPROVED"
-  # AC5: 인라인 조회 실패 + APPROVED → default-deny(차단).
-  chk "AC5 인라인 조회 실패 → default-deny(차단)" \
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK" SC_THREADS="$OK_C" ag)" "APPROVED"
+  # AC5: 스레드 조회 실패 + APPROVED → default-deny(차단).
+  chk "AC5 스레드 조회 실패 → default-deny(차단)" \
     "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_API_FAIL=1 ag)" ""
   # AC5: head 미확정 + APPROVED → default-deny(차단).
   chk "AC5 head 미확정 → default-deny(차단)" \
-    "$(SC_DECISION=APPROVED SC_HEAD="" SC_COMMENTS="$OK_C" ag)" ""
+    "$(SC_DECISION=APPROVED SC_HEAD="" SC_THREADS="$OK_C" ag)" ""
   # AC5: 조회 실패 시 stderr 표면화(거짓 승인 금지).
   ( SC_DECISION=APPROVED SC_HEAD=$H SC_API_FAIL=1 FORGE_CMD=mock_forge_gh mg_approval_gh 708 ) \
     2>"$TMP/ag_err" >/dev/null

--- a/plugins/autopilot/skills/dispatch/references/review-loop.sh
+++ b/plugins/autopilot/skills/dispatch/references/review-loop.sh
@@ -51,6 +51,9 @@ set -uo pipefail
 
 REVIEW_ROUNDS_MAX="${REVIEW_ROUNDS_MAX:-3}"
 REVIEW_BOT_LOGIN_RE="${REVIEW_BOT_LOGIN_RE:-(\[bot\]$|claude|github-actions)}"
+# 차단성 인라인 태그(리터럴 부분문자열) — 리뷰 워크플로 본문 `**[<severity>/<conf>] title**` 형식
+# (.github/workflows/{codex,claude}-review.yml). `[blocking` 는 `[non_blocking` 미매치. 주입 가능.
+BLOCKING_TAG="${BLOCKING_TAG:-[blocking}"
 
 REVIEW_FETCH_CMD="${REVIEW_FETCH_CMD:-rl_review_fetch_gh}"
 REVIEW_PRODUCE_CMD="${REVIEW_PRODUCE_CMD:-rl_produce_review_skill}"
@@ -75,12 +78,29 @@ rl_review_fetch_gh() {
   if [[ -z "$approve" && -n "$head" ]] && gh pr view "$pr" --json reviews \
         --jq '.reviews[] | (.author.login // "") + "\t" + (.body // "")' 2>/dev/null \
        | grep -E "$REVIEW_BOT_LOGIN_RE" | grep -qE "head_sha=${head}[^>]*verdict=approve"; then approve=1; fi
-  # 현재 head 의 인라인 지적(타당성 판단은 워커가 change-adoption 으로 — 여기선 원천만 평탄화).
-  findings="$(gh api "repos/{owner}/{repo}/pulls/$pr/comments" \
-        --jq ".[] | select(.commit_id==\"$head\") | .body" 2>/dev/null \
+  # 현재 head 인라인 코멘트 1회 조회: login\tcommit_id\tbody(본문 개행·탭 공백화).
+  local comments crc blocking=""
+  comments="$(gh api "repos/{owner}/{repo}/pulls/$pr/comments" --paginate \
+        --jq '.[] | (.user.login // "")+"\t"+(.commit_id // "")+"\t"+((.body // "")|gsub("[\n\t]";" "))' 2>/dev/null)"
+  crc=$?
+  # 신뢰봇이 현재 head 에 남긴 [blocking] 인라인 — approve 를 가리는 가산 차단(PR #385).
+  #   조회 실패·head 미확정은 보수적 차단(default-deny). login 은 field1 단독에 정규식 적용.
+  if [[ $crc -ne 0 || -z "$head" ]]; then
+    blocking="FETCH_FAILED"
+  elif printf '%s\n' "$comments" \
+       | awk -F'\t' -v h="$head" -v tag="$BLOCKING_TAG" '$2==h && index($3,tag)>0 {print $1}' \
+       | grep -qE "$REVIEW_BOT_LOGIN_RE"; then
+    blocking=1
+  fi
+  # 현재 head 의 전체 인라인 지적(타당성 판단은 워커가 change-adoption 으로 — 여기선 원천만 평탄화).
+  findings="$(printf '%s\n' "$comments" | awk -F'\t' -v h="$head" '$2==h{print $3}' \
        | sed -E 's/<!--[^>]*-->//g' | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
-  if [[ -n "$approve" ]]; then
+  if [[ -n "$approve" && -z "$blocking" ]]; then
     echo "verdict: approve"
+  elif [[ "$blocking" == "FETCH_FAILED" ]]; then
+    # 인라인 조회 실패 → 거짓 승인 금지. changes 로 표면화(무진전 가드가 에스컬레이션 유도).
+    echo "verdict: changes"
+    echo "finding: [blocking] 인라인 조회 실패 — default-deny(보수적 차단), 확인 필요"
   elif [[ -n "$findings" ]]; then
     echo "verdict: changes"
     echo "finding: $findings"
@@ -601,6 +621,48 @@ rl_selftest() {
   prod_simple sha-DU unavailable > "$RV/$kDU.produce"
   MOCK_HEAD=sha-DU rl_round_direct "$rd" "$kDU" "$base" "feat/run1-du" >/dev/null; rc=$?
   chk "AC7 direct unavailable 에스컬레이션(rc=10)" "$rc" "10"
+
+  # =====================================================================
+  # AC4/AC5/AC6: rl_review_fetch_gh — 현재 head 신뢰봇 미해결 [blocking] 인라인이
+  #   approve 를 가린다(verdict=approve → changes). gh 를 시나리오 변수 mock 으로 치환.
+  #   SC_* 는 substitution 안에서 env-prefix 해야 함수 환경에 도달한다.
+  # =====================================================================
+  gh() {
+    case "$1 $2" in
+      "pr view")
+        case "$*" in
+          *"--json headRefOid"*)     printf '%s\n' "${SC_HEAD:-}" ;;
+          *"--json reviewDecision"*) printf '%s\n' "${SC_DECISION:-}" ;;
+          *"--json reviews"*)
+            case "$*" in
+              *'"\t"'*) printf '%b' "${SC_REVIEWS:-}" ;;                       # 마커 jq(login\tbody)
+              *)        printf '%b' "${SC_SUMMARY:-state: NONE\nauthor: \n}" ;; # state/author 요약
+            esac ;;
+        esac ;;
+      "api "*|api) [[ "${SC_API_FAIL:-}" == "1" ]] && return 1; printf '%b' "${SC_COMMENTS:-}" ;;
+    esac
+    return 0
+  }
+  rvg() { rl_review_fetch_gh "${1:-200}" 2>/dev/null | grep -i '^verdict:' | sed -E 's/^[^:]*:[[:space:]]*//'; }
+  local GH="sha-GH"
+  local GBLK="github-actions[bot]\t$GH\t**[blocking/98] 차단 지적** 상세\n"
+  local GOKC="github-actions[bot]\t$GH\t**[non_blocking/85] 정보성** 상세\n"
+
+  chk "AC4 approve+head [blocking] → changes" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_COMMENTS="$GBLK" rvg)" "changes"
+  chk "AC4 approve+blocking없음(정보성) → approve" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_COMMENTS="$GOKC" rvg)" "approve"
+  chk "AC4 비승인+head [blocking] → changes" \
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_COMMENTS="$GBLK" rvg)" "changes"
+  chk "AC3 outdated [blocking]+approve → approve(차단 안 함)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_COMMENTS="github-actions[bot]\toldSHA\t**[blocking/98] 이전**\n" rvg)" "approve"
+  chk "AC3 비신뢰봇 [blocking]+approve → approve(차단 안 함)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_COMMENTS="random-human\t$GH\t**[blocking/98] 위조**\n" rvg)" "approve"
+  chk "AC5 인라인 조회 실패 → changes(default-deny)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_API_FAIL=1 rvg)" "changes"
+  out="$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_API_FAIL=1 rl_review_fetch_gh 205 2>/dev/null)"
+  case "$out" in *조회\ 실패*|*default-deny*) ok "AC5 조회 실패 finding 표면화";; *) bad "AC5 조회 실패 finding 표면화";; esac
+  unset -f gh
 
   # ---- force 미사용 (mock_git force 보면 exit99; 여기 도달했으면 미사용) ----
   [[ -s "$PUSHLOG" ]] && ok "재작업 라운드 실제 push 수행" || bad "재작업 라운드 실제 push 수행"

--- a/plugins/autopilot/skills/dispatch/references/review-loop.sh
+++ b/plugins/autopilot/skills/dispatch/references/review-loop.sh
@@ -78,21 +78,41 @@ rl_review_fetch_gh() {
   if [[ -z "$approve" && -n "$head" ]] && gh pr view "$pr" --json reviews \
         --jq '.reviews[] | (.author.login // "") + "\t" + (.body // "")' 2>/dev/null \
        | grep -E "$REVIEW_BOT_LOGIN_RE" | grep -qE "head_sha=${head}[^>]*verdict=approve"; then approve=1; fi
-  # 현재 head 인라인 코멘트 1회 조회: login\tcommit_id\tbody(본문 개행·탭 공백화).
-  local comments crc blocking=""
-  comments="$(gh api "repos/{owner}/{repo}/pulls/$pr/comments" --paginate \
-        --jq '.[] | (.user.login // "")+"\t"+(.commit_id // "")+"\t"+((.body // "")|gsub("[\n\t]";" "))' 2>/dev/null)"
-  crc=$?
-  # 신뢰봇이 현재 head 에 남긴 [blocking] 인라인 — approve 를 가리는 가산 차단(PR #385).
-  #   조회 실패·head 미확정은 보수적 차단(default-deny). login 은 field1 단독에 정규식 적용.
-  if [[ $crc -ne 0 || -z "$head" ]]; then
+  # 현재 head 미해결(isResolved=false) 스레드의 인라인 코멘트만 조회(GraphQL): login\tcommit_oid\tbody.
+  #   resolve 된 스레드는 제외해 resolve→재리뷰 데드락을 막는다. raw JSON 을 jq 로 필터
+  #   (mock=raw 반환으로 isResolved 필터를 결정적 검증). 조회/owner 확정 실패·head 미확정은
+  #   보수적 차단(default-deny).
+  local on owner name raw comments crc=0 blocking=""
+  on="$(gh repo view --json owner,name --jq '.owner.login+" "+.name' 2>/dev/null)" || on=""
+  owner="${on%% *}"; name="${on##* }"
+  if [[ -z "$head" || -z "$owner" || -z "$name" ]]; then
+    crc=1
+  else
+    raw="$(gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr" -f query='
+query($owner:String!,$name:String!,$pr:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$pr){
+      reviewThreads(first:100){nodes{isResolved comments(first:50){nodes{author{login} commit{oid} body}}}}
+    }}}' 2>/dev/null)"
+    if [[ $? -ne 0 || -z "$raw" ]]; then
+      crc=1
+    else
+      comments="$(printf '%s' "$raw" | jq -r '
+            .data.repository.pullRequest.reviewThreads.nodes[]
+            | select(.isResolved==false)
+            | .comments.nodes[]
+            | (.author.login // "")+"\t"+(.commit.oid // "")+"\t"+((.body // "")|gsub("[\n\t]";" "))' 2>/dev/null)" || crc=1
+    fi
+  fi
+  # 신뢰봇이 현재 head 에 남긴 미해결 [blocking] 인라인 — approve 를 가리는 가산 차단(PR #385).
+  if [[ $crc -ne 0 ]]; then
     blocking="FETCH_FAILED"
   elif printf '%s\n' "$comments" \
        | awk -F'\t' -v h="$head" -v tag="$BLOCKING_TAG" '$2==h && index($3,tag)>0 {print $1}' \
        | grep -qE "$REVIEW_BOT_LOGIN_RE"; then
     blocking=1
   fi
-  # 현재 head 의 전체 인라인 지적(타당성 판단은 워커가 change-adoption 으로 — 여기선 원천만 평탄화).
+  # 현재 head 미해결 스레드의 전체 인라인 지적(타당성 판단은 워커가 change-adoption 으로 — 원천만 평탄화).
   findings="$(printf '%s\n' "$comments" | awk -F'\t' -v h="$head" '$2==h{print $3}' \
        | sed -E 's/<!--[^>]*-->//g' | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
   if [[ -n "$approve" && -z "$blocking" ]]; then
@@ -639,25 +659,30 @@ rl_selftest() {
               *)        printf '%b' "${SC_SUMMARY:-state: NONE\nauthor: \n}" ;; # state/author 요약
             esac ;;
         esac ;;
-      "api "*|api) [[ "${SC_API_FAIL:-}" == "1" ]] && return 1; printf '%b' "${SC_COMMENTS:-}" ;;
+      "repo view") printf '%s %s\n' "${SC_OWNER:-o}" "${SC_NAME:-n}" ;;
+      "api graphql"|"api "*|api) [[ "${SC_API_FAIL:-}" == "1" ]] && return 1; printf '%s' "${SC_THREADS:-}" ;;
     esac
     return 0
   }
+  # thr <isResolved> <login> <oid> <body> — 단일 리뷰 스레드 raw GraphQL JSON 빌더.
+  thr() { printf '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":%s,"comments":{"nodes":[{"author":{"login":"%s"},"commit":{"oid":"%s"},"body":"%s"}]}}]}}}}}' "$1" "$2" "$3" "$4"; }
   rvg() { rl_review_fetch_gh "${1:-200}" 2>/dev/null | grep -i '^verdict:' | sed -E 's/^[^:]*:[[:space:]]*//'; }
   local GH="sha-GH"
-  local GBLK="github-actions[bot]\t$GH\t**[blocking/98] 차단 지적** 상세\n"
-  local GOKC="github-actions[bot]\t$GH\t**[non_blocking/85] 정보성** 상세\n"
+  local GBLK; GBLK="$(thr false "github-actions[bot]" "$GH" "**[blocking/98] 차단 지적**")"
+  local GOKC; GOKC="$(thr false "github-actions[bot]" "$GH" "**[non_blocking/85] 정보성**")"
 
   chk "AC4 approve+head [blocking] → changes" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_COMMENTS="$GBLK" rvg)" "changes"
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$GBLK" rvg)" "changes"
   chk "AC4 approve+blocking없음(정보성) → approve" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_COMMENTS="$GOKC" rvg)" "approve"
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$GOKC" rvg)" "approve"
   chk "AC4 비승인+head [blocking] → changes" \
-    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_COMMENTS="$GBLK" rvg)" "changes"
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_THREADS="$GBLK" rvg)" "changes"
+  chk "resolved 스레드 [blocking]+approve → approve(차단 안 함)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$(thr true "github-actions[bot]" "$GH" "**[blocking/98] 해결됨**")" rvg)" "approve"
   chk "AC3 outdated [blocking]+approve → approve(차단 안 함)" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_COMMENTS="github-actions[bot]\toldSHA\t**[blocking/98] 이전**\n" rvg)" "approve"
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$(thr false "github-actions[bot]" "oldSHA" "**[blocking/98] 이전**")" rvg)" "approve"
   chk "AC3 비신뢰봇 [blocking]+approve → approve(차단 안 함)" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_COMMENTS="random-human\t$GH\t**[blocking/98] 위조**\n" rvg)" "approve"
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$(thr false "random-human" "$GH" "**[blocking/98] 위조**")" rvg)" "approve"
   chk "AC5 인라인 조회 실패 → changes(default-deny)" \
     "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_API_FAIL=1 rvg)" "changes"
   out="$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_API_FAIL=1 rl_review_fetch_gh 205 2>/dev/null)"

--- a/plugins/autopilot/skills/dispatch/references/review-loop.sh
+++ b/plugins/autopilot/skills/dispatch/references/review-loop.sh
@@ -88,11 +88,17 @@ rl_review_fetch_gh() {
   if [[ -z "$head" || -z "$owner" || -z "$name" ]]; then
     crc=1
   else
-    raw="$(gh api graphql -F owner="$owner" -F name="$name" -F pr="$pr" -f query='
-query($owner:String!,$name:String!,$pr:Int!){
+    # 모든 reviewThreads 페이지를 --paginate(pageInfo+after:$endCursor)로 따라간다(100개 초과
+    #   스레드 누락 방지). comments first:100(단일 스레드 100개 초과는 비현실적). gh 는 페이지별
+    #   JSON 을 연결 출력하고 아래 jq 가 스트림 전체를 처리한다.
+    raw="$(gh api graphql --paginate -F owner="$owner" -F name="$name" -F pr="$pr" -f query='
+query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
   repository(owner:$owner,name:$name){
     pullRequest(number:$pr){
-      reviewThreads(first:100){nodes{isResolved comments(first:50){nodes{author{login} commit{oid} body}}}}
+      reviewThreads(first:100, after:$endCursor){
+        pageInfo{hasNextPage endCursor}
+        nodes{isResolved comments(first:100){nodes{author{login} commit{oid} body}}}
+      }
     }}}' 2>/dev/null)"
     if [[ $? -ne 0 || -z "$raw" ]]; then
       crc=1
@@ -679,6 +685,8 @@ rl_selftest() {
     "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_THREADS="$GBLK" rvg)" "changes"
   chk "resolved 스레드 [blocking]+approve → approve(차단 안 함)" \
     "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$(thr true "github-actions[bot]" "$GH" "**[blocking/98] 해결됨**")" rvg)" "approve"
+  chk "pagination: 2페이지의 [blocking]+approve → changes" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$(thr false "github-actions[bot]" "$GH" "**[non_blocking/80] 1p**")$(thr false "github-actions[bot]" "$GH" "**[blocking/98] 2p**")" rvg)" "changes"
   chk "AC3 outdated [blocking]+approve → approve(차단 안 함)" \
     "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$(thr false "github-actions[bot]" "oldSHA" "**[blocking/98] 이전**")" rvg)" "approve"
   chk "AC3 비신뢰봇 [blocking]+approve → approve(차단 안 함)" \


### PR DESCRIPTION
🤖 이 PR 은 dispatch 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

SPEC: /workspace/claude-plugins/.claude/worktrees/autopilot-repair-skill-spec/docs/specs/2026-06-14-merge-gate-blocking-inline/SPEC.md
dispatch-run: 20260614T015944-f5ccfa4

## 요약


dispatch 의 머지 승인 게이트(`merge.sh` 의 승인 판정)와 리뷰 판정(`review-loop.sh` 의 verdict)이, 현재 head 에 **신뢰 봇이 남긴 미해결 `[blocking]` 인라인 리뷰 지적**이 있으면 승인으로 보지 않고 **머지를 차단**하도록 강화한다. 지금은 `reviewDecision==APPROVED`(또는 현재 head 의 `verdict=approve` 마커)만 보고, 한 리뷰어가 `[blocking]` 인라인을 남기되 formal verdict 를 `comment` 로 둔 경우를 통과시키는 갭이 있다.
