### PR TITLE
🤖 [자동 리뷰] fix: 미해결 non_blocking 리뷰 finding을 머지 시점에 표면화·follow-up triage (갭 Y, #485 정책 연결)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.56.2
+
+### 버그 수정
+- **미해결 리뷰 스레드면 태그 무관 머지 차단(미해결 non_blocking finding 의 silent 머지 방지, 갭 Y)** — 머지 승인 게이트가 종전에는 현재 head 의 **`[blocking]` 태그가 붙은** 미해결 인라인 스레드만 차단하고 `[non_blocking]` 미해결 스레드는 APPROVED 와 함께 통과시켰다. 그 결과 미해결 non_blocking finding(실제 버그 포함, #489)이 추적 없이 머지돼 사후 별도 수정(#490)이 필요했다. 이제 세 곳의 게이트(`merge.sh` `mg_blocking_inline_gate`·`execute-task.sh` `et_blocking_inline_gh`·`review-loop.sh` `rl_review_fetch_gh`)가 **태그 필터(`BLOCKING_TAG`)를 제거**해 현재 head 에 신뢰봇이 남긴 **미해결(isResolved=false) 리뷰 스레드가 하나라도 있으면 태그 무관하게 차단**한다(head 일치·신뢰봇 login·resolve 제외 컨벤션은 유지). 진행하려면 finding 을 수정하거나 해명 댓글을 단 뒤 스레드를 resolve 해야 한다 → "머지됨 = 모든 리뷰 지적이 반영 또는 명시적 resolve" 가 보장돼 리뷰 유실이 사라진다. 기존 `[blocking]` 차단은 더 강한 "모든 미해결 차단" 규칙에 포함돼 회귀 없이 유지된다. 회귀 가드(merge selftest·execute-task blocking-gate·review-loop selftest)가 (a) 미해결 non_blocking·무태그 스레드 → 차단, (b) resolve 후 → 통과, (c) `[blocking]`·old-head·비신뢰봇·조회실패 동작 유지를 단언한다.
+
 ## autopilot 0.56.1
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.56.1",
+  "version": "0.56.2",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/forge/lib/merge.sh
+++ b/plugins/autopilot/forge/lib/merge.sh
@@ -60,13 +60,8 @@ mg_die() { echo "merge: $*" >&2; return 1; }
 #       남긴 본문 마커 `<!-- <prefix> head_sha=<sha> verdict=approve -->`(prefix=*-formal-review).
 # 신뢰 봇 로그인(App bot / github-actions[bot])만 마커를 신뢰한다(위조 마커 거부).
 REVIEW_BOT_LOGINS_RE="${REVIEW_BOT_LOGINS_RE:-(\[bot\]$|^github-actions$|courtesy-bot)}"
-# 차단성 인라인 태그(리터럴 부분문자열) — 리뷰 워크플로 본문 `**[<severity>/<conf>] title**` 형식
-# (.github/workflows/{codex,claude}-review.yml). `[blocking` 는 `[non_blocking` 을 매치하지 않음.
-# 봇 컨벤션 결합을 끊기 위해 주입 가능 변수로 둔다(awk index() 리터럴 매치 → awk별 escape 비의존).
-BLOCKING_TAG="${BLOCKING_TAG:-[blocking}"
-
-# mg_blocking_inline_gate <pr> <head> — 현재 head 에 신뢰봇이 남긴 **미해결** [blocking] 인라인이
-#   하나라도 있으면 1(차단), 없으면 0(통과).
+# mg_blocking_inline_gate <pr> <head> — 현재 head 에 신뢰봇이 남긴 **미해결 리뷰 스레드(태그 무관, #493)**
+#   가 하나라도 있으면 1(차단), 없으면 0(통과).
 #   - 미해결 판정: 리뷰 스레드 isResolved(GraphQL). resolve 된 스레드는 제외 → resolve→재리뷰
 #     워크플로 데드락 방지(commit_id 일치만으로 영구 차단하지 않음).
 #   - 현재 head 대응: 코멘트 commit.oid==head(재푸시로 head 가 바뀌면 outdated 는 자동 해소).
@@ -75,7 +70,7 @@ BLOCKING_TAG="${BLOCKING_TAG:-[blocking}"
 mg_blocking_inline_gate() {
   local pr="$1" head="$2" on owner name raw out
   if [[ -z "$head" ]]; then
-    echo "merge: 승인 차단 — 현재 head 미확정으로 [blocking] 인라인 검증 불가(default-deny)" >&2
+    echo "merge: 승인 차단 — 현재 head 미확정으로 미해결 리뷰 스레드 검증 불가(default-deny)" >&2
     return 1
   fi
   # shellcheck disable=SC2086
@@ -110,11 +105,11 @@ query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
         | .comments.nodes[]
         | (.author.login // "")+"\t"+(.commit.oid // "")+"\t"+((.body // "")|gsub("[\n\t]";" "))' 2>/dev/null)" \
     || { echo "merge: 승인 차단 — 리뷰 스레드 파싱 실패(default-deny)" >&2; return 1; }
-  # 미해결 + 현재 head 대응(field2==head) + [blocking] 태그(field3 리터럴) 줄의 login 을 신뢰봇 grep.
+  # 미해결 + 현재 head 대응(field2==head) 줄의 login 을 신뢰봇 grep(태그 무관, #493).
   if printf '%s\n' "$out" \
-       | awk -F'\t' -v h="$head" -v tag="$BLOCKING_TAG" '$2==h && index($3,tag)>0 {print $1}' \
+       | awk -F'\t' -v h="$head" '$2==h {print $1}' \
        | grep -qE "$REVIEW_BOT_LOGINS_RE"; then
-    echo "merge: 승인 차단 — 신뢰봇이 현재 head($head)에 남긴 미해결 [blocking] 인라인 존재" >&2
+    echo "merge: 승인 차단 — 신뢰봇이 현재 head($head)에 남긴 미해결 리뷰 스레드 존재" >&2
     return 1
   fi
   return 0
@@ -122,7 +117,7 @@ query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
 
 # mg_approval_gh <pr> — 승인이면 "APPROVED" 출력(없으면 빈 값). 주입 가능(MERGE_APPROVAL_CMD).
 #   승인 신호(reviewDecision==APPROVED 또는 현재 head verdict=approve 마커)가 있어도, 현재 head 의
-#   신뢰봇 미해결 [blocking] 인라인이 있으면 승인을 가린다(가산 차단, PR #385 회귀 가드).
+#   신뢰봇 미해결 리뷰 스레드가 있으면 승인을 가린다(가산 차단, PR #385 회귀 가드).
 mg_approval_gh() {
   local pr="$1" decision head approved=""
   # shellcheck disable=SC2086
@@ -143,7 +138,7 @@ mg_approval_gh() {
     approved=1
   fi
   [[ -n "$approved" ]] || return 0
-  # 승인 신호가 있어도 현재 head 의 신뢰봇 [blocking] 인라인이 가린다(차단되면 APPROVED 미출력).
+  # 승인 신호가 있어도 현재 head 의 신뢰봇 미해결 리뷰 스레드가 가린다(차단되면 APPROVED 미출력).
   mg_blocking_inline_gate "$pr" "$head" || return 0
   echo "APPROVED"
 }
@@ -656,7 +651,7 @@ BR
   if grep -qiE 'force|(^| )-f( |$)' "$trace"; then bad "sweep force 미사용"; else ok "sweep force 미사용"; fi
 
   # =====================================================================
-  # 승인 게이트 ── 현재 head 의 신뢰봇 미해결 [blocking] 인라인이 approve 를 가린다(PR #385).
+  # 승인 게이트 ── 현재 head 의 신뢰봇 **미해결 스레드(태그 무관, #493)** 가 approve 를 가린다(PR #385).
   #   mg_approval_gh 를 직접 호출(merge_finish 경로는 MERGE_APPROVAL_CMD 가 mock 이라
   #   gh-경로를 안 탐). FORGE_CMD 를 시나리오 변수로 구동하는 mock 으로 치환.
   # =====================================================================
@@ -687,13 +682,22 @@ BR
   local MARK="courtesy-bot\t<!-- claude-formal-review head_sha=$H verdict=approve -->\n"
   local BLK; BLK="$(thr false "github-actions[bot]" "$H" "**[blocking/98] 차단 지적**")"
   local OK_C; OK_C="$(thr false "github-actions[bot]" "$H" "**[non_blocking/85] 정보성**")"
+  local NOTAG; NOTAG="$(thr false "github-actions[bot]" "$H" "태그 없는 일반 코멘트")"
+  # EMPTY: 미해결 스레드 없음 — 승인신호(마커/#432) 검증 시 게이트가 끼어들지 않도록 filler 로 사용.
+  local EMPTY='{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[]}}}}}'
 
   # AC2: APPROVED 인데 현재 head 신뢰봇 미해결 [blocking] → 승인 아님(차단).
   chk "AC2 approved+head [blocking] → 차단(빈값)" \
     "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$BLK" ag)" ""
-  # AC1: blocking 없음 + APPROVED → APPROVED 통과.
-  chk "AC1 approved+blocking없음 → APPROVED" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$OK_C" ag)" "APPROVED"
+  # #493: 미해결이면 태그 무관 차단 — APPROVED 라도 미해결 non_blocking 스레드는 승인을 가린다.
+  chk "#493 approved+미해결 non_blocking → 차단(빈값)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$OK_C" ag)" ""
+  # #493: 태그 없는 미해결 스레드도 차단(차단 판정이 태그에 의존하지 않음).
+  chk "#493 approved+태그없는 미해결 스레드 → 차단(빈값)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$NOTAG" ag)" ""
+  # AC1: 미해결 스레드 없음 + APPROVED → APPROVED 통과.
+  chk "AC1 approved+미해결 스레드 없음 → APPROVED" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$EMPTY" ag)" "APPROVED"
   # isResolved: resolve 된 스레드의 [blocking] → 차단 안 함(APPROVED) — resolve→재리뷰 데드락 방지.
   chk "resolved 스레드 [blocking] → 차단 안 함(APPROVED)" \
     "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_THREADS="$(thr true "github-actions[bot]" "$H" "**[blocking/98] 해결됨**")" ag)" "APPROVED"
@@ -709,9 +713,9 @@ BR
   # AC2: 강등 승인 마커(verdict=approve) + head 미해결 [blocking] → 차단.
   chk "AC2 마커승인+head [blocking] → 차단(빈값)" \
     "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK" SC_THREADS="$BLK" ag)" ""
-  # 강등 승인 마커 + blocking 없음 → APPROVED.
-  chk "마커승인+blocking없음 → APPROVED" \
-    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK" SC_THREADS="$OK_C" ag)" "APPROVED"
+  # 강등 승인 마커 + 미해결 스레드 없음 → APPROVED.
+  chk "마커승인+미해결 스레드 없음 → APPROVED" \
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK" SC_THREADS="$EMPTY" ag)" "APPROVED"
   # #432: 봇 로그인 정규식을 login 필드 단독에 적용해야 앵커(\[bot\]$/^github-actions$)가 성립.
   #   결합 라인(login\tbody) grep 회귀 가드 — [bot]/github-actions 계열 마커 승인 감지.
   local MARK_GA="github-actions[bot]\t<!-- claude-formal-review head_sha=$H verdict=approve -->\n"
@@ -719,13 +723,13 @@ BR
   local MARK_EVIL="evil-user\t<!-- forged head_sha=$H verdict=approve -->\n"
   local MARK_OLD="github-actions[bot]\t<!-- claude-formal-review head_sha=otherSHA verdict=approve -->\n"
   chk "#432 github-actions[bot] 마커승인 → APPROVED" \
-    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK_GA" SC_THREADS="$OK_C" ag)" "APPROVED"
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK_GA" SC_THREADS="$EMPTY" ag)" "APPROVED"
   chk "#432 codex[bot] 마커승인 → APPROVED" \
-    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK_CX" SC_THREADS="$OK_C" ag)" "APPROVED"
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK_CX" SC_THREADS="$EMPTY" ag)" "APPROVED"
   chk "#432 비신뢰(evil-user) 마커 → 미승인(빈값)" \
-    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK_EVIL" SC_THREADS="$OK_C" ag)" ""
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK_EVIL" SC_THREADS="$EMPTY" ag)" ""
   chk "#432 head 불일치 마커 → 미승인(빈값)" \
-    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK_OLD" SC_THREADS="$OK_C" ag)" ""
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$H" SC_REVIEWS="$MARK_OLD" SC_THREADS="$EMPTY" ag)" ""
   # AC5: 스레드 조회 실패 + APPROVED → default-deny(차단).
   chk "AC5 스레드 조회 실패 → default-deny(차단)" \
     "$(SC_DECISION=APPROVED SC_HEAD="$H" SC_API_FAIL=1 ag)" ""

--- a/plugins/autopilot/forge/lib/review-loop.sh
+++ b/plugins/autopilot/forge/lib/review-loop.sh
@@ -51,9 +51,6 @@ set -uo pipefail
 
 REVIEW_ROUNDS_MAX="${REVIEW_ROUNDS_MAX:-3}"
 REVIEW_BOT_LOGIN_RE="${REVIEW_BOT_LOGIN_RE:-(\[bot\]$|claude|github-actions)}"
-# 차단성 인라인 태그(리터럴 부분문자열) — 리뷰 워크플로 본문 `**[<severity>/<conf>] title**` 형식
-# (.github/workflows/{codex,claude}-review.yml). `[blocking` 는 `[non_blocking` 미매치. 주입 가능.
-BLOCKING_TAG="${BLOCKING_TAG:-[blocking}"
 
 REVIEW_FETCH_CMD="${REVIEW_FETCH_CMD:-rl_review_fetch_gh}"
 REVIEW_PRODUCE_CMD="${REVIEW_PRODUCE_CMD:-rl_produce_review_skill}"
@@ -114,11 +111,11 @@ query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
             | (.author.login // "")+"\t"+(.commit.oid // "")+"\t"+((.body // "")|gsub("[\n\t]";" "))' 2>/dev/null)" || crc=1
     fi
   fi
-  # 신뢰봇이 현재 head 에 남긴 미해결 [blocking] 인라인 — approve 를 가리는 가산 차단(PR #385).
+  # 신뢰봇이 현재 head 에 남긴 미해결 리뷰 스레드 — approve 를 가리는 가산 차단(태그 무관, #493; PR #385).
   if [[ $crc -ne 0 ]]; then
     blocking="FETCH_FAILED"
   elif printf '%s\n' "$comments" \
-       | awk -F'\t' -v h="$head" -v tag="$BLOCKING_TAG" '$2==h && index($3,tag)>0 {print $1}' \
+       | awk -F'\t' -v h="$head" '$2==h {print $1}' \
        | grep -qE "$REVIEW_BOT_LOGIN_RE"; then
     blocking=1
   fi
@@ -130,7 +127,7 @@ query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
   elif [[ "$blocking" == "FETCH_FAILED" ]]; then
     # 인라인 조회 실패 → 거짓 승인 금지. changes 로 표면화(무진전 가드가 에스컬레이션 유도).
     echo "verdict: changes"
-    echo "finding: [blocking] 인라인 조회 실패 — default-deny(보수적 차단), 확인 필요"
+    echo "finding: 미해결 리뷰 스레드 조회 실패 — default-deny(보수적 차단), 확인 필요"
   elif [[ -n "$findings" ]]; then
     echo "verdict: changes"
     echo "finding: $findings"
@@ -699,7 +696,7 @@ rl_selftest() {
   chk "AC7 direct unavailable 에스컬레이션(rc=10)" "$rc" "10"
 
   # =====================================================================
-  # AC4/AC5/AC6: rl_review_fetch_gh — 현재 head 신뢰봇 미해결 [blocking] 인라인이
+  # AC4/AC5/AC6: rl_review_fetch_gh — 현재 head 신뢰봇 **미해결 스레드(태그 무관, #493)** 가
   #   approve 를 가린다(verdict=approve → changes). gh 를 시나리오 변수 mock 으로 치환.
   #   SC_* 는 substitution 안에서 env-prefix 해야 함수 환경에 도달한다.
   # =====================================================================
@@ -729,8 +726,12 @@ rl_selftest() {
 
   chk "AC4 approve+head [blocking] → changes" \
     "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$GBLK" rvg)" "changes"
-  chk "AC4 approve+blocking없음(정보성) → approve" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$GOKC" rvg)" "approve"
+  # #493: 미해결이면 태그 무관 차단 — approve 라도 미해결 non_blocking 스레드는 changes 로 표면화.
+  chk "approve+미해결 non_blocking(정보성) → changes(태그 무관)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$GOKC" rvg)" "changes"
+  # #493: 태그 없는 미해결 스레드도 차단(차단 판정이 태그에 의존하지 않음).
+  chk "approve+태그없는 미해결 스레드 → changes" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$(thr false "github-actions[bot]" "$GH" "태그 없는 일반 코멘트")" rvg)" "changes"
   chk "AC4 비승인+head [blocking] → changes" \
     "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_THREADS="$GBLK" rvg)" "changes"
   chk "resolved 스레드 [blocking]+approve → approve(차단 안 함)" \

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -25,15 +25,12 @@ REVIEW_MAX="${REVIEW_MAX:-5}"
 APPROVAL_WAIT_MAX="${APPROVAL_WAIT_MAX:-360}"          # 총 대기 상한(초, 논리 누적)
 APPROVAL_POLL_INTERVAL="${APPROVAL_POLL_INTERVAL:-20}" # 폴링 간격(초)
 APPROVAL_CHECK_CMD="${APPROVAL_CHECK_CMD:-et_approval_gh}"  # <pr> → 승인이면 rc0 (mock 치환 가능)
-# 미해결 [blocking] 인라인 가산 게이트. <pr> → 차단 없음(clear)이면 rc0, blocking 존재/조회실패면 rc1.
+# 미해결 리뷰 스레드 가산 게이트(태그 무관, #493). <pr> → 차단 없음(clear)이면 rc0, 미해결 스레드 존재/조회실패면 rc1.
 #   approval 신호와 AND 결합돼 승인 판정을 가린다(mock 치환 가능). merge.sh mg_blocking_inline_gate 미러.
 BLOCKING_CHECK_CMD="${BLOCKING_CHECK_CMD:-et_blocking_inline_gh}"
 SLEEP_CMD="${SLEEP_CMD:-sleep}"                        # 폴링 sleep (테스트 no-op 치환 가능)
 # 신뢰 봇 로그인(.github/workflows/{codex,claude}-review.yml 컨벤션) — merge.sh mg_approval_gh 와 동일.
 REVIEW_BOT_LOGINS_RE="${REVIEW_BOT_LOGINS_RE:-(\[bot\]$|^github-actions$|courtesy-bot)}"
-# 차단성 인라인 태그(리터럴 부분문자열) — merge.sh BLOCKING_TAG 와 동일 컨벤션. `[blocking` 는
-# `[non_blocking` 을 매치하지 않는다(awk index() 리터럴 매치).
-BLOCKING_TAG="${BLOCKING_TAG:-[blocking}"
 
 die() { echo "execute-task: $*" >&2; exit 1; }
 
@@ -41,7 +38,7 @@ die() { echo "execute-task: $*" >&2; exit 1; }
 #   승인 신호 두 가지(merge.sh mg_approval_gh / review-loop rl_review_fetch_gh 와 동일 컨벤션):
 #     (a) 공식 APPROVE 리뷰 → reviewDecision==APPROVED.
 #     (b) App 토큰 self-approve 불가로 APPROVE→COMMENT 강등된 신뢰 봇의 현재 head verdict=approve 마커.
-#   머지 직전 merge.sh 의 단발 승인 게이트(미해결 [blocking] 인라인 가산 차단 포함)가 재검증한다.
+#   머지 직전 merge.sh 의 단발 승인 게이트(미해결 리뷰 스레드 가산 차단 포함)가 재검증한다.
 et_approval_gh() {
   local pr="$1" decision head
   [[ -n "$pr" ]] || return 1
@@ -60,10 +57,10 @@ et_approval_gh() {
      | grep -qE "$REVIEW_BOT_LOGINS_RE"
 }
 
-# et_blocking_inline_gh <pr> — 현재 head 에 신뢰봇이 남긴 **미해결**(isResolved=false) [blocking]
-#   인라인 스레드가 없으면 0(clear=머지 가능), 하나라도 있으면 1(차단=대기).
-#   merge.sh mg_blocking_inline_gate / review-loop.sh 와 동일 컨벤션(BLOCKING_TAG, commit.oid==head,
-#   신뢰봇 로그인). 게이트는 스레드를 **스스로 resolve 하지 않는다** — resolved 전이는 봇/리뷰어
+# et_blocking_inline_gh <pr> — 현재 head 에 신뢰봇이 남긴 **미해결**(isResolved=false) 리뷰 스레드가
+#   없으면 0(clear=머지 가능), 하나라도 있으면 1(차단=대기) — 태그 무관(#493).
+#   merge.sh mg_blocking_inline_gate / review-loop.sh 와 동일 컨벤션(commit.oid==head, 신뢰봇 로그인).
+#   게이트는 스레드를 **스스로 resolve 하지 않는다** — resolved 전이는 봇/리뷰어
 #   책임이고 여기선 폴링으로 관찰만 한다. head/owner·name 미확정·조회/파싱 실패는 보수적 차단
 #   (default-deny=1)하되, 호출자(폴링 루프)의 상한과 결합돼 영구 멈춤은 없다.
 et_blocking_inline_gh() {
@@ -93,11 +90,11 @@ query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
         | .comments.nodes[]
         | (.author.login // "")+"\t"+(.commit.oid // "")+"\t"+((.body // "")|gsub("[\n\t]";" "))' 2>/dev/null)" \
     || return 1   # 파싱 실패 → 보수적 차단
-  # 미해결 + 현재 head 대응(field2==head) + [blocking] 태그(field3 리터럴) 줄의 login 을 신뢰봇 grep.
+  # 미해결 + 현재 head 대응(field2==head) 줄의 login 을 신뢰봇 grep(태그 무관, #493).
   if printf '%s\n' "$out" \
-       | awk -F'\t' -v h="$head" -v tag="$BLOCKING_TAG" '$2==h && index($3,tag)>0 {print $1}' \
+       | awk -F'\t' -v h="$head" '$2==h {print $1}' \
        | grep -qE "$REVIEW_BOT_LOGINS_RE"; then
-    return 1   # 신뢰봇 미해결 [blocking] 존재 → 차단
+    return 1   # 신뢰봇 미해결 리뷰 스레드 존재 → 차단
   fi
   return 0
 }
@@ -173,11 +170,11 @@ et_start() {
     # PR(forge) 경로: review 라운드(=rl_round, $FORGE_CMD review)의 반환코드로 분기한다(#426).
     #   리워크로 진전 가능 → 진행 / 진전 불가 → 빠른 실패 / 깨끗+비동기 승인 대기만 → 폴링 유지.
     #   반환코드 계약(forge/lib review-loop.sh rl_round, 소비만 — 변경 없음):
-    #     30 = approve         → 머지 진행(merge.sh 가 미해결 [blocking] 가산 게이트를 머지 직전 재검증).
+    #     30 = approve         → 머지 진행(merge.sh 가 미해결 스레드 가산 게이트를 머지 직전 재검증).
     #     0  = 재작업 재푸시(진전) → 새 head 가 올라갔으니 재리뷰 위해 루프 계속(무의미 대기 아님).
     #     10 = 에스컬레이션/라운드상한/핑퐁(진전 불가) → 폴링 상한 더 안 기다리고 즉시 blocked.
     #     20 = 할 일 없음(깨끗한 코드가 비동기 봇 승인만 대기) → 기존 APPROVAL_WAIT_MAX 폴링 유지(#419).
-    #          이때만 폴링이 의미: 승인 = 호스팅 승인 신호 AND 현재 head 미해결 [blocking] 인라인 없음.
+    #          이때만 폴링이 의미: 승인 = 호스팅 승인 신호 AND 현재 head 미해결 리뷰 스레드 없음.
     #     기타 비-0 = 미정의 신호 → 보수적 즉시 blocked(default-deny). rl_round 미경유 호출은 없다.
     case "$APPROVAL_POLL_INTERVAL" in ''|*[!0-9]*|0) APPROVAL_POLL_INTERVAL=1;; esac
     # 비숫자/빈값 상한은 산술 비교((( waited >= MAX )))를 0>=0 으로 망가뜨려 즉시 오종료(또는

--- a/plugins/autopilot/skills/execute-task/tests/test-execute-task-blocking-gate.sh
+++ b/plugins/autopilot/skills/execute-task/tests/test-execute-task-blocking-gate.sh
@@ -5,9 +5,9 @@
 #     (b) 대기 중 [blocking] 가 resolved 되면 승인→머지(done)
 #     (c) blocking 없음 + APPROVED → 대기 없이 머지(done)
 #     (d) 조회 실패(보수적 차단=대기) → 상한까지 미해결 → blocked, merge 미호출
-#   단위(et_blocking_inline_gh, gh 모킹):
-#     미해결+head+신뢰봇+[blocking] → 차단(rc1); resolved/old-head/non_blocking → clear(rc0);
-#     head 미확정/조회실패 → 보수적 차단(rc1)
+#   단위(et_blocking_inline_gh, gh 모킹) — 태그 무관 모든 미해결 스레드 차단(#493):
+#     미해결+head+신뢰봇 → 차단(rc1)([blocking]·[non_blocking]·무태그 공통);
+#     resolved/old-head/비신뢰봇 → clear(rc0); head 미확정/조회실패 → 보수적 차단(rc1)
 #   자동 resolve 금지: 소스에 resolve 뮤테이션 호출 부재
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -136,13 +136,21 @@ chk "(u2) resolved → clear(rc0)" "$(ubg H1 "o n" "$TMP/gq_resolved.json")" "0"
 # old head(commit.oid!=head) → clear(rc0)
 chk "(u3) old-head blocking → clear(rc0)" "$(ubg H2 "o n" "$TMP/gq_block.json")" "0"
 
-# non_blocking 태그 → clear(rc0)
+# non_blocking 태그도 미해결이면 차단(rc1) — 태그 무관 모든 미해결 스레드 차단(#493)
 cat > gq_nonblock.json <<'EOF'
 {"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
 {"isResolved":false,"comments":{"nodes":[{"author":{"login":"courtesy-bot"},"commit":{"oid":"H1"},"body":"**[non_blocking/20] nit**"}]}}
 ]}}}}}
 EOF
-chk "(u4) non_blocking → clear(rc0)" "$(ubg H1 "o n" "$TMP/gq_nonblock.json")" "0"
+chk "(u4) 미해결 non_blocking → 차단(rc1)" "$(ubg H1 "o n" "$TMP/gq_nonblock.json")" "1"
+
+# 태그 없는 미해결 스레드도 차단(rc1) — 차단 판정이 태그에 의존하지 않음(#493)
+cat > gq_notag.json <<'EOF'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[
+{"isResolved":false,"comments":{"nodes":[{"author":{"login":"courtesy-bot"},"commit":{"oid":"H1"},"body":"태그 없는 일반 코멘트"}]}}
+]}}}}}
+EOF
+chk "(u7) 태그 없는 미해결 스레드 → 차단(rc1)" "$(ubg H1 "o n" "$TMP/gq_notag.json")" "1"
 
 # head 미확정(빈값) → 보수적 차단(rc1)
 chk "(u5) head 미확정 → 보수적 차단(rc1)" "$(ubg "" "o n" "$TMP/gq_block.json")" "1"


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 493

## 요약

머지 게이트가 현재 head에 **미해결 리뷰 스레드가 하나라도 있으면(블로킹 태그 무관) 머지를 차단**하도록 한다. 진행하려면 그 finding을 수정하거나 해명 댓글을 단 뒤 스레드를 **resolve**해야 한다 — non_blocking이라도 미해결이면 머지 금지.
