### PR TITLE
🤖 [자동 리뷰] rubric-fix-review-rule-creator

### DIFF
--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",

--- a/plugins/project-init/skills/review-rule-creator/README.md
+++ b/plugins/project-init/skills/review-rule-creator/README.md
@@ -1,0 +1,9 @@
+# review-rule-creator
+
+프로젝트의 리뷰 지침을 리뷰 카테고리 디렉터리 아래 두 sub-룰 파일(`rules/review/principles.md`·`rules/review/change-adoption.md`)로 생성·갱신하는 스킬.
+
+- **무엇** — 공통 리뷰 원칙(principles)과 거기서 나온 지적의 반영 판단(change-adoption)을 설계된 페어로 함께 기록.
+- **언제** — project-init 초기화 흐름 중 호출되거나, 사용자가 리뷰 지침을 새로 만들고 싶을 때.
+- **호출** — `Skill(skill="project-init:review-rule-creator")`.
+
+페어로 함께 기록하는 이유·템플릿 레이아웃·생성 절차·확인 게이트 등 동작 명세는 단일 출처인 [`SKILL.md`](./SKILL.md)를 참조한다.

--- a/plugins/project-init/skills/review-rule-creator/SKILL.md
+++ b/plugins/project-init/skills/review-rule-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-rule-creator
-description: 현재 프로젝트에 맞는 리뷰 지침을 리뷰 카테고리 디렉터리 아래 두 sub-룰 파일(`rules/review/principles.md`·`rules/review/change-adoption.md`)로 생성하거나 갱신할 때 활성화됩니다. project-init 초기화 흐름 중 호출되거나, 사용자가 리뷰 지침을 새로 만들고 싶어 할 때.
+description: 현재 프로젝트에 맞는 리뷰 지침(review rule·코드 리뷰 규칙)을 리뷰 카테고리 디렉터리 아래 두 sub-룰 파일(`rules/review/principles.md`·`rules/review/change-adoption.md`)로 생성하거나 갱신할 때 활성화됩니다. project-init 초기화 흐름 중 호출되거나, 사용자가 리뷰 지침·코드 리뷰 원칙을 새로 만들고 싶어 할 때 — "리뷰 지침 생성", "코드 리뷰 규칙 만들어줘", "PR 리뷰 원칙 세팅", "change adoption·변경 반영 판단 지침 작성", "principles·change-adoption sub-룰 파일 작성" 같은 표현을 포함합니다.
 allowed-tools:
   - AskUserQuestion
   - Read


### PR DESCRIPTION
🤖 이 PR 은 dispatch 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

SPEC: /workspace/claude-plugins/.claude/worktrees/rubric-fix-specs/docs/specs/2026-06-14-rubric-fix-review-rule-creator/SPEC.md
dispatch-run: 20260614T055709-25a638d

## 요약

`plugins/project-init/skills/review-rule-creator` 스킬의 루브릭 지적 2건(S-README, T-KEYWORDS)을 해소한다.

- S-README: 스킬 폴더에 사람 대상 `README.md`를 신규 생성한다. 내용은 스킬 정체·언제 활성화되는지·호출 방법을 계약·포인터 수준으로 담되, `SKILL.md` 본문 내용을 복제하지 않는다.
- T-KEYWORDS: `SKILL.md` frontmatter의 `description` 필드에 사용자가 실제로 쓸 자연어 동의어·키워드를 보강한다. 트리거 매칭 표면을 넓히는 것이며, WHAT/WHEN 구조와 스킬 동작 기술은 불변이다.
