### PR TITLE
🤖 [자동 리뷰] codex 리뷰가 현재 코드와 모순되는 stale [blocking] finding 을 재게시하는 문제

### DIFF
--- a/.github/scripts/pr-review-supersede.js
+++ b/.github/scripts/pr-review-supersede.js
@@ -1,0 +1,82 @@
+'use strict';
+
+// Deterministic supersede-resolve for the codex PR review workflow.
+//
+// Problem this guards against: the review model can re-emit a finding with the
+// SAME deterministic fingerprint on a new head (e.g. it re-flags an already
+// fixed hunk surfaced by the incremental diff). The workflow then posts a fresh
+// inline thread for that fingerprint while the PREVIOUS run's open thread for
+// the same fingerprint stays open — open threads pile up two-per-fingerprint,
+// and a stale (current-code-contradicting) [blocking] thread can keep the
+// auto-merge gate falsely blocked forever.
+//
+// Rule (additive to the existing resolved_threads/fallback resolve tiers — it
+// does NOT weaken them): whenever a fingerprint is NEWLY posted this round and
+// more than one open self thread carries that fingerprint, keep only the newest
+// open thread and mark the older one(s) to be resolved (superseded). At most one
+// open thread (the newest) survives per posted fingerprint.
+//
+// This is resolve-only: the function returns thread ids to resolve and NEVER a
+// suppression signal — the new finding is always posted (no false-green). It is
+// scoped strictly to fingerprints posted this round, so it never touches a
+// finding that wasn't re-reported (those are handled by the existing fallback
+// tier) and never touches another reviewer's or a different fingerprint's
+// thread.
+//
+// CommonJS, pure function, no I/O or network: it operates only on the
+// fingerprints the workflow posted and the open self threads it already
+// fetched.
+
+// Resolve order key for a thread. A larger key means newer. Threads are created
+// in id/databaseId-monotonic order, so the freshly posted thread (this round)
+// has the largest key and is the one kept. When `order` is absent or not a
+// finite number, fall back to the thread's position in the input array (passed
+// as `idx`) so ties are still deterministic and the later-listed thread is
+// treated as newer.
+function orderOf(thread, idx) {
+  const o = thread && thread.order;
+  return (typeof o === 'number' && Number.isFinite(o)) ? o : idx;
+}
+
+// selectSupersededThreads({ postedFingerprints, openThreads }) -> string[]
+//   postedFingerprints: iterable (Array | Set) of fingerprints newly posted
+//                       this round. Empty when nothing was posted (skipped /
+//                       failed submit) — then nothing is ever superseded.
+//   openThreads: [{ id, fingerprint, order? }] for currently-open self-owned
+//                threads. Already-resolved threads must NOT be included by the
+//                caller; threads without a fingerprint are ignored here.
+// Returns the ids of older duplicate threads to resolve (newest kept).
+function selectSupersededThreads(input) {
+  const arg = input || {};
+  const posted = arg.postedFingerprints instanceof Set
+    ? arg.postedFingerprints
+    : new Set(Array.isArray(arg.postedFingerprints) ? arg.postedFingerprints : []);
+  const openThreads = Array.isArray(arg.openThreads) ? arg.openThreads : [];
+
+  if (posted.size === 0) return [];
+
+  // Group open threads (with a fingerprint that was posted this round) by
+  // fingerprint, preserving each thread's input index for tie-breaking.
+  const groups = new Map();
+  openThreads.forEach((t, idx) => {
+    if (!t || typeof t.fingerprint !== 'string' || t.fingerprint.length === 0) return;
+    if (!posted.has(t.fingerprint)) return;
+    if (!groups.has(t.fingerprint)) groups.set(t.fingerprint, []);
+    groups.get(t.fingerprint).push({ id: t.id, key: orderOf(t, idx) });
+  });
+
+  const superseded = [];
+  for (const group of groups.values()) {
+    if (group.length <= 1) continue; // only the newest exists — nothing to do
+    // Keep the single newest (largest key); resolve every other.
+    let newestIdx = 0;
+    for (let i = 1; i < group.length; i += 1) {
+      // `>=` so a later-in-array tie wins (treated as newer).
+      if (group[i].key >= group[newestIdx].key) newestIdx = i;
+    }
+    group.forEach((g, i) => { if (i !== newestIdx) superseded.push(g.id); });
+  }
+  return superseded;
+}
+
+module.exports = { selectSupersededThreads };

--- a/.github/scripts/pr-review-supersede.test.js
+++ b/.github/scripts/pr-review-supersede.test.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+'use strict';
+
+// Unit test for the deterministic supersede-resolve module used by the codex
+// PR review workflow to prevent stale [blocking] finding accumulation.
+//
+// Background: when the review model re-emits a finding with the SAME
+// fingerprint on a new head, the workflow posts a fresh inline thread while the
+// previous run's open thread for that fingerprint stays open — two open threads
+// per fingerprint pile up, and a stale/contradicted [blocking] thread can keep
+// the auto-merge gate falsely blocked. The supersede rule resolves the OLDER
+// duplicate(s) so at most one open thread (the newest) survives per fingerprint
+// that was newly posted this round. It NEVER suppresses posting (resolve-only).
+//
+// Static, hermetic: no GitHub, npm, or model calls. Pure function over the
+// fingerprints posted this round and the currently-open self threads.
+
+const assert = require('node:assert');
+const path = require('node:path');
+
+const M = require(path.join(__dirname, 'pr-review-supersede.js'));
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed += 1;
+  console.log(`OK: ${name}`);
+}
+
+// ---- contract: only resolve-only output (array of thread ids) ----
+
+test('exports selectSupersededThreads', () => {
+  assert.strictEqual(typeof M.selectSupersededThreads, 'function');
+});
+
+test('returns an array (resolve-only contract — never a suppression signal)', () => {
+  const out = M.selectSupersededThreads({ postedFingerprints: [], openThreads: [] });
+  assert.ok(Array.isArray(out));
+  assert.strictEqual(out.length, 0);
+});
+
+// ---- core: same fingerprint, an older open thread is superseded ----
+
+test('same fingerprint existing open thread → older resolved, newest kept', () => {
+  // old thread (order 10) from a prior head + new thread (order 20) just posted.
+  const out = M.selectSupersededThreads({
+    postedFingerprints: ['fpA'],
+    openThreads: [
+      { id: 'OLD', fingerprint: 'fpA', order: 10 },
+      { id: 'NEW', fingerprint: 'fpA', order: 20 },
+    ],
+  });
+  assert.deepStrictEqual(out, ['OLD']);
+});
+
+test('accepts postedFingerprints as a Set', () => {
+  const out = M.selectSupersededThreads({
+    postedFingerprints: new Set(['fpA']),
+    openThreads: [
+      { id: 'OLD', fingerprint: 'fpA', order: 10 },
+      { id: 'NEW', fingerprint: 'fpA', order: 20 },
+    ],
+  });
+  assert.deepStrictEqual(out, ['OLD']);
+});
+
+// ---- multiple older duplicates: keep only newest ----
+
+test('multiple older duplicates of a posted fingerprint → all but newest resolved', () => {
+  const out = M.selectSupersededThreads({
+    postedFingerprints: ['fpA'],
+    openThreads: [
+      { id: 'T1', fingerprint: 'fpA', order: 1 },
+      { id: 'T2', fingerprint: 'fpA', order: 2 },
+      { id: 'T3', fingerprint: 'fpA', order: 3 },
+    ],
+  });
+  assert.deepStrictEqual(out.sort(), ['T1', 'T2']);
+});
+
+// ---- safety: do not touch fingerprints NOT posted this round ----
+
+test('fingerprint not posted this round → untouched even if duplicated', () => {
+  const out = M.selectSupersededThreads({
+    postedFingerprints: ['fpA'],
+    openThreads: [
+      { id: 'B1', fingerprint: 'fpB', order: 1 },
+      { id: 'B2', fingerprint: 'fpB', order: 2 },
+    ],
+  });
+  assert.deepStrictEqual(out, []);
+});
+
+// ---- safety: a single open thread for a posted fingerprint is the newest → keep ----
+
+test('single open thread for a posted fingerprint → nothing to supersede', () => {
+  const out = M.selectSupersededThreads({
+    postedFingerprints: ['fpA'],
+    openThreads: [{ id: 'ONLY', fingerprint: 'fpA', order: 5 }],
+  });
+  assert.deepStrictEqual(out, []);
+});
+
+// ---- safety: nothing posted this round (suppressed/skipped) → nothing touched ----
+
+test('empty postedFingerprints (no new post) → never resolves anything', () => {
+  const out = M.selectSupersededThreads({
+    postedFingerprints: [],
+    openThreads: [
+      { id: 'OLD', fingerprint: 'fpA', order: 10 },
+      { id: 'NEWER', fingerprint: 'fpA', order: 20 },
+    ],
+  });
+  assert.deepStrictEqual(out, []);
+});
+
+// ---- mixed: only the posted fingerprint's older dup is resolved ----
+
+test('mixed fingerprints → only posted-fp older dup resolved, others untouched', () => {
+  const out = M.selectSupersededThreads({
+    postedFingerprints: ['fpA'],
+    openThreads: [
+      { id: 'A_OLD', fingerprint: 'fpA', order: 1 },
+      { id: 'A_NEW', fingerprint: 'fpA', order: 9 },
+      { id: 'B_OLD', fingerprint: 'fpB', order: 2 },
+      { id: 'B_NEW', fingerprint: 'fpB', order: 8 },
+    ],
+  });
+  assert.deepStrictEqual(out, ['A_OLD']);
+});
+
+// ---- robustness: threads with no fingerprint are ignored ----
+
+test('threads missing a fingerprint are ignored', () => {
+  const out = M.selectSupersededThreads({
+    postedFingerprints: ['fpA'],
+    openThreads: [
+      { id: 'NOFP', order: 1 },
+      { id: 'A_OLD', fingerprint: 'fpA', order: 2 },
+      { id: 'A_NEW', fingerprint: 'fpA', order: 3 },
+    ],
+  });
+  assert.deepStrictEqual(out, ['A_OLD']);
+});
+
+// ---- robustness: tie/missing order is deterministic (array order breaks ties,
+//      later-in-array treated as newer) ----
+
+test('equal/missing order falls back to array position (later = newer)', () => {
+  const out = M.selectSupersededThreads({
+    postedFingerprints: ['fpA'],
+    openThreads: [
+      { id: 'FIRST', fingerprint: 'fpA' },
+      { id: 'SECOND', fingerprint: 'fpA' },
+    ],
+  });
+  // SECOND appears later → treated as newest → FIRST superseded.
+  assert.deepStrictEqual(out, ['FIRST']);
+});
+
+// ---- robustness: empty/garbage input never throws ----
+
+test('garbage/empty input is handled without throwing', () => {
+  assert.deepStrictEqual(M.selectSupersededThreads({}), []);
+  assert.deepStrictEqual(M.selectSupersededThreads({ postedFingerprints: null, openThreads: null }), []);
+  assert.deepStrictEqual(M.selectSupersededThreads(), []);
+});
+
+console.log(`\nALL ${passed} CHECKS PASSED`);

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1015,6 +1015,26 @@ jobs:
             // (workflow-computed, not model-supplied) — the fallback tier resolves
             // any self thread whose fingerprint is absent from this set.
             const findingFingerprints = new Set(findings.map((f) => computeFingerprint(f)));
+            // Supersede tier — fingerprints we ACTUALLY posted as inline comments
+            // this round. Only populated when a submission really happened
+            // (submitOk): if the submit was skipped as a duplicate or failed, no
+            // new thread was created, so nothing should be superseded. When the
+            // model re-emits a finding with the same fingerprint on a new head,
+            // the fresh thread we just posted plus the prior run's open thread
+            // both carry that fingerprint; the supersede module keeps only the
+            // newest open thread per posted fingerprint and resolves the older
+            // duplicate(s) so stale [blocking] threads don't pile up. This is
+            // resolve-only (the finding is always posted) and additive to the
+            // resolved_threads/fallback tiers above — never weakening them.
+            const postedThisRound = submitOk
+              ? new Set(inlineFindings.map((f) => computeFingerprint(f)))
+              : new Set();
+            let selectSupersededThreads = () => [];
+            try {
+              ({ selectSupersededThreads } = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/pr-review-supersede.js`));
+            } catch (e) {
+              core.warning(`Supersede module unavailable (${e.message}); skipping supersede tier (resolved_threads/fallback still apply).`);
+            }
             try {
               const threadResp = await github.graphql(`
                 query($owner:String!, $repo:String!, $pr:Int!) {
@@ -1025,7 +1045,7 @@ jobs:
                           id
                           isResolved
                           comments(first: 1) {
-                            nodes { author { login } body }
+                            nodes { databaseId author { login } body }
                           }
                         }
                       }
@@ -1038,6 +1058,32 @@ jobs:
               // accept both forms.
               const botLoginGql = botLogin.replace(/\[bot\]$/, '');
               const fpRe = /<!-- codex-review-inline fingerprint=([^\s]+) -->/;
+              // Identify a thread's fingerprint iff it is an open self-owned codex
+              // inline thread carrying our marker; null otherwise.
+              const selfThreadFp = (t) => {
+                if (!t || t.isResolved) return null;
+                const author = t.comments?.nodes?.[0]?.author?.login;
+                if (author !== botLogin && author !== botLoginGql) return null;
+                const cbody = t.comments?.nodes?.[0]?.body || '';
+                if (!cbody.includes(inlineMarkerBase)) return null;
+                const m = cbody.match(fpRe);
+                return (m && m[1]) || null;
+              };
+              // Supersede pre-pass: among open self threads whose fingerprint was
+              // posted this round, keep only the newest (largest first-comment
+              // databaseId) and resolve older duplicates. Computed over the full
+              // thread set so the freshly posted thread is correctly identified as
+              // newest. ids → resolved via the bySupersede reason in the loop.
+              const openThreads = threads
+                .map((t) => ({ t, fp: selfThreadFp(t) }))
+                .filter((x) => x.fp)
+                .map((x) => ({
+                  id: x.t.id,
+                  fingerprint: x.fp,
+                  order: x.t.comments?.nodes?.[0]?.databaseId,
+                }));
+              const supersededIds = new Set(
+                selectSupersededThreads({ postedFingerprints: postedThisRound, openThreads }));
               for (const t of threads) {
                 if (t.isResolved) continue;
                 const author = t.comments?.nodes?.[0]?.author?.login;
@@ -1049,7 +1095,12 @@ jobs:
                 if (!fp) continue; // legacy/markerless thread — leave untouched
                 const byModel = resolvedFingerprints.has(fp);
                 const byFallback = !byModel && !findingFingerprints.has(fp);
-                if (!byModel && !byFallback) continue; // still reported — leave
+                // Supersede: this is an OLDER duplicate of a fingerprint we just
+                // re-posted (a newer open thread for it survives). Resolve it so
+                // stale [blocking] threads don't accumulate. The finding itself
+                // stays posted in the newest thread (no suppression).
+                const bySupersede = supersededIds.has(t.id);
+                if (!byModel && !byFallback && !bySupersede) continue; // still reported — leave
                 try {
                   await github.graphql(`
                     mutation($id:ID!) {
@@ -1057,7 +1108,8 @@ jobs:
                         thread { id isResolved }
                       }
                     }`, { id: t.id });
-                  core.info(`Resolved self inline thread ${t.id} (fingerprint=${fp}, via=${byModel ? 'resolved_threads' : 'fallback'}).`);
+                  const via = byModel ? 'resolved_threads' : (byFallback ? 'fallback' : 'supersede');
+                  core.info(`Resolved self inline thread ${t.id} (fingerprint=${fp}, via=${via}).`);
                 } catch (e) {
                   core.warning(`Failed to resolve thread ${t.id}: ${e.message}`);
                 }


### PR DESCRIPTION
🤖 이 PR 은 dispatch 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

SPEC: /workspace/claude-plugins/.claude/worktrees/autopilot-repair-skill-spec/docs/specs/2026-06-14-codex-stale-finding-repost/SPEC.md
dispatch-run: 20260614T060132-0549e31

## 요약


codex 리뷰 워크플로가 **현재 head 의 코드와 사실이 맞지 않는(이미 해결된) finding 을 다시 `[blocking]` 으로 게시하지 않도록** 한다. finding 의 근거가 현재 head 코드와 모순되면(예: "페이지네이션 안 함"이라고 하는데 현재 코드엔 `--paginate` 가 있음) 그 finding 은 차단성으로 표면화되지 않아야 한다 — 자동 머지 게이트가 거짓 차단(false block)으로 영구 정체되지 않게.

이 변경은 codex 리뷰의 **finding 산출·재게시 단계**(워크플로 `merge` job 의 fingerprint dedup·incremental-base·게시 로직)에 한정한다. 리뷰 LLM 자체의 판단 품질을 보장하진 않되, **현재 head 코드와 교차 검증되지 않은 stale 재게시**를 억제하는 가드를 둔다.
