### PR TITLE
chore(autopilot): persist task backend config SoT to main

### DIFF
--- a/.autopilot/task-backend.json
+++ b/.autopilot/task-backend.json
@@ -1,8 +1,5 @@
 {
   "backend": "github-project",
   "lease_ttl_seconds": 300,
-  "heartbeat_interval_seconds": 60,
-  "github_project_url": "https://github.com/users/ch-courtesy/projects/1",
-  "github_owner": "ch-courtesy",
-  "github_repo": "claude-plugins"
+  "heartbeat_interval_seconds": 60
 }


### PR DESCRIPTION
백엔드 선택 SoT(`.autopilot/task-backend.json`)를 메인에 영속화. config 파일 단독 변경.