### PR TITLE
test(loop): test-loop-sh.sh를 #450 병합 동작에 맞게 수정 + WORKER_FILE 셋업 보강

### DIFF
--- a/tests/autopilot/test-loop-sh.sh
+++ b/tests/autopilot/test-loop-sh.sh
@@ -55,8 +55,8 @@ cat > "$PROJECT/.gitignore" <<'EOF'
 .loop-lock
 .loop-wt
 EOF
-# main-tracked CLAUDE.md — start 가 constitution 으로 덮어쓰고 skip-worktree 설정하는
-# 분별 능력(false-positive halt 차단)을 검증하기 위한 baseline.
+# main-tracked CLAUDE.md — start 가 원본 프로젝트 지침을 보존하고 constitution 을 병합한 뒤
+# skip-worktree 설정하는 분별 능력(false-positive halt 차단)을 검증하기 위한 baseline.
 echo "# placeholder root CLAUDE.md" > "$PROJECT/CLAUDE.md"
 git add -A
 git commit -q -m "chore: baseline (.gitignore + CLAUDE.md)"
@@ -138,8 +138,12 @@ WT2="$PROJECT/specs/basic/.worktree"
 MAX_ITERATIONS=10 WALL_CLOCK_MINUTES=10 loop start "$SPEC2"
 [[ -d "$WT2" ]] || { echo "FAIL: 워크트리 미생성"; exit 1; }
 [[ -f "$WT2/CLAUDE.md" ]] || { echo "FAIL: CLAUDE.md 미복사"; exit 1; }
-diff "$CONSTITUTION_SRC" "$WT2/CLAUDE.md" >/dev/null \
-  || { echo "FAIL: CLAUDE.md가 constitution.md와 다름"; exit 1; }
+# #450: 워커 지침 = 원본 프로젝트 지침 보존 + constitution 병합(덮어쓰기 아님).
+grep -qF "placeholder root CLAUDE.md" "$WT2/CLAUDE.md" \
+  || { echo "FAIL: CLAUDE.md 에 원본 프로젝트 지침이 보존되지 않음"; exit 1; }
+const_first="$(grep -m1 -v '^[[:space:]]*$' "$CONSTITUTION_SRC")"
+grep -qF "$const_first" "$WT2/CLAUDE.md" \
+  || { echo "FAIL: CLAUDE.md 에 constitution 병합 내용이 없음"; exit 1; }
 # 메타는 .loop/ 아래 (구 contract 의 .iterations/·PLAN.md 시드 아님)
 [[ -f "$WT2/.loop/BASE_SHA" ]] || { echo "FAIL: .loop/BASE_SHA 미생성"; exit 1; }
 [[ -f "$WT2/.loop/iterations/1.log" ]] || { echo "FAIL: .loop/iterations/1.log 미생성"; exit 1; }
@@ -274,6 +278,7 @@ echo "=== TEST 11: acquire_lock 이 stale lock(죽은 PID) 자동 정리 (source
   set +e
   source "$LOOP_SH_SRC"
   LOCK_FILE="$WORK_DIR/al-stale.lock"
+  WORKER_FILE="$WORK_DIR/al-stale.worker"   # acquire_lock 의 orphan 판정용(미존재=워커 없음)
   SPEC_PATH="x"
   echo "999999" > "$LOCK_FILE"
   ( acquire_lock; [[ "$(cat "$LOCK_FILE")" == "$$" ]] ) || exit 1
@@ -287,6 +292,7 @@ echo "=== TEST 12: acquire_lock 이 빈/비숫자 PID 도 stale 로 인식 (sour
   set +e
   source "$LOOP_SH_SRC"
   LOCK_FILE="$WORK_DIR/al-empty.lock"
+  WORKER_FILE="$WORK_DIR/al-empty.worker"   # orphan 판정용(미존재=워커 없음)
   SPEC_PATH="x"
   : > "$LOCK_FILE"          # 빈 PID
   ( acquire_lock ) || exit 1


### PR DESCRIPTION
## 요약
`tests/autopilot/test-loop-sh.sh`를 #450(PR #453)의 변경 동작에 맞게 고치고, 그 과정에서 드러난 TEST 11/12의 셋업 누락을 보강한다.

## 배경
- **#450 회귀**: #450에서 loop이 워커 지침(`CLAUDE.md`/`AGENTS.md`)을 `constitution.md`로 덮어쓰던 것을 **원본 프로젝트 지침 보존 + constitution 병합**으로 바꿨다. 그 결과 `CLAUDE.md`가 더 이상 `constitution.md`와 정확히 같지 않은데, 이 테스트는 `diff CONSTITUTION CLAUDE.md` 정확 일치를 단언해 깨졌다. (#450 검증 시 `skills/loop/tests/`만 돌리고 `tests/autopilot/`를 안 돌려 놓쳤고, 봇 리뷰는 테스트를 실행하지 않아 그대로 머지됨.)
- 단언을 **"원본 프로젝트 지침 보존 + constitution 병합 내용 포함"** 검증으로 교체.
- 위 수정으로 이전엔 line 142에서 일찍 실패해 **가려져 있던 TEST 11/12의 잠재 결함**이 드러났다: `acquire_lock`을 sourced로 단독 호출하며 `LOCK_FILE`만 설정하고 `WORKER_FILE`을 누락해 `set -u` unbound가 났다. 테스트 셋업에 `WORKER_FILE`(미존재 경로=워커 없음)을 추가.

## 검증
- `test-loop-sh.sh` **36개 전부 통과**.
- tests-only 변경(watch 디렉토리 `plugins/` 무관 → 버전 범프 불필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
