### PR TITLE
🤖 [자동 리뷰] execute-task: 리워크 구동/빠른 실패로 '오지 않을 승인 무의미 대기' 제거

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.48.5
+
+### 변경(호환)
+- **execute-task PR 경로가 review 라운드 반환코드로 분기해 '오지 않을 승인 무의미 대기'를 제거** — 단일 동기 드라이버인 execute-task의 PR(forge) 승인 폴링이 매 반복 `$FORGE_CMD review`를 호출하면서도 그 반환코드를 무시(`|| true`)하고 실제 승인 상태만 봐서, 리워크가 필요한 미해결 `[blocking]` 지적으로 미승인일 때 리워크를 구동하지 못하고 오지 않을 승인을 `APPROVAL_WAIT_MAX`까지 헛되이 폴링하다 timeout→blocked로 끝나던 갭(관측: PR #424)을 메운다. 이제 forge github 어댑터(`fg_review`)가 dispatch `review-loop.sh`의 `round`(=`rl_round`)를 호출해 반환코드(`0`=재작업 재푸시·`10`=에스컬레이션/라운드상한/핑퐁·`20`=대기·`30`=approve)를 그대로 표면화하고, execute-task PR 경로가 이 코드로 분기한다: `30`→머지 진행(merge.sh가 미해결 `[blocking]` 가산 게이트를 머지 직전 재검증), `0`→재푸시 진전이므로 루프 계속(재리뷰), `10`·기타 비-0→리워크로 해소 불가이므로 폴링 상한을 더 기다리지 않고 즉시 `blocked`로 사유와 함께 종료, `20`→깨끗한 코드가 비동기 봇 승인만 기다리는 경우로 기존 `APPROVAL_WAIT_MAX` 폴링 대기 유지. dispatch `review-loop.sh`/`merge.sh`의 계약·동작은 변경 없이 재사용(소비만)하며, direct(PR 없음) 경로는 기존 `run-direct` 동기 리뷰로 불변이다.
+
 ## autopilot 0.48.4
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.48.4",
+  "version": "0.48.5",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/repair/loop/dispatch/review/flow 6-skill family — spec으로 기능 의도에서 SPEC 작성, repair로 버그·증상·실패 테스트를 정적 분석 진단해 수정용 SPEC 작성(spec 자산 재사용·진단 섹션 추가), loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 준비된 SPEC당 서브에이전트가 한 컨텍스트에서 구현(loop)·리뷰(review)·머지를 소유하는 모델 주도 오케스트레이션(dispatch는 의존성·웨이브·동시성·실패 격리만 총괄, 머지=done이면 의존자 해제; forge 백엔드 가용이면 PR 적대 리뷰→가용 토큰 ff-only 머지(분리 승인 신원 불필요), 미가용이면 로컬 적대 리뷰→ff-only 직접 머지; 대상 브랜치 --target-branch), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 추가로 태스크 중심 3-skill family(create-task/execute-task/workflow-task) — create-task로 의도를 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge 워커 헬퍼/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/forge/contract.md
+++ b/plugins/autopilot/forge/contract.md
@@ -21,10 +21,15 @@ origin url 없음            → direct  (로컬 review + ff-only 직접 머지)
 | 동사 | 인자 | 내부 위임(github / direct) |
 |---|---|---|
 | `integrate` | `<spec> <run_dir> <key>` | `integration.sh integrate` / `integrate-direct` |
-| `review` | `<run_dir> <key> <spec> [pr] [branch]` | `review-loop.sh run` / `run-direct` |
+| `review` | `<run_dir> <key> <spec> [pr] [branch]` | `review-loop.sh round` / `run-direct` |
 | `merge` | `<spec> <run_dir> <key> [pr]` | `merge.sh finish <...> [pr]` / `finish <...> "" 1` |
 
 관리 동사: `host`(감지된 호스트 출력), `selftest`(라우팅 검증).
+
+`review`(github)는 `round`(=`rl_round`)를 호출해 반환코드(`0`=재작업 재푸시·`10`=에스컬레이션/라운드상한/핑퐁·
+`20`=대기·`30`=approve)를 **그대로 표면화**한다. 단일 동기 드라이버(execute-task)가 이 코드로 리워크 진행/빠른
+실패/승인 폴링을 분기하기 위함이다(`run` 은 코드를 `0` 으로 collapse 해 분기 불가). direct 는 PR 메타가 없어
+기존 `run-direct`(동기 단발 리뷰)를 유지한다.
 
 ## 런타임 재사용
 

--- a/plugins/autopilot/forge/github.sh
+++ b/plugins/autopilot/forge/github.sh
@@ -5,8 +5,12 @@
 fg_integrate() {  # <spec> <run_dir> <key>
   bash "$FG_REF/integration.sh" integrate "$@"
 }
-fg_review() {     # <run_dir> <key> <spec> [pr] [branch]
-  bash "$FG_REF/review-loop.sh" run "$@"
+fg_review() {     # <run_dir> <key> <spec> <pr> [branch] → rl_round 반환코드 그대로(0/10/20/30)
+  # `round`(rl_round 직접)를 호출해 반환코드를 표면화한다. `run`(rl_review_loop)은 0/10/20/30 을
+  # 전부 return 0 으로 collapse 하므로 단일 동기 드라이버(execute-task)가 분기할 수 없다(#426).
+  # execute-task PR 경로가 30=approve / 0=재작업 재푸시 / 10=에스컬레이션·상한·핑퐁 / 20=대기 로 분기.
+  # branch 영속화는 integrate(integration.sh int_set_branch)가 이미 수행 → merge 의 int_get_branch 불변.
+  bash "$FG_REF/review-loop.sh" round "$@"
 }
 fg_merge() {      # <spec> <run_dir> <key> [pr]
   bash "$FG_REF/merge.sh" finish "$@"

--- a/plugins/autopilot/forge/tests/test-forge-routing.sh
+++ b/plugins/autopilot/forge/tests/test-forge-routing.sh
@@ -11,4 +11,17 @@ if bash "$F" selftest; then ok "forge selftest"; else bad "forge selftest"; fi
 # gitlab 구현은 호출 시 비-0 (조용한 실패 금지 — 확장점)
 ( source "$HERE/../gitlab.sh"; fg_integrate x y z ) >/dev/null 2>&1 && bad "gitlab integrate abort" || ok "gitlab integrate abort(비-0)"
 
+# fg_review 위임 검증(#426): github 은 review-loop.sh `round`(rl_round 코드 0/10/20/30 표면화),
+#   direct 는 `run-direct`(기존 동기 리뷰, collapse). 스텁 review-loop.sh 로 서브커맨드 캡처.
+TMPD="$(mktemp -d)"; trap 'rm -rf "$TMPD"' EXIT
+mkdir -p "$TMPD/ref"
+cat > "$TMPD/ref/review-loop.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "$1" > "$RL_SUB"
+EOF
+( source "$HERE/../github.sh"; FG_REF="$TMPD/ref" RL_SUB="$TMPD/sub.gh" fg_review rd key spec 7 br )
+[[ "$(cat "$TMPD/sub.gh")" == "round" ]] && ok "github fg_review → review-loop.sh round" || bad "github fg_review → round (got '$(cat "$TMPD/sub.gh")')"
+( source "$HERE/../direct.sh"; FG_REF="$TMPD/ref" RL_SUB="$TMPD/sub.dir" fg_review rd key spec "" br )
+[[ "$(cat "$TMPD/sub.dir")" == "run-direct" ]] && ok "direct fg_review → review-loop.sh run-direct(불변)" || bad "direct fg_review → run-direct (got '$(cat "$TMPD/sub.dir")')"
+
 echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -166,30 +166,41 @@ et_start() {
 
   local approved=0
   if [[ -n "$pr" ]]; then
-    # PR(forge) 경로: 비동기 호스팅 리뷰 봇 승인을 상한 내에서 sleep+폴링으로 기다린다.
-    #   review 라운드는 재작업/대기/에스컬레이션을 내부 가드로 처리하되(반환코드는 승인 판정에
-    #   쓰지 않는다 — 단순 0 반환을 승인으로 오해하지 않음), 승인 여부는 실제 PR 승인 상태
-    #   ($APPROVAL_CHECK_CMD)로 직접 확인한다. 상한까지 미게시일 때만 blocked 로 종착한다.
+    # PR(forge) 경로: review 라운드(=rl_round, $FORGE_CMD review)의 반환코드로 분기한다(#426).
+    #   리워크로 진전 가능 → 진행 / 진전 불가 → 빠른 실패 / 깨끗+비동기 승인 대기만 → 폴링 유지.
+    #   반환코드 계약(dispatch review-loop.sh rl_round, 소비만 — 변경 없음):
+    #     30 = approve         → 머지 진행(merge.sh 가 미해결 [blocking] 가산 게이트를 머지 직전 재검증).
+    #     0  = 재작업 재푸시(진전) → 새 head 가 올라갔으니 재리뷰 위해 루프 계속(무의미 대기 아님).
+    #     10 = 에스컬레이션/라운드상한/핑퐁(진전 불가) → 폴링 상한 더 안 기다리고 즉시 blocked.
+    #     20 = 할 일 없음(깨끗한 코드가 비동기 봇 승인만 대기) → 기존 APPROVAL_WAIT_MAX 폴링 유지(#419).
+    #          이때만 폴링이 의미: 승인 = 호스팅 승인 신호 AND 현재 head 미해결 [blocking] 인라인 없음.
+    #     기타 비-0 = 미정의 신호 → 보수적 즉시 blocked(default-deny). rl_round 미경유 호출은 없다.
     case "$APPROVAL_POLL_INTERVAL" in ''|*[!0-9]*|0) APPROVAL_POLL_INTERVAL=1;; esac
     # 비숫자/빈값 상한은 산술 비교((( waited >= MAX )))를 0>=0 으로 망가뜨려 즉시 오종료(또는
     # 빈값 시 무한 멈춤)시키므로 기본값(360)으로 보정한다. 0 은 "대기 없이 1회 확인"으로 안전히
     # 허용한다(간격과 달리 0 이어도 영구 멈춤이 없다 — 첫 확인 후 0>=0 으로 정상 종료).
     case "$APPROVAL_WAIT_MAX" in ''|*[!0-9]*) APPROVAL_WAIT_MAX=360;; esac
-    local waited=0 rounds=0
+    local waited=0 rounds=0 rrc
     while true; do
       rounds=$((rounds+1))
-      $FORGE_CMD review "$run_dir" "$key" "$sp" "$pr" "$branch" || true
-      # 승인 = 호스팅 승인 신호 AND 현재 head 미해결 [blocking] 인라인 없음(가산 차단).
-      #   APPROVED 여도 신뢰봇 미해결 [blocking] 가 있으면 머지하지 않고 resolved(또는 head 변경
-      #   해소)될 때까지 상한 내에서 폴링 대기한다. 게이트는 스레드를 스스로 resolve 하지 않는다.
-      if $APPROVAL_CHECK_CMD "$pr" && $BLOCKING_CHECK_CMD "$pr"; then approved=1; break; fi
-      (( waited >= APPROVAL_WAIT_MAX )) && break
-      $SLEEP_CMD "$APPROVAL_POLL_INTERVAL"
-      waited=$((waited + APPROVAL_POLL_INTERVAL))
+      rrc=0; $FORGE_CMD review "$run_dir" "$key" "$sp" "$pr" "$branch" || rrc=$?
+      case "$rrc" in
+        30) approved=1; break ;;   # approve → 머지(아래 merge 가 #423 가산 게이트 재검증)
+        0)  continue ;;            # 재작업 재푸시(진전) → 재리뷰 위해 루프 계속
+        20)                        # 깨끗+비동기 봇 승인 대기 → 승인 폴링 유지(정당한 대기)
+          if $APPROVAL_CHECK_CMD "$pr" && $BLOCKING_CHECK_CMD "$pr"; then approved=1; break; fi
+          (( waited >= APPROVAL_WAIT_MAX )) && break
+          $SLEEP_CMD "$APPROVAL_POLL_INTERVAL"
+          waited=$((waited + APPROVAL_POLL_INTERVAL)) ;;
+        *)                         # 10(에스컬레이션/라운드상한/핑퐁) 등 진전 불가 → 빠른 실패
+          $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "리뷰 진전 불가(리워크로 해소 불가, rl_round rc=$rrc) — 폴링 상한 대기 생략" >/dev/null
+          $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "review 진전 불가(rc=$rrc) — 즉시 종료($rounds 라운드)" >/dev/null
+          return 1 ;;
+      esac
     done
     if (( ! approved )); then
       $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "리뷰 미승인(승인 폴링 상한 ${APPROVAL_WAIT_MAX}s 초과)" >/dev/null
-      $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "review 승인 미게시 — 폴링 상한 초과($rounds 회 확인)" >/dev/null
+      $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "review 승인 미게시 — 폴링 상한 초과($rounds 라운드)" >/dev/null
       return 1
     fi
   else

--- a/plugins/autopilot/skills/execute-task/tests/test-execute-task-approval-poll.sh
+++ b/plugins/autopilot/skills/execute-task/tests/test-execute-task-approval-poll.sh
@@ -30,12 +30,14 @@ esac
 EOF
 chmod +x bin/loop
 
-# mock forge: integrate→branch(+pr; NO_PR=1 이면 pr 생략), review→rc0, merge→rc0(+기록)
+# mock forge: integrate→branch(+pr; NO_PR=1 이면 pr 생략), review→rc20(할 일 없음=깨끗+비동기
+#   승인대기, rl_round #426 계약 → 승인 폴링 유지 시나리오), merge→rc0(+기록)
 cat > bin/forge <<'EOF'
 #!/usr/bin/env bash
 case "$1" in
   integrate) echo "branch: feat/x"; [[ "${NO_PR:-}" == "1" ]] || echo "pr: 7"; exit 0;;
-  review) exit 0;;
+  # direct(NO_PR=1) 은 run-direct(항상 0=approve collapse) 미러; PR 은 round 20(승인 폴링 유지) 미러.
+  review) [[ "${NO_PR:-}" == "1" ]] && exit 0 || exit 20;;
   merge) [[ -n "${MERGE_LOG:-}" ]] && echo merged >> "$MERGE_LOG"; exit 0;;
   *) exit 0;;
 esac

--- a/plugins/autopilot/skills/execute-task/tests/test-execute-task-blocking-gate.sh
+++ b/plugins/autopilot/skills/execute-task/tests/test-execute-task-blocking-gate.sh
@@ -30,12 +30,13 @@ case "$1" in
 esac
 EOF
 chmod +x bin/loop
-# mock forge: integrate→branch+pr(7); review→rc0; merge→기록(+rc0)
+# mock forge: integrate→branch+pr(7); review→rc20(할 일 없음=깨끗+비동기 승인대기, rl_round #426
+#   계약 → 승인 폴링 유지 시나리오에서 미해결 [blocking] 가산 게이트 검증); merge→기록(+rc0)
 cat > bin/forge <<'EOF'
 #!/usr/bin/env bash
 case "$1" in
   integrate) echo "branch: feat/x"; echo "pr: 7"; exit 0;;
-  review) exit 0;;
+  review) exit 20;;
   merge) [[ -n "${MERGE_LOG:-}" ]] && echo merged >> "$MERGE_LOG"; exit 0;;
   *) exit 0;;
 esac

--- a/plugins/autopilot/skills/execute-task/tests/test-execute-task-lifecycle.sh
+++ b/plugins/autopilot/skills/execute-task/tests/test-execute-task-lifecycle.sh
@@ -22,12 +22,13 @@ case "$1" in
 esac
 EOF
 chmod +x bin/loop
-# mock forge: integrate→branch 출력, review/merge→rc0
+# mock forge: integrate→branch 출력, review→rc20(할 일 없음=깨끗+비동기 승인대기), merge→rc0.
+#   review 반환코드는 rl_round 계약(#426): 20 = 승인 폴링 유지 시나리오. 해피패스는 즉시 승인.
 cat > bin/forge <<'EOF'
 #!/usr/bin/env bash
 case "$1" in
   integrate) echo "branch: feat/x"; echo "pr: 7"; exit 0;;
-  review) exit 0;;
+  review) exit 20;;
   merge) exit 0;;
   *) exit 0;;
 esac

--- a/plugins/autopilot/skills/execute-task/tests/test-execute-task-review-codes.sh
+++ b/plugins/autopilot/skills/execute-task/tests/test-execute-task-review-codes.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# test-execute-task-review-codes.sh — PR 경로가 rl_round(=$FORGE_CMD review) 반환코드로 분기하는지 검증(#426).
+#   리워크 구동/빠른 실패로 '오지 않을 승인 무의미 대기' 제거.
+#   (30) approve     → 머지 진행(done), 승인폴링/sleep 미경유
+#   (0)  재작업 재푸시 → 루프 계속(재리뷰). 0,0,30 시퀀스 → 3 라운드 후 done, sleep 미경유
+#   (10) 에스컬레이션/라운드상한/핑퐁 → 폴링 상한 대기 없이 즉시 blocked(review 1회, sleep 0), merge 미호출
+#   (7)  알 수 없는 비-0 → 보수적 즉시 blocked(빠른 실패)
+#   (20) 할 일 없음(깨끗+비동기 승인대기) → 기존 APPROVAL_WAIT_MAX 폴링 유지(회귀)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ET="$HERE/../references/execute-task.sh"
+ADAPTER="$HERE/../../../task-backend/adapter.sh"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"; git init -q; git config user.email t@t; git config user.name t
+bash "$ADAPTER" init --backend filesystem >/dev/null
+
+mkdir -p bin
+cat > bin/loop <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  start|cleanup) exit 0;;
+  status) printf '{"state":"terminal","signals":["DONE"]}\n';;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/loop
+
+# mock forge: review 가 rl_round 코드를 표면화하도록 시뮬레이션.
+#   REVIEW_SEQ(파일, 줄당 코드)로 순차 반환(소진 후 마지막 줄 고정), 없으면 REVIEW_RC(단일).
+#   review:<code> 를 REVIEW_LOG 에 기록(호출 횟수·코드 추적). integrate→branch+pr(7), merge→기록.
+cat > bin/forge <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  integrate) echo "branch: feat/x"; echo "pr: 7"; exit 0;;
+  review)
+    code="${REVIEW_RC:-20}"
+    if [[ -n "${REVIEW_SEQ:-}" ]]; then
+      idxf="${REVIEW_SEQ}.idx"
+      i=$(( $(cat "$idxf" 2>/dev/null || echo 0) + 1 )); printf '%s' "$i" > "$idxf"
+      code="$(sed -n "${i}p" "$REVIEW_SEQ")"; [[ -n "$code" ]] || code="$(tail -n1 "$REVIEW_SEQ")"
+    fi
+    [[ -n "${REVIEW_LOG:-}" ]] && echo "review:$code" >> "$REVIEW_LOG"
+    exit "$code";;
+  merge) [[ -n "${MERGE_LOG:-}" ]] && echo merged >> "$MERGE_LOG"; exit 0;;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/forge
+
+# mock approval: 호출 카운트 증가. APPROVE_AFTER 설정 시 n>=AFTER 면 승인(rc0), 아니면 미승인(rc1).
+#   미설정 → 항상 미승인(rc1). 비-20 분기에서 이 mock 이 호출되면 안 됨(카운트로 검증).
+cat > bin/approve <<'EOF'
+#!/usr/bin/env bash
+f="${APPROVE_COUNTER:?}"
+n=$(( $(cat "$f" 2>/dev/null || echo 0) + 1 )); printf '%s' "$n" > "$f"
+[[ -n "${APPROVE_AFTER:-}" && "$n" -ge "$APPROVE_AFTER" ]]
+EOF
+chmod +x bin/approve
+
+# mock sleep: 호출 기록(실제 대기 없음).
+cat > bin/sleeprec <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >> "${SLEEP_LOG:?}"
+EOF
+chmod +x bin/sleeprec
+
+status_of(){ bash "$ADAPTER" get_task --task-id "$1" | jq -r .status; }
+newtask(){ bash "$ADAPTER" create_task --title "$1" --body '## 목표'$'\n'x | jq -r .task_id; }
+# BLOCKING_CHECK_CMD=:(clear) 로 가산 게이트 중립화 — 이 파일은 review 반환코드 분기만 검증한다.
+run() { local id="$1"; shift
+  env ADAPTER_CMD="bash $ADAPTER" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+      HEARTBEAT_INTERVAL=1 BLOCKING_CHECK_CMD=: "$@" bash "$ET" start "$id"; }
+rc_count(){ wc -l < "$1" 2>/dev/null | tr -d ' '; }
+
+# (30) approve → 머지(done). 승인폴링/sleep 미경유(approval mock 미호출).
+id="$(newtask A30)"; rlog="$TMP/rA"; : > "$rlog"; mlog="$TMP/mA"; : > "$mlog"
+acnt="$TMP/acA"; printf 0 > "$acnt"; slog="$TMP/sA"; : > "$slog"
+run "$id" REVIEW_RC=30 REVIEW_LOG="$rlog" MERGE_LOG="$mlog" \
+  APPROVAL_CHECK_CMD="bash $TMP/bin/approve" APPROVE_COUNTER="$acnt" \
+  SLEEP_CMD="bash $TMP/bin/sleeprec" SLEEP_LOG="$slog" >/dev/null 2>&1 || true
+chk "(30) approve → done" "$(status_of "$id")" "done"
+chk "(30) merge 호출" "$(grep -c merged "$mlog")" "1"
+chk "(30) 승인폴링 미호출" "$(cat "$acnt")" "0"
+chk "(30) sleep 미호출" "$(rc_count "$slog")" "0"
+
+# (0,0,30) 재작업 재푸시 진전 → 루프 계속 → 3 라운드 후 approve → done. sleep 미경유.
+id="$(newtask A0)"; rlog="$TMP/r0"; : > "$rlog"; mlog="$TMP/m0"; : > "$mlog"
+seq="$TMP/seq0"; printf '0\n0\n30\n' > "$seq"; slog="$TMP/s0"; : > "$slog"
+run "$id" REVIEW_SEQ="$seq" REVIEW_LOG="$rlog" MERGE_LOG="$mlog" \
+  APPROVAL_CHECK_CMD=false SLEEP_CMD="bash $TMP/bin/sleeprec" SLEEP_LOG="$slog" >/dev/null 2>&1 || true
+chk "(0) 재작업 진전 → 루프 계속 → done" "$(status_of "$id")" "done"
+chk "(0) review 3 라운드 수행" "$(rc_count "$rlog")" "3"
+chk "(0) merge 호출" "$(grep -c merged "$mlog")" "1"
+chk "(0) 진전 루프는 sleep 미경유" "$(rc_count "$slog")" "0"
+
+# (10) 에스컬레이션/라운드상한/핑퐁 → 폴링 상한 대기 없이 즉시 blocked. review 1회, sleep 0, merge 미호출.
+id="$(newtask A10)"; rlog="$TMP/r10"; : > "$rlog"; mlog="$TMP/m10"; : > "$mlog"
+acnt="$TMP/ac10"; printf 0 > "$acnt"; slog="$TMP/s10"; : > "$slog"
+run "$id" REVIEW_RC=10 REVIEW_LOG="$rlog" MERGE_LOG="$mlog" \
+  APPROVAL_CHECK_CMD="bash $TMP/bin/approve" APPROVE_COUNTER="$acnt" \
+  APPROVAL_WAIT_MAX=1000 APPROVAL_POLL_INTERVAL=10 \
+  SLEEP_CMD="bash $TMP/bin/sleeprec" SLEEP_LOG="$slog" >/dev/null 2>&1 || true
+chk "(10) 진전 불가 → 즉시 blocked" "$(status_of "$id")" "blocked"
+chk "(10) review 1회만(폴링 미대기)" "$(rc_count "$rlog")" "1"
+chk "(10) sleep 미호출(빠른 실패)" "$(rc_count "$slog")" "0"
+chk "(10) 승인폴링 미호출" "$(cat "$acnt")" "0"
+chk "(10) merge 미호출" "$(rc_count "$mlog")" "0"
+
+# (7) 알 수 없는 비-0 → 보수적 즉시 blocked(빠른 실패).
+id="$(newtask A7)"; rlog="$TMP/r7"; : > "$rlog"; slog="$TMP/s7"; : > "$slog"
+run "$id" REVIEW_RC=7 REVIEW_LOG="$rlog" \
+  APPROVAL_CHECK_CMD=false APPROVAL_WAIT_MAX=1000 APPROVAL_POLL_INTERVAL=10 \
+  SLEEP_CMD="bash $TMP/bin/sleeprec" SLEEP_LOG="$slog" >/dev/null 2>&1 || true
+chk "(7) 알 수 없는 rc → 즉시 blocked" "$(status_of "$id")" "blocked"
+chk "(7) review 1회만" "$(rc_count "$rlog")" "1"
+chk "(7) sleep 미호출" "$(rc_count "$slog")" "0"
+
+# (20) 할 일 없음 → 기존 승인 폴링 유지(회귀). 2회째 승인 → 폴링 후 done, sleep 경유.
+id="$(newtask A20)"; acnt="$TMP/ac20"; : > "$acnt"; slog="$TMP/s20"; : > "$slog"; mlog="$TMP/m20"; : > "$mlog"
+run "$id" REVIEW_RC=20 MERGE_LOG="$mlog" \
+  APPROVAL_CHECK_CMD="bash $TMP/bin/approve" APPROVE_COUNTER="$acnt" APPROVE_AFTER=2 \
+  APPROVAL_WAIT_MAX=100 APPROVAL_POLL_INTERVAL=10 \
+  SLEEP_CMD="bash $TMP/bin/sleeprec" SLEEP_LOG="$slog" >/dev/null 2>&1 || true
+chk "(20) 깨끗+비동기 승인대기 → 폴링 후 done" "$(status_of "$id")" "done"
+chk "(20) merge 호출" "$(grep -c merged "$mlog")" "1"
+chk "(20) 승인까지 2회 폴링" "$(cat "$acnt")" "2"
+[[ "$(rc_count "$slog")" -ge 1 ]] && ok "(20) 폴링 대기 sleep 경유(1회+)" || bad "(20) 폴링 대기 sleep 경유 got $(rc_count "$slog")"
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail


### PR DESCRIPTION
🤖 이 PR 은 dispatch 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

SPEC: /workspace/claude-plugins/.claude/worktrees/using-autopilot-task-routing/.task-work/426/SPEC.md
dispatch-run: 426
