### PR TITLE
🤖 [자동 리뷰] fix: 배포되는 플러그인 디렉터리 안의 테스트(skills/*/tests·forge/tests)를 프로젝트 tests/ 트리로 이전

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.56.3
+
+### 변경(호환)
+- **배포되는 플러그인 디렉터리 안의 디렉터리형 테스트를 프로젝트 `tests/` 트리로 이전 (배포 산출물에서 dev 테스트 제거)** — `plugins/autopilot/` 하위에 박혀 있던 디렉터리형 테스트를 프로젝트 테스트 트리로 옮겼다: `skills/loop/tests/`→`tests/autopilot/loop/`, `skills/execute-task/tests/`→`tests/autopilot/execute-task/`, `skills/review/tests/`→`tests/autopilot/review/`, `forge/tests/`→`tests/forge/`. 컨슈머에게 배포되는 산출물(플러그인 디렉터리)에서 dev 아티팩트를 제거하고, 소스↔테스트 매핑을 프로젝트 레벨로 일관화한다. 이동한 18개 테스트가 소스를 참조하던 상대 경로(`$SCRIPT_DIR/../references/…`, `$HERE/../forge.sh`, CI 워크플로 경로 등)를 새 위치 기준으로 갱신했고, 전체 스위트가 새 위치에서 green 임을 확인했다(테스트 내용 변경 없음 — 이동·경로 갱신만). 소스 `.sh` 내장 self-test 함수는 디렉터리형이 아니므로 비대상. 본 변경은 #499 scope(loop·execute-task·review·forge) 한정이며, 그 외 스킬의 테스트 디렉터리 이전은 후속 작업이다.
+
 ## autopilot 0.56.2
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.56.2",
+  "version": "0.56.3",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/tests/autopilot/execute-task/test-execute-task-approval-marker.sh
+++ b/tests/autopilot/execute-task/test-execute-task-approval-marker.sh
@@ -6,7 +6,7 @@
 #   단위(et_approval_gh, gh 모킹): 봇 로그인 매치(통과)/비신뢰·위조·head불일치(거부)/경로 a(APPROVED) 불변.
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ET="$HERE/../references/execute-task.sh"
+ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
 fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
 chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
 

--- a/tests/autopilot/execute-task/test-execute-task-approval-poll.sh
+++ b/tests/autopilot/execute-task/test-execute-task-approval-poll.sh
@@ -8,9 +8,9 @@
 #   (f) 머지 게이트(forge/lib/merge.sh mg_approval_gate)는 단발 검사로 유지
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ET="$HERE/../references/execute-task.sh"
-ADAPTER="$HERE/../../../task-backend/adapter.sh"
-MERGE="$HERE/../../../forge/lib/merge.sh"
+ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
+ADAPTER="$HERE/../../../plugins/autopilot/task-backend/adapter.sh"
+MERGE="$HERE/../../../plugins/autopilot/forge/lib/merge.sh"
 fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
 chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
 

--- a/tests/autopilot/execute-task/test-execute-task-blocking-gate.sh
+++ b/tests/autopilot/execute-task/test-execute-task-blocking-gate.sh
@@ -11,8 +11,8 @@
 #   자동 resolve 금지: 소스에 resolve 뮤테이션 호출 부재
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ET="$HERE/../references/execute-task.sh"
-ADAPTER="$HERE/../../../task-backend/adapter.sh"
+ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
+ADAPTER="$HERE/../../../plugins/autopilot/task-backend/adapter.sh"
 fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
 chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
 

--- a/tests/autopilot/execute-task/test-execute-task-lifecycle.sh
+++ b/tests/autopilot/execute-task/test-execute-task-lifecycle.sh
@@ -2,8 +2,8 @@
 # test-execute-task-lifecycle.sh — task-id→materialize→loop→(forge)→상태전이 (mock 엔진).
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ET="$HERE/../references/execute-task.sh"
-ADAPTER="$HERE/../../../task-backend/adapter.sh"
+ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
+ADAPTER="$HERE/../../../plugins/autopilot/task-backend/adapter.sh"
 fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
 chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
 

--- a/tests/autopilot/execute-task/test-execute-task-review-codes.sh
+++ b/tests/autopilot/execute-task/test-execute-task-review-codes.sh
@@ -8,8 +8,8 @@
 #   (20) 할 일 없음(깨끗+비동기 승인대기) → 기존 APPROVAL_WAIT_MAX 폴링 유지(회귀)
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ET="$HERE/../references/execute-task.sh"
-ADAPTER="$HERE/../../../task-backend/adapter.sh"
+ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
+ADAPTER="$HERE/../../../plugins/autopilot/task-backend/adapter.sh"
 fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
 chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
 

--- a/tests/autopilot/loop/test-loop-base-ref.sh
+++ b/tests/autopilot/loop/test-loop-base-ref.sh
@@ -9,12 +9,12 @@
 
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOOP_SH="$SCRIPT_DIR/../references/loop.sh"
+LOOP_SH="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references/loop.sh"
 
 command -v git >/dev/null 2>&1 || { echo "SKIP: git 미설치"; exit 0; }
 
 # loop.sh source — dispatcher 는 BASH_SOURCE guard 로 비실행, 함수만 노출.
-# shellcheck source=../references/loop.sh
+# shellcheck source=../../../plugins/autopilot/skills/loop/references/loop.sh
 source "$LOOP_SH"
 set +e   # loop.sh 의 errexit 해제 — 함수 반환·fallback 캡처 위해 필수
 

--- a/tests/autopilot/loop/test-loop-lifecycle.sh
+++ b/tests/autopilot/loop/test-loop-lifecycle.sh
@@ -16,7 +16,7 @@
 
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOOP_SH="$SCRIPT_DIR/../references/loop.sh"
+LOOP_SH="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references/loop.sh"
 
 command -v git >/dev/null 2>&1 || { echo "SKIP: git 미설치"; exit 0; }
 command -v yq  >/dev/null 2>&1 || { echo "SKIP: yq 미설치"; exit 0; }

--- a/tests/autopilot/loop/test-loop-no-secondary-reuse.sh
+++ b/tests/autopilot/loop/test-loop-no-secondary-reuse.sh
@@ -15,12 +15,12 @@
 
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOOP_SH="$SCRIPT_DIR/../references/loop.sh"
+LOOP_SH="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references/loop.sh"
 
 command -v git >/dev/null 2>&1 || { echo "SKIP: git 미설치"; exit 0; }
 
 # loop.sh source — dispatcher 는 BASH_SOURCE guard 로 비실행.
-# shellcheck source=../references/loop.sh
+# shellcheck source=../../../plugins/autopilot/skills/loop/references/loop.sh
 source "$LOOP_SH"
 set +e   # loop.sh 의 errexit 해제
 

--- a/tests/autopilot/loop/test-loop-per-spec-layout.sh
+++ b/tests/autopilot/loop/test-loop-per-spec-layout.sh
@@ -11,12 +11,12 @@
 
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOOP_SH="$SCRIPT_DIR/../references/loop.sh"
+LOOP_SH="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references/loop.sh"
 
 command -v git >/dev/null 2>&1 || { echo "SKIP: git 미설치"; exit 0; }
 
 # loop.sh source — dispatcher 는 BASH_SOURCE guard 로 비실행.
-# shellcheck source=../references/loop.sh
+# shellcheck source=../../../plugins/autopilot/skills/loop/references/loop.sh
 source "$LOOP_SH"
 set +e
 

--- a/tests/autopilot/loop/test-loop-persona-lateral.sh
+++ b/tests/autopilot/loop/test-loop-persona-lateral.sh
@@ -31,13 +31,13 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REFS="$SCRIPT_DIR/../references"
+REFS="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references"
 CONSTITUTION="$REFS/constitution.md"
 AGENT_PROMPTS="$REFS/agent-prompts.md"
 OPERATIONAL="$REFS/operational-guide.md"
 LOOP_SH="$REFS/loop.sh"
 # 페르소나 카탈로그 단일 출처 (선행 spec 스킬). loop는 이를 참조만 한다.
-PERSONAS="$SCRIPT_DIR/../../../references/personas.md"
+PERSONAS="$SCRIPT_DIR/../../../plugins/autopilot/references/personas.md"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "OK: $*"; }

--- a/tests/autopilot/loop/test-loop-preserve-project-guidelines.sh
+++ b/tests/autopilot/loop/test-loop-preserve-project-guidelines.sh
@@ -4,7 +4,7 @@
 # CLAUDE.md/AGENTS.md 로 cp 덮어써 워커가 프로젝트 지침(versioning 등)을 보지 못했다.
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REFS="$SCRIPT_DIR/../references"
+REFS="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references"
 LOOP_SH="$REFS/loop.sh"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }

--- a/tests/autopilot/loop/test-loop-read-scope-yaml.sh
+++ b/tests/autopilot/loop/test-loop-read-scope-yaml.sh
@@ -7,13 +7,13 @@
 
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOOP_SH="$SCRIPT_DIR/../references/loop.sh"
+LOOP_SH="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references/loop.sh"
 
 command -v yq  >/dev/null 2>&1 || { echo "SKIP: yq 미설치"; exit 0; }
 command -v git >/dev/null 2>&1 || { echo "SKIP: git 미설치"; exit 0; }
 
 # loop.sh 를 source 해 함수만 사용 (dispatcher 는 BASH_SOURCE guard 로 비실행).
-# shellcheck source=../references/loop.sh
+# shellcheck source=../../../plugins/autopilot/skills/loop/references/loop.sh
 source "$LOOP_SH"
 set +e   # loop.sh 가 켠 errexit 해제 — 테스트는 조건 분기를 직접 제어
 

--- a/tests/autopilot/loop/test-loop-rules-index.sh
+++ b/tests/autopilot/loop/test-loop-rules-index.sh
@@ -5,7 +5,7 @@
 # 생성하고 워커 컨텍스트(_loop_merged)에 포함하는지 검증한다.
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REFS="$SCRIPT_DIR/../references"
+REFS="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references"
 LOOP_SH="$REFS/loop.sh"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }

--- a/tests/autopilot/loop/test-loop-stop-orphan-guard.sh
+++ b/tests/autopilot/loop/test-loop-stop-orphan-guard.sh
@@ -18,12 +18,12 @@
 
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOOP_SH="$SCRIPT_DIR/../references/loop.sh"
+LOOP_SH="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references/loop.sh"
 
 command -v git >/dev/null 2>&1 || { echo "SKIP: git 미설치"; exit 0; }
 
 # loop.sh source — dispatcher 는 BASH_SOURCE guard 로 비실행.
-# shellcheck source=../references/loop.sh
+# shellcheck source=../../../plugins/autopilot/skills/loop/references/loop.sh
 source "$LOOP_SH"
 # loop.sh 는 `set -euo pipefail` 을 켜므로, 의도적 비-0 rc 캡처(stop 실패 경로 등)가
 # errexit 로 테스트를 중단시키지 않게 errexit 만 해제한다(테스트가 rc 를 직접 검사).

--- a/tests/autopilot/loop/test-loop-wt-meta.sh
+++ b/tests/autopilot/loop/test-loop-wt-meta.sh
@@ -13,12 +13,12 @@
 
 set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-LOOP_SH="$SCRIPT_DIR/../references/loop.sh"
+LOOP_SH="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references/loop.sh"
 
 command -v git >/dev/null 2>&1 || { echo "SKIP: git 미설치"; exit 0; }
 
 # loop.sh source — dispatcher 는 BASH_SOURCE guard 로 비실행.
-# shellcheck source=../references/loop.sh
+# shellcheck source=../../../plugins/autopilot/skills/loop/references/loop.sh
 source "$LOOP_SH"
 set +e   # loop.sh 의 errexit 해제 — 함수 return 1 캡처 위해 필수
 

--- a/tests/autopilot/review/test-review-harness.sh
+++ b/tests/autopilot/review/test-review-harness.sh
@@ -25,7 +25,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REVIEW_SH="$SCRIPT_DIR/../references/review.sh"
+REVIEW_SH="$SCRIPT_DIR/../../../plugins/autopilot/skills/review/references/review.sh"
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 ok()   { echo "OK: $*"; }
@@ -257,7 +257,7 @@ ma="$(echo "$out" | jq -r '.automation_safety.may_approve')"
 [[ "$v" != "approve" && "$ma" == "false" ]] || fail "H17b: non-approve(verdict=$v)인데 may_approve=$ma (false 기대)"
 # CI 게이트(claude-review.yml)가 모델 자가판정이 아니라 verdict 파생임을 교차 확인.
 # 플러그인 자기완결을 위해 파일이 있을 때만 검사한다(소비 리포 밖 설치 시 graceful skip).
-CI_WORKFLOW="${CI_WORKFLOW:-$SCRIPT_DIR/../../../../../.github/workflows/claude-review.yml}"
+CI_WORKFLOW="${CI_WORKFLOW:-$SCRIPT_DIR/../../../.github/workflows/claude-review.yml}"
 if [[ -f "$CI_WORKFLOW" ]]; then
   if grep -qF 'r.automation_safety?.may_approve' "$CI_WORKFLOW"; then
     fail "H17: CI 게이트가 모델 자가판정 automation_safety.may_approve 에 의존 — verdict 파생 불일치 (#480)"

--- a/tests/autopilot/review/test-review-skill.sh
+++ b/tests/autopilot/review/test-review-skill.sh
@@ -23,7 +23,7 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKILL_DIR="$SCRIPT_DIR/.."
+SKILL_DIR="$SCRIPT_DIR/../../../plugins/autopilot/skills/review"
 SKILL_MD="$SKILL_DIR/SKILL.md"
 REVIEW_SH="$SKILL_DIR/references/review.sh"
 AGENT_PROMPTS="$SKILL_DIR/references/agent-prompts.md"

--- a/tests/forge/test-forge-routing.sh
+++ b/tests/forge/test-forge-routing.sh
@@ -2,14 +2,14 @@
 # test-forge-routing.sh — origin url 별 호스트 라우팅 + gitlab 확장점 abort 검증.
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-F="$HERE/../forge.sh"
+F="$HERE/../../plugins/autopilot/forge/forge.sh"
 fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
 
 # 라우팅 셀프테스트 위임
 if bash "$F" selftest; then ok "forge selftest"; else bad "forge selftest"; fi
 
 # gitlab 구현은 호출 시 비-0 (조용한 실패 금지 — 확장점)
-( source "$HERE/../gitlab.sh"; fg_integrate x y z ) >/dev/null 2>&1 && bad "gitlab integrate abort" || ok "gitlab integrate abort(비-0)"
+( source "$HERE/../../plugins/autopilot/forge/gitlab.sh"; fg_integrate x y z ) >/dev/null 2>&1 && bad "gitlab integrate abort" || ok "gitlab integrate abort(비-0)"
 
 # fg_review 위임 검증(#426): github 은 review-loop.sh `round`(rl_round 코드 0/10/20/30 표면화),
 #   direct 는 `run-direct`(기존 동기 리뷰, collapse). 스텁 review-loop.sh 로 서브커맨드 캡처.
@@ -19,9 +19,9 @@ cat > "$TMPD/ref/review-loop.sh" <<'EOF'
 #!/usr/bin/env bash
 echo "$1" > "$RL_SUB"
 EOF
-( source "$HERE/../github.sh"; FG_REF="$TMPD/ref" RL_SUB="$TMPD/sub.gh" fg_review rd key spec 7 br )
+( source "$HERE/../../plugins/autopilot/forge/github.sh"; FG_REF="$TMPD/ref" RL_SUB="$TMPD/sub.gh" fg_review rd key spec 7 br )
 [[ "$(cat "$TMPD/sub.gh")" == "round" ]] && ok "github fg_review → review-loop.sh round" || bad "github fg_review → round (got '$(cat "$TMPD/sub.gh")')"
-( source "$HERE/../direct.sh"; FG_REF="$TMPD/ref" RL_SUB="$TMPD/sub.dir" fg_review rd key spec "" br )
+( source "$HERE/../../plugins/autopilot/forge/direct.sh"; FG_REF="$TMPD/ref" RL_SUB="$TMPD/sub.dir" fg_review rd key spec "" br )
 [[ "$(cat "$TMPD/sub.dir")" == "run-direct" ]] && ok "direct fg_review → review-loop.sh run-direct(불변)" || bad "direct fg_review → run-direct (got '$(cat "$TMPD/sub.dir")')"
 
 echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 499

## 요약

배포되는 플러그인 디렉터리(`plugins/autopilot/`) 안에 박혀 있는 테스트 디렉터리들(`skills/*/tests/`, `forge/tests/`)을 **프로젝트 테스트 트리(`tests/`)로 이전**한다. 배포 산출물에서 dev 테스트를 제거하고, 소스↔테스트 위치를 프로젝트 레벨로 일관화한다.
