### PR TITLE
🤖 [자동 리뷰] fix: forge review-loop rework가 detached 워크트리에서 feat 브랜치로 동작 + escalate에 유발 finding 표면화 (갭 X+Z)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.56.1
+
+### 버그 수정
+- **forge review-loop 의 rework 가 detached 구현 워크트리에서도 feat 브랜치를 대상으로 동작 + 재구현 실패 escalate 에 유발 finding 표면화 (갭 X+Z)** — `rl_implement_loop` 이 종전에는 `git worktree list` 에서 **feat 브랜치가 체크아웃된 워크트리만** 찾았는데, 구현 워크트리는 `worktree add --detach` 로 만들어져 어떤 로컬 브랜치에도 체크아웃돼 있지 않아 매치 0 → 항상 실패 → escalate 했다(리뷰 finding 이 있어도 rework 가 진행되지 못함). 이제 feat 브랜치 체크아웃 워크트리를 못 찾으면 **feat 브랜치(로컬 ref)가 존재하는지 확인 후** 그 브랜치를 체크아웃한 전용 임시 워크트리를 만들어 그 안에서 loop 를 secondary 모드로 수행한다(끝나면 정리). ref 가 없으면 거짓 성공 대신 비-0(에스컬레이션)으로 엉뚱한 체크아웃 push 금지 불변식을 보존한다. 또한 재구현 실패로 escalate 할 때 reason 에 **rework 를 유발한 PR 인라인 finding(must) 요약**을 포함해, 오케스트레이터가 'false escalation' 으로 오진해 정당한 차단을 수동 머지로 덮는 일을 막는다. 회귀 가드(review-loop selftest)가 (a) detached 워크트리에서 feat 브랜치 확보 후 rework 수행, (b) feat ref 부재 시 비-0, (c) escalate reason 에 유발 finding 포함을 단언한다.
+
 ## autopilot 0.56.0
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/forge/lib/review-loop.sh
+++ b/plugins/autopilot/forge/lib/review-loop.sh
@@ -146,16 +146,34 @@ rl_produce_review_skill() {
 
 # 기본: 자율 실행기(loop)에 SPEC 델타 위임. loop 는 --branch 미지원이므로 같은 PR 브랜치 위
 # 재구현은 그 브랜치가 체크아웃된 워크트리 안에서 loop 를 secondary 모드로 호출해 수행한다
-# (SPEC 위험 섹션). 그 작업 브랜치 워크트리를 찾지 못하면 **거짓 성공 대신 실패(비-0)** 를
-# 반환해 호출자가 에스컬레이션하게 한다 — 엉뚱한 체크아웃의 변경을 push 하지 않는다.
-# (selftest 에선 IMPLEMENT_CMD 가 mock 으로 대체되어 이 경로를 타지 않는다.)
+# (SPEC 위험 섹션).
+#   (1) feat 브랜치가 이미 체크아웃된 워크트리가 있으면 그 안에서 수행.
+#   (2) 없으면(구현 워크트리는 `worktree add --detach` 라 어떤 로컬 브랜치에도 미체크아웃 — 갭X)
+#       feat 브랜치(로컬 ref)가 **실제로 존재할 때만** 그 브랜치를 체크아웃한 전용 임시 워크트리를
+#       만들어 그 안에서 loop 를 수행한다. feat 브랜치 ref 확인 후에만 진행하므로 엉뚱한 체크아웃의
+#       변경을 push 하지 않는 불변식이 보존된다. ref 가 없으면 거짓 성공 대신 비-0(에스컬레이션 유도).
+# (selftest 갭X 케이스를 빼면 IMPLEMENT_CMD 가 mock 으로 대체되어 이 경로를 타지 않는다.)
 rl_implement_loop() {
-  local spec="$1" branch="$2" wt
+  local spec="$1" branch="$2" wt rc tmpwt
   wt="$(${GIT_CMD:-git} worktree list --porcelain 2>/dev/null \
     | awk -v b="refs/heads/$branch" '$1=="worktree"{w=$2} $1=="branch"&&$2==b{print w; exit}')"
-  [[ -n "$wt" ]] || return 1
+  if [[ -n "$wt" ]]; then
+    # shellcheck disable=SC2086
+    ( cd "$wt" && ${LOOP_CMD:-true} start "$spec" >/dev/null 2>&1 )
+    return $?
+  fi
+  # feat 브랜치 ref 가 없으면 확보 불가 — 엉뚱한 체크아웃 push 금지 불변식(거짓 성공 대신 비-0).
+  ${GIT_CMD:-git} rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1 || return 1
+  tmpwt="$(mktemp -d)/wt"
   # shellcheck disable=SC2086
-  ( cd "$wt" && ${LOOP_CMD:-true} start "$spec" >/dev/null 2>&1 )
+  ${GIT_CMD:-git} worktree add --quiet "$tmpwt" "$branch" >/dev/null 2>&1 \
+    || { rmdir "$(dirname "$tmpwt")" 2>/dev/null || true; return 1; }
+  # shellcheck disable=SC2086
+  ( cd "$tmpwt" && ${LOOP_CMD:-true} start "$spec" >/dev/null 2>&1 ); rc=$?
+  # shellcheck disable=SC2086
+  ${GIT_CMD:-git} worktree remove --force "$tmpwt" >/dev/null 2>&1 || true
+  rmdir "$(dirname "$tmpwt")" 2>/dev/null || true
+  return $rc
 }
 
 # ===== 리뷰 메타 파싱 (사람/head 게이트 전용) =====
@@ -316,9 +334,12 @@ rl_round() {
 
   local delta; delta="$(rl_spec_delta "$rd" "$key" "$base" "$pr" "$mustfile")"
   # 구현이 작업 브랜치에서 실패하면 거짓 성공·엉뚱한 push 대신 에스컬레이션(자동수정 보류).
+  # 갭Z: rework 를 유발한 PR 인라인 finding(must)을 reason 에 표면화 — 정당한 차단성 escalate 임을
+  #   오케스트레이터가 식별해 'false escalation' 오진·수동 머지 우회를 막는다.
   # shellcheck disable=SC2086
   if ! $IMPLEMENT_CMD "$delta" "$branch"; then
-    rl_escalate "$rd" "$key" "재구현 실패 — 작업 브랜치($branch) 워크트리에서 구현 불가(자동수정 보류)"
+    local fz; fz="$(tr '\n' ';' < "$mustfile" | sed -E 's/;+$//; s/;/; /g')"
+    rl_escalate "$rd" "$key" "재구현 실패 — 작업 브랜치($branch) 워크트리 확보 불가(자동수정 보류). 유발 finding: $fz"
     return 10
   fi
   in_push_branch "$branch"
@@ -539,9 +560,34 @@ rl_selftest() {
   # ---- 재구현 실패 → 거짓 성공·엉뚱한 push 대신 에스컬레이션 ----
   local kF="f-fff9"
   forge_review sha-FFF changes '구현 불가 항목' > "$RV/119.review"
-  IMPLEMENT_CMD='false' rl_round "$rd" "$kF" "$base" 119 "feat/run1-f" >/dev/null 2>&1; rc=$?
+  out="$(IMPLEMENT_CMD='false' rl_round "$rd" "$kF" "$base" 119 "feat/run1-f" 2>/dev/null)"; rc=$?
   chk "구현 실패 → 에스컬레이션(rc=10)" "$rc" "10"
   if grep -q 'feat/run1-f' "$PUSHLOG"; then bad "구현 실패인데 push 함"; else ok "구현 실패 → push 안 함"; fi
+  # 갭Z: rework 유발 finding 을 escalate reason 에 표면화(정상 차단을 오케스트레이터가 식별).
+  case "$out" in *구현\ 불가\ 항목*) ok "갭Z 재구현 실패 escalate 에 유발 finding 포함";; *) bad "갭Z 재구현 실패 escalate 에 유발 finding 포함 (out='$out')";; esac
+
+  # ---- 갭X: detached 구현 워크트리 + 존재하는 feat 브랜치 → rework 가 feat 브랜치 워크트리 확보 ----
+  #   selftest 는 IMPLEMENT_CMD 를 mock 으로 두지만, 이 케이스는 실제 rl_implement_loop 를 진짜 git
+  #   으로 구동해 detached 구현 워크트리에서도 feat 브랜치를 대상으로 loop 가 도는지 검증한다(갭X 회귀 가드).
+  local GX; GX="$(mktemp -d)"
+  ( cd "$GX"
+    git init -q && git config user.email t@t && git config user.name t || exit 1
+    git commit -q --allow-empty -m init
+    git branch feat/gx                              # 통합이 생성한 로컬 feat ref(어디에도 미체크아웃)
+    git worktree add -q --detach "$GX/impl" HEAD    # 구현 워크트리 = detached HEAD
+    printf '#!/usr/bin/env bash\ngit rev-parse --abbrev-ref HEAD > "%s/branch.seen"\n' "$GX" > "$GX/loopmock"
+    chmod +x "$GX/loopmock"
+    cd "$GX/impl"                                   # 현실 시나리오: detached 구현 워크트리 안에서 호출
+    GIT_CMD=git LOOP_CMD="$GX/loopmock" rl_implement_loop "$GX/spec.md" feat/gx )
+  if [[ "$(cat "$GX/branch.seen" 2>/dev/null)" == "feat/gx" ]]; then
+    ok "갭X detached 워크트리에서 feat 브랜치 확보 후 rework"
+  else
+    bad "갭X detached 워크트리에서 feat 브랜치 확보 후 rework (seen='$(cat "$GX/branch.seen" 2>/dev/null)')"
+  fi
+  # feat 브랜치 ref 부재 → 확보 불가 → 비-0(엉뚱한 체크아웃 push 금지 불변식 보존).
+  ( cd "$GX" && GIT_CMD=git LOOP_CMD="$GX/loopmock" rl_implement_loop "$GX/spec.md" feat/nope ); rc=$?
+  chk "갭X feat 브랜치 부재 → 확보 불가(비-0)" "$rc" "1"
+  rm -rf "$GX"
 
   # ---- approve(PR 상태/마커) → 머지 진행가능, 추가 라운드·구현 미시작(로컬 review 미호출) ----
   local kB="b-bbb2"; : > "$IMPLLOG"


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 492

## 요약

forge review-loop의 rework(재구현)가 **detached HEAD인 구현 워크트리에서도 feat 작업 브랜치를 대상으로 동작**하게 하고(갭 X), rework를 유발한 **리뷰 finding을 escalate reason에 표면화**(갭 Z)해, 정상 리뷰 지적이 오케스트레이터의 오진으로 묻히지 않게 한다.
