### PR TITLE
chore(autopilot): 태스크 백엔드 선택 SoT(.autopilot/task-backend.json) 메인 영속화

### DIFF
--- a/.autopilot/task-backend.json
+++ b/.autopilot/task-backend.json
@@ -1,0 +1,8 @@
+{
+  "backend": "github-project",
+  "lease_ttl_seconds": 300,
+  "heartbeat_interval_seconds": 60,
+  "github_project_url": "https://github.com/users/ch-courtesy/projects/1",
+  "github_owner": "ch-courtesy",
+  "github_repo": "claude-plugins"
+}


### PR DESCRIPTION
## 목적
`.autopilot/task-backend.json`(백엔드 선택 SoT)을 메인에 추적 파일로 영속화. `.gitignore`가 이미 추적 대상으로 명시(런타임 `runs/`만 무시)하나, create-task init이 파일만 쓰고 커밋하지 않아 워크트리 로컬에만 남아 있었다 → 새 체크아웃·CI·다른 세션에서 백엔드 미설정.

## 변경
- `.autopilot/task-backend.json`만 추가(config-only). github-project 백엔드(claude-plugins #1).
- 워치 디렉토리(plugins/) 미변경 → 버전 범프 불필요.

create-task init이 이 영속화를 자동 수행하도록 하는 동작 변경은 task #421에서 다룬다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)