### PR TITLE
🤖 [자동 리뷰] set_body 백엔드 동사 신설 (contract.md + filesystem/github/beads)

### DIFF
--- a/plugins/autopilot/task-backend/adapter.sh
+++ b/plugins/autopilot/task-backend/adapter.sh
@@ -78,7 +78,7 @@ main() {
     init)     tb_init "$@";;
     selftest) tb_selftest;;
     backend)  tb_load_backend; jq -nc --arg b "$TB_BACKEND" '{backend:$b}';;
-    create_task|get_task|get_body|set_status|link_dependency|list_ready|append_log|materialize|renew_lease|claim)
+    create_task|get_task|get_body|set_body|set_status|link_dependency|list_ready|append_log|materialize|renew_lease|claim)
       tb_load_backend; "be_$verb" "$@";;
     ""|-h|--help|help)
       cat >&2 <<'EOF'
@@ -86,6 +86,7 @@ usage: adapter.sh <verb> [args]
   init --backend <filesystem|github-project|beads> [--github-project-url U --github-owner O --github-repo R]
   create_task --title T --body B [--depends-on a,b]
   get_task|get_body|materialize|renew_lease --task-id ID
+  set_body --task-id ID --body B
   set_status --task-id ID --status S [--reason R]
   link_dependency --task-id ID --depends-on-id ID
   append_log --task-id ID --marker decision|handoff|blocked --text T

--- a/plugins/autopilot/task-backend/beads.sh
+++ b/plugins/autopilot/task-backend/beads.sh
@@ -42,6 +42,13 @@ be_get_body() {
   bd show "$id" --json 2>/dev/null | jq -c '{task_id:.id, title:.title, body:(.description//"")}' || tb_die "bd show 실패: $id"
 }
 
+# be_set_body — get_body 의 쓰기 짝. description(=본문/SPEC)만 교체. status·depends_on 은 bd 네이티브라 불변.
+be_set_body() {
+  local id body; id="$(_argval --task-id "$@")"; body="$(_argval --body "$@")"
+  bd update "$id" --description "$body" >/dev/null 2>&1 || tb_die "bd update --description 실패"
+  jq -nc --arg id "$id" '{task_id:$id}'
+}
+
 be_set_status() {
   local id s; id="$(_argval --task-id "$@")"; s="$(_argval --status "$@")"
   bd update "$id" --status "$s" >/dev/null 2>&1 || tb_die "bd update --status 실패"

--- a/plugins/autopilot/task-backend/contract.md
+++ b/plugins/autopilot/task-backend/contract.md
@@ -73,7 +73,9 @@ DoD 확인 방법(테스트·관찰 지표·수동 단계).
 - [ ] ...
 ```
 
-`get_body`는 위 본문을 반환하고, `materialize`는 `# <title>` H1을 앞에 붙여 임시 spec 파일로 쓴다.
+`get_body`는 위 본문을 반환하고, `set_body`는 그 쓰기 짝으로 **본문만 교체**한다(상태·frontmatter·depends_on 보존
+— 이미 등록된 in_design 태스크의 설계 본문 갱신·인터뷰 재개에 쓴다). `materialize`는 `# <title>` H1을 앞에 붙여 임시
+spec 파일로 쓴다.
 
 ## 의존성 (depends_on 단일 축)
 
@@ -88,7 +90,7 @@ DoD 확인 방법(테스트·관찰 지표·수동 단계).
 - `list_ready`는 lease가 **stale**(now − lease_renewed_at > `lease_ttl_seconds`)인 in_progress 태스크를 ready로
   반환한다(크래시·행 워커 회수). lease가 신선하면 제외(이중 실행 방지).
 
-## 동사 (9개)
+## 동사 (10개)
 
 모든 동사는 성공 시 한 줄 JSON을 stdout에 쓴다.
 
@@ -97,6 +99,7 @@ DoD 확인 방법(테스트·관찰 지표·수동 단계).
 | `create_task` | `--title <s> --body <s> [--depends-on <id,...>]` | `{"task_id","status":"backlog","url":<s|null>}` |
 | `get_task` | `--task-id <id>` | `{"task_id","title","status","depends_on":[...],"url"}` |
 | `get_body` | `--task-id <id>` | `{"task_id","title","body"}` |
+| `set_body` | `--task-id <id> --body <s>` | `{"task_id"}` |
 | `set_status` | `--task-id <id> --status <state> [--reason <s>]` | `{"task_id","status"}` |
 | `link_dependency` | `--task-id <id> --depends-on-id <id>` | `{"task_id","depends_on":[...]}` |
 | `list_ready` | (없음) | `[{"task_id","title"},...]` (depends_on 충족 + stale-lease in_progress) |

--- a/plugins/autopilot/task-backend/filesystem.sh
+++ b/plugins/autopilot/task-backend/filesystem.sh
@@ -95,6 +95,18 @@ be_get_body() {
     '{task_id:$id, title:$t, body:$b}'
 }
 
+# be_set_body — get_body 의 쓰기 짝. frontmatter(닫는 --- 포함)만 보존하고 본문 영역을 새 본문으로 교체.
+#   status·depends_on 등 frontmatter 는 불변. 본문 영역(get_body 가 읽는 곳)만 바뀐다.
+be_set_body() {
+  local id body; id="$(_argval --task-id "$@")"; body="$(_argval --body "$@")"
+  fs_exists "$id" || tb_die "set_body: 없음 $id"
+  local f; f="$(fs_file "$id")"
+  awk 'BEGIN{n=0} {print} /^---[[:space:]]*$/{n++; if(n==2) exit}' "$f" > "$f.tmp"
+  printf '%s\n' "$body" >> "$f.tmp"
+  mv "$f.tmp" "$f"
+  jq -nc --arg id "$id" '{task_id:$id}'
+}
+
 fs_claim_dir() { printf '%s/.task-work/.claims' "$TB_ROOT"; }
 fs_release_claim() { rm -rf "$(fs_claim_dir)/$1" 2>/dev/null || true; }
 

--- a/plugins/autopilot/task-backend/github.sh
+++ b/plugins/autopilot/task-backend/github.sh
@@ -77,6 +77,17 @@ be_get_body() {
     --arg b "$(gh issue view "$id" $(gh_repo_args) --json body -q .body)" '{task_id:$id, title:$t, body:$b}'
 }
 
+# be_set_body — get_body 의 쓰기 짝. 이슈 본문(=SPEC)을 교체하되 내부 depends_on 마커는 보존.
+#   status 는 라벨, lease 는 전용 코멘트라 본문 교체와 독립(자동 보존).
+be_set_body() {
+  local id body; id="$(_argval --task-id "$@")"; body="$(_argval --body "$@")"
+  local marker; marker="$(gh_body "$id" | sed -n '/^<!-- autopilot:depends_on:.*-->$/p' | head -1)"
+  local full="$body"
+  [[ -n "$marker" ]] && full+=$'\n\n'"$marker"
+  gh issue edit "$id" $(gh_repo_args) --body "$full" >/dev/null 2>&1 || tb_die "set_body 본문 갱신 실패"
+  jq -nc --arg id "$id" '{task_id:$id}'
+}
+
 be_set_status() {
   local id s; id="$(_argval --task-id "$@")"; s="$(_argval --status "$@")"
   local old; old="$(gh_status_label "$id")"

--- a/plugins/autopilot/task-backend/tests/test-filesystem.sh
+++ b/plugins/autopilot/task-backend/tests/test-filesystem.sh
@@ -51,4 +51,13 @@ chk "claim 후 in_progress" "$(bash "$A" get_task --task-id "$d" | jq -r .status
 bash "$A" set_status --task-id "$d" --status done >/dev/null
 [[ -d "$TMP/.task-work/.claims/$d" ]] && bad "done 시 claim 해제" || ok "done 시 claim 해제"
 
+# set_body: 본문만 교체, frontmatter(status·depends_on) 보존
+e="$(bash "$A" create_task --title "E" --body $'## 목표\n원본' --depends-on "$a" | jq -r .task_id)"
+bash "$A" set_status --task-id "$e" --status in_design >/dev/null
+chk "set_body 반환 task_id" "$(bash "$A" set_body --task-id "$e" --body $'## 목표\n교체본문\n## 검증\nok' | jq -r .task_id)" "$e"
+chk "set_body 후 get_body 새 본문" "$(bash "$A" get_body --task-id "$e" | jq -r .body | sed -n 2p)" "교체본문"
+chk "set_body 후 status 불변" "$(bash "$A" get_task --task-id "$e" | jq -r .status)" "in_design"
+chk "set_body 후 depends_on 불변" "$(bash "$A" get_task --task-id "$e" | jq -r '.depends_on[0]')" "$a"
+chk "set_body 후 title 불변" "$(bash "$A" get_body --task-id "$e" | jq -r .title)" "E"
+
 echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 447
