### PR TITLE
🤖 [자동 리뷰] fix: 플러그인 forge 머지 엔진의 프로젝트-소유 버전 게이트 제거 (정책 계층 역전·비이식성 해소)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.53.0
+
+### 변경(깨짐)
+- **forge 머지 엔진에서 프로젝트-소유 버전 범프 게이트 제거(정책-불간섭)** — 머지 엔진(`forge/lib/merge.sh`)이 plugins/ 변경 시 `plugin.json` 버전 범프를 단언하던 게이트(`mg_version_gate`와 보조 함수군·`WATCH_DIRS`·`version-gate` 서브커맨드·`blocked: version-bump` 종착)와, 그 게이트를 충족시키려 존재하던 통합 엔진(`forge/lib/integration.sh`)의 병렬 동일-버전 자동 재범프(`in_ensure_version_ahead`)·버전-전용 충돌 결정적 해소(`in_conflict_version_only`·`in_resolve_version_conflict`·`in_reapply_bump`)를 제거했다. 버전 범프는 컨슈밍 프로젝트 소유 정책(`rules/engineering/versioning.md`)이므로 범용 플러그인이 이를 집행하는 것은 계층 역전이며, 게이트 구현이 `plugin.json`·`plugins/`를 하드코딩해 다른 형태(`package.json`·`pyproject.toml`)의 프로젝트에서 오작동하는 비이식성 결함이었다. 이제 머지 경로는 정책-중립 게이트(PR 존재·승인·ff-only)만 유지하고 버전 정책에 간섭하지 않는다. `plugin.json` 충돌은 일반 rebase 충돌 전략으로 귀결된다. 버전 강제가 필요하면 컨슈밍 프로젝트가 자기 CI로 도입한다(플러그인은 강제하지 않음).
+
 ## autopilot 0.52.0
 
 ### 변경(깨짐)

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.52.1",
+  "version": "0.53.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/forge/lib/integration.sh
+++ b/plugins/autopilot/forge/lib/integration.sh
@@ -169,76 +169,20 @@ in_ensure_work_branch() {
 
 # =====================================================================
 # 3) git 통합 — base sync(rebase, ff 가능 시) → push. force 금지.
-#    타겟 전진으로 인한 충돌은 워커가 자율 해결한다(결정적 버전 해소 + 일반 충돌은
-#    전략 해소 + 비결정 표시로 머지 전 재검증 유도). 자동 해결·재동기화·재시도는 non-force.
-#    정책 단일 출처: 본 절(결정적 헬퍼) + 워커 계약(subagent-prompt.md).
+#    타겟 전진으로 인한 충돌은 워커가 전략으로 자율 해소하고 비결정 표시로 머지 전 재검증을
+#    유도한다(버전 범프 정책은 컨슈밍 프로젝트 소유 — plugin.json 충돌도 일반 충돌로 처리).
+#    자동 해결·재동기화·재시도는 non-force. 정책 단일 출처: 본 절 + 워커 계약(subagent-prompt.md).
 # =====================================================================
 
-# INT_AUTORESOLVE_FLAG — 직전 base sync 에서 '비결정(일반) 충돌'을 전략으로 해소했으면
-#   'needs-verify'. 워커는 이 표시가 있으면 머지 전 검증(완료 조건/selftest)을 재실행하고
-#   통과할 때만 진행한다(거짓 green 방지). 결정적(버전-only) 해소만 있었으면 비어 있음.
+# INT_AUTORESOLVE_FLAG — 직전 base sync 에서 충돌을 전략으로 해소했으면 'needs-verify'.
+#   워커는 이 표시가 있으면 머지 전 검증(완료 조건/selftest)을 재실행하고 통과할 때만
+#   진행한다(거짓 green 방지). 충돌 해소가 없었으면 비어 있음.
 INT_AUTORESOLVE_FLAG=""
 
-# in_json_version <ref> <path> — ref 의 plugin.json version 값(예 0.39.0). 없으면 빈 문자열.
-in_json_version() {
-  # shellcheck disable=SC2086
-  $GIT_CMD show "$1:$2" 2>/dev/null \
-    | grep -m1 -E '"version"[[:space:]]*:' \
-    | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"?([0-9][0-9.]*)"?.*/\1/'
-}
-
-# in_reapply_bump <target> <base> <our> — base→our 의 최상위 증가 필드(major/minor/patch)를
-#   target 위에 재적용한 새 버전 echo. 범프 레벨을 못 가리면 target 의 patch+1(보수적 최소 증가).
-#   결과는 항상 target 보다 엄격히 크다(작업 브랜치 범프 의도 보존 + 타겟 전진 반영).
-in_reapply_bump() {
-  local tgt="$1" base="$2" our="$3" oldIFS="$IFS"
-  IFS=.; # shellcheck disable=SC2206
-  local -a t=($tgt) b=($base) o=($our); IFS="$oldIFS"
-  local lvl=2 i bi oi
-  for ((i=0;i<3;i++)); do
-    bi="${b[i]:-0}"; oi="${o[i]:-0}"; bi="${bi//[!0-9]/}"; oi="${oi//[!0-9]/}"
-    [[ -n "$bi" ]] || bi=0; [[ -n "$oi" ]] || oi=0
-    if (( 10#$oi > 10#$bi )); then lvl=$i; break; fi
-  done
-  local -a r=("${t[0]:-0}" "${t[1]:-0}" "${t[2]:-0}") j
-  for ((j=0;j<3;j++)); do r[j]="${r[j]//[!0-9]/}"; [[ -n "${r[j]}" ]] || r[j]=0; done
-  r[lvl]=$(( 10#${r[lvl]} + 1 ))
-  for ((j=lvl+1;j<3;j++)); do r[j]=0; done
-  printf '%s.%s.%s\n' "${r[0]}" "${r[1]}" "${r[2]}"
-}
-
-# in_conflict_version_only <file> — 충돌 블록(<<< ~ >>>) 안 비-마커 라인이 모두 "version" 라인이면 0.
-#   결정적(버전-only) 충돌 판정 — 그 외(코드 의미) 충돌과 구분한다.
-in_conflict_version_only() {
-  awk '
-    /^<<<<<<< /{inc=1; seen=1; next}
-    /^=======$/{next}
-    /^>>>>>>> /{inc=0; next}
-    inc && $0 !~ /"version"[[:space:]]*:/ { bad=1 }
-    END { exit ((seen && !bad)?0:1) }
-  ' "$1"
-}
-
-# in_resolve_version_conflict <file> — 진행 중 rebase 의 버전-only 충돌 결정적 해소.
-#   새 베이스(HEAD=origin/main) plugin.json 전체를 취하고 version 만 in_reapply_bump 값으로.
-in_resolve_version_conflict() {
-  local f="$1" tgt our base mb newv
-  tgt="$(in_json_version HEAD "$f")"          # rebase 중 HEAD = 새 베이스(origin/main)
-  our="$(in_json_version REBASE_HEAD "$f")"   # 재적용 중 작업 커밋
-  # shellcheck disable=SC2086
-  mb="$($GIT_CMD merge-base REBASE_HEAD HEAD 2>/dev/null)"
-  base="$(in_json_version "$mb" "$f")"
-  newv="$(in_reapply_bump "$tgt" "$base" "$our")"
-  [[ -n "$newv" ]] || return 1
-  # shellcheck disable=SC2086
-  $GIT_CMD show "HEAD:$f" 2>/dev/null \
-    | sed -E "s/(\"version\"[[:space:]]*:[[:space:]]*\")[0-9][0-9.]*(\")/\1$newv\2/" > "$f" || return 1
-  return 0
-}
-
 # in_autoresolve_rebase <branch> — 진행 중(충돌 정지) rebase 를 자율 해결.
-#   파일별: plugin.json 버전-only → 결정적 해소; 그 외 → DISPATCH_CONFLICT_STRATEGY
-#   (기본 incoming=재적용 중 작업 커밋 쪽 --theirs, base=새 베이스 쪽 --ours) + 비결정 표시.
+#   파일별: DISPATCH_CONFLICT_STRATEGY (기본 incoming=재적용 중 작업 커밋 쪽 --theirs,
+#   base=새 베이스 쪽 --ours) + 비결정 표시. plugin.json 버전 충돌도 일반 충돌로 처리한다
+#   (버전 범프 정책은 컨슈밍 프로젝트 소유 — 통합 엔진은 버전-전용 해소를 집행하지 않음).
 #   닫으면 rebase --continue 후 0, 닫지 못하면 abort 후 1. force 미사용.
 in_autoresolve_rebase() {
   local branch="$1" f resolved_general=0 unmerged
@@ -247,16 +191,12 @@ in_autoresolve_rebase() {
   [[ -n "$unmerged" ]] || { $GIT_CMD rebase --abort 2>/dev/null || true; return 1; }
   while IFS= read -r f; do
     [[ -n "$f" ]] || continue
-    if [[ "$f" =~ (^|/)plugin\.json$ ]] && in_conflict_version_only "$f"; then
-      in_resolve_version_conflict "$f" || { $GIT_CMD rebase --abort 2>/dev/null || true; return 1; }
-    else
-      # shellcheck disable=SC2086
-      case "${DISPATCH_CONFLICT_STRATEGY:-incoming}" in
-        base) $GIT_CMD checkout --ours   -- "$f" 2>/dev/null || true ;;
-        *)    $GIT_CMD checkout --theirs -- "$f" 2>/dev/null || true ;;
-      esac
-      resolved_general=1
-    fi
+    # shellcheck disable=SC2086
+    case "${DISPATCH_CONFLICT_STRATEGY:-incoming}" in
+      base) $GIT_CMD checkout --ours   -- "$f" 2>/dev/null || true ;;
+      *)    $GIT_CMD checkout --theirs -- "$f" 2>/dev/null || true ;;
+    esac
+    resolved_general=1
     # shellcheck disable=SC2086
     $GIT_CMD add -- "$f" 2>/dev/null || true
   done <<< "$unmerged"
@@ -358,109 +298,6 @@ _in_base_sync_core() {
 in_push_branch() {
   # shellcheck disable=SC2086
   $GIT_CMD push origin "$1" || { in_die "push 실패(force 금지): $1"; return 1; }
-}
-
-# =====================================================================
-# 3b2) 병렬 동일-버전 범프 자동 재범프 — base sync 후, feat 브랜치 plugin.json 버전이
-#   새 베이스(origin/main)보다 **앞서지 않으면(<=)** 새 베이스보다 한 단계 앞서게 재범프한다.
-#   배경: 두 작업이 같은 버전으로 범프하면 늦은 쪽 rebase 에 version 변경이 이미 적용된 동일
-#   변경이라 git 충돌이 없고(in_resolve_version_conflict 미발동), 머지 단계 버전게이트가 동률을
-#   blocked 처리한다(수동 재범프 유발). 재범프는 history 재작성이 아닌 **append commit** 이라
-#   기존 원격 브랜치/PR 이 있어도 ff-safe(force 불필요). 충돌 기반 재적용 경로(in_resolve_version_conflict)는
-#   그대로 보존한다.
-# =====================================================================
-
-# in_semver_gt <new> <old> — new 가 old 보다 큰 SemVer 면 0. old 가 비면(신규 매니페스트) new 만
-#   있으면 0(앞섬). 동일/작으면 1. 외부 도구 없이 필드별 숫자 비교(bash 3.2).
-in_semver_gt() {
-  local new="$1" old="$2"
-  [[ -n "$new" ]] || return 1
-  [[ -n "$old" ]] || return 0
-  local oldIFS="$IFS"; IFS=.
-  # shellcheck disable=SC2206
-  local -a na=($new) oa=($old); IFS="$oldIFS"
-  local i n o
-  for ((i=0; i<3; i++)); do
-    n="${na[i]:-0}"; o="${oa[i]:-0}"; n="${n//[!0-9]/}"; o="${o//[!0-9]/}"
-    [[ -n "$n" ]] || n=0; [[ -n "$o" ]] || o=0
-    if (( 10#$n > 10#$o )); then return 0; fi
-    if (( 10#$n < 10#$o )); then return 1; fi
-  done
-  return 1
-}
-
-# _in_ensure_version_ahead_core <branch> <wt> — 분리 워크트리(wt, 분리 HEAD=origin/$branch tip) 안에서
-#   브랜치가 워치 디렉토리(plugins)에서 건드린 플러그인의 plugin.json 이 base(origin/main)보다 앞서지
-#   않으면 한 단계 앞서게 재기입·commit·push(HEAD:refs/heads/$branch, ff append) 한다.
-#   중요: 병렬 동일-버전 범프에서는 늦은 쪽 plugin.json 이 base 와 **완전히 동일**해 diff(변경 매니페스트)에
-#   잡히지 않는다. 그래서 변경 파일이 아니라 **건드린 플러그인 루트의 매니페스트**를 ls-tree 로 찾아
-#   버전이 앞서는지 검사한다(머지 버전게이트가 동률을 차단하는 바로 그 조건과 정렬). 재범프할 게
-#   없으면 no-op(이미 앞섬·워치 미접촉 → 불변).
-_in_ensure_version_ahead_core() {
-  local branch="$1" wt="$2" m base our newv any=0 touched roots root manifests
-  local wd="${INT_WATCH_DIRS:-plugins}"   # versioning.md 워치 디렉토리(머지 게이트 기본과 동일).
-  # 브랜치가 워치 디렉토리에서 건드린 파일(origin/main..HEAD).
-  # shellcheck disable=SC2086
-  touched="$($GIT_CMD diff --name-only "origin/$DEFAULT_BRANCH...HEAD" 2>/dev/null | grep -E "^$wd/" || true)"
-  [[ -n "$touched" ]] || return 0   # 워치 디렉토리 미접촉 → 버전게이트 차단 대상 아님(불변).
-  # 건드린 최상위 플러그인 루트(<wd>/<name>) 별로 그 매니페스트가 base 보다 앞서도록 보장.
-  roots="$(printf '%s\n' "$touched" | sed -E "s#^($wd/[^/]+)(/.*)?\$#\1#" | sort -u)"
-  while IFS= read -r root; do
-    [[ -n "$root" ]] || continue
-    # shellcheck disable=SC2086
-    manifests="$($GIT_CMD ls-tree -r --name-only HEAD -- "$root" 2>/dev/null | grep -E '(^|/)plugin\.json$' || true)"
-    while IFS= read -r m; do
-      [[ -n "$m" ]] || continue
-      base="$(in_json_version "origin/$DEFAULT_BRANCH" "$m")"
-      our="$(in_json_version HEAD "$m")"
-      in_semver_gt "$our" "$base" && continue   # 이미 앞섬 → 불변(criterion 3).
-      newv="$(in_reapply_bump "$base" "$base" "$our")"
-      [[ -n "$newv" ]] || continue
-      # 새 베이스보다 한 단계 앞선 버전으로 매니페스트 version 라인만 재기입(나머지 내용 보존).
-      mkdir -p "$(dirname "$wt/$m")" 2>/dev/null || true
-      # shellcheck disable=SC2086
-      $GIT_CMD show "HEAD:$m" 2>/dev/null \
-        | sed -E "s/(\"version\"[[:space:]]*:[[:space:]]*\")[0-9][0-9.]*(\")/\1$newv\2/" > "$wt/$m" \
-        || { in_die "버전 재기입 실패: $m"; return 1; }
-      # shellcheck disable=SC2086
-      $GIT_CMD add -- "$m" || { in_die "재범프 add 실패: $m"; return 1; }
-      printf 'version-ahead: rebump %s -> %s (%s, branch=%s)\n' "$our" "$newv" "$m" "$branch" >&2
-      any=1
-    done <<< "$manifests"
-  done <<< "$roots"
-  [[ "$any" == "1" ]] || return 0   # 모두 이미 앞섬 → push 없이 종료(불변).
-  # shellcheck disable=SC2086
-  $GIT_CMD commit -m "chore: 병렬 동일-버전 충돌 회피 재범프(새 베이스 위로 전진)" >/dev/null \
-    || { in_die "재범프 commit 실패: $branch"; return 1; }
-  # append push(ff-safe, force 금지). 기존 PR 이 있으면 head 가 전진해 재리뷰가 자연 처리한다.
-  # shellcheck disable=SC2086
-  $GIT_CMD push origin "HEAD:refs/heads/$branch" \
-    || { in_die "재범프 push 실패(force 금지): $branch"; return 1; }
-  return 0
-}
-
-# in_ensure_version_ahead <branch> — base sync·push 후 호출. #452 격리와 동일하게 공유 체크아웃을
-#   건드리지 않도록 전용 분리(detached) 워크트리에서 재범프를 수행하고 정리한다. origin 최신 상태를
-#   먼저 fetch 해 진짜 원격 tip(origin/$branch) 기준으로 판단한다(base_sync 의 모든 반환 경로 후 통일 처리).
-in_ensure_version_ahead() {
-  local branch="$1" _wt _rc=0 _save_git="$GIT_CMD"
-  # shellcheck disable=SC2086
-  $GIT_CMD fetch origin "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
-  # shellcheck disable=SC2086
-  $GIT_CMD fetch origin "$branch" >/dev/null 2>&1 || true
-  _wt="$(mktemp -d)/wt"
-  # 원격 tip(origin/$branch) 우선, 없으면 로컬 $branch 에서 분리 체크아웃(최초 통합 등).
-  # shellcheck disable=SC2086
-  $GIT_CMD worktree add --quiet --detach "$_wt" "origin/$branch" >/dev/null 2>&1 \
-    || $GIT_CMD worktree add --quiet --detach "$_wt" "$branch" >/dev/null 2>&1 \
-    || { in_die "재범프 전용 워크트리 생성 실패: $branch"; rmdir "$(dirname "$_wt")" 2>/dev/null || true; return 1; }
-  GIT_CMD="$_save_git -C $_wt"
-  _in_ensure_version_ahead_core "$branch" "$_wt"; _rc=$?
-  GIT_CMD="$_save_git"
-  # shellcheck disable=SC2086
-  $GIT_CMD worktree remove "$_wt" >/dev/null 2>&1 || true
-  rmdir "$(dirname "$_wt")" 2>/dev/null || true
-  return "$_rc"
 }
 
 # =====================================================================
@@ -697,9 +534,6 @@ in_integrate() {
       # #452: rebase 경로에선 base_sync 가 분리 워크트리에서 원격으로 직접 push 하므로(INT_BASESYNC_PUSHED)
       # in_push_branch 를 건너뛴다. rebase 불필요(조기 반환) 경로에선 ref 이름으로 push.
       [[ "${INT_BASESYNC_PUSHED:-}" == "1" ]] || in_push_branch "$branch" || { int_set_phase "$rd" "$key" blocked; return 4; }
-      # 병렬 동일-버전 범프 자동 재범프: feat 버전이 새 베이스보다 앞서지 않으면 한 단계 앞서게
-      # 재범프(ff append)해 버전게이트 동률 blocked 를 막는다(이미 앞서면 no-op).
-      in_ensure_version_ahead "$branch" || { int_set_phase "$rd" "$key" blocked; return 4; }
       local title pr
       title="$(in_spec_title "$spec")"
       pr="$(in_ensure_pr "$branch" "$title" "$spec" "$rid")" || { int_set_phase "$rd" "$key" blocked; return 4; }
@@ -851,8 +685,8 @@ in_selftest() {
   #   브랜치 존재를 실제로 모사한다(BRANCHES 파일) — checkout 을 무조건 성공시키지 않는다(AC5).
   #   rev-parse --verify refs/heads/<b> = 브랜치 존재 검사, rev-parse HEAD = 결과 커밋,
   #   branch <name> [<commit>] = 브랜치 생성(force 금지 보장됨).
-  local PUSHLOG="$TMP/pushlog" GITLOG="$TMP/gitlog" BRANCHES="$TMP/branches" REMOTE_BRANCHES="$TMP/remotebranches" COMMITLOG="$TMP/commitlog"
-  : > "$PUSHLOG"; : > "$GITLOG"; : > "$BRANCHES"; : > "$REMOTE_BRANCHES"; : > "$COMMITLOG"
+  local PUSHLOG="$TMP/pushlog" GITLOG="$TMP/gitlog" BRANCHES="$TMP/branches" REMOTE_BRANCHES="$TMP/remotebranches"
+  : > "$PUSHLOG"; : > "$GITLOG"; : > "$BRANCHES"; : > "$REMOTE_BRANCHES"
   mock_git() {
     # 선행 -C <dir> 흡수(loop 결과 워크트리에서 결과 커밋을 읽을 때 사용).
     if [[ "$1" == "-C" ]]; then shift 2; fi
@@ -883,19 +717,6 @@ in_selftest() {
           *HEAD*) echo "resultcommitsha7"; return 0 ;;
         esac ;;
       branch) printf '%s\n' "$2" >> "$BRANCHES" ;;   # branch <name> [<commit>]
-      # version-ahead 재범프 경로 모사: diff(워치 접촉 파일)·ls-tree(플러그인 루트 매니페스트)·show(버전)·add·commit.
-      #   기본(MOCK_* 미설정)엔 접촉 없음/빈 버전 → ensure_version_ahead 가 no-op(기존 테스트 불변).
-      diff)
-        if [[ "$*" == *"--name-only"* && "$*" == *"...HEAD"* ]]; then printf '%s\n' ${MOCK_TOUCHED:-}; fi ;;
-      ls-tree)
-        printf '%s\n' ${MOCK_MANIFESTS:-} ;;   # ls-tree -r --name-only HEAD -- <root>
-      show)
-        case "$2" in
-          origin/*) [[ -n "${MOCK_BASE_VER:-}" ]] && echo "  \"version\": \"${MOCK_BASE_VER}\"," ;;
-          *)        [[ -n "${MOCK_OUR_VER:-}"  ]] && echo "  \"version\": \"${MOCK_OUR_VER}\","  ;;
-        esac ;;
-      add) : ;;
-      commit) printf '%s\n' "$*" >> "$COMMITLOG" ;;
       checkout)
         # 실제처럼: 존재하지 않는 브랜치 checkout 은 실패한다(무조건 성공 금지).
         grep -Fxq "$2" "$BRANCHES" 2>/dev/null || { echo "error: pathspec '$2' did not match" >&2; return 1; } ;;
@@ -1198,27 +1019,15 @@ SPECEOF
   [[ -s "$PUSHLOG" || -s "$GITLOG" ]] && ok "git/push 실제 수행됨" || bad "git/push 실제 수행됨"
   if grep -qiE 'force|(^| )-f( |$)' "$GITLOG"; then bad "force 미사용"; else ok "force 미사용(git 인자에 force 없음)"; fi
 
-  # ---- AC: 자동 충돌 해결 — 결정적 버전 해소 산식(in_reapply_bump: 타겟 위 의도 범프 재적용) ----
-  chk "AC reapply minor"          "$(in_reapply_bump 0.38.1 0.38.0 0.39.0)" "0.39.0"
-  chk "AC reapply minor leapfrog" "$(in_reapply_bump 0.40.0 0.38.0 0.39.0)" "0.41.0"
-  chk "AC reapply patch"          "$(in_reapply_bump 0.38.5 0.38.0 0.38.1)" "0.38.6"
-  chk "AC reapply major"          "$(in_reapply_bump 1.2.3 0.38.0 1.0.0)"   "2.0.0"
-  chk "AC reapply no-bump→patch"  "$(in_reapply_bump 0.38.1 0.38.0 0.38.0)" "0.38.2"
-
-  # ---- AC: 버전-only 충돌 판정(결정적 vs 코드 의미 구분) ----
-  local cvf="$TMP/conf_ver.json" ccf="$TMP/conf_code.sh"
-  printf '{\n<<<<<<< HEAD\n  "version": "0.38.1",\n=======\n  "version": "0.39.0",\n>>>>>>> x\n}\n' > "$cvf"
-  printf 'f(){\n<<<<<<< HEAD\n  echo a\n=======\n  echo b\n>>>>>>> x\n}\n' > "$ccf"
-  in_conflict_version_only "$cvf" && ok "AC 버전-only 충돌 인식" || bad "AC 버전-only 충돌 인식"
-  in_conflict_version_only "$ccf" && bad "AC 코드 충돌을 버전-only 로 오인" || ok "AC 코드 충돌은 버전-only 아님(결정적 해소 제외)"
-
   # ---- AC: in_autoresolve_rebase 일반(비결정) 충돌 → 전략 해소 + needs-verify 표시(워커 재검증 유도) ----
+  #   #482: plugin.json 버전 충돌도 결정적 해소가 아니라 일반 전략으로 처리된다(버전 범프 정책 비간섭).
   local U2LOG="$TMP/arlog"; : > "$U2LOG"; rm -f "$TMP/ar_done"
   mock_git_ar() {
     local a; for a in "$@"; do case "$a" in *force*|-f) echo "FORCE USED" >&2; exit 99;; esac; done
     printf '%s\n' "$*" >> "$U2LOG"
     if [[ "$1" == "diff" && "$*" == *--diff-filter=U* ]]; then
-      [[ -f "$TMP/ar_done" ]] || echo "src/foo.sh"   # add 전엔 미해결, add 후엔 해결됨.
+      # add 전엔 미해결(코드 파일 + plugin.json 동시 충돌), add 후엔 해결됨.
+      [[ -f "$TMP/ar_done" ]] || printf '%s\n%s\n' "src/foo.sh" "plugins/autopilot/.claude-plugin/plugin.json"
       return 0
     fi
     [[ "$1" == "add" ]] && : > "$TMP/ar_done"
@@ -1230,35 +1039,20 @@ SPECEOF
   chk "AC autoresolve 일반 충돌 rc=0" "$rc" "0"
   chk "AC autoresolve 비결정→needs-verify" "$INT_AUTORESOLVE_FLAG" "needs-verify"
   grep -q 'checkout --theirs' "$U2LOG" && ok "AC autoresolve incoming 전략=--theirs(작업 커밋 쪽)" || bad "AC autoresolve incoming 전략=--theirs"
+  grep -q 'checkout --theirs -- plugins/autopilot/.claude-plugin/plugin.json' "$U2LOG" \
+    && ok "AC#482 plugin.json 버전 충돌도 일반 전략(--theirs)으로 처리(결정적 해소 제거)" \
+    || bad "AC#482 plugin.json 버전 충돌 일반 전략 처리(--theirs)"
   grep -q 'rebase --continue' "$U2LOG" && ok "AC autoresolve rebase --continue 로 진행" || bad "AC autoresolve rebase --continue"
   if grep -qiE 'force' "$U2LOG"; then bad "AC autoresolve force 미사용"; else ok "AC autoresolve force 미사용"; fi
   INT_AUTORESOLVE_FLAG=""
 
-  # ---- AC(#467): 병렬 동일-버전 범프 — feat 버전이 새 베이스보다 앞서지 않으면(<=) 자동 재범프(ff append). ----
-  #   #461·#462 시나리오: 둘 다 0.51.2 범프, #461 먼저 머지로 main 0.51.2 → #462 동률 → 버전게이트 blocked.
-  #   통합 경로가 origin/main 보다 한 단계 앞서게 재범프(0.51.3) commit 을 append·push 해 수동 개입 제거.
-  #   현실 모사: 늦은 쪽 plugin.json 은 base 와 동일(0.51.2)이라 diff(변경 파일)엔 비-매니페스트(feature.txt)만
-  #   잡힌다. 매니페스트는 ls-tree 로 플러그인 루트에서 발견해 동률을 검사·재범프한다.
-  local kVA="x-va00001"; : > "$PUSHLOG"; : > "$COMMITLOG"
-  st_done > "$LP/SPEC.md.json"; : > "$LP/SPEC.md.logs"
-  out="$(MOCK_EXISTING_PR="77" MOCK_TOUCHED="plugins/autopilot/feature.txt" \
-         MOCK_MANIFESTS="plugins/autopilot/.claude-plugin/plugin.json" \
-         MOCK_BASE_VER="0.51.2" MOCK_OUR_VER="0.51.2" in_integrate "$spec" "$rd" "$kVA" 2>&1)"; rc=$?
-  chk "AC#467 동률 통합 rc=0(blocked 아님)" "$rc" "0"
-  [[ -s "$COMMITLOG" ]] && ok "AC#467 동률 → 재범프 commit append" || bad "AC#467 동률 → 재범프 commit append"
-  grep -qE 'push origin HEAD:refs/heads/feat/' "$PUSHLOG" && ok "AC#467 재범프를 원격 작업 브랜치로 직접 push(ff append)" || bad "AC#467 재범프 직접 push(HEAD:refs/heads)"
-  grep -q 'rebump 0.51.2 -> 0.51.3' <<< "$out" && ok "AC#467 새 베이스보다 한 단계 앞서게 재범프(0.51.2 -> 0.51.3)" || bad "AC#467 재범프 산식(0.51.2 -> 0.51.3) (got: $(grep -o 'rebump[^\n]*' <<< "$out" | head -1))"
-  if grep -qiE 'force' "$PUSHLOG" "$GITLOG"; then bad "AC#467 재범프 force 미사용"; else ok "AC#467 재범프 force 미사용"; fi
-
-  # ---- AC(#467): 버전이 이미 앞선 정상 경로 불변 — 재범프 no-op(commit·push 없음). ----
-  local kVB="x-va00002"; : > "$PUSHLOG"; : > "$COMMITLOG"
-  st_done > "$LP/SPEC.md.json"; : > "$LP/SPEC.md.logs"
-  out="$(MOCK_EXISTING_PR="77" MOCK_TOUCHED="plugins/autopilot/feature.txt" \
-         MOCK_MANIFESTS="plugins/autopilot/.claude-plugin/plugin.json" \
-         MOCK_BASE_VER="0.51.2" MOCK_OUR_VER="0.51.3" in_integrate "$spec" "$rd" "$kVB" 2>&1)"; rc=$?
-  chk "AC#467 이미 앞선 통합 rc=0" "$rc" "0"
-  [[ ! -s "$COMMITLOG" ]] && ok "AC#467 이미 앞섬 → 재범프 commit 없음(불변)" || bad "AC#467 이미 앞섬 → 재범프 commit 없음(불변)"
-  if grep -qE 'push origin HEAD:refs/heads/feat/' "$PUSHLOG"; then bad "AC#467 이미 앞섬인데 재범프 push(불변 위반)"; else ok "AC#467 이미 앞섬 → 재범프 push 없음(불변)"; fi
+  # ---- 회귀 가드(#482): 버전-전용 충돌 해소·동일-버전 자동 재범프 경로가 제거됐다(정책-불간섭) ----
+  #   버전 범프는 컨슈밍 프로젝트 소유 정책(versioning.md) — 통합 엔진은 버전 함수로 집행하지 않는다.
+  local _fn
+  for _fn in in_reapply_bump in_conflict_version_only in_resolve_version_conflict \
+             in_semver_gt in_ensure_version_ahead _in_ensure_version_ahead_core in_json_version; do
+    if declare -f "$_fn" >/dev/null 2>&1; then bad "회귀: $_fn 함수 잔존(버전 경로 미제거)"; else ok "회귀: $_fn 함수 제거됨"; fi
+  done
 
   echo "----"
   [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"

--- a/plugins/autopilot/forge/lib/merge.sh
+++ b/plugins/autopilot/forge/lib/merge.sh
@@ -2,8 +2,6 @@
 # merge.sh — forge per-SPEC 머지 (M4)
 #
 # 책임 (파이프라인 종착: "리뷰가 approve 로 수렴하면 머지되고 SPEC 은 done(=머지됨)이 된다"):
-#   - 버전 범프 게이트: 머지될 변경이 워치 디렉토리(plugins/)를 건드리면 같은 변경 안에서
-#     plugin.json 버전이 올랐는지 단언한다. 안 올랐으면 머지 차단(비완료 종착).
 #   - 머지: 백엔드 가용 여부로 라우팅. **백엔드(forge host) 가용 시 로컬 머지 금지** — 호스트의
 #     PR 기반 서버사이드 머지로만 통합한다(로컬 `git checkout <base>` 안 함). 백엔드/origin 미가용
 #     (direct)일 때만 default 브랜치에 fast-forward 전용(--ff-only) 로컬 머지(+base push)한다. 머지
@@ -22,14 +20,12 @@
 #   - force(강제) 머지·push 금지. 머지는 git merge --ff-only 만.
 #   - 작업 공간은 직접 지우지 않고 loop 공개 cleanup 으로만 위임.
 #   - per-SPEC 상태는 lib-integration.sh(run-dir + 키)로만. 키는 호출자 주입.
-#   - 버전 게이트는 rules/engineering/versioning.md 실행자.
 #
 # 모든 외부 인터페이스(git·forge·loop CLI)는 주입 가능. mock 으로 독립 검증
 # (self-referential: 실제 머지·PR 미수행). bash 3.2+ 호환.
 #
 # 환경 변수 (mock 치환 가능):
 #   GIT_CMD/FORGE_CMD/LOOP_CMD/DEFAULT_BRANCH   integration.sh 와 공유.
-#   WATCH_DIRS      버전 워치 디렉토리 prefix(기본: plugins/).
 
 set -uo pipefail
 
@@ -48,7 +44,6 @@ FORGE_CMD="${FORGE_CMD:-gh}"
 LOOP_CMD_DEFAULT="bash $MG_SCRIPT_DIR/../../skills/loop/references/loop.sh"
 LOOP_CMD="${LOOP_CMD:-$LOOP_CMD_DEFAULT}"
 DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
-WATCH_DIRS="${WATCH_DIRS:-plugins/}"
 MERGE_APPROVAL_CMD="${MERGE_APPROVAL_CMD:-mg_approval_gh}"
 # 서버사이드 PR 머지 완료 확인 폴링 — `--auto`(예약) 성공을 곧 머지 완료로 보지 않고 실제
 # PR state==MERGED 를 폴링 확인한다(예약만 되고 미머지인 상태로 완료 처리되는 것 방지).
@@ -159,69 +154,6 @@ mg_approval_gate() {
   local decision
   decision="$($MERGE_APPROVAL_CMD "$1" | tr -d '[:space:]')"
   [[ "$decision" == "APPROVED" ]]
-}
-
-# ===== 1) 버전 범프 게이트 — versioning.md 실행자 =====
-mg_merge_changed_files() {
-  # shellcheck disable=SC2086
-  $GIT_CMD diff --name-only "origin/$DEFAULT_BRANCH...$1" 2>/dev/null
-}
-mg_touches_watch_dir() {
-  mg_merge_changed_files "$1" | grep -qE "^$WATCH_DIRS" 2>/dev/null
-}
-mg_changed_manifests() {
-  mg_merge_changed_files "$1" | grep -E '(^|/)plugin\.json$' || true
-}
-# mg_json_version <ref> <path> — 해당 ref 의 plugin.json 에서 version 값(예 0.19.0) 추출.
-#   없으면 빈 문자열. diff 라인 존재가 아니라 실제 값을 본다.
-mg_json_version() {
-  # shellcheck disable=SC2086
-  $GIT_CMD show "$1:$2" 2>/dev/null \
-    | grep -m1 -E '"version"[[:space:]]*:' \
-    | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"?([0-9][0-9.]*)"?.*/\1/'
-}
-
-# mg_semver_gt <new> <old> — new 가 old 보다 큰 SemVer 면 0, 아니면 1.
-#   old 가 비었으면(신규 매니페스트) new 만 있으면 0(증가로 간주). major.minor.patch 를
-#   필드별 숫자 비교(bash 3.2, 외부 도구 없이).
-mg_semver_gt() {
-  local new="$1" old="$2"
-  [[ -n "$new" ]] || return 1
-  [[ -n "$old" ]] || return 0
-  local oldIFS="$IFS"; IFS=.
-  # shellcheck disable=SC2206
-  local -a na=($new) oa=($old); IFS="$oldIFS"
-  local i n o
-  for ((i=0; i<3; i++)); do
-    n="${na[i]:-0}"; o="${oa[i]:-0}"
-    n="${n//[!0-9]/}"; o="${o//[!0-9]/}"
-    [[ -n "$n" ]] || n=0; [[ -n "$o" ]] || o=0
-    if (( 10#$n > 10#$o )); then return 0; fi
-    if (( 10#$n < 10#$o )); then return 1; fi
-  done
-  return 1   # 모든 필드 동일 → 증가 아님(같은 값 재기입·재정렬 차단).
-}
-
-# mg_manifest_version_bumped <branch> — 변경된 plugin.json 중 하나라도 base 대비
-#   실제 SemVer 가 증가했으면 0. 추가된 "version" 라인 존재가 아니라 old/new 값 비교.
-mg_manifest_version_bumped() {
-  local branch="$1" m oldv newv
-  while IFS= read -r m; do
-    [[ -n "$m" ]] || continue
-    oldv="$(mg_json_version "origin/$DEFAULT_BRANCH" "$m")"
-    newv="$(mg_json_version "$branch" "$m")"
-    if mg_semver_gt "$newv" "$oldv"; then return 0; fi
-  done < <(mg_changed_manifests "$branch")
-  return 1
-}
-# mg_version_gate <branch> — 워치 디렉토리 건드리는데 범프 없으면 1(차단). 없으면 0.
-mg_version_gate() {
-  local branch="$1"
-  if mg_touches_watch_dir "$branch"; then
-    mg_manifest_version_bumped "$branch" && return 0
-    return 1
-  fi
-  return 0
 }
 
 # ===== 2) 머지 직렬화 락 — run-dir 단위(mkdir 원자성) =====
@@ -410,15 +342,16 @@ mg_sweep_merged_branches() {
   return 0
 }
 
-# ===== 5) 메인 진입 — 버전 게이트 통과 시 머지하고 phase=merged =====
+# ===== 5) 메인 진입 — 게이트 통과 시 머지하고 phase=merged =====
 # mg_merge_finish <spec> <run_dir> <key> [pr] [direct]
 #   direct=1 이면 direct 서브모드(forge 백엔드 미가용 — PR 없이 **로컬 ff-only** 머지) 계약으로,
 #   PR 보강·승인 게이트·PR 출력을 건너뛴다. direct≠1(forge 백엔드 가용)은 PR 기반 **서버사이드
 #   머지**로만 통합하고 로컬 base 체크아웃을 하지 않는다(백엔드 가용 시 로컬 머지 금지).
-#   version 범프 게이트·직렬화 락·작업공간 정리는 두 서브모드 공통.
+#   직렬화 락·작업공간 정리는 두 서브모드 공통. 버전 범프 정책은 컨슈밍 프로젝트 소유라
+#   머지 엔진은 간섭하지 않는다(정책-불간섭).
 #   머지는 분리 approver 승인을 전제하지 않고 가용 토큰으로 수행한다(리뷰 수렴은 상위 책임).
 #   반환: 0=머지 완료(phase=merged) / 1=차단(phase=blocked, 비완료 종착 — forge PR 없음·미승인·
-#         버전게이트·서버사이드 머지 실패).
+#         서버사이드 머지 실패).
 mg_merge_finish() {
   local spec="$1" rd="$2" key="$3" pr="${4:-}" direct="${5:-}"
   [[ -n "$spec" && -n "$rd" && -n "$key" ]] || { mg_die "사용: merge.sh finish <spec> <run_dir> <key> [pr] [direct]"; return 1; }
@@ -452,16 +385,7 @@ mg_merge_finish() {
     return 1
   fi
 
-  # 2) 버전 범프 게이트(비완료 종착).
-  if ! mg_version_gate "$branch"; then
-    int_set_phase "$rd" "$key" blocked
-    int_log "$rd" "$key" "버전 게이트 차단: plugins/ 변경에 plugin.json 범프 없음 — 머지 안 함(비완료 종착)"
-    echo "key:     $key"
-    echo "blocked: version-bump — plugins/ 를 건드리지만 plugin.json 버전이 오르지 않았습니다."
-    return 1
-  fi
-
-  # 3) 머지 실행 — 백엔드 가용 여부로 라우팅. **백엔드(forge) 가용 시 로컬 머지 금지**.
+  # 2) 머지 실행 — 백엔드 가용 여부로 라우팅. **백엔드(forge) 가용 시 로컬 머지 금지**.
   #    direct=1(forge 백엔드/origin 미가용) → 로컬 ff-only(checkout+ff+push). review 스킬이
   #      phase 로 승인 보증하는 로컬 direct 머지(PR/서버 없음).
   #    direct≠1(forge 백엔드 가용, PR 존재) → 호스트의 PR 기반 서버사이드 머지만. 로컬
@@ -475,7 +399,7 @@ mg_merge_finish() {
     mg_merge_pr_serverside "$rd" "$pr" "$branch" || { int_set_phase "$rd" "$key" blocked; return 1; }
   fi
 
-  # 4) 완료. 머지 확정 후 사후 단계로 정리한다(순서: 워크트리 정리 → 작업 브랜치 삭제).
+  # 3) 완료. 머지 확정 후 사후 단계로 정리한다(순서: 워크트리 정리 → 작업 브랜치 삭제).
   #    워크트리를 먼저 위임 정리해야 그 워크트리에 체크아웃된 작업 브랜치를 로컬에서 삭제할 수 있다.
   #    정리 실패는 경고로 표면화하되 머지·완료 판정을 뒤집지 않는다(아래 헬퍼들이 rc 0 유지).
   #    작업 브랜치 삭제는 **direct(로컬) 머지에서만** 워커가 수행한다. 서버사이드 경로는 머지가
@@ -503,22 +427,22 @@ mg_usage() {
 usage: merge.sh <command> [args]
 
 Commands:
-  version-gate <branch>            버전 범프 게이트 판정(0=통과,1=차단).
   finish <spec> <run_dir> <key> [pr] [direct]
-                                   버전 게이트 통과 시 직렬화 ff-only 머지(가용 토큰) 후
+                                   승인 게이트 통과 시 직렬화 ff-only 머지(가용 토큰) 후
                                    phase=merged + 작업 공간 정리 위임. direct=1 이면 PR 없이.
   sweep [target]                   dispatch 자기 출처 작업 브랜치 중 target(미지정 시 DEFAULT_BRANCH)
                                    에 머지된 것만 force 없이 일괄 삭제. 미머지·비-dispatch 브랜치는
                                    보존. 부분 실패는 경고로 격리. 명시 요청 정비 진입점.
 
-환경 변수: GIT_CMD FORGE_CMD LOOP_CMD DEFAULT_BRANCH WATCH_DIRS SWEEP_BRANCH_SIGNATURE_RE
+환경 변수: GIT_CMD FORGE_CMD LOOP_CMD DEFAULT_BRANCH SWEEP_BRANCH_SIGNATURE_RE
 EOF
   return 1
 }
 
 # =====================================================================
-# selftest — mock 인터페이스로 버전 게이트·ff-only·직렬화 락·force 미사용 검증.
-#   (분리 approver 요구 없음 — 머지는 버전 게이트 통과 시 가용 토큰으로 수행.)
+# selftest — mock 인터페이스로 ff-only·직렬화 락·force 미사용·승인 게이트 검증.
+#   (분리 approver 요구 없음 — 머지는 승인 게이트 통과 시 가용 토큰으로 수행.)
+#   (버전 범프 정책은 컨슈밍 프로젝트 소유 — 머지 엔진 비간섭.)
 # =====================================================================
 mg_selftest() {
   local TMP; TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' RETURN
@@ -532,22 +456,16 @@ mg_selftest() {
       ls-remote)
         # 기본 mock: 작업 브랜치가 원격에 존재한다고 본다(forge 머지 성공 경로의 원격 삭제 검증).
         echo "deadbeef refs/heads/work"; return 0 ;;
-      diff)
-        if [[ "$*" == *"--name-only"* ]]; then printf '%s\n' ${MOCK_FILES:-}; return 0; fi
-        ;;
-      show)
-        # git show <ref>:<path> — plugin.json version 값 시뮬(실제 값 비교 경로).
-        #   base(origin/*)=1.0.0. branch: MOCK_BUMP=1 → 1.1.0(증가), MOCK_BUMP=same →
-        #   1.0.0(동일, 차단되어야 함), 그 외 → 1.0.0.
-        case "$2" in
-          origin/*) echo '  "version": "1.0.0"' ;;
-          *) if [[ "${MOCK_BUMP:-}" == "1" ]]; then echo '  "version": "1.1.0"'; else echo '  "version": "1.0.0"'; fi ;;
-        esac
-        ;;
     esac
     return 0
   }
-  mock_forge() { echo "forge $*" >> "$trace"; return 0; }
+  # mock forge: 서버사이드 머지 발행은 성공, state 폴링은 MERGED 를 돌려줘 완료를 모사한다
+  #   (mg_merge_pr_serverside 의 "발행 ≠ 완료" 계약 — state==MERGED 확인 후에야 0 반환).
+  mock_forge() {
+    echo "forge $*" >> "$trace"
+    case "$*" in *"pr view"*state*) echo "MERGED" ;; esac
+    return 0
+  }
   mock_loop() { echo "loop $*" >> "$trace"; return 0; }
   mock_approval() { echo "${MOCK_APPROVED:-APPROVED}"; }
   GIT_CMD=mock_git; FORGE_CMD=mock_forge; LOOP_CMD=mock_loop; MERGE_APPROVAL_CMD=mock_approval
@@ -562,11 +480,10 @@ mg_selftest() {
   setup() { local k="$1"; int_set_branch "$rd" "$k" "feat/run1-$k"; int_set_pr "$rd" "$k" 77; }
   reset() { : > "$trace"; }
 
-  # ---- forge: 워치 변경 없음 → 서버사이드 PR 머지 + phase=merged + cleanup (approver 불필요) ----
+  # ---- forge: 승인됨 → 서버사이드 PR 머지 + phase=merged + cleanup (approver 불필요) ----
   #   백엔드 가용 경로는 로컬 checkout/ff/push 를 타지 않고 호스트 PR 머지로만 통합한다.
   reset; setup k1
-  MOCK_FILES="README.md" MOCK_BUMP="" \
-    mg_merge_finish "$spec" "$rd" k1 >/dev/null 2>&1; local rc=$?
+  mg_merge_finish "$spec" "$rd" k1 >/dev/null 2>&1; local rc=$?
   chk "forge 머지 rc=0(approver 불필요)" "$rc" "0"
   has 'forge pr merge' && ok "서버사이드 PR 머지 호출" || bad "서버사이드 PR 머지 호출"
   if has 'git checkout main'; then bad "forge 가용인데 로컬 checkout main(로컬머지 금지 위반)"; else ok "로컬 checkout main 미호출"; fi
@@ -582,7 +499,7 @@ mg_selftest() {
   # ---- forge: 서버사이드 머지 실패(권한·브랜치 보호 등) → 차단(rc=1), 조용한 성공 금지 ----
   reset; setup kssfail
   mock_forge_mergefail() { echo "forge $*" >> "$trace"; case "$1 $2" in "pr merge") return 1;; esac; return 0; }
-  FORGE_CMD=mock_forge_mergefail MOCK_FILES="README.md" MOCK_BUMP="" \
+  FORGE_CMD=mock_forge_mergefail \
     mg_merge_finish "$spec" "$rd" kssfail >/dev/null 2>&1; rc=$?
   chk "서버사이드 머지 실패 rc=1(차단)" "$rc" "1"
   chk "서버사이드 머지 실패 phase=blocked" "$(int_get_phase "$rd" kssfail)" "blocked"
@@ -590,7 +507,7 @@ mg_selftest() {
 
   # ---- forge: PR 미승인(reviewDecision!=APPROVED) → 차단(승인 전 머지 차단, PR #353 회귀 가드) ----
   reset; setup knapp
-  MOCK_FILES="README.md" MOCK_APPROVED="REVIEW_REQUIRED" \
+  MOCK_APPROVED="REVIEW_REQUIRED" \
     mg_merge_finish "$spec" "$rd" knapp >/dev/null 2>&1; rc=$?
   chk "forge 미승인 rc=1(차단)" "$rc" "1"
   if has 'git merge --ff-only'; then bad "미승인인데 머지함"; else ok "미승인 → 머지 안 함"; fi
@@ -599,57 +516,38 @@ mg_selftest() {
   if has 'push origin --delete'; then bad "차단인데 원격 브랜치 삭제함(보존 위반)"; else ok "차단 → 원격 브랜치 보존"; fi
   if has 'branch -d'; then bad "차단인데 로컬 브랜치 삭제함(보존 위반)"; else ok "차단 → 로컬 브랜치 보존"; fi
 
-  # ---- forge: plugins/ 변경 + 범프 없음 → 차단(비완료 종착 rc=1) ----
-  reset; setup k4
-  MOCK_FILES="plugins/autopilot/.claude-plugin/plugin.json" MOCK_BUMP="" \
-    mg_merge_finish "$spec" "$rd" k4 >/dev/null 2>&1; rc=$?
-  chk "워치+범프없음 rc=1(차단)" "$rc" "1"
-  if has 'git merge --ff-only'; then bad "범프없음 머지 안 함"; else ok "범프없음 머지 안 함"; fi
-  chk "차단 phase=blocked" "$(int_get_phase "$rd" k4)" "blocked"
-
-  # ---- forge: plugins/ 변경 + 범프 있음 → 서버사이드 머지 ----
-  reset; setup k5
-  MOCK_FILES="plugins/autopilot/.claude-plugin/plugin.json" MOCK_BUMP="1" \
-    mg_merge_finish "$spec" "$rd" k5 >/dev/null 2>&1; rc=$?
-  chk "워치+범프있음 rc=0" "$rc" "0"
-  has 'forge pr merge' && ok "범프시 서버사이드 머지" || bad "범프시 서버사이드 머지"
-  if has 'git checkout main'; then bad "범프 forge인데 로컬 checkout(로컬머지 금지 위반)"; else ok "범프 forge → 로컬 checkout 미호출"; fi
-
-  # ---- 같은 version 값 재기입(라인은 추가되나 값 동일) → 차단 (Codex blocking 회귀 가드) ----
-  reset; setup k6
-  MOCK_FILES="plugins/autopilot/.claude-plugin/plugin.json" MOCK_BUMP="same" \
-    mg_merge_finish "$spec" "$rd" k6 >/dev/null 2>&1; rc=$?
-  chk "동일 버전 재기입 rc=1(차단)" "$rc" "1"
-  if has 'git merge --ff-only'; then bad "동일 버전인데 머지함"; else ok "동일 버전 → 머지 안 함"; fi
+  # ---- 회귀 가드(#482): 머지 엔진은 버전 범프 정책에 간섭하지 않는다(정책-불간섭) ----
+  #   버전 범프는 컨슈밍 프로젝트 소유 정책(versioning.md)이므로 플러그인 머지 엔진은 게이트로
+  #   집행하지 않는다. plugins/ 를 건드린 브랜치가 plugin.json 범프 없이도 버전 사유로 차단되지
+  #   않고(승인됨이면 서버사이드 머지로 통과), 버전 게이트 함수·차단 메시지가 잔존하지 않아야 한다.
+  if declare -f mg_version_gate >/dev/null 2>&1; then bad "회귀: mg_version_gate 함수 잔존(게이트 미제거)"; else ok "회귀: mg_version_gate 함수 제거됨"; fi
+  reset; setup kvg
+  out="$(mg_merge_finish "$spec" "$rd" kvg 2>&1)"; rc=$?
+  chk "회귀: plugins/ 변경+범프없음 rc=0(버전 비차단)" "$rc" "0"
+  chk "회귀: phase=merged(버전 게이트 부재)" "$(int_get_phase "$rd" kvg)" "merged"
+  case "$out" in *version-bump*) bad "회귀: version-bump 차단 메시지 잔존";; *) ok "회귀: version-bump 차단 메시지 없음";; esac
 
   # ---- forge: PR 없음(보강 실패·상태 손상) → 차단(rc=1), merge/push 미호출 (codex blocking/96 가드) ----
   reset
   int_set_branch "$rd" knopr "feat/run1-knopr"   # PR 미설정(int_set_pr 안 함) → int_get_pr 빈 값
-  MOCK_FILES="README.md" mg_merge_finish "$spec" "$rd" knopr >/dev/null 2>&1; rc=$?
+  mg_merge_finish "$spec" "$rd" knopr >/dev/null 2>&1; rc=$?
   chk "forge PR없음 rc=1(차단)" "$rc" "1"
   if has 'git merge --ff-only'; then bad "forge PR없음인데 머지/push 호출됨(차단 실패)"; else ok "forge PR없음 머지/push 미호출"; fi
   chk "forge PR없음 phase=blocked" "$(int_get_phase "$rd" knopr)" "blocked"
   # 대조: direct=1 은 PR 없이도 머지(PR 게이트는 forge 전용).
   reset
   int_set_branch "$rd" kdnopr "feat/run1-kdnopr"
-  MOCK_FILES="README.md" mg_merge_finish "$spec" "$rd" kdnopr "" 1 >/dev/null 2>&1; rc=$?
+  mg_merge_finish "$spec" "$rd" kdnopr "" 1 >/dev/null 2>&1; rc=$?
   chk "direct PR없음 rc=0(머지)" "$rc" "0"
   has 'git merge --ff-only' && ok "direct PR없음에도 머지함(forge 전용 게이트)" || bad "direct PR없음인데 머지 안 됨(게이트가 direct에 오적용)"
 
-  # ---- direct=1 → PR 없이 머지(version gate·ff-only 유지) ----
+  # ---- direct=1 → PR 없이 ff-only 머지 ----
   reset; setup kd1   # setup 은 int_set_pr 77 을 심는다 — direct 경로가 이 stale PR 을 끌어오면 안 된다.
-  out="$(MOCK_FILES="README.md" mg_merge_finish "$spec" "$rd" kd1 "" 1 2>/dev/null)"; rc=$?
+  out="$(mg_merge_finish "$spec" "$rd" kd1 "" 1 2>/dev/null)"; rc=$?
   chk "direct 머지 rc=0" "$rc" "0"
   has 'git merge --ff-only' && ok "direct ff-only 머지" || bad "direct ff-only 머지"
   chk "direct phase=merged" "$(int_get_phase "$rd" kd1)" "merged"
   case "$out" in *77*) bad "direct stale PR(77) 미출력";; *) ok "direct stale PR(77) 미출력";; esac
-
-  # ---- direct=1 이어도 version gate 는 유지(차단) ----
-  reset; setup kd2
-  MOCK_FILES="plugins/autopilot/.claude-plugin/plugin.json" MOCK_BUMP="" \
-    mg_merge_finish "$spec" "$rd" kd2 "" 1 >/dev/null 2>&1; rc=$?
-  chk "direct version gate 차단 rc=1" "$rc" "1"
-  if has 'git merge --ff-only'; then bad "direct 범프없음 머지 안 함"; else ok "direct 범프없음 머지 안 함"; fi
 
   # ---- 브랜치 삭제 실패 → 경고로 표면화, 머지 판정(merged)은 유지(정리는 사후 단계) ----
   #   작업 브랜치 삭제는 direct(로컬) 머지 경로의 사후 단계 — direct=1 로 검증한다.
@@ -664,11 +562,10 @@ mg_selftest() {
     esac
     case "$1" in
       ls-remote) echo "deadbeef refs/heads/work"; return 0 ;;  # 원격에 존재 → 삭제 시도되고 실패해 WARN
-      show) case "$2" in origin/*) echo '  "version": "1.0.0"';; *) echo '  "version": "1.0.0"';; esac ;;
     esac
     return 0
   }
-  err="$(GIT_CMD=mock_git_delfail MOCK_FILES="README.md" mg_merge_finish "$spec" "$rd" kdelfail "" 1 2>&1 >/dev/null)"; rc=$?
+  err="$(GIT_CMD=mock_git_delfail mg_merge_finish "$spec" "$rd" kdelfail "" 1 2>&1 >/dev/null)"; rc=$?
   chk "삭제 실패해도 머지 rc=0" "$rc" "0"
   chk "삭제 실패해도 phase=merged" "$(int_get_phase "$rd" kdelfail)" "merged"
   case "$err" in *WARN*) ok "브랜치 삭제 실패 경고 표면화";; *) bad "브랜치 삭제 실패 경고 표면화(조용한 실패 금지)";; esac
@@ -683,11 +580,10 @@ mg_selftest() {
     case "$1" in
       ls-remote) return 0 ;;  # 원격에 브랜치 없음 = 빈 출력
       push) case "$*" in *--delete*) return 1;; esac ;;  # 호출되면 실패(원격에 없으므로)
-      show) case "$2" in origin/*) echo '  "version": "1.0.0"';; *) echo '  "version": "1.0.0"';; esac ;;
     esac
     return 0
   }
-  err="$(GIT_CMD=mock_git_noremote MOCK_FILES="README.md" mg_merge_finish "$spec" "$rd" kdnoremote "" 1 2>&1 >/dev/null)"; rc=$?
+  err="$(GIT_CMD=mock_git_noremote mg_merge_finish "$spec" "$rd" kdnoremote "" 1 2>&1 >/dev/null)"; rc=$?
   chk "원격 미존재 direct 머지 rc=0" "$rc" "0"
   if has 'push origin --delete feat/run1-kdnoremote'; then bad "원격 미존재인데 원격 삭제 시도(불필요)"; else ok "원격 미존재 → 원격 삭제 미시도"; fi
   case "$err" in *"원격 작업 브랜치 삭제 실패"*) bad "원격 미존재인데 spurious WARN 방출";; *) ok "원격 미존재 → spurious WARN 없음";; esac
@@ -701,7 +597,7 @@ mg_selftest() {
 
   # ---- force 미사용 (mock_git force 보면 exit99; 위 머지 케이스 통과 = 미사용) ----
   reset; setup k7
-  MOCK_FILES="README.md" mg_merge_finish "$spec" "$rd" k7 >/dev/null 2>&1
+  mg_merge_finish "$spec" "$rd" k7 >/dev/null 2>&1
   if grep -qiE 'force|(^| )-f( |$)' "$trace"; then bad "force 미사용"; else ok "force 미사용(git 인자에 force 없음)"; fi
 
   # ---- sweep — dispatch 자기 출처 작업 브랜치 중 대상 머지된 것만 일괄 삭제 ----
@@ -857,7 +753,6 @@ BR
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   SUB="${1:-}"; shift || true
   case "$SUB" in
-    version-gate) [[ $# -ge 1 ]] || mg_usage; mg_version_gate "$1" && echo pass || { echo block; exit 1; } ;;
     finish)       mg_merge_finish "$@" ;;
     sweep)        mg_sweep_merged_branches "$@" ;;
     selftest)     mg_selftest ;;


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 482

## 요약

autopilot 플러그인의 forge 머지 엔진에서 **프로젝트-소유 버전 범프 정책을 집행하는 게이트를 제거**한다. 구체적으로 `forge/lib/merge.sh`의 버전 게이트(`mg_version_gate` 및 보조 `mg_touches_watch_dir`/`mg_changed_manifests`/`mg_manifest_version_bumped`/`mg_json_version`/`mg_semver_gt`)와, 그 게이트를 충족시키려 존재하는 `forge/lib/integration.sh`의 자동 재범프(`in_ensure_version_ahead`/`_in_ensure_version_ahead_core`/`in_reapply_bump`/버전-전용 충돌 해소)를 제거해, 머지 엔진을 **버전 정책-불간섭**으로 만든다.
