### PR TITLE
fix(loop): 워커가 프로젝트 지침 잃지 않도록 원본 보존+constitution 병합 (#450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.48.12
+
+### 버그 수정
+- **loop 워커가 프로젝트 지침을 잃던 문제 수정** — `loop`이 워크트리의 `CLAUDE.md`/`AGENTS.md`를 플러그인 `constitution.md`로 덮어써, 워커가 소비 프로젝트의 벤더 지침(`rules/` 인덱스 → versioning 등)을 보지 못했다. 이제 워크트리의 원본 프로젝트 지침을 보존하고 그 뒤에 `constitution`을 병합해, 워커가 프로젝트 지침(예: `plugins/` 변경 시 `plugin.json` 버전 범프)과 loop 헌법을 모두 받는다. 플러그인은 특정 프로젝트 규칙을 하드코딩하지 않는다.
+
 ## project-init 0.21.0
 
 ### 새 기능

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.48.11",
+  "version": "0.48.12",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/repair/loop/dispatch/review/flow 6-skill family — spec으로 기능 의도에서 SPEC 작성, repair로 버그·증상·실패 테스트를 정적 분석 진단해 수정용 SPEC 작성(spec 자산 재사용·진단 섹션 추가), loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 준비된 SPEC당 서브에이전트가 한 컨텍스트에서 구현(loop)·리뷰(review)·머지를 소유하는 모델 주도 오케스트레이션(dispatch는 의존성·웨이브·동시성·실패 격리만 총괄, 머지=done이면 의존자 해제; forge 백엔드 가용이면 PR 적대 리뷰→PR 서버사이드 머지(로컬 머지 금지, 분리 승인 신원 불필요), 미가용이면 로컬 적대 리뷰→ff-only 직접 머지; 대상 브랜치 --target-branch), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 추가로 태스크 중심 3-skill family(create-task/execute-task/workflow-task) — create-task로 의도를 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge 워커 헬퍼/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -551,12 +551,27 @@ prepare_workspace() {
   # 어느 cwd 에서 호출되든 같은 작업 공간을 본다.
   printf '%s\n' "$WT" > "$SPEC_DIR/.loop-wt"
 
-  # 헌법을 워크트리의 Claude/Codex 지침 파일로 복사. 워커 계약(노트·signals/ 컨벤션 등)의 SoT 는
-  # constitution.md 이므로 별도 append 없이 cp 만으로 충분하다.
-  cp "$SCRIPT_DIR/constitution.md" "$WT/CLAUDE.md" \
+  # 워커 지침 파일(CLAUDE.md/AGENTS.md)을 구성한다. 워크트리에 이미 있는 소비 프로젝트의 벤더 지침
+  # (AGENTS.md 본문 = rules 인덱스 등 프로젝트 지침)을 보존하고, 그 뒤에 워커 계약 SoT 인
+  # constitution.md 를 병합한다. 이렇게 해야 워커가 프로젝트 지침(예: versioning — plugins/ 변경 시
+  # plugin.json 범프)과 loop 헌법을 모두 받는다. 플러그인은 특정 프로젝트 규칙을 하드코딩하지 않는다.
+  # CLAUDE.md 의 @import 해석에 의존하지 않도록 AGENTS.md 본문을 인라인 기반으로 쓴다(없으면 CLAUDE.md).
+  [[ -f "$SCRIPT_DIR/constitution.md" ]] \
     || die "constitution.md를 찾을 수 없음: $SCRIPT_DIR/constitution.md"
-  cp "$SCRIPT_DIR/constitution.md" "$WT/AGENTS.md" \
-    || die "constitution.md를 찾을 수 없음: $SCRIPT_DIR/constitution.md"
+  local _loop_const _loop_base _loop_merged
+  _loop_const="$(cat "$SCRIPT_DIR/constitution.md")"
+  _loop_base=""
+  if [[ -s "$WT/AGENTS.md" ]]; then _loop_base="$(cat "$WT/AGENTS.md")"
+  elif [[ -s "$WT/CLAUDE.md" ]]; then _loop_base="$(cat "$WT/CLAUDE.md")"; fi
+  if [[ -n "$_loop_base" ]]; then
+    _loop_merged="$(printf '%s\n\n---\n\n%s' "$_loop_base" "$_loop_const")"
+  else
+    _loop_merged="$_loop_const"
+  fi
+  printf '%s\n' "$_loop_merged" > "$WT/CLAUDE.md" \
+    || die "워커 지침 CLAUDE.md 작성 실패: $WT/CLAUDE.md"
+  printf '%s\n' "$_loop_merged" > "$WT/AGENTS.md" \
+    || die "워커 지침 AGENTS.md 작성 실패: $WT/AGENTS.md"
   if git -C "$WT" ls-files --error-unmatch CLAUDE.md >/dev/null 2>&1; then
     git -C "$WT" update-index --skip-worktree CLAUDE.md || true
   fi

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -556,13 +556,16 @@ prepare_workspace() {
   # constitution.md 를 병합한다. 이렇게 해야 워커가 프로젝트 지침(예: versioning — plugins/ 변경 시
   # plugin.json 범프)과 loop 헌법을 모두 받는다. 플러그인은 특정 프로젝트 규칙을 하드코딩하지 않는다.
   # CLAUDE.md 의 @import 해석에 의존하지 않도록 AGENTS.md 본문을 인라인 기반으로 쓴다(없으면 CLAUDE.md).
+  # 원본 프로젝트 지침은 git HEAD(pristine)에서 읽는다 — prepare_workspace 는 재시작 시 워크트리를
+  # 재사용하므로, 이미 병합·skip-worktree 된 작업 사본을 base 로 다시 읽으면 constitution 이 매
+  # 재시작마다 중복 누적된다. HEAD 는 워커가 변경하지 않아(skip-worktree+헌법 금지) 병합이 멱등하다.
   [[ -f "$SCRIPT_DIR/constitution.md" ]] \
     || die "constitution.md를 찾을 수 없음: $SCRIPT_DIR/constitution.md"
   local _loop_const _loop_base _loop_merged
-  _loop_const="$(cat "$SCRIPT_DIR/constitution.md")"
-  _loop_base=""
-  if [[ -s "$WT/AGENTS.md" ]]; then _loop_base="$(cat "$WT/AGENTS.md")"
-  elif [[ -s "$WT/CLAUDE.md" ]]; then _loop_base="$(cat "$WT/CLAUDE.md")"; fi
+  _loop_const="$(cat "$SCRIPT_DIR/constitution.md")" \
+    || die "constitution.md 읽기 실패: $SCRIPT_DIR/constitution.md"
+  _loop_base="$(git -C "$WT" show HEAD:AGENTS.md 2>/dev/null || true)"
+  [[ -z "$_loop_base" ]] && _loop_base="$(git -C "$WT" show HEAD:CLAUDE.md 2>/dev/null || true)"
   if [[ -n "$_loop_base" ]]; then
     _loop_merged="$(printf '%s\n\n---\n\n%s' "$_loop_base" "$_loop_const")"
   else

--- a/plugins/autopilot/skills/loop/tests/test-loop-preserve-project-guidelines.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-preserve-project-guidelines.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# loop 워커 지침 구성이 소비 프로젝트의 벤더 지침(AGENTS.md/CLAUDE.md → rules 인덱스 등)을
+# 보존하고 그 뒤에 constitution 을 병합하는지 검증(정적). 회귀: 과거엔 constitution 을
+# CLAUDE.md/AGENTS.md 로 cp 덮어써 워커가 프로젝트 지침(versioning 등)을 보지 못했다.
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFS="$SCRIPT_DIR/../references"
+LOOP_SH="$REFS/loop.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[[ -f "$LOOP_SH" ]] || fail "loop.sh 부재: $LOOP_SH"
+
+# 1) 더 이상 constitution 을 CLAUDE.md/AGENTS.md 로 덮어쓰지(cp) 않는다(프로젝트 지침 유실 회귀 방지).
+if grep -qE 'cp +"\$SCRIPT_DIR/constitution\.md" +"\$WT/(CLAUDE|AGENTS)\.md"' "$LOOP_SH"; then
+  fail "loop.sh 가 여전히 constitution 을 CLAUDE.md/AGENTS.md 로 cp 덮어쓴다 — 프로젝트 지침 유실"
+fi
+
+# 2) 원본(프로젝트 지침) 보존 + 병합 로직 존재.
+grep -q '_loop_base' "$LOOP_SH"   || fail "원본 지침 보존(_loop_base) 로직 부재"
+grep -q '_loop_merged' "$LOOP_SH" || fail "병합(_loop_merged) 로직 부재"
+
+# 3) 병합본을 두 워커 지침 파일에 기록.
+grep -qE 'printf .+_loop_merged.+> *"\$WT/CLAUDE\.md"' "$LOOP_SH" \
+  || fail "CLAUDE.md 에 병합본 기록 부재"
+grep -qE 'printf .+_loop_merged.+> *"\$WT/AGENTS\.md"' "$LOOP_SH" \
+  || fail "AGENTS.md 에 병합본 기록 부재"
+
+# 4) 병합 기반은 워크트리의 기존 프로젝트 지침(AGENTS.md 우선, 없으면 CLAUDE.md)이어야 한다.
+grep -q '"\$WT/AGENTS.md"' "$LOOP_SH" || fail "병합 기반에서 워크트리 AGENTS.md 참조 부재"
+
+echo "=== loop 프로젝트 지침 보존+병합 테스트 통과 ==="

--- a/plugins/autopilot/skills/loop/tests/test-loop-preserve-project-guidelines.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-preserve-project-guidelines.sh
@@ -26,7 +26,18 @@ grep -qE 'printf .+_loop_merged.+> *"\$WT/CLAUDE\.md"' "$LOOP_SH" \
 grep -qE 'printf .+_loop_merged.+> *"\$WT/AGENTS\.md"' "$LOOP_SH" \
   || fail "AGENTS.md 에 병합본 기록 부재"
 
-# 4) 병합 기반은 워크트리의 기존 프로젝트 지침(AGENTS.md 우선, 없으면 CLAUDE.md)이어야 한다.
-grep -q '"\$WT/AGENTS.md"' "$LOOP_SH" || fail "병합 기반에서 워크트리 AGENTS.md 참조 부재"
+# 4) 멱등성: 병합 기반은 작업 사본이 아니라 git HEAD(pristine)에서 읽어야 한다.
+#    prepare_workspace 가 워크트리를 재사용하므로, 이미 병합된 작업 사본을 base 로 다시 읽으면
+#    재시작마다 constitution 이 중복 누적된다.
+grep -qE 'git -C "\$WT" show HEAD:AGENTS\.md' "$LOOP_SH" \
+  || fail "멱등 base(git show HEAD:AGENTS.md) 미사용 — 재시작 시 constitution 중복 누적 위험"
+# 작업 사본을 base 로 cat 하지 않는다(중복 누적 회귀 방지).
+if grep -qE '_loop_base="\$\(cat "\$WT/(AGENTS|CLAUDE)\.md"\)"' "$LOOP_SH"; then
+  fail "병합 base 를 작업 사본에서 cat 한다 — 재시작 시 중복 누적"
+fi
+
+# 5) constitution 읽기 실패는 즉시 die(silent failure 방지).
+grep -A1 '_loop_const="\$(cat' "$LOOP_SH" | grep -q '|| die' \
+  || fail "constitution 읽기 실패 시 die 부재(silent failure)"
 
 echo "=== loop 프로젝트 지침 보존+병합 테스트 통과 ==="


### PR DESCRIPTION
## 요약
`loop`이 워크트리의 `CLAUDE.md`/`AGENTS.md`를 플러그인 `constitution.md`로 `cp` 덮어써, 워커가 **소비 프로젝트의 벤더 지침**(`rules/` 인덱스 → `versioning` 등)을 보지 못하던 결함(#450)을 고친다.

`#447` 실행에서 워커가 `plugins/` 변경 시 `plugin.json` 버전 범프(프로젝트 versioning 규칙)를 몰라 안 했고, `merge.sh` 버전게이트가 blocked된 근본 원인이다.

## 변경
- `loop.sh`: `cp` 덮어쓰기 → **원본 프로젝트 지침 보존(AGENTS.md 본문 우선) + constitution 병합**. `--system-prompt-file`의 @import 해석 의존을 피하려 AGENTS.md 본문을 인라인 기반으로 사용. 플러그인은 특정 프로젝트 규칙을 하드코딩하지 않음.
- 회귀 테스트 추가(`test-loop-preserve-project-guidelines.sh`).
- autopilot `0.48.11` → `0.48.12`, CHANGELOG.

## 검증
- loop 테스트 8/8 통과(신규 포함), forge/execute-task 6/6 통과, `bash -n` OK.

closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)
