### PR TITLE
🤖 [자동 리뷰] fix: test-fix-skill.sh S7 단언을 frontmatter-first 템플릿의 '완료 조건' 어휘에 정합(stale 테스트)

### DIFF
--- a/tests/autopilot/test-fix-skill.sh
+++ b/tests/autopilot/test-fix-skill.sh
@@ -68,13 +68,13 @@ if grep -rqE 'repair 고유|create-task 자체 소유|feature 자체 소유' "$F
 fi
 ok "fix 참조: 타 스킬 소유 표기 부재"
 
-# === S7: fix task-body-template 에 진단 섹션 + 완료 기준 ===
-echo "=== S7: fix 본문 템플릿 진단 섹션 + 완료 기준 ==="
+# === S7: fix task-body-template 에 진단 섹션 + 완료 조건 ===
+echo "=== S7: fix 본문 템플릿 진단 섹션 + 완료 조건 ==="
 grep -qE '^##[[:space:]]*진단' "$FIX/references/task-body-template.md" \
   || fail "S7: fix task-body-template에 '## 진단' 섹션 없음"
-grep -q '완료 기준' "$FIX/references/task-body-template.md" \
-  || fail "S7: fix task-body-template에 완료 기준 없음"
-ok "fix 본문 템플릿: 진단 섹션 + 완료 기준"
+grep -qE '^##[[:space:]]*완료 조건' "$FIX/references/task-body-template.md" \
+  || fail "S7: fix task-body-template에 '## 완료 조건' 섹션 없음"
+ok "fix 본문 템플릿: 진단 섹션 + 완료 조건"
 
 # === S8: fix 진단은 정적 한정 + 가설 프레이밍 + 마커 ===
 echo "=== S8: fix diagnosis 정적 한정 + 마커 ==="


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 476

## 요약

`tests/autopilot/test-fix-skill.sh`의 S7 단언이 현재 fix 본문 템플릿(frontmatter-first)의 DoD 섹션 어휘와 정합하도록 고쳐, S7가 통과하게 한다. 템플릿은 그대로 둔다(테스트만 정정).
