### PR TITLE
fix(review): GitHub-resolved thread를 해소로 크레딧해 증분 리뷰 approve 복원

### DIFF
--- a/.github/prompts/claude-pr-review.ko.md
+++ b/.github/prompts/claude-pr-review.ko.md
@@ -71,6 +71,7 @@
 - 기존 Claude finding과 같은 문제를 반복하지 않습니다.
 - 기존 Claude(자신) self inline thread의 hidden marker에는 그 finding의 fingerprint가 들어 있습니다. 현재 변경에서 그 thread의 문제가 해결되었다고 판단되면, 해당 marker의 fingerprint를 근거로 resolved_threads에 그 fingerprint와 reason을 기록합니다.
 - 아직 해결되지 않은 기존 Claude self thread는 unresolved_threads에 남은 문제를 구체적으로 기록합니다.
+- **이미 GitHub에서 resolved된 self thread는 해소된 것으로 간주합니다.** `review-threads.json`에서 `isResolved: true`인 thread의 `body`에 담긴 self 마커 fingerprint는, **현재 증분 diff가 그 파일을 건드리지 않았더라도** active blocking으로 세지 않고 unresolved_threads에 넣지 않습니다(이전 증분 또는 관리자가 이미 해소). 그 fingerprint는 resolved_threads에 reason="GitHub에서 이미 resolved됨"으로 기록합니다. 즉 resolve 판단은 현재 증분뿐 아니라 GitHub thread 상태도 근거로 합니다.
 - 다른 리뷰어가 만든 thread/comment는 resolve하거나 수정하지 않습니다.
 - Claude가 만든 thread/comment만 관리합니다.
 

--- a/.github/prompts/codex-pr-review.ko.md
+++ b/.github/prompts/codex-pr-review.ko.md
@@ -82,6 +82,7 @@
 - 기존 Codex finding과 같은 문제를 반복하지 않습니다.
 - 기존 Codex(자신) self inline thread의 hidden marker에는 그 finding의 fingerprint가 들어 있습니다. 현재 변경에서 그 thread의 문제가 해결되었다고 판단되면, 해당 marker의 fingerprint를 근거로 resolved_threads에 그 fingerprint와 reason을 기록합니다.
 - 아직 해결되지 않은 기존 Codex self thread는 unresolved_threads에 남은 문제를 구체적으로 기록합니다.
+- **이미 GitHub에서 resolved된 self thread는 해소된 것으로 간주합니다.** `review-threads.json`에서 `isResolved: true`인 thread의 `body`에 담긴 self 마커 fingerprint는, **현재 증분 diff가 그 파일을 건드리지 않았더라도** active blocking으로 세지 않고 unresolved_threads에 넣지 않습니다(이전 증분 또는 관리자가 이미 해소). 그 fingerprint는 resolved_threads에 reason="GitHub에서 이미 resolved됨"으로 기록합니다. 즉 resolve 판단은 현재 증분뿐 아니라 GitHub thread 상태도 근거로 합니다.
 - 다른 리뷰어가 만든 thread/comment는 resolve하거나 수정하지 않습니다.
 - Codex가 만든 thread/comment만 관리합니다.
 

--- a/.github/scripts/pr-review-context.sh
+++ b/.github/scripts/pr-review-context.sh
@@ -64,6 +64,28 @@ gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
 gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments" \
   > "$REVIEW_OUTPUT_DIR/review-comments.json"
 
+# Review THREAD resolution state (GraphQL) — the REST /pulls/comments endpoint above
+# carries NO resolution flag. Without it an incremental reviewer cannot tell that a
+# prior finding was already resolved (by a maintainer, or by a fix in an EARLIER
+# increment that the current diff does not touch), so it keeps re-counting that
+# finding as active blocking and never reaches approve. Each thread's first comment
+# body carries the reviewer's hidden `fingerprint=` marker, so the model can map its
+# own findings to GitHub's resolution state by fingerprint. Non-fatal on failure.
+gh api graphql -F owner="${GITHUB_REPOSITORY%/*}" -F name="${GITHUB_REPOSITORY#*/}" -F pr="$PR_NUMBER" -f query='
+  query($owner:String!,$name:String!,$pr:Int!){
+    repository(owner:$owner,name:$name){
+      pullRequest(number:$pr){
+        reviewThreads(first:100){ nodes{
+          isResolved isOutdated
+          comments(first:1){ nodes{ databaseId author{login} body } } } } } } }' \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | {
+          isResolved, isOutdated,
+          comment_id: (.comments.nodes[0].databaseId),
+          author: (.comments.nodes[0].author.login // null),
+          body: (.comments.nodes[0].body // "") }]' \
+  > "$REVIEW_OUTPUT_DIR/review-threads.json" 2>/dev/null \
+  || echo '[]' > "$REVIEW_OUTPUT_DIR/review-threads.json"
+
 case "$mode" in
   incremental)
     git diff --patch "$incremental_base" "$PR_HEAD_SHA" > "$REVIEW_OUTPUT_DIR/diff.patch" || {

--- a/.github/scripts/pr-review-context.sh
+++ b/.github/scripts/pr-review-context.sh
@@ -71,19 +71,36 @@ gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/comments" \
 # finding as active blocking and never reaches approve. Each thread's first comment
 # body carries the reviewer's hidden `fingerprint=` marker, so the model can map its
 # own findings to GitHub's resolution state by fingerprint. Non-fatal on failure.
-gh api graphql -F owner="${GITHUB_REPOSITORY%/*}" -F name="${GITHUB_REPOSITORY#*/}" -F pr="$PR_NUMBER" -f query='
-  query($owner:String!,$name:String!,$pr:Int!){
-    repository(owner:$owner,name:$name){
-      pullRequest(number:$pr){
-        reviewThreads(first:100){ nodes{
-          isResolved isOutdated
-          comments(first:1){ nodes{ databaseId author{login} body } } } } } } }' \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | {
-          isResolved, isOutdated,
-          comment_id: (.comments.nodes[0].databaseId),
-          author: (.comments.nodes[0].author.login // null),
-          body: (.comments.nodes[0].body // "") }]' \
-  > "$REVIEW_OUTPUT_DIR/review-threads.json" 2>/dev/null \
+# Paginate ALL review threads — GraphQL caps reviewThreads at 100/page. A PR with
+# >100 threads would otherwise drop resolution state for the remainder, leaving those
+# resolved findings invisible (REST review-comments has them, but no isResolved) and
+# reintroducing the same approve-block this change fixes. Walk pageInfo.endCursor.
+collect_review_threads() {
+  local cursor="" acc="[]" resp page has args
+  while :; do
+    args=(-f owner="${GITHUB_REPOSITORY%/*}" -f name="${GITHUB_REPOSITORY#*/}" -F pr="$PR_NUMBER")
+    if [ -n "$cursor" ]; then args+=(-f cursor="$cursor"); fi
+    resp="$(gh api graphql "${args[@]}" -f query='
+      query($owner:String!,$name:String!,$pr:Int!,$cursor:String){
+        repository(owner:$owner,name:$name){
+          pullRequest(number:$pr){
+            reviewThreads(first:100, after:$cursor){
+              pageInfo{ hasNextPage endCursor }
+              nodes{ isResolved isOutdated
+                comments(first:1){ nodes{ databaseId author{login} body } } } } } } }')" || return 1
+    page="$(printf '%s' "$resp" | jq -c '[.data.repository.pullRequest.reviewThreads.nodes[] | {
+              isResolved, isOutdated,
+              comment_id: (.comments.nodes[0].databaseId),
+              author: (.comments.nodes[0].author.login // null),
+              body: (.comments.nodes[0].body // "") }]')" || return 1
+    acc="$(jq -cn --argjson a "$acc" --argjson b "$page" '$a + $b')" || return 1
+    has="$(printf '%s' "$resp" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage')"
+    cursor="$(printf '%s' "$resp" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor')"
+    [ "$has" = "true" ] || break
+  done
+  printf '%s\n' "$acc"
+}
+collect_review_threads > "$REVIEW_OUTPUT_DIR/review-threads.json" 2>/dev/null \
   || echo '[]' > "$REVIEW_OUTPUT_DIR/review-threads.json"
 
 case "$mode" in

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -252,8 +252,12 @@ jobs:
             cat .review-context/issue-comments.json
             printf '\n\nExisting review comments JSON:\n'
             cat .review-context/review-comments.json
-            printf '\n\nReview thread resolution state JSON (isResolved 등 — 각 thread body 의 fingerprint 로 self finding 매칭; isResolved:true 는 이미 해소된 thread):\n'
-            cat .review-context/review-threads.json
+            # review-threads.json 은 trusted-base 의 pr-review-context.sh 가 만든다 — 이 스크립트
+            # 변경이 base 에 머지되기 전에는 파일이 없을 수 있으므로(post-merge 적용) 존재할 때만 주입.
+            if [ -f .review-context/review-threads.json ]; then
+              printf '\n\nReview thread resolution state JSON (isResolved 등 — 각 thread body 의 fingerprint 로 self finding 매칭; isResolved:true 는 이미 해소된 thread):\n'
+              cat .review-context/review-threads.json
+            fi
             if [ -f .review-context/thread.json ]; then
               printf '\n\nTarget review thread JSON:\n'
               cat .review-context/thread.json

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -252,6 +252,8 @@ jobs:
             cat .review-context/issue-comments.json
             printf '\n\nExisting review comments JSON:\n'
             cat .review-context/review-comments.json
+            printf '\n\nReview thread resolution state JSON (isResolved 등 — 각 thread body 의 fingerprint 로 self finding 매칭; isResolved:true 는 이미 해소된 thread):\n'
+            cat .review-context/review-threads.json
             if [ -f .review-context/thread.json ]; then
               printf '\n\nTarget review thread JSON:\n'
               cat .review-context/thread.json

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -217,6 +217,8 @@ jobs:
             cat .review-context/issue-comments.json
             printf '\n\nExisting review comments JSON:\n'
             cat .review-context/review-comments.json
+            printf '\n\nReview thread resolution state JSON (isResolved 등 — 각 thread body 의 fingerprint 로 self finding 매칭; isResolved:true 는 이미 해소된 thread):\n'
+            cat .review-context/review-threads.json
             if [ -f .review-context/thread.json ]; then
               printf '\n\nTarget review thread JSON:\n'
               cat .review-context/thread.json

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -217,8 +217,12 @@ jobs:
             cat .review-context/issue-comments.json
             printf '\n\nExisting review comments JSON:\n'
             cat .review-context/review-comments.json
-            printf '\n\nReview thread resolution state JSON (isResolved 등 — 각 thread body 의 fingerprint 로 self finding 매칭; isResolved:true 는 이미 해소된 thread):\n'
-            cat .review-context/review-threads.json
+            # review-threads.json 은 trusted-base 의 pr-review-context.sh 가 만든다 — 이 스크립트
+            # 변경이 base 에 머지되기 전에는 파일이 없을 수 있으므로(post-merge 적용) 존재할 때만 주입.
+            if [ -f .review-context/review-threads.json ]; then
+              printf '\n\nReview thread resolution state JSON (isResolved 등 — 각 thread body 의 fingerprint 로 self finding 매칭; isResolved:true 는 이미 해소된 thread):\n'
+              cat .review-context/review-threads.json
+            fi
             if [ -f .review-context/thread.json ]; then
               printf '\n\nTarget review thread JSON:\n'
               cat .review-context/thread.json


### PR DESCRIPTION
## 문제

증분(synchronize) 리뷰에서 **봇(codex/claude)이 자신의 이전 blocking finding을 영영 해소로 인정하지 못해 approve하지 못하는** 경우가 있다. PR #413에서 codex 결과 JSON으로 확정:

```json
"verdict":"comment", "reviewed_context":{"diff_truncated":false},
"automation_safety":{"may_approve":false,
  "reason":"새 finding은 없지만 기존 Codex blocking finding이 남아 있어 승인할 수 없습니다."},
"findings":[], "unresolved_threads":[{ #94 }, { #99 }]
```

#94·#99는 **이전 커밋에서 실제로 수정**됐지만, 그 뒤 증분 diff가 해당 파일을 건드리지 않자 리뷰어가 "이번 증분이 안 고쳤다"며 계속 active blocking으로 간주 → `may_approve=false`.

## 근본 원인

리뷰 컨텍스트가 `GET /pulls/{pr}/comments`(REST)만 사용해 **thread resolve 상태(isResolved)가 없다.** 그래서 리뷰어는 GitHub에서 이미 resolved된(관리자 또는 이전 증분이 해소한) thread조차 모르고, resolve 판단을 "현재 증분 diff" 하나로만 한다.

## 수정

- **`pr-review-context.sh`**: GraphQL `reviewThreads { isResolved, comments(first:1){ body } }`를 `review-threads.json`으로 추가(첫 코멘트 body에 self 마커 `fingerprint=`가 있어 매칭 가능). 실패 시 `[]` 폴백(비치명).
- **codex/claude 워크플로**: 모델 컨텍스트에 `review-threads.json` 주입.
- **codex/claude 프롬프트**: "`isResolved:true`인 self thread는 **현재 증분이 파일을 안 건드려도** 해소로 간주 — active blocking으로 세지 말고 `unresolved_threads`에 넣지 말며 `resolved_threads`에 기록"하는 규칙 추가. resolve 판단 근거에 GitHub thread 상태를 포함.

## 효과

이미 수정·resolve된 finding을 리뷰어가 다시 active로 잡지 않아, 모든 thread가 resolved된 깨끗한 head에서 **approve가 가능**해진다. 동작 변화는 "GitHub에서 resolve된 thread를 신뢰"하는 것(관리자 resolve = 수용)으로, inline-only 정책·증분 리뷰 구조는 유지.

## 검증

- `pr-review-context.sh` `bash -n` 통과, 두 워크플로 YAML 유효(yq).
- GraphQL 쿼리를 PR #413에 직접 실행해 각 thread의 `isResolved`+`fingerprint` 정상 산출 확인.
- 변경 최소(28줄/5파일). `.github/` 변경이라 plugin 버전 범프 없음.
- 참고: `tests/codex/test-codex-review-workflow.sh`의 `openai/codex-action` 카운트 실패는 **이 PR과 무관한 main 기존 실패**(codex-action 3 vs 기대 2). claude 테스트는 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)