### PR TITLE
fix(autopilot): execute-task 머지 전 비동기 봇 승인 폴링 대기 (#419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.48.1
+
+### 버그 수정
+- **execute-task가 비동기 봇 승인을 기다리지 않고 조기 차단되던 문제 수정** — PR(forge) 경로에서 호스팅 리뷰 봇(GitHub Actions Claude/Codex PR 리뷰, 승인 게시까지 관측 ~2.5분)이 APPROVED를 달기 전에 승인 검사가 끝나 태스크가 잘못 `blocked(not-approved)`로 종착하던 결함을 고쳤다. 이제 execute-task는 머지 전 실제 PR 승인 상태(`reviewDecision==APPROVED` 또는 신뢰 봇의 현재 head `verdict=approve` 마커)를 sleep+폴링으로 상한(`APPROVAL_WAIT_MAX`, 기본 360초; 간격 `APPROVAL_POLL_INTERVAL`, 기본 20초) 내에서 기다리고, 상한까지 미게시일 때만 차단한다. review 라운드의 단순 0 반환을 승인으로 오해하지 않는다. direct(PR 없음) 경로의 기존 동작과 dispatch의 공유 머지 게이트(`merge.sh`)는 변경하지 않는다.
+
 ## autopilot 0.48.0
 
 ### 새 기능

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/repair/loop/dispatch/review/flow 6-skill family — spec으로 기능 의도에서 SPEC 작성, repair로 버그·증상·실패 테스트를 정적 분석 진단해 수정용 SPEC 작성(spec 자산 재사용·진단 섹션 추가), loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 준비된 SPEC당 서브에이전트가 한 컨텍스트에서 구현(loop)·리뷰(review)·머지를 소유하는 모델 주도 오케스트레이션(dispatch는 의존성·웨이브·동시성·실패 격리만 총괄, 머지=done이면 의존자 해제; forge 백엔드 가용이면 PR 적대 리뷰→가용 토큰 ff-only 머지(분리 승인 신원 불필요), 미가용이면 로컬 적대 리뷰→ff-only 직접 머지; 대상 브랜치 --target-branch), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 추가로 태스크 중심 3-skill family(create-task/execute-task/workflow-task) — create-task로 의도를 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge 워커 헬퍼/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -21,8 +21,34 @@ FORGE_CMD="${FORGE_CMD:-bash $PLUGIN/forge/forge.sh}"
 LOOP_CMD="${LOOP_CMD:-bash $PLUGIN/skills/loop/references/loop.sh}"
 HEARTBEAT_INTERVAL="${HEARTBEAT_INTERVAL:-60}"
 REVIEW_MAX="${REVIEW_MAX:-5}"
+# 비동기 호스팅 리뷰 봇 승인 폴링(PR 경로). 봇 승인 게시 지연(관측 ~2.5분)을 상한 내에서 대기.
+APPROVAL_WAIT_MAX="${APPROVAL_WAIT_MAX:-360}"          # 총 대기 상한(초, 논리 누적)
+APPROVAL_POLL_INTERVAL="${APPROVAL_POLL_INTERVAL:-20}" # 폴링 간격(초)
+APPROVAL_CHECK_CMD="${APPROVAL_CHECK_CMD:-et_approval_gh}"  # <pr> → 승인이면 rc0 (mock 치환 가능)
+SLEEP_CMD="${SLEEP_CMD:-sleep}"                        # 폴링 sleep (테스트 no-op 치환 가능)
+# 신뢰 봇 로그인(.github/workflows/{codex,claude}-review.yml 컨벤션) — merge.sh mg_approval_gh 와 동일.
+REVIEW_BOT_LOGINS_RE="${REVIEW_BOT_LOGINS_RE:-(\[bot\]$|^github-actions$|courtesy-bot)}"
 
 die() { echo "execute-task: $*" >&2; exit 1; }
+
+# et_approval_gh <pr> — PR 호스팅 리뷰가 승인 상태면 0, 아니면 1.
+#   승인 신호 두 가지(merge.sh mg_approval_gh / review-loop rl_review_fetch_gh 와 동일 컨벤션):
+#     (a) 공식 APPROVE 리뷰 → reviewDecision==APPROVED.
+#     (b) App 토큰 self-approve 불가로 APPROVE→COMMENT 강등된 신뢰 봇의 현재 head verdict=approve 마커.
+#   머지 직전 merge.sh 의 단발 승인 게이트(미해결 [blocking] 인라인 가산 차단 포함)가 재검증한다.
+et_approval_gh() {
+  local pr="$1" decision head
+  [[ -n "$pr" ]] || return 1
+  command -v gh >/dev/null 2>&1 || return 1
+  decision="$(gh pr view "$pr" --json reviewDecision --jq '.reviewDecision' 2>/dev/null)"
+  [[ "$decision" == "APPROVED" ]] && return 0
+  head="$(gh pr view "$pr" --json headRefOid --jq '.headRefOid' 2>/dev/null)"
+  [[ -n "$head" ]] || return 1
+  gh pr view "$pr" --json reviews \
+       --jq '.reviews[] | (.author.login // "") + "\t" + (.body // "")' 2>/dev/null \
+     | grep -E "$REVIEW_BOT_LOGINS_RE" \
+     | grep -qE "head_sha=${head}[^>]*verdict=approve"
+}
 
 HB_PID=""
 cleanup_hb() { [[ -n "${HB_PID:-}" ]] && kill "$HB_PID" 2>/dev/null || true; }
@@ -90,16 +116,40 @@ et_start() {
   branch="$(printf '%s' "$iout" | sed -n 's/^branch:[[:space:]]*//p' | head -1)"
   pr="$(printf '%s' "$iout" | sed -n 's/^pr:[[:space:]]*//p' | head -1)"
 
-  local n=0 approved=0
-  while (( n < REVIEW_MAX )); do
-    n=$((n+1))
-    if $FORGE_CMD review "$run_dir" "$key" "$sp" "$pr" "$branch"; then approved=1; break; fi
-    # 비-0: 재작업/대기/에스컬레이션 — review-loop 내부 가드가 재구현/판정. 한 라운드 더 시도.
-  done
-  if (( ! approved )); then
-    $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "리뷰 미승인(에스컬레이션/가드)" >/dev/null
-    $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "review 미승인 ($n 라운드)" >/dev/null
-    return 1
+  local approved=0
+  if [[ -n "$pr" ]]; then
+    # PR(forge) 경로: 비동기 호스팅 리뷰 봇 승인을 상한 내에서 sleep+폴링으로 기다린다.
+    #   review 라운드는 재작업/대기/에스컬레이션을 내부 가드로 처리하되(반환코드는 승인 판정에
+    #   쓰지 않는다 — 단순 0 반환을 승인으로 오해하지 않음), 승인 여부는 실제 PR 승인 상태
+    #   ($APPROVAL_CHECK_CMD)로 직접 확인한다. 상한까지 미게시일 때만 blocked 로 종착한다.
+    case "$APPROVAL_POLL_INTERVAL" in ''|*[!0-9]*|0) APPROVAL_POLL_INTERVAL=1;; esac
+    local waited=0 rounds=0
+    while true; do
+      rounds=$((rounds+1))
+      $FORGE_CMD review "$run_dir" "$key" "$sp" "$pr" "$branch" || true
+      if $APPROVAL_CHECK_CMD "$pr"; then approved=1; break; fi
+      (( waited >= APPROVAL_WAIT_MAX )) && break
+      $SLEEP_CMD "$APPROVAL_POLL_INTERVAL"
+      waited=$((waited + APPROVAL_POLL_INTERVAL))
+    done
+    if (( ! approved )); then
+      $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "리뷰 미승인(승인 폴링 상한 ${APPROVAL_WAIT_MAX}s 초과)" >/dev/null
+      $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "review 승인 미게시 — 폴링 상한 초과($rounds 회 확인)" >/dev/null
+      return 1
+    fi
+  else
+    # direct(PR 없음) 경로: 로컬 동기 리뷰 — 비동기 승인 대기 불필요(기존 동작 보존).
+    local n=0
+    while (( n < REVIEW_MAX )); do
+      n=$((n+1))
+      if $FORGE_CMD review "$run_dir" "$key" "$sp" "$pr" "$branch"; then approved=1; break; fi
+      # 비-0: 재작업/대기/에스컬레이션 — review-loop 내부 가드가 재구현/판정. 한 라운드 더 시도.
+    done
+    if (( ! approved )); then
+      $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "리뷰 미승인(에스컬레이션/가드)" >/dev/null
+      $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "review 미승인 ($n 라운드)" >/dev/null
+      return 1
+    fi
   fi
 
   if $FORGE_CMD merge "$sp" "$run_dir" "$key" "$pr"; then

--- a/plugins/autopilot/skills/execute-task/tests/test-execute-task-approval-poll.sh
+++ b/plugins/autopilot/skills/execute-task/tests/test-execute-task-approval-poll.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# test-execute-task-approval-poll.sh — PR 경로 비동기 호스팅 봇 승인 폴링 대기 검증.
+#   (a) 미승인→N초 후 APPROVED → 대기 후 머지·done
+#   (b) 상한까지 미승인 → blocked
+#   (c) 폴링 상한/간격 env override
+#   (d) 즉시 APPROVED → 대기(sleep) 없이 머지(회귀)
+#   (e) direct(PR 없음) 경로는 폴링 미적용(기존 동작 보존)
+#   (f) dispatch 머지 게이트(merge.sh mg_approval_gate)는 단발 검사로 유지
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ET="$HERE/../references/execute-task.sh"
+ADAPTER="$HERE/../../../task-backend/adapter.sh"
+MERGE="$HERE/../../dispatch/references/merge.sh"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"; git init -q; git config user.email t@t; git config user.name t
+bash "$ADAPTER" init --backend filesystem >/dev/null
+
+mkdir -p bin
+# mock loop: start/cleanup noop, status→DONE 신호.
+cat > bin/loop <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  start|cleanup) exit 0;;
+  status) printf '{"state":"terminal","signals":["%s"]}\n' "${MOCK_RESULT:-DONE}";;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/loop
+
+# mock forge: integrate→branch(+pr; NO_PR=1 이면 pr 생략), review→rc0, merge→rc0(+기록)
+cat > bin/forge <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  integrate) echo "branch: feat/x"; [[ "${NO_PR:-}" == "1" ]] || echo "pr: 7"; exit 0;;
+  review) exit 0;;
+  merge) [[ -n "${MERGE_LOG:-}" ]] && echo merged >> "$MERGE_LOG"; exit 0;;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/forge
+
+# mock approval check: 호출 카운트($APPROVE_COUNTER) 증가, n>=APPROVE_AFTER 면 승인(rc0).
+cat > bin/approve <<'EOF'
+#!/usr/bin/env bash
+f="${APPROVE_COUNTER:?}"
+n=$(( $(cat "$f" 2>/dev/null || echo 0) + 1 )); printf '%s' "$n" > "$f"
+[[ -n "${APPROVE_AFTER:-}" && "$n" -ge "$APPROVE_AFTER" ]]
+EOF
+chmod +x bin/approve
+
+# mock sleep: 호출 기록(실제 대기 없음).
+cat > bin/sleeprec <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >> "${SLEEP_LOG:?}"
+EOF
+chmod +x bin/sleeprec
+
+status_of(){ bash "$ADAPTER" get_task --task-id "$1" | jq -r .status; }
+newtask(){ bash "$ADAPTER" create_task --title "$1" --body '## 목표'$'\n'x | jq -r .task_id; }
+run_poll() { local id="$1"; shift
+  env ADAPTER_CMD="bash $ADAPTER" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+      HEARTBEAT_INTERVAL=1 MOCK_RESULT=DONE "$@" bash "$ET" start "$id"
+}
+
+# (a) 미승인 후 폴링하다 3번째 확인에서 APPROVED → 대기 후 머지·done
+id="$(newtask A)"; cnt="$TMP/cntA"; : > "$cnt"
+run_poll "$id" APPROVAL_CHECK_CMD="bash $TMP/bin/approve" APPROVE_COUNTER="$cnt" APPROVE_AFTER=3 \
+  APPROVAL_WAIT_MAX=100 APPROVAL_POLL_INTERVAL=10 SLEEP_CMD=: >/dev/null 2>&1 || true
+chk "(a) 폴링 후 승인 → done" "$(status_of "$id")" "done"
+chk "(a) 승인까지 3회 확인" "$(cat "$cnt")" "3"
+
+# (b) 상한까지 미승인 → blocked (MAX=4,interval=2 → 3회 확인)
+id="$(newtask B)"; cnt="$TMP/cntB"; : > "$cnt"
+run_poll "$id" APPROVAL_CHECK_CMD="bash $TMP/bin/approve" APPROVE_COUNTER="$cnt" \
+  APPROVAL_WAIT_MAX=4 APPROVAL_POLL_INTERVAL=2 SLEEP_CMD=: >/dev/null 2>&1 || true
+chk "(b) 상한까지 미승인 → blocked" "$(status_of "$id")" "blocked"
+chk "(b) 상한 내 확인 횟수=3" "$(cat "$cnt")" "3"
+
+# (c) override: MAX=6,interval=2 → 4회 확인
+id="$(newtask C)"; cnt="$TMP/cntC"; : > "$cnt"
+run_poll "$id" APPROVAL_CHECK_CMD="bash $TMP/bin/approve" APPROVE_COUNTER="$cnt" \
+  APPROVAL_WAIT_MAX=6 APPROVAL_POLL_INTERVAL=2 SLEEP_CMD=: >/dev/null 2>&1 || true
+chk "(c) override 상한/간격 반영(6/2→4회)" "$(cat "$cnt")" "4"
+
+# (d) 즉시 APPROVED → 대기(sleep) 없이 머지·done (회귀)
+id="$(newtask D)"; cnt="$TMP/cntD"; : > "$cnt"; slog="$TMP/slogD"; : > "$slog"
+run_poll "$id" APPROVAL_CHECK_CMD="bash $TMP/bin/approve" APPROVE_COUNTER="$cnt" APPROVE_AFTER=1 \
+  APPROVAL_WAIT_MAX=100 APPROVAL_POLL_INTERVAL=10 SLEEP_CMD="bash $TMP/bin/sleeprec" SLEEP_LOG="$slog" \
+  >/dev/null 2>&1 || true
+chk "(d) 즉시 승인 → done" "$(status_of "$id")" "done"
+chk "(d) 즉시 승인 시 1회만 확인" "$(cat "$cnt")" "1"
+chk "(d) 즉시 승인 → sleep 미호출" "$(wc -l < "$slog" | tr -d ' ')" "0"
+
+# (e) direct(PR 없음) 경로: 폴링 미적용, 기존 동작 보존 → done, 승인 확인 미호출
+id="$(newtask E)"; cnt="$TMP/cntE"; rm -f "$cnt"
+run_poll "$id" NO_PR=1 APPROVAL_CHECK_CMD="bash $TMP/bin/approve" APPROVE_COUNTER="$cnt" APPROVE_AFTER=9999 \
+  SLEEP_CMD=: >/dev/null 2>&1 || true
+chk "(e) direct 경로 → done(폴링 미적용)" "$(status_of "$id")" "done"
+chk "(e) direct 경로 승인 폴링 미호출" "$(cat "$cnt" 2>/dev/null || echo 0)" "0"
+
+# (f) merge.sh mg_approval_gate 는 단발 검사(sleep/loop 없음) 유지
+gate="$(awk '/^mg_approval_gate\(\)/{f=1} f{print} f&&/^}/{if(NR>1)exit}' "$MERGE")"
+if printf '%s' "$gate" | grep -qE 'sleep|while|[^a-z]for[^a-z]'; then bad "(f) merge gate 단발 유지(폴링 없음)"; else ok "(f) merge gate 단발 유지(폴링 없음)"; fi
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail

--- a/plugins/autopilot/skills/execute-task/tests/test-execute-task-lifecycle.sh
+++ b/plugins/autopilot/skills/execute-task/tests/test-execute-task-lifecycle.sh
@@ -34,8 +34,9 @@ esac
 EOF
 chmod +x bin/forge
 
+# 승인 게이트는 실제 PR 승인 상태로 판정한다(review rc 아님). 해피패스 = 즉시 승인(true).
 run() { ADAPTER_CMD="bash $ADAPTER" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
-        HEARTBEAT_INTERVAL=1 bash "$ET" "$@"; }
+        HEARTBEAT_INTERVAL=1 APPROVAL_CHECK_CMD=true SLEEP_CMD=: bash "$ET" "$@"; }
 status_of(){ bash "$ADAPTER" get_task --task-id "$1" | jq -r .status; }
 
 # 1) --stop-at review: DONE → review 에서 정지


### PR DESCRIPTION
## 목적
`execute-task`가 PR 머지 전 비동기 호스팅 리뷰 봇(courtesy-bot Claude/Codex PR 리뷰, 승인 게시까지 ~1\~2.5분)의 승인을 기다리지 않고 조기에 `blocked(not-approved)`로 종착하던 버그 수정. (task #419)

## 근본 원인
- `merge.sh` `mg_approval_gate`는 `reviewDecision`을 단발로 검사 → 봇 승인 게시 전이라 차단.
- `execute-task.sh` review 루프가 `fg_review`의 0 반환(항상 0)을 승인으로 오해 + 시도 간 sleep 없음.

## 변경
- PR 경로: 반환코드 대신 실제 승인 상태(`reviewDecision==APPROVED` 또는 신뢰 봇 `verdict=approve` head 마커)를 `APPROVAL_CHECK_CMD`로 확인하고, 미게시면 상한(`APPROVAL_WAIT_MAX` 기본 360s, 간격 `APPROVAL_POLL_INTERVAL` 기본 20s) 내 sleep+폴링 대기. 상한까지 미게시일 때만 blocked.
- direct(PR 없음) 경로·dispatch 공유 게이트(`merge.sh`)는 미변경.
- 폴링 상한/간격/검사/sleep은 env override 가능(테스트 모킹).
- 신규 테스트 `tests/test-execute-task-approval-poll.sh`(11 케이스) 전부 통과, 라이프사이클 테스트 통과.
- 워치 디렉토리(plugins/) 게이트 충족: plugin.json 0.48.0→0.48.1, CHANGELOG 버그수정 기록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)