### PR TITLE
🤖 [자동 리뷰] fix: claude-review 자동승인 게이트가 정상 삭제류 변경을 미승인 처리 — may_approve 시맨틱 불일치 / 에스컬레이션 경로 부재

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1003,17 +1003,25 @@ jobs:
               core.info(`${excludedFindings.length} finding(s) excluded as off-diff; ${inlineFindings.length} in-diff finding(s) will be submitted.`);
             }
 
-            // Aggregate verdict/safety across chunks. APPROVE only when EVERY
-            // reviewed chunk's verdict is approve, the merged findings are empty,
-            // every chunk allows approval, and no chunk's input was truncated.
+            // Aggregate verdict/safety across chunks. APPROVE only when the merged
+            // findings are empty, every chunk is reviewed (approve|comment), and no
+            // chunk's input was truncated — a deterministic verdict-derivation, not
+            // the model's automation_safety.may_approve self-judgment (#480).
             const chunkVerdicts = reviewedResults.map((r) => r.verdict);
-            const mayApprove = reviewedResults.every((r) => !!r.automation_safety?.may_approve);
             const anyTruncated = reviewedResults.some((r) => !!r.reviewed_context?.diff_truncated);
             // #451: 모델이 0 findings 에서도 verdict:"comment" 를 반환하는 비일관성을 흡수한다.
-            // 리뷰가 완료된 한(approve|comment) findings 0 · 모델 승인 허용 · 미절단이면 APPROVE 한다.
+            // 리뷰가 완료된 한(approve|comment) findings 0 · 미절단이면 APPROVE 한다.
             // (needs_context/unavailable 처럼 리뷰가 불완전한 verdict 는 제외 — 불완전 리뷰는 승인하지 않는다.)
             const allReviewed = chunkVerdicts.every((v) => v === 'approve' || v === 'comment');
-            const canApprove = (findings.length === 0 && allReviewed && mayApprove && !anyTruncated);
+            // #480: may_approve 는 리뷰 verdict 에서 결정적으로 파생한다 — SKILL 하니스
+            // review.sh:180(may_approve = (verdict==approve))와 동일한 단일 출처 규칙.
+            // 모델의 automation_safety.may_approve 자가판정에 의존하지 않는다: 프롬프트가
+            // 그 필드의 판정 기준을 정의하지 않아 #451 verdict:"comment"-on-0-findings 와
+            // 상관해 보수적 false 를 내고, findings 0·미절단 clean 삭제류 PR 까지 spurious
+            // blocked 시켰다(#477/#479). 여기서 verdict==approve ⇔ 병합 findings 0 ·
+            // 전 청크 리뷰완료(approve|comment) · 미절단.
+            const mayApprove = (findings.length === 0 && allReviewed && !anyTruncated);
+            const canApprove = mayApprove;
             // verdict label kept for the idempotency marker (single, deterministic) — event 와 정합.
             const verdict = canApprove ? 'approve' : 'comment';
 

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/review/references/output-schema.json
+++ b/plugins/autopilot/skills/review/references/output-schema.json
@@ -74,6 +74,7 @@
       }
     },
     "automation_safety": {
+      "$comment": "may_approve 는 verdict 에서 결정적으로 파생된다: may_approve = (verdict==approve). 하니스(review.sh:180)·CI 자동승인 게이트(claude-review.yml)·본 스키마의 단일 출처 규칙(#480). 모델의 무기준 자가판정으로 두지 않는다 — clean 리뷰(verdict=approve)는 자동승인하고, 자동승인이 부적절하면 리뷰어가 finding 을 내어 verdict 를 comment 로 낮춘다.",
       "type": "object",
       "additionalProperties": false,
       "required": ["may_approve", "may_request_changes", "reason"],

--- a/plugins/autopilot/skills/review/references/review.sh
+++ b/plugins/autopilot/skills/review/references/review.sh
@@ -177,6 +177,8 @@ mediate() {
           skipped_files: ($ctx.skipped_files // [])
         },
         automation_safety: {
+          # may_approve 는 verdict 에서 결정적으로 파생한다(단일 출처 규칙, #480).
+          # CI 자동승인 게이트(claude-review.yml)·output-schema.json 도 동일 규칙을 따른다.
           may_approve: ($verdict == "approve"),
           may_request_changes: (($blocking | length) > 0),
           reason: (if $unavail then "안전하게 approve 불가(컨텍스트 불완전)"

--- a/plugins/autopilot/skills/review/tests/test-review-harness.sh
+++ b/plugins/autopilot/skills/review/tests/test-review-harness.sh
@@ -238,5 +238,32 @@ echo "$res"   | grep -q "$stillfp" && fail "H16: 유지 스레드가 잘못 reso
 echo "$unres" | grep -q "$stillfp" || fail "H16: 유지 스레드가 unresolved 에 없음"
 ok "H16 스레드 라이프사이클: resolved=$gonefp, unresolved=$stillfp"
 
+# === H17: automation_safety.may_approve = (pipeline_verdict==approve) ===
+# may_approve 는 verdict 에서 결정적으로 파생된다(review.sh:180). CI claude-review
+# 게이트(claude-review.yml)도 동일 규칙(verdict 파생)이어야 하며(#480), 모델 자가판정에
+# 의존하지 않는다. 이 불변식이 하니스·CI 양쪽 산출의 단일 출처다.
+echo "=== H17: may_approve = (verdict==approve) 파생 불변식 ==="
+export REVIEW_STATE_DIR="$WORK/state-h17a"
+set_mocks "$(mk_ctx false false)" "$(mk_spec '["AC1","AC2"]')" "$(mk_lens '[]' '["AC1","AC2"]' false)" "$(mk_threads '')"
+out="$(run_review t17a)" || fail "H17a: run 비정상 종료"
+v="$(echo "$out" | jq -r '.pipeline_verdict')"
+ma="$(echo "$out" | jq -r '.automation_safety.may_approve')"
+[[ "$v" == "approve" && "$ma" == "true" ]] || fail "H17a: approve 인데 may_approve=$ma (true 기대)"
+export REVIEW_STATE_DIR="$WORK/state-h17b"
+set_mocks "$(mk_ctx false false)" "$(mk_spec '["AC1"]')" "$(mk_lens "$GOOD_BLOCKING" '["AC1"]' false)" "$(mk_threads '')"
+out="$(run_review t17b)" || fail "H17b: run 비정상 종료"
+v="$(echo "$out" | jq -r '.pipeline_verdict')"
+ma="$(echo "$out" | jq -r '.automation_safety.may_approve')"
+[[ "$v" != "approve" && "$ma" == "false" ]] || fail "H17b: non-approve(verdict=$v)인데 may_approve=$ma (false 기대)"
+# CI 게이트(claude-review.yml)가 모델 자가판정이 아니라 verdict 파생임을 교차 확인.
+# 플러그인 자기완결을 위해 파일이 있을 때만 검사한다(소비 리포 밖 설치 시 graceful skip).
+CI_WORKFLOW="${CI_WORKFLOW:-$SCRIPT_DIR/../../../../../.github/workflows/claude-review.yml}"
+if [[ -f "$CI_WORKFLOW" ]]; then
+  if grep -qF 'r.automation_safety?.may_approve' "$CI_WORKFLOW"; then
+    fail "H17: CI 게이트가 모델 자가판정 automation_safety.may_approve 에 의존 — verdict 파생 불일치 (#480)"
+  fi
+fi
+ok "H17 may_approve 파생 불변식 (하니스·CI 일관)"
+
 echo ""
 echo "ALL HARNESS TESTS PASSED"

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -257,7 +257,16 @@ grep -qF "submit('COMMENT')" "$WORKFLOW" \
   || fail "APPROVE 실패 시 같은 inline 코멘트로 COMMENT 강등 제출 부재 (AC7)"
 grep -qF 'may_approve' "$WORKFLOW" \
   || fail "approve safety gate(may_approve) 부재"
-ok "check 6: 단일 inline 리뷰 제출 (APPROVE/COMMENT) + 승인 본문(요약 미작성) + 멱등 + APPROVE fallback"
+# #480: 자동승인 게이트는 모델의 무기준 자가판정(automation_safety.may_approve)이
+# 아니라 리뷰 verdict 에서 결정적으로 파생돼야 한다(하니스 review.sh:180 과 동일 규칙).
+# 모델 필드 의존이 잔존하면 findings 0·미절단 clean 리뷰조차 보수적 false 로 막혀
+# 삭제류 정상 PR 이 spurious blocked 된다(#477/#479).
+if grep -qF 'r.automation_safety?.may_approve' "$WORKFLOW"; then
+  fail "자동승인 게이트가 모델 자가판정 automation_safety.may_approve 에 의존 — verdict 파생으로 정합 필요 (#480)"
+fi
+grep -qF 'const mayApprove = (findings.length === 0 && allReviewed && !anyTruncated)' "$WORKFLOW" \
+  || fail "mayApprove 가 verdict 파생(findings 0·allReviewed·미절단) predicate 로 산출되지 않음 (#480)"
+ok "check 6: 단일 inline 리뷰 제출 (APPROVE/COMMENT) + 승인 본문(요약 미작성) + 멱등 + APPROVE fallback + verdict-파생 게이트(#480)"
 
 echo ""
 echo "=== check 7: 별도 마커 관리형 이슈 레벨 코멘트 게시 경로 부재 (AC6) ==="


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 480

## 요약

CI claude-review의 `automation_safety.may_approve`를 리뷰 SKILL 하니스(`review.sh`)와 동일하게 **verdict에서 결정적으로 파생**(`may_approve = (verdict == approve)`)하도록 만들어, findings 0건의 정상 변경(테스트·문서 삭제 포함)이 일관되게 자동 `approve`로 처리되고 auto-merge 게이트가 열리게 한다.
