### PR TITLE
fix(review): 0 findings 면 APPROVE 강제 — codex·claude verdict 비대칭 (#451)

### DIFF
--- a/.github/scripts/pr-review-chunking.js
+++ b/.github/scripts/pr-review-chunking.js
@@ -231,14 +231,16 @@ function needsChunking(estimatedDiffTokens, opts) {
   return (estimatedDiffTokens || 0) > threshold;
 }
 
-// 리뷰 이벤트 결정(전 청크 합산): 모든 청크 verdict 가 approve 이고, 병합된
-// findings 가 비어 있고, may_approve=true 이며, 어떤 청크도 truncate 되지
-// 않았고, 청크가 하나 이상일 때만 APPROVE. 그 외 COMMENT.
+// 리뷰 이벤트 결정(전 청크 합산): 리뷰가 완료된 한(모든 청크 verdict 가 approve|comment),
+// 병합된 findings 가 비어 있고, may_approve=true 이며, 어떤 청크도 truncate 되지 않았고,
+// 청크가 하나 이상일 때 APPROVE. 그 외 COMMENT.
+// #451: 모델이 0 findings 에서도 verdict:"comment" 를 반환하는 비일관성을 흡수하기 위해
+// approve 구두 verdict 를 강제하지 않는다(needs_context/unavailable 같은 불완전 리뷰는 제외).
 function decideReviewEvent({ chunkVerdicts, mergedFindingsCount, mayApprove, anyTruncated }) {
   const verdicts = Array.isArray(chunkVerdicts) ? chunkVerdicts : [];
   if (verdicts.length === 0) return 'COMMENT';
-  const allApprove = verdicts.every((v) => v === 'approve');
-  if (allApprove && mergedFindingsCount === 0 && !!mayApprove && !anyTruncated) {
+  const allReviewed = verdicts.every((v) => v === 'approve' || v === 'comment');
+  if (allReviewed && mergedFindingsCount === 0 && !!mayApprove && !anyTruncated) {
     return 'APPROVE';
   }
   return 'COMMENT';

--- a/.github/scripts/pr-review-chunking.test.js
+++ b/.github/scripts/pr-review-chunking.test.js
@@ -223,9 +223,21 @@ test('decide: APPROVE only when all approve, no findings, may_approve, no trunca
   }), 'APPROVE');
 });
 
-test('decide: COMMENT when any chunk verdict is not approve', () => {
+// #451: 모델이 0 findings 에서도 comment verdict 를 반환하는 비일관성 흡수 — comment 도 APPROVE.
+test('decide: APPROVE when a chunk verdict is comment but no findings (#451)', () => {
+  assert.strictEqual(M.decideReviewEvent({
+    chunkVerdicts: ['approve', 'comment'], mergedFindingsCount: 0,
+    mayApprove: true, anyTruncated: false,
+  }), 'APPROVE');
+});
+
+test('decide: COMMENT when a chunk verdict is request_changes/needs_context (불완전·차단)', () => {
   assert.strictEqual(M.decideReviewEvent({
     chunkVerdicts: ['approve', 'request_changes'], mergedFindingsCount: 0,
+    mayApprove: true, anyTruncated: false,
+  }), 'COMMENT');
+  assert.strictEqual(M.decideReviewEvent({
+    chunkVerdicts: ['comment', 'needs_context'], mergedFindingsCount: 0,
     mayApprove: true, anyTruncated: false,
   }), 'COMMENT');
 });

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1009,15 +1009,19 @@ jobs:
             const chunkVerdicts = reviewedResults.map((r) => r.verdict);
             const mayApprove = reviewedResults.every((r) => !!r.automation_safety?.may_approve);
             const anyTruncated = reviewedResults.some((r) => !!r.reviewed_context?.diff_truncated);
-            // verdict label kept for the idempotency marker (single, deterministic).
-            const verdict = chunkVerdicts.every((v) => v === 'approve') ? 'approve' : 'comment';
+            // #451: 모델이 0 findings 에서도 verdict:"comment" 를 반환하는 비일관성을 흡수한다.
+            // 리뷰가 완료된 한(approve|comment) findings 0 · 모델 승인 허용 · 미절단이면 APPROVE 한다.
+            // (needs_context/unavailable 처럼 리뷰가 불완전한 verdict 는 제외 — 불완전 리뷰는 승인하지 않는다.)
+            const allReviewed = chunkVerdicts.every((v) => v === 'approve' || v === 'comment');
+            const canApprove = (findings.length === 0 && allReviewed && mayApprove && !anyTruncated);
+            // verdict label kept for the idempotency marker (single, deterministic) — event 와 정합.
+            const verdict = canApprove ? 'approve' : 'comment';
 
             // Event decision — official review event is APPROVE or COMMENT only.
             // The changes-requested review state is abolished: blocking findings
             // surface as inline comments (inline-only policy), not a review state.
             let event;
-            if (findings.length === 0 && chunkVerdicts.every((v) => v === 'approve')
-                && mayApprove && !anyTruncated) {
+            if (canApprove) {
               event = 'APPROVE';
             } else {
               event = 'COMMENT';

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -877,15 +877,19 @@ jobs:
             const chunkVerdicts = reviewedResults.map((r) => r.verdict);
             const mayApprove = reviewedResults.every((r) => !!r.automation_safety?.may_approve);
             const anyTruncated = reviewedResults.some((r) => !!r.reviewed_context?.diff_truncated);
-            // verdict label kept for the idempotency marker (single, deterministic).
-            const verdict = chunkVerdicts.every((v) => v === 'approve') ? 'approve' : 'comment';
+            // #451: 모델이 0 findings 에서도 verdict:"comment" 를 반환하는 비일관성을 흡수한다.
+            // 리뷰가 완료된 한(approve|comment) findings 0 · 모델 승인 허용 · 미절단이면 APPROVE 한다.
+            // (needs_context/unavailable 처럼 리뷰가 불완전한 verdict 는 제외 — 불완전 리뷰는 승인하지 않는다.)
+            const allReviewed = chunkVerdicts.every((v) => v === 'approve' || v === 'comment');
+            const canApprove = (findings.length === 0 && allReviewed && mayApprove && !anyTruncated);
+            // verdict label kept for the idempotency marker (single, deterministic) — event 와 정합.
+            const verdict = canApprove ? 'approve' : 'comment';
 
             // Event decision — official review event is APPROVE or COMMENT only.
             // The changes-requested review state is abolished: blocking findings
             // surface as inline comments (inline-only policy), not a review state.
             let event;
-            if (findings.length === 0 && chunkVerdicts.every((v) => v === 'approve')
-                && mayApprove && !anyTruncated) {
+            if (canApprove) {
               event = 'APPROVE';
             } else {
               event = 'COMMENT';


### PR DESCRIPTION
## 요약
review 봇(codex·claude)이 0 findings 에서도 모델이 `verdict:"comment"` 를 반환하면 APPROVE 대신 COMMENT 를 게시하던 비일관성(#448 codex·#455 claude)을 흡수한다.

## 변경
- verdict 결정에서 `chunkVerdicts.every(approve)`(모델 구두 verdict) 요구 제거 → **리뷰 완료(approve|comment) + findings 0 + may_approve + 미절단이면 APPROVE**. `needs_context`/`unavailable` 같은 불완전 리뷰는 제외. verdict 마커도 event 와 정합.
- `codex-review.yml`·`claude-review.yml`(인라인, 동일) + 공유 `pr-review-chunking.js`(decideReviewEvent) + 테스트.

## 검증
- `pr-review-chunking.test.js` 33개 통과(#451 케이스 추가), claude-review-workflow 테스트 통과.
- (참고) codex-review-workflow 테스트의 'codex-action 3 vs 2' 실패는 본 변경과 무관한 기존 실패.

closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)