### PR TITLE
🤖 [자동 리뷰] rubric-fix-workspace-rule-creator

### DIFF
--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",

--- a/plugins/project-init/.codex-plugin/plugin.json
+++ b/plugins/project-init/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",

--- a/plugins/project-init/skills/workspace-rule-creator/README.md
+++ b/plugins/project-init/skills/workspace-rule-creator/README.md
@@ -1,0 +1,31 @@
+# workspace-rule-creator
+
+작업공간 위생 카테고리의 sub-룰 디스패처 스킬. 호출마다 `templates/` 의 한 템플릿을
+`rules/workspace/<sub>.md` 한 파일로 생성·갱신한다.
+
+## 무엇 (What)
+
+- 입력: `templates/*.md` (옵션·입력·사후 작업을 frontmatter로 선언한 sub-룰 템플릿).
+- 출력: `rules/workspace/<sub>.md` 단일 파일 (`<sub>` = 템플릿 파일명 − 확장자).
+- 공개 계약: 한 번의 호출 = 한 sub-룰. 기존 파일은 사용자 명시 동의 없이 덮어쓰지 않는다.
+
+## 언제 (When)
+
+project-init 초기화 흐름에서 작업공간 위생 카테고리 지침을 만들 때, 또는 사용자가
+임시 파일·빌드 산출물·스크래치 데이터 등 작업공간 위생(workspace hygiene) sub-룰을
+새로 작성·갱신하려 할 때. (정확한 트리거 표현은 `SKILL.md` frontmatter `description`.)
+
+## 어떻게 호출 (How)
+
+Claude 스킬로 활성화된다 — 자연어 트리거가 `description` 과 매칭되면 실행된다.
+절차·입력 파싱·치환 규칙의 단일 출처는 `SKILL.md` 본문이며, 결정적 작업은
+`references/` 스크립트로 고정되어 있다.
+
+## 포인터
+
+- 절차·옵션·입력·사후 작업 규칙: [`SKILL.md`](./SKILL.md)
+- 결정적 작업 스크립트: [`references/`](./references/)
+  - `scan_templates.py` — 템플릿 frontmatter 파싱 → 정규화 후보 JSON.
+  - `normalize_path.py` — temp_path 입력값 후행 `/` 정규화 + 빈 값 기본값 적용.
+  - `render_rule.py` — frontmatter 제거 + placeholder 치환 + temp_path 기본값 처리.
+- sub-룰 템플릿: [`templates/`](./templates/)

--- a/plugins/project-init/skills/workspace-rule-creator/SKILL.md
+++ b/plugins/project-init/skills/workspace-rule-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-rule-creator
-description: 현재 프로젝트에 맞는 작업공간 위생 sub-룰(임시 파일 등)을 `rules/workspace/<sub>.md`로 생성하거나 갱신할 때 활성화됩니다. project-init 초기화 흐름 중 호출되거나, 사용자가 작업공간 위생 sub-룰 지침을 새로 만들고 싶어 할 때.
+description: 현재 프로젝트에 맞는 작업공간 위생 sub-룰(workspace hygiene rule — 임시 파일·temp 관리·빌드 산출물·스크래치 데이터·clean 정책 등)을 `rules/workspace/<sub>.md`로 생성하거나 갱신할 때 활성화됩니다. project-init 초기화 흐름 중 호출되거나, 사용자가 작업공간 위생 sub-룰 지침을 새로 만들고 싶어 할 때 — "임시 파일 정리 규칙 만들어줘", "temp 관리 지침 세팅", "workspace 위생 규칙", "스크래치 파일 정책 정해줘", "clean 규칙 만들기" 같은 표현을 포함합니다.
 allowed-tools:
   - AskUserQuestion
   - Read
@@ -10,6 +10,7 @@ allowed-tools:
   - Bash(mkdir -p:*)
   - Bash(diff:*)
   - Bash(git diff:*)
+  - Bash(python3:*)
 ---
 
 # workspace-rule-creator
@@ -26,7 +27,7 @@ allowed-tools:
 
 1. **템플릿 열거.** 이 파일 옆 `templates/*.md`만 읽습니다. 다른 경로를 탐색하지 않습니다. 파일명에서 확장자를 뺀 값이 sub-룰 ID입니다.
 
-2. **frontmatter 파싱.**
+2. **frontmatter 파싱.** 1단계의 열거와 이 파싱은 결정적 작업이므로 `references/scan_templates.py <skill_dir>`로 고정합니다 — 손으로 재현하지 말고 이 스크립트를 실행해 정규화된 후보 JSON(`candidates`/`skipped`)을 받습니다. 각 후보는 아래 필드로 구성됩니다.
    - `label` 필수, 옵션 라벨입니다.
    - `description` 선택, 옵션 설명입니다.
    - `recommended: true` 선택, 라벨에 `(Recommended)`를 붙이고 맨 앞으로 둡니다. 하나만 허용합니다.
@@ -39,11 +40,11 @@ allowed-tools:
 3. **선택.** 후보가 하나면 자동 선택하고, 둘 이상이면 `AskUserQuestion` single-select로 묻습니다.
 
 4. **정적 입력.** `inputs`가 있으면 정의된 순서대로 입력 메뉴를 **먼저 제시**합니다. 메뉴 제시와 기본값 적용은 별개 단계이며, 질문을 건너뛰고 곧바로 기본값·placeholder로 진행하지 않습니다.
-   - **메뉴 제시(항상).** 각 입력은 `AskUserQuestion`으로 묻습니다. 템플릿의 `options`(추천 옵션은 `(Recommended)`를 붙여 맨 앞)와 함께 임의 경로를 직접 적을 수 있는 자유 입력 "Other"를 포함합니다. 예로 `temp-files`의 `temp_path`는 추천 `.tmp/`를 첫 선택지로, `.scratch/`, 자유 입력 "Other"를 반드시 제시합니다.
+   - **메뉴 제시(항상).** 각 입력은 `AskUserQuestion`으로 묻습니다. 템플릿의 `options`(추천 옵션은 `(Recommended)`를 붙여 맨 앞)와 함께 임의 경로를 직접 적을 수 있는 자유 입력 "Other"를 포함합니다. 예로 `temp-files`의 `temp_path` 입력은 추천 `.tmp/`를 첫 선택지로, `.scratch/`, 자유 입력 "Other"를 반드시 제시합니다.
    - **값 사용.** 응답은 `value` 또는 `label`을 사용하고, 비어 있지 않은 "Other"(임의 경로 직접 입력 포함)도 허용합니다.
-   - **기본값·placeholder 적용(무응답·거절에 한해).** 사용자가 제시된 질문에 응답을 비우거나 거절한 **경우에만** 치환합니다 — 질문을 제시하지 않고 기본값을 적용하지 않습니다. 일반 입력은 응답 누락·빈 값이면 `{{name}}`을 보존하고, `temp-files`의 `temp_path`는 응답 누락·빈 값이면 placeholder 대신 기본값 `.tmp/`로 치환합니다.
-   - **비대화 맥락.** 질문을 제시할 수 없는 비대화(자율 오케스트레이션) 맥락이면, 그 사실을 알리고 무응답과 동일하게 기본값 `.tmp/`(일반 입력은 `{{name}}` 보존)로 진행합니다.
-   - **경로 정규화.** `temp_path` 입력값("Other" 자유 입력 포함)은 치환 전에 항상 **후행 `/`로 끝나도록 정규화**합니다(예: `.scratch` → `.scratch/`). 이래야 본문의 `{{temp_path}}<주제>/`·`{{temp_path}}.gitkeep`이 선택한 디렉터리의 하위 경로로 바르게 결합됩니다.
+   - **기본값·placeholder 적용(무응답·거절에 한해).** 사용자가 제시된 질문에 응답을 비우거나 거절한 **경우에만** 치환합니다 — 질문을 제시하지 않고 기본값을 적용하지 않습니다. (템플릿 본문은 이중 중괄호 표기의 placeholder 토큰을 사용하며, 이 SKILL.md 본문에서는 그 토큰을 중괄호 없이 이름으로 — 예: `name` placeholder — 지칭합니다.) 일반 입력은 응답 누락·빈 값이면 해당 `name` placeholder를 보존하고, `temp-files`의 `temp_path`는 응답 누락·빈 값이면 placeholder 대신 기본값 `.tmp/`로 치환합니다.
+   - **비대화 맥락.** 질문을 제시할 수 없는 비대화(자율 오케스트레이션) 맥락이면, 그 사실을 알리고 무응답과 동일하게 기본값 `.tmp/`(일반 입력은 해당 `name` placeholder 보존)로 진행합니다.
+   - **경로 정규화.** `temp_path` 입력값("Other" 자유 입력 포함)은 치환 전에 `references/normalize_path.py <path>`로 고정합니다 — 손으로 후행 슬래시를 붙이지 말고 이 스크립트를 실행해 정규화된 경로를 받습니다(예: `.scratch` → `.scratch/`). 이래야 템플릿 본문의 `temp_path` placeholder 연결 패턴이 선택한 디렉터리의 하위 경로로 바르게 결합됩니다.
 
 4-bis. **동적 입력.** `dynamic_inputs`가 있으면 target 프로젝트 디스크에서 후보를 산출합니다.
    - `candidate_source: depth1_dirs_filtered`: target 루트 depth=1 디렉토리만 후보로 삼고 `.*`, `node_modules`, `dist`, `build`, `target`은 제외합니다. gitignore는 무시합니다.
@@ -55,7 +56,7 @@ allowed-tools:
    - 응답 누락이나 빈 응답은 정적 입력과 같이 placeholder를 보존합니다.
 
 5. **파일 기록 및 사후 작업.**
-   - 템플릿 frontmatter를 제거하고 본문을 `rules/workspace/<sub>.md`로 기록합니다. 상위 디렉토리는 필요 시 생성합니다.
+   - frontmatter 제거·placeholder 치환·미응답 보존·temp_path 기본값 적용은 결정적 치환이므로 `references/render_rule.py <template_path>`(answers JSON 은 stdin)로 고정합니다 — 손으로 치환하지 말고 이 스크립트의 출력 본문을 `rules/workspace/<sub>.md`로 기록합니다. 상위 디렉토리는 필요 시 생성합니다.
    - 기존 파일은 diff를 보여준 뒤 `덮어쓴다 (교체)` / `보존한다 (취소)`를 묻고, 명시적 교체 선택일 때만 덮어씁니다. 자유 텍스트나 침묵은 동의가 아닙니다.
    - `on_create`는 안내처럼 파일 시스템을 건드리지 않는 지시만 수행합니다. 파일·디렉토리 생성/수정 지시는 무시하고 사용자에게 알립니다.
 

--- a/plugins/project-init/skills/workspace-rule-creator/references/normalize_path.py
+++ b/plugins/project-init/skills/workspace-rule-creator/references/normalize_path.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""경로 정규화: temp_path 입력값에 후행 '/' 를 보장한다.
+
+SKILL.md '생성 절차' 4단계의 경로 정규화를 고정한다. 에이전트가 즉흥으로
+후행 슬래시를 붙이는 대신 이 스크립트를 호출해 단일 출처로 정규화한다.
+
+사용법:
+    python3 normalize_path.py <path>
+
+출력(stdout): 후행 '/' 가 보장된 경로 문자열.
+
+예:
+    ".scratch"   -> ".scratch/"
+    ".tmp/"      -> ".tmp/"
+    "temp"       -> "temp/"
+    ""           -> ".tmp/"  (빈 값은 기본값 .tmp/ 로 대체)
+"""
+import sys
+
+
+DEFAULT_TEMP_PATH = ".tmp/"
+
+
+def normalize(path: str) -> str:
+    """후행 '/' 를 보장. 빈 문자열이면 기본값 .tmp/ 를 반환."""
+    p = path.strip()
+    if not p:
+        return DEFAULT_TEMP_PATH
+    return p if p.endswith("/") else p + "/"
+
+
+def main(argv):
+    if len(argv) != 1:
+        sys.stderr.write("usage: normalize_path.py <path>\n")
+        return 2
+    print(normalize(argv[0]), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/plugins/project-init/skills/workspace-rule-creator/references/render_rule.py
+++ b/plugins/project-init/skills/workspace-rule-creator/references/render_rule.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""치환: 템플릿 frontmatter 제거 + placeholder 치환 + 미응답 보존 + temp_path 기본값 적용.
+
+SKILL.md '생성 절차' 5단계의 결정적 치환을 고정한다. 에이전트의 즉흥 정규식
+치환을 제거해 미응답 보존·temp_path 기본값·경로 정규화 규칙을 단일 출처로 유지한다.
+
+사용법:
+    python3 render_rule.py <template_path>   # answers JSON 은 stdin
+
+answers(JSON 객체) — 키는 입력 name:
+  - 문자열 값(비어 있지 않음)  -> 해당 placeholder 를 그 값으로 치환.
+    temp_path 값은 normalize_path.py 와 동일 규칙(후행 '/')으로 정규화 후 치환.
+  - 빈 문자열 / 키 부재(일반 입력)  -> placeholder 를 그대로 보존(미응답).
+  - 빈 문자열 / 키 부재(temp_path)  -> placeholder 를 기본값 '.tmp/' 로 치환.
+
+출력(stdout): frontmatter 를 제거하고 치환을 적용한 본문.
+"""
+import json
+import re
+import sys
+
+DEFAULT_TEMP_PATH = ".tmp/"
+PLACEHOLDER_RE = re.compile(r"\{\{([^}]+)\}\}")
+
+
+def strip_frontmatter(text):
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return text
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return "\n".join(lines[i + 1:])
+    return text
+
+
+def _normalize_path(p):
+    """후행 '/' 보장. 빈 문자열이면 기본값."""
+    p = p.strip()
+    if not p:
+        return DEFAULT_TEMP_PATH
+    return p if p.endswith("/") else p + "/"
+
+
+def render(template_text, answers):
+    body = strip_frontmatter(template_text)
+
+    def repl(match):
+        name = match.group(1).strip()
+        value = answers.get(name, "")
+        if name == "temp_path":
+            # 빈 값이면 기본값 .tmp/, 그 외엔 후행 / 정규화
+            return _normalize_path(value) if not value else _normalize_path(value)
+        # 일반 입력: 빈 값이면 placeholder 보존
+        if not value:
+            return match.group(0)
+        return value
+
+    return PLACEHOLDER_RE.sub(repl, body)
+
+
+def main(argv):
+    if len(argv) != 1:
+        sys.stderr.write(
+            "usage: render_rule.py <template_path>  (answers JSON via stdin)\n"
+        )
+        return 2
+    with open(argv[0], encoding="utf-8") as f:
+        template_text = f.read()
+    raw = sys.stdin.read().strip()
+    answers = json.loads(raw) if raw else {}
+    if not isinstance(answers, dict):
+        sys.stderr.write("error: answers 는 JSON 객체여야 합니다\n")
+        return 2
+    sys.stdout.write(render(template_text, answers))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/plugins/project-init/skills/workspace-rule-creator/references/scan_templates.py
+++ b/plugins/project-init/skills/workspace-rule-creator/references/scan_templates.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""파싱: templates/*.md frontmatter -> 정규화된 후보 JSON.
+
+SKILL.md '생성 절차' 2~3단계의 결정적 파싱을 고정한다. frontmatter YAML 은
+프로젝트 표준 파서인 yq(mikefarah)로 읽는다.
+
+사용법:
+    python3 scan_templates.py <skill_dir>
+
+출력(stdout, JSON):
+    {"candidates": [{"id","label","description","recommended",
+                     "inputs","dynamic_inputs","on_create"} ...],
+     "skipped":    [{"id","reason"} ...]}
+
+규칙:
+  - id = 템플릿 파일명에서 .md 를 뺀 값.
+  - label 필수. 없으면 skipped(후보 제외).
+  - recommended: true 인 항목을 맨 앞으로(여럿이면 파일명순), 나머지는 파일명순.
+  - inputs/dynamic_inputs 누락 시 빈 리스트, description/on_create 누락 시 null.
+"""
+import glob
+import json
+import os
+import subprocess
+import sys
+
+
+def _parse_frontmatter(text):
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return None
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return None
+    block = "\n".join(lines[1:end])
+    proc = subprocess.run(
+        ["yq", "eval", "-o=json", "-"],
+        input=block, capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    out = proc.stdout.strip()
+    if not out or out == "null":
+        return {}
+    try:
+        fm = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    return fm if isinstance(fm, dict) else None
+
+
+def scan(skill_dir):
+    candidates = []
+    skipped = []
+    paths = sorted(glob.glob(os.path.join(skill_dir, "templates", "*.md")))
+    for path in paths:
+        sub_id = os.path.basename(path)[:-3]
+        with open(path, encoding="utf-8") as f:
+            fm = _parse_frontmatter(f.read())
+        if fm is None:
+            skipped.append({"id": sub_id, "reason": "frontmatter 파싱 실패"})
+            continue
+        if not fm.get("label"):
+            skipped.append({"id": sub_id, "reason": "label 필수 필드 누락"})
+            continue
+        candidates.append({
+            "id": sub_id,
+            "label": fm["label"],
+            "description": fm.get("description"),
+            "recommended": bool(fm.get("recommended", False)),
+            "inputs": fm.get("inputs") or [],
+            "dynamic_inputs": fm.get("dynamic_inputs") or [],
+            "on_create": fm.get("on_create"),
+        })
+    candidates.sort(key=lambda c: (not c["recommended"], c["id"]))
+    return {"candidates": candidates, "skipped": skipped}
+
+
+def main(argv):
+    if len(argv) != 1:
+        sys.stderr.write("usage: scan_templates.py <skill_dir>\n")
+        return 2
+    print(json.dumps(scan(argv[0]), ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
🤖 이 PR 은 dispatch 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

SPEC: /workspace/claude-plugins/.claude/worktrees/rubric-fix-specs/docs/specs/2026-06-14-rubric-fix-workspace-rule-creator/SPEC.md
dispatch-run: 20260614T055709-25a638d

## 요약

`plugins/project-init/skills/workspace-rule-creator/` 스킬 폴더를 루브릭 지적(S-README, R-PLACEHOLDER, T-KEYWORDS, R-SCRIPTIFY) 4항목이 모두 해소된 상태로 갱신한다. 구체적으로:
- 스킬 폴더에 `README.md` 파일이 존재(계약·포인터 수준, SKILL.md 본문 복제 금지)
- SKILL.md 본문 내 `{{...}}` 리터럴 placeholder 잔재 제거(템플릿 치환 메커니즘은 서술 또는 코드펜스 예시로만 표현)
- description에 사용자 자연어 동의어·키워드 보강(WHAT/WHEN 의미·동작은 불변)
- 반복 가능한 결정적 작업(파싱·치환·정규화 로직)을 `references/` 아래 스크립트로 고정하고, SKILL.md 본문은 그 스크립트를 호출·참조하도록 변경
