### PR TITLE
🤖 [자동 리뷰] set_body 백엔드 동사 신설 (contract.md + filesystem/github/beads)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.49.0
+
+### 새 기능
+- **task-backend에 `set_body` 동사 신설 — 기존 태스크 본문(=SPEC) 갱신 수단** — 어댑터에 본문 쓰기 프리미티브가 없어(`get_body` 읽기 전용) 이미 등록된 in_design 태스크의 SPEC을 갱신할 수 없던 공백을 메웠다. `set_body --task-id <id> --body <s>` → `{"task_id"}` 를 contract.md 동사표에 `get_body`의 쓰기 짝으로 추가하고 3개 백엔드(filesystem/github-project/beads)에 구현했다. 본문만 교체하고 status·frontmatter·`depends_on` 등 메타는 보존한다(filesystem: frontmatter 뒤 본문 영역만 교체; github: 이슈 본문 교체하되 라벨=status·전용 코멘트 lease는 본문과 독립이라 보존하고 `depends_on` 마커는 재부착; beads: `bd update --description`로 status·`bd dep`와 무관하게 본문만). 작성/등록 분리(#445)·인터뷰 재개(#443)의 본문 갱신 의존성을 푼다.
+
 ## autopilot 0.48.12
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.48.12",
+  "version": "0.49.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. spec/repair/loop/dispatch/review/flow 6-skill family — spec으로 기능 의도에서 SPEC 작성, repair로 버그·증상·실패 테스트를 정적 분석 진단해 수정용 SPEC 작성(spec 자산 재사용·진단 섹션 추가), loop으로 스펙 파일 기반 로컬 자율 실행, dispatch로 준비된 SPEC당 서브에이전트가 한 컨텍스트에서 구현(loop)·리뷰(review)·머지를 소유하는 모델 주도 오케스트레이션(dispatch는 의존성·웨이브·동시성·실패 격리만 총괄, 머지=done이면 의존자 해제; forge 백엔드 가용이면 PR 적대 리뷰→PR 서버사이드 머지(로컬 머지 금지, 분리 승인 신원 불필요), 미가용이면 로컬 적대 리뷰→ff-only 직접 머지; 대상 브랜치 --target-branch), review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 추가로 태스크 중심 3-skill family(create-task/execute-task/workflow-task) — create-task로 의도를 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge 워커 헬퍼/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/task-backend/adapter.sh
+++ b/plugins/autopilot/task-backend/adapter.sh
@@ -78,7 +78,7 @@ main() {
     init)     tb_init "$@";;
     selftest) tb_selftest;;
     backend)  tb_load_backend; jq -nc --arg b "$TB_BACKEND" '{backend:$b}';;
-    create_task|get_task|get_body|set_status|link_dependency|list_ready|append_log|materialize|renew_lease|claim)
+    create_task|get_task|get_body|set_body|set_status|link_dependency|list_ready|append_log|materialize|renew_lease|claim)
       tb_load_backend; "be_$verb" "$@";;
     ""|-h|--help|help)
       cat >&2 <<'EOF'
@@ -86,6 +86,7 @@ usage: adapter.sh <verb> [args]
   init --backend <filesystem|github-project|beads> [--github-project-url U --github-owner O --github-repo R]
   create_task --title T --body B [--depends-on a,b]
   get_task|get_body|materialize|renew_lease --task-id ID
+  set_body --task-id ID --body B
   set_status --task-id ID --status S [--reason R]
   link_dependency --task-id ID --depends-on-id ID
   append_log --task-id ID --marker decision|handoff|blocked --text T
@@ -117,6 +118,10 @@ tb_selftest() {
   ( cd "$TMP" && bash "$A" set_status --task-id "$id1" --status done >/dev/null )
   ready="$(cd "$TMP" && bash "$A" list_ready | jq -r '.[].task_id' | tr '\n' ' ')"
   chk "dep 해제 후 후행 ready" "$ready" "$id2 "
+  # set_body: 본문만 교체, status·depends_on 보존
+  ( cd "$TMP" && bash "$A" set_body --task-id "$id2" --body $'## 목표\n교체본문' >/dev/null )
+  chk "set_body 새 본문" "$(cd "$TMP" && bash "$A" get_body --task-id "$id2" | jq -r .body | grep -c '교체본문')" "1"
+  chk "set_body depends_on 보존" "$(cd "$TMP" && bash "$A" get_task --task-id "$id2" | jq -r '.depends_on[0]')" "$id1"
   # materialize
   local mr; mr="$(cd "$TMP" && bash "$A" materialize --task-id "$id2")"
   local sp; sp="$(printf '%s' "$mr" | jq -r .spec_path)"

--- a/plugins/autopilot/task-backend/beads.sh
+++ b/plugins/autopilot/task-backend/beads.sh
@@ -42,6 +42,13 @@ be_get_body() {
   bd show "$id" --json 2>/dev/null | jq -c '{task_id:.id, title:.title, body:(.description//"")}' || tb_die "bd show 실패: $id"
 }
 
+# be_set_body — 본문(=SPEC)만 교체. status·depends_on(bd dep)·notes 는 별도 경로라 보존된다.
+be_set_body() {
+  local id body; id="$(_argval --task-id "$@")"; body="$(_argval --body "$@")"
+  bd update "$id" --description "$body" >/dev/null 2>&1 || tb_die "bd update --description 실패"
+  jq -nc --arg id "$id" '{task_id:$id}'
+}
+
 be_set_status() {
   local id s; id="$(_argval --task-id "$@")"; s="$(_argval --status "$@")"
   bd update "$id" --status "$s" >/dev/null 2>&1 || tb_die "bd update --status 실패"

--- a/plugins/autopilot/task-backend/contract.md
+++ b/plugins/autopilot/task-backend/contract.md
@@ -73,7 +73,8 @@ DoD 확인 방법(테스트·관찰 지표·수동 단계).
 - [ ] ...
 ```
 
-`get_body`는 위 본문을 반환하고, `materialize`는 `# <title>` H1을 앞에 붙여 임시 spec 파일로 쓴다.
+`get_body`는 위 본문을 반환하고, `set_body`는 위 본문만 교체(status·frontmatter·depends_on 등 메타 보존)하며,
+`materialize`는 `# <title>` H1을 앞에 붙여 임시 spec 파일로 쓴다.
 
 ## 의존성 (depends_on 단일 축)
 
@@ -88,7 +89,7 @@ DoD 확인 방법(테스트·관찰 지표·수동 단계).
 - `list_ready`는 lease가 **stale**(now − lease_renewed_at > `lease_ttl_seconds`)인 in_progress 태스크를 ready로
   반환한다(크래시·행 워커 회수). lease가 신선하면 제외(이중 실행 방지).
 
-## 동사 (9개)
+## 동사 (11개)
 
 모든 동사는 성공 시 한 줄 JSON을 stdout에 쓴다.
 
@@ -97,6 +98,7 @@ DoD 확인 방법(테스트·관찰 지표·수동 단계).
 | `create_task` | `--title <s> --body <s> [--depends-on <id,...>]` | `{"task_id","status":"backlog","url":<s|null>}` |
 | `get_task` | `--task-id <id>` | `{"task_id","title","status","depends_on":[...],"url"}` |
 | `get_body` | `--task-id <id>` | `{"task_id","title","body"}` |
+| `set_body` | `--task-id <id> --body <s>` | `{"task_id"}` (본문만 교체, status·depends_on·meta 보존) |
 | `set_status` | `--task-id <id> --status <state> [--reason <s>]` | `{"task_id","status"}` |
 | `link_dependency` | `--task-id <id> --depends-on-id <id>` | `{"task_id","depends_on":[...]}` |
 | `list_ready` | (없음) | `[{"task_id","title"},...]` (depends_on 충족 + stale-lease in_progress) |

--- a/plugins/autopilot/task-backend/filesystem.sh
+++ b/plugins/autopilot/task-backend/filesystem.sh
@@ -95,6 +95,18 @@ be_get_body() {
     '{task_id:$id, title:$t, body:$b}'
 }
 
+# be_set_body — 본문(=SPEC)만 교체. frontmatter(status·depends_on·meta) 보존.
+#   닫는 --- 까지(frontmatter)를 그대로 두고 그 뒤 본문 영역을 새 본문으로 교체한다.
+be_set_body() {
+  local id body; id="$(_argval --task-id "$@")"; body="$(_argval --body "$@")"
+  fs_exists "$id" || tb_die "set_body: 없음 $id"
+  local f; f="$(fs_file "$id")"
+  { awk 'BEGIN{n=0} /^---[[:space:]]*$/{n++; print; if(n==2) exit; next} n<2{print}' "$f"
+    printf '%s\n' "$body"
+  } > "$f.tmp" && mv "$f.tmp" "$f"
+  jq -nc --arg id "$id" '{task_id:$id}'
+}
+
 fs_claim_dir() { printf '%s/.task-work/.claims' "$TB_ROOT"; }
 fs_release_claim() { rm -rf "$(fs_claim_dir)/$1" 2>/dev/null || true; }
 

--- a/plugins/autopilot/task-backend/github.sh
+++ b/plugins/autopilot/task-backend/github.sh
@@ -77,6 +77,17 @@ be_get_body() {
     --arg b "$(gh issue view "$id" $(gh_repo_args) --json body -q .body)" '{task_id:$id, title:$t, body:$b}'
 }
 
+# be_set_body — 이슈 본문(=SPEC)만 교체. status(라벨)·lease(전용 코멘트)는 본문과 독립이라 보존되고,
+#   depends_on 은 본문 마커라 명시 보존한다(기존 마커를 새 본문 끝에 재부착; 새 본문에 섞여온 마커는 제거).
+be_set_body() {
+  local id body; id="$(_argval --task-id "$@")"; body="$(_argval --body "$@")"
+  local marker; marker="$(gh_body "$id" | sed -n '/^<!-- autopilot:depends_on:.*-->$/p' | head -1)"
+  local new; new="$(printf '%s' "$body" | sed '/^<!-- autopilot:depends_on:.*-->$/d')"
+  [[ -n "$marker" ]] && new+=$'\n'"$marker"
+  gh issue edit "$id" $(gh_repo_args) --body "$new" >/dev/null 2>&1 || tb_die "set_body: 본문 갱신 실패"
+  jq -nc --arg id "$id" '{task_id:$id}'
+}
+
 be_set_status() {
   local id s; id="$(_argval --task-id "$@")"; s="$(_argval --status "$@")"
   local old; old="$(gh_status_label "$id")"

--- a/plugins/autopilot/task-backend/tests/test-filesystem.sh
+++ b/plugins/autopilot/task-backend/tests/test-filesystem.sh
@@ -43,6 +43,16 @@ c="$(bash "$A" create_task --title "C" --body "## 목표"$'\n'"씨" | jq -r .tas
 bash "$A" link_dependency --task-id "$b" --depends-on-id "$c" >/dev/null
 chk "link_dependency 추가" "$(bash "$A" get_task --task-id "$b" | jq -r '.depends_on | length')" "2"
 
+# set_body: 본문만 교체, status·frontmatter(depends_on)·title 보존
+e="$(bash "$A" create_task --title "E" --body $'## 목표\n원본본문' --depends-on "$a" | jq -r .task_id)"
+bash "$A" set_status --task-id "$e" --status in_design >/dev/null
+bash "$A" set_body --task-id "$e" --body $'## 목표\n교체된본문' >/dev/null
+chk "set_body 새 본문 반환" "$(bash "$A" get_body --task-id "$e" | jq -r .body | grep -c '교체된본문')" "1"
+chk "set_body 원본 제거" "$(bash "$A" get_body --task-id "$e" | jq -r .body | grep -c '원본본문')" "0"
+chk "set_body status 보존" "$(bash "$A" get_task --task-id "$e" | jq -r .status)" "in_design"
+chk "set_body depends_on 보존" "$(bash "$A" get_task --task-id "$e" | jq -r '.depends_on[0]')" "$a"
+chk "set_body title 보존" "$(bash "$A" get_body --task-id "$e" | jq -r .title)" "E"
+
 # 원자적 claim: 첫 획득 true, 신선 점유 중 재획득 false
 d="$(bash "$A" create_task --title D --body '## 목표'$'\n'디 | jq -r .task_id)"
 chk "claim 1회 true" "$(bash "$A" claim --task-id "$d" --owner w1 | jq -r .claimed)" "true"


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 447
