### PR TITLE
🤖 [자동 리뷰] fix: loop 워크트리 base를 로컬 HEAD가 아닌 origin/<default-branch> 기준으로 (stale base 방지)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.56.0
+
+### 버그 수정
+- **loop 워크트리 base 를 로컬 체크아웃 HEAD 가 아닌 origin/<default-branch> 기준으로 (stale base 방지)** — `loop.sh` 가 워크트리를 만들 때 부모 체크아웃의 `HEAD` 를 그대로 base 로 잡던 것을, caller 가 주입한 base ref(기본값 = fetch 한 `origin/<default-branch>` tip)로 시작하도록 고쳤다. 공유 체크아웃이 origin 보다 뒤처져 있어도 워커가 stale 트리에서 작업하지 않아, 직전 머지가 이동·삭제한 파일을 옛 위치로 보고 SPEC scope(현재 경로)와 어긋나던 wrong-layout 편집·중간 rebase 충돌과 수동-ff 운영 부담을 제거한다. caller 는 `--base-ref REF`(CLI) 또는 `AUTOPILOT_BASE_REF`(env)로 base 를 override 할 수 있다(미지정 시 origin 기본). origin 미가용(fetch 실패, airgap)이면 종전대로 로컬 HEAD 로 fallback 하되 경고 로그를 남겨 가시화한다. BASE_SHA(게이트 diff 기준)도 base SHA 로 박제돼 scope·oscillation 게이트가 origin tip 기준으로 정합된다. 회귀 가드(`tests/test-loop-base-ref.sh`)가 (a) stale 로컬→origin tip, (b) 주입 ref 사용, (c) fetch 실패 fallback+경고를 단언한다.
+
 ## autopilot 0.55.0
 
 ### 변경(호환)

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.55.0",
+  "version": "0.56.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -2,7 +2,7 @@
 # loop.sh — 스펙 파일 기반 로컬 자율 루프 드라이버 (subcommand 기반)
 #
 # 사용:
-#   bash .../loop/references/loop.sh start  <spec-path> [--max-iterations N] [--wall-clock-minutes N]
+#   bash .../loop/references/loop.sh start  <spec-path> [--max-iterations N] [--wall-clock-minutes N] [--base-ref REF]
 #   bash .../loop/references/loop.sh status [<spec-path>]
 #   bash .../loop/references/loop.sh stop   <spec-path>
 #   bash .../loop/references/loop.sh list
@@ -16,6 +16,8 @@
 # 환경 변수:
 #   MAX_ITERATIONS         이터 상한 (기본: 30)
 #   WALL_CLOCK_MINUTES     시계 캡 (기본: 120)
+#   AUTOPILOT_BASE_REF     워크트리 base ref 주입 (미지정 시 fetch 한
+#                          origin/<default-branch>; --base-ref 가 우선)
 #   AUTOPILOT_WORKER_VENDOR  worker CLI 선택 (기본: claude; claude|codex)
 #   AUTOPILOT_WORKER_FAIL_STREAK_LIMIT  worker 비정상 exit 연속 허용 (기본: 3)
 
@@ -380,6 +382,48 @@ read_base_sha() {
   printf '%s' "$sha"
 }
 
+# origin 의 기본 브랜치명 추정 — 네트워크 없이 우선 origin/HEAD 심볼릭 ref 에서,
+# 없으면 remote show(네트워크) 질의, 그래도 없으면 main 으로 fallback.
+detect_default_branch() {
+  local repo="$1" b
+  b=$(git -C "$repo" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+  b="${b#origin/}"
+  [[ -n "$b" ]] && { printf '%s\n' "$b"; return 0; }
+  b=$(git -C "$repo" remote show origin 2>/dev/null \
+        | sed -n 's/^[[:space:]]*HEAD branch:[[:space:]]*//p' | head -1 || true)
+  [[ -n "$b" ]] && { printf '%s\n' "$b"; return 0; }
+  printf 'main\n'
+}
+
+# 워크트리 base ref 결정. stdout 으로 base 커밋 SHA 출력.
+#   1) caller 가 BASE_REF 를 주입하면 그 ref 를 해석해 사용(origin fetch 생략).
+#   2) 미지정이면 origin/<default-branch> 를 fetch 해 그 tip 을 base 로 사용.
+#   3) origin 미가용(fetch 실패)이면 로컬 HEAD 로 fallback 하고 경고를 stderr 에 남긴다.
+# 로컬 체크아웃 HEAD 의 staleness 가 워커 base 로 전파되지 않게 하는 것이 목적(#488).
+resolve_base_ref() {
+  local repo="$1" sha
+
+  # 1) caller 주입 우선
+  if [[ -n "${BASE_REF:-}" ]]; then
+    sha=$(git -C "$repo" rev-parse --verify --quiet "${BASE_REF}^{commit}" 2>/dev/null) \
+      || die "주입된 base ref 를 해석할 수 없음: $BASE_REF"
+    printf '%s\n' "$sha"
+    return 0
+  fi
+
+  # 2) 기본: fetch 한 origin/<default-branch> tip
+  local def_branch; def_branch=$(detect_default_branch "$repo")
+  if git -C "$repo" fetch --quiet origin "$def_branch" 2>/dev/null; then
+    sha=$(git -C "$repo" rev-parse --verify --quiet "FETCH_HEAD^{commit}" 2>/dev/null || true)
+    [[ -z "$sha" ]] && sha=$(git -C "$repo" rev-parse --verify --quiet "origin/$def_branch^{commit}" 2>/dev/null || true)
+    [[ -n "$sha" ]] && { printf '%s\n' "$sha"; return 0; }
+  fi
+
+  # 3) fallback: 로컬 HEAD + 경고 (offline·airgap 에서도 loop 이 돌게)
+  echo "[$(now_iso)] 경고: origin/$def_branch fetch 실패 — 로컬 HEAD 로 fallback (stale base 위험)." >&2
+  git -C "$repo" rev-parse HEAD
+}
+
 # 변경 파일이 scope.include 안인지 검사. 위반 파일 목록 출력(있으면).
 diff_vs_scope() {
   local base_sha="$1"
@@ -563,11 +607,16 @@ iterate() {
 # 이미 동일 전용 워크트리가 있으면(같은 스펙 재기동) 재사용한다.
 prepare_workspace() {
   if [[ ! -d "$WT" ]]; then
-    echo "[$(now_iso)] 워크트리 생성: $WT (detached HEAD)"
-    git -C "$SPEC_DIR" worktree add --detach "$WT" HEAD \
+    # base 는 로컬 체크아웃 HEAD 가 아니라 caller 주입 ref(기본=fetch 한
+    # origin/<default-branch>) 기준 — 공유 체크아웃 staleness 가 워커 base 로
+    # 전파되지 않게 한다(#488). origin 미가용 시 로컬 HEAD fallback(경고).
+    local base_sha; base_sha=$(resolve_base_ref "$SPEC_DIR") \
+      || die "base ref 해석 실패"
+    echo "[$(now_iso)] 워크트리 생성: $WT (detached HEAD $base_sha)"
+    git -C "$SPEC_DIR" worktree add --detach "$WT" "$base_sha" \
       || die "git worktree add 실패: $WT"
     mkdir -p "$LOOP_DIR/iterations" "$LOOP_DIR/signals"
-    git -C "$WT" rev-parse HEAD > "$LOOP_DIR/BASE_SHA" \
+    printf '%s\n' "$base_sha" > "$LOOP_DIR/BASE_SHA" \
       || die "BASE SHA 캡처 실패: $LOOP_DIR/BASE_SHA"
   else
     echo "[$(now_iso)] 기존 워크트리 사용: $WT"
@@ -639,14 +688,19 @@ cmd_start() {
   require_tool yq
   require_tool "$(worker_executable)"
 
-  local max_iterations_override="" wall_clock_minutes_override=""
+  local max_iterations_override="" wall_clock_minutes_override="" base_ref_override=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --max-iterations) max_iterations_override="$2"; shift 2 ;;
       --wall-clock-minutes) wall_clock_minutes_override="$2"; shift 2 ;;
+      --base-ref) base_ref_override="$2"; shift 2 ;;
       *) die "알 수 없는 옵션: $1" ;;
     esac
   done
+
+  # 워크트리 base ref 주입 — CLI(--base-ref) 우선, 없으면 env(AUTOPILOT_BASE_REF),
+  # 둘 다 없으면 빈 값(=resolve_base_ref 가 fetch 한 origin/<default-branch> 기본).
+  BASE_REF="${base_ref_override:-${AUTOPILOT_BASE_REF:-}}"
 
   compute_paths "$input"
 

--- a/plugins/autopilot/skills/loop/tests/test-loop-base-ref.sh
+++ b/plugins/autopilot/skills/loop/tests/test-loop-base-ref.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# test-loop-base-ref.sh
+#
+# resolve_base_ref() 회귀 가드 (#488) — 워크트리 base 를 로컬 체크아웃 HEAD 가
+# 아닌 origin/<default-branch> 기준으로 잡는지 검증.
+#   C1 stale 로컬 HEAD (기본 모드)        → base 가 origin tip
+#   C2 caller 가 base ref 주입            → 그 ref 사용 (origin 무시)
+#   C3 origin 부재로 fetch 실패           → 로컬 HEAD fallback + 경고 로그
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOOP_SH="$SCRIPT_DIR/../references/loop.sh"
+
+command -v git >/dev/null 2>&1 || { echo "SKIP: git 미설치"; exit 0; }
+
+# loop.sh source — dispatcher 는 BASH_SOURCE guard 로 비실행, 함수만 노출.
+# shellcheck source=../references/loop.sh
+source "$LOOP_SH"
+set +e   # loop.sh 의 errexit 해제 — 함수 반환·fallback 캡처 위해 필수
+
+fail=0
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---- fixture: bare 원격 + seed + stale 로컬 클론 + origin 전진 ----
+REMOTE="$TMP/remote.git"
+git init -q --bare -b main "$REMOTE"
+SEED="$TMP/seed"
+git init -q -b main "$SEED"
+git -C "$SEED" config user.email t@t; git -C "$SEED" config user.name t
+echo a > "$SEED/f"; git -C "$SEED" add .; git -C "$SEED" commit -qm c1
+git -C "$SEED" remote add origin "$REMOTE"; git -C "$SEED" push -q origin main
+
+LOCAL="$TMP/local"
+git clone -q "$REMOTE" "$LOCAL"
+git -C "$LOCAL" config user.email t@t; git -C "$LOCAL" config user.name t
+LOCAL_HEAD="$(git -C "$LOCAL" rev-parse HEAD)"
+
+# origin 전진 — 로컬이 뒤처진 stale 상태 재현.
+echo b > "$SEED/f2"; git -C "$SEED" add .; git -C "$SEED" commit -qm c2
+git -C "$SEED" push -q origin main
+ORIGIN_TIP="$(git -C "$SEED" rev-parse HEAD)"
+
+[[ "$LOCAL_HEAD" != "$ORIGIN_TIP" ]] \
+  || { echo "FAIL: fixture — 로컬이 origin 과 동일(stale 아님)"; exit 1; }
+
+# C1 stale 로컬 HEAD, 기본 모드 → origin tip
+BASE_REF=""
+got="$(resolve_base_ref "$LOCAL" 2>/dev/null)"
+if [[ "$got" == "$ORIGIN_TIP" ]]; then
+  echo "PASS  C1 stale 로컬 → origin tip"
+else
+  echo "FAIL  C1 got=$got expected=$ORIGIN_TIP"; fail=1
+fi
+
+# C2 caller 주입 base ref → 그 ref 사용(여기선 로컬 옛 HEAD)
+BASE_REF="$LOCAL_HEAD"
+got="$(resolve_base_ref "$LOCAL" 2>/dev/null)"
+if [[ "$got" == "$LOCAL_HEAD" ]]; then
+  echo "PASS  C2 주입 ref 사용"
+else
+  echo "FAIL  C2 got=$got expected=$LOCAL_HEAD"; fail=1
+fi
+BASE_REF=""
+
+# C3 origin 부재(fetch 실패) → 로컬 HEAD fallback + 경고
+NOORIG="$TMP/noorigin"
+git init -q -b main "$NOORIG"
+git -C "$NOORIG" config user.email t@t; git -C "$NOORIG" config user.name t
+echo x > "$NOORIG/f"; git -C "$NOORIG" add .; git -C "$NOORIG" commit -qm c1
+NO_HEAD="$(git -C "$NOORIG" rev-parse HEAD)"
+err="$TMP/c3.err"
+got="$(resolve_base_ref "$NOORIG" 2>"$err")"
+if [[ "$got" == "$NO_HEAD" ]] && grep -qi '경고' "$err"; then
+  echo "PASS  C3 fetch 실패 → 로컬 HEAD fallback + 경고"
+else
+  echo "FAIL  C3 got=$got expected=$NO_HEAD err=$(cat "$err")"; fail=1
+fi
+
+if [[ $fail -ne 0 ]]; then
+  echo "FAIL: resolve_base_ref 일부 case 실패"
+  exit 1
+fi
+echo "PASS: resolve_base_ref 모든 case (3건)"


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 488

## 요약

loop이 워크트리를 만들 때 **로컬 체크아웃 HEAD** 대신 **caller가 주입한 base ref(기본값=fetch한 origin/<default-branch>)** 기준으로 시작하도록 base 결정을 고친다. 공유 체크아웃이 origin보다 뒤처져 있어도 워커가 stale base에서 작업하지 않게 한다.

확정 설계(인터뷰): (1) **base ref는 caller가 주입**할 수 있고, 미지정 시 기본값은 fetch한 `origin/<default-branch>` tip이다(execute-task는 기본대로 최신 main; 특정 브랜치 기준이 필요한 caller는 override). (2) **offline·origin 미가용 시** fetch 실패하면 기존 **로컬 HEAD로 fallback하되 경고 로그**를 남긴다(airgap에서도 loop이 돌아가게).
