### PR TITLE
🤖 [자동 리뷰] fix: execute-task SIGKILL 후 heartbeat orphan이 lease 영구 갱신 — stale 감지 불가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## autopilot 0.60.0
 
 ### 버그 수정
-- **execute-task SIGKILL 후 heartbeat orphan이 lease 영구 갱신 — stale 감지 불가 수정 (#506)** — `execute-task.sh` 의 heartbeat subshell 이 `trap cleanup_hb EXIT` 로 보호받지 못하는 SIGKILL 경로에서 orphan 이 돼 `renew_lease` 를 계속 호출하고 태스크가 `in_progress` 로 영구 박제되던 버그를 수정했다. 부모 PID·시작 시간을 subshell 시작 전에 캡처하고, heartbeat 루프 첫머리에 부모 생존 확인 후 자가종료 로직을 추가했다. **감지 방식**: Linux(`/proc` 가용)는 `/proc/PID/stat` 시작 시간 비교로 SIGKILL·PID 재사용 양쪽 감지; 비-Linux는 세마포어 파일(`/tmp/execute-task-$$.alive`, EXIT trap 삭제)만 사용해 SIGTERM·정상 종료를 감지(`kill -0` 는 PID 재사용 시 다른 프로세스를 부모로 오인해 orphan 재발 가능성이 있어 제외, 비-Linux SIGKILL 은 허용된 한계). SIGTERM·정상 exit 경로의 기존 `cleanup_hb` 동작에 변경 없음. 회귀 가드(`test-execute-task-sigkill-heartbeat.sh`)가 SIGKILL 후 heartbeat 자가종료와 세마포어 파일 생성 두 조건을 모두 단언한다.
+- **execute-task SIGKILL 후 heartbeat orphan이 lease 영구 갱신 — stale 감지 불가 수정 (#506)** — `execute-task.sh` 의 heartbeat subshell 이 `trap cleanup_hb EXIT` 로 보호받지 못하는 SIGKILL 경로에서 orphan 이 돼 `renew_lease` 를 계속 호출하고 태스크가 `in_progress` 로 영구 박제되던 버그를 수정했다. 부모 PID·시작 시간을 subshell 시작 전에 캡처하고, heartbeat 루프 첫머리에 부모 생존 확인 후 자가종료 로직을 추가했다. **감지 방식**: Linux(`/proc` 가용)는 `/proc/PID/stat` 시작 시간 비교로 SIGKILL·PID 재사용 양쪽 감지; 비-Linux는 `$BASHPID` 기반 ppid 확인(`ps -o ppid=`)으로 SIGKILL 후 re-parenting을 감지하고, 세마포어 파일(`/tmp/execute-task-$$.alive`)로 SIGTERM·정상 종료를 보완(`kill -0` 는 PID 재사용 시 orphan 재발 가능성이 있어 제외). SIGTERM·정상 exit 경로의 기존 `cleanup_hb` 동작에 변경 없음. 회귀 가드(`test-execute-task-sigkill-heartbeat.sh`)가 SIGKILL 후 heartbeat 자가종료와 세마포어 파일 생성 두 조건을 모두 단언한다.
 
 ## autopilot 0.59.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.60.0
+
+### 버그 수정
+- **execute-task SIGKILL 후 heartbeat orphan이 lease 영구 갱신 — stale 감지 불가 수정 (#506)** — `execute-task.sh` 의 heartbeat subshell 이 `trap cleanup_hb EXIT` 로 보호받지 못하는 SIGKILL 경로에서 orphan 이 돼 `renew_lease` 를 60s 마다 계속 호출하고 태스크가 `in_progress` 로 영구 박제되던 버그를 수정했다. 부모 PID(`PARENT_PID=$$`)를 subshell 시작 전에 캡처하고, heartbeat 루프 첫머리에 `kill -0 "$PARENT_PID" 2>/dev/null || exit 0` 을 추가해 부모 프로세스가 어떤 이유로든 종료되면 heartbeat 가 다음 인터벌 내에 자가종료한다. SIGTERM·정상 exit 경로의 기존 `cleanup_hb` 동작에 변경 없음. 회귀 가드(`tests/autopilot/execute-task/test-execute-task-sigkill-heartbeat.sh`)가 SIGKILL 후 heartbeat PID 가 `HEARTBEAT_INTERVAL` 내에 종료됨을 단언한다.
+
 ## autopilot 0.59.0
 
 ### 버그 수정

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## autopilot 0.60.0
 
 ### 버그 수정
-- **execute-task SIGKILL 후 heartbeat orphan이 lease 영구 갱신 — stale 감지 불가 수정 (#506)** — `execute-task.sh` 의 heartbeat subshell 이 `trap cleanup_hb EXIT` 로 보호받지 못하는 SIGKILL 경로에서 orphan 이 돼 `renew_lease` 를 계속 호출하고 태스크가 `in_progress` 로 영구 박제되던 버그를 수정했다. 부모 PID·시작 시간을 subshell 시작 전에 캡처하고, heartbeat 루프 첫머리에 부모 생존 확인 후 자가종료 로직을 추가했다. **감지 방식**: Linux(`/proc` 가용)는 `/proc/PID/stat` 시작 시간 비교로 SIGKILL·PID 재사용 양쪽 감지; 비-Linux는 세마포어 파일(`/tmp/execute-task-$$.alive`, EXIT trap 삭제) + `kill -0` 이중 확인으로 SIGTERM+PID 재사용·SIGKILL 각각 감지. SIGTERM·정상 exit 경로의 기존 `cleanup_hb` 동작에 변경 없음. 회귀 가드(`test-execute-task-sigkill-heartbeat.sh`)가 SIGKILL 후 heartbeat 자가종료와 세마포어 파일 생성 두 조건을 모두 단언한다.
+- **execute-task SIGKILL 후 heartbeat orphan이 lease 영구 갱신 — stale 감지 불가 수정 (#506)** — `execute-task.sh` 의 heartbeat subshell 이 `trap cleanup_hb EXIT` 로 보호받지 못하는 SIGKILL 경로에서 orphan 이 돼 `renew_lease` 를 계속 호출하고 태스크가 `in_progress` 로 영구 박제되던 버그를 수정했다. 부모 PID·시작 시간을 subshell 시작 전에 캡처하고, heartbeat 루프 첫머리에 부모 생존 확인 후 자가종료 로직을 추가했다. **감지 방식**: Linux(`/proc` 가용)는 `/proc/PID/stat` 시작 시간 비교로 SIGKILL·PID 재사용 양쪽 감지; 비-Linux는 세마포어 파일(`/tmp/execute-task-$$.alive`, EXIT trap 삭제)만 사용해 SIGTERM·정상 종료를 감지(`kill -0` 는 PID 재사용 시 다른 프로세스를 부모로 오인해 orphan 재발 가능성이 있어 제외, 비-Linux SIGKILL 은 허용된 한계). SIGTERM·정상 exit 경로의 기존 `cleanup_hb` 동작에 변경 없음. 회귀 가드(`test-execute-task-sigkill-heartbeat.sh`)가 SIGKILL 후 heartbeat 자가종료와 세마포어 파일 생성 두 조건을 모두 단언한다.
 
 ## autopilot 0.59.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## autopilot 0.60.0
 
 ### 버그 수정
-- **execute-task SIGKILL 후 heartbeat orphan이 lease 영구 갱신 — stale 감지 불가 수정 (#506)** — `execute-task.sh` 의 heartbeat subshell 이 `trap cleanup_hb EXIT` 로 보호받지 못하는 SIGKILL 경로에서 orphan 이 돼 `renew_lease` 를 60s 마다 계속 호출하고 태스크가 `in_progress` 로 영구 박제되던 버그를 수정했다. 부모 PID(`PARENT_PID=$$`)를 subshell 시작 전에 캡처하고, heartbeat 루프 첫머리에 `kill -0 "$PARENT_PID" 2>/dev/null || exit 0` 을 추가해 부모 프로세스가 어떤 이유로든 종료되면 heartbeat 가 다음 인터벌 내에 자가종료한다. SIGTERM·정상 exit 경로의 기존 `cleanup_hb` 동작에 변경 없음. 회귀 가드(`tests/autopilot/execute-task/test-execute-task-sigkill-heartbeat.sh`)가 SIGKILL 후 heartbeat PID 가 `HEARTBEAT_INTERVAL` 내에 종료됨을 단언한다.
+- **execute-task SIGKILL 후 heartbeat orphan이 lease 영구 갱신 — stale 감지 불가 수정 (#506)** — `execute-task.sh` 의 heartbeat subshell 이 `trap cleanup_hb EXIT` 로 보호받지 못하는 SIGKILL 경로에서 orphan 이 돼 `renew_lease` 를 계속 호출하고 태스크가 `in_progress` 로 영구 박제되던 버그를 수정했다. 부모 PID·시작 시간을 subshell 시작 전에 캡처하고, heartbeat 루프 첫머리에 부모 생존 확인 후 자가종료 로직을 추가했다. **감지 방식**: Linux(`/proc` 가용)는 `/proc/PID/stat` 시작 시간 비교로 SIGKILL·PID 재사용 양쪽 감지; 비-Linux는 세마포어 파일(`/tmp/execute-task-$$.alive`, EXIT trap 삭제) + `kill -0` 이중 확인으로 SIGTERM+PID 재사용·SIGKILL 각각 감지. SIGTERM·정상 exit 경로의 기존 `cleanup_hb` 동작에 변경 없음. 회귀 가드(`test-execute-task-sigkill-heartbeat.sh`)가 SIGKILL 후 heartbeat 자가종료와 세마포어 파일 생성 두 조건을 모두 단언한다.
 
 ## autopilot 0.59.0
 

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -130,17 +130,17 @@ et_start() {
 
   # 백그라운드 heartbeat (lease 갱신). 연속 실패 시 lease 를 잃어 이중 실행 위험 → fail-fast 로 메인 중단.
   # SIGKILL orphan 방지: 부모 PID 와 시작 시간을 미리 캡처해 subshell 에서 생존 확인 후 자가종료.
-  # /proc 가용 시(Linux): 시작 시간 비교로 PID 재사용·SIGKILL 양쪽 감지. 비가용 시: 세마포어만 사용.
+  # /proc 가용 시(Linux): 시작 시간 비교로 PID 재사용·SIGKILL 양쪽 감지. 비가용 시: ppid+세마포어 조합.
   local PARENT_PID=$$
   local PARENT_STARTTIME; PARENT_STARTTIME="$(awk '{print $22}' /proc/$$/stat 2>/dev/null || true)"
   # 세마포어 파일: EXIT trap 삭제 → SIGTERM 후 PID 재사용 시에도 heartbeat 가 정상 종료로 오인 없음.
-  # SIGKILL 시 EXIT trap 미실행으로 파일 잔존 가능(비-Linux 허용 한계; Linux 는 /proc 로 감지).
+  # SIGKILL 시 EXIT trap 미실행으로 파일 잔존 가능 — 비-Linux 는 ppid 기반으로 SIGKILL 도 감지.
   PARENT_ALIVE_FILE="/tmp/execute-task-$$.alive"
   touch "$PARENT_ALIVE_FILE" 2>/dev/null || PARENT_ALIVE_FILE=""
   ( fail=0
     while true; do
       # orphan 자가종료: 부모(execute-task 메인 프로세스)가 종료되면 heartbeat 도 즉시 종료.
-      # /proc 가용 시: 존재 + 시작 시간 비교(PID 재사용 구분). 비가용 시: 세마포어(정상·SIGTERM 감지).
+      # /proc 가용 시: 존재 + 시작 시간 비교(PID 재사용 구분). 비가용 시: ppid(SIGKILL)+세마포어(SIGTERM).
       if [[ -n "$PARENT_STARTTIME" ]]; then
         if [[ -r "/proc/$PARENT_PID/stat" ]]; then
           [[ "$(awk '{print $22}' "/proc/$PARENT_PID/stat" 2>/dev/null)" == "$PARENT_STARTTIME" ]] || exit 0
@@ -148,9 +148,14 @@ et_start() {
           exit 0
         fi
       else
-        # 비-Linux: 세마포어 파일만 사용(정상/SIGTERM 종료 감지). kill -0 는 PID 재사용 시
-        # 다른 프로세스를 부모로 오인해 orphan 이 재발하므로 제외한다.
-        # SIGKILL 시 파일 잔존 → heartbeat 계속 실행(비-Linux SIGKILL 는 허용된 한계).
+        # 비-Linux: ppid 기반(SIGKILL 포함) + 세마포어(SIGTERM/정상 종료) 조합.
+        # SIGKILL 후 subshell 이 init 에 re-parent → ppid ≠ PARENT_PID → 자가종료.
+        # $BASHPID(bash 4+): subshell 자신의 PID. ps -o ppid= 는 macOS/BSD 이식성 높음.
+        if [[ -n "${BASHPID:-}" ]]; then
+          _ppid="$(ps -o ppid= -p "$BASHPID" 2>/dev/null | tr -d ' ')"
+          if [[ -n "$_ppid" ]]; then [[ "$_ppid" == "$PARENT_PID" ]] || exit 0; fi
+        fi
+        # 세마포어: EXIT trap 기반(SIGTERM/정상 종료). $BASHPID 미지원 시 주요 감지 수단.
         if [[ -n "${PARENT_ALIVE_FILE:-}" && ! -f "$PARENT_ALIVE_FILE" ]]; then exit 0; fi
       fi
       if $ADAPTER_CMD renew_lease --task-id "$id" --owner "$owner" >/dev/null 2>&1; then fail=0

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -100,7 +100,11 @@ query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
 }
 
 HB_PID=""
-cleanup_hb() { [[ -n "${HB_PID:-}" ]] && kill "$HB_PID" 2>/dev/null || true; }
+PARENT_ALIVE_FILE=""
+cleanup_hb() {
+  [[ -n "${HB_PID:-}" ]] && kill "$HB_PID" 2>/dev/null || true
+  [[ -n "${PARENT_ALIVE_FILE:-}" ]] && rm -f "$PARENT_ALIVE_FILE" 2>/dev/null || true
+}
 trap cleanup_hb EXIT
 
 et_start() {
@@ -126,13 +130,17 @@ et_start() {
 
   # 백그라운드 heartbeat (lease 갱신). 연속 실패 시 lease 를 잃어 이중 실행 위험 → fail-fast 로 메인 중단.
   # SIGKILL orphan 방지: 부모 PID 와 시작 시간을 미리 캡처해 subshell 에서 생존 확인 후 자가종료.
-  # /proc 가용 시(Linux) 시작 시간도 비교해 PID 재사용으로 인한 orphan 재발을 방지한다.
+  # /proc 가용 시(Linux): 시작 시간 비교로 PID 재사용·SIGKILL 양쪽 감지. 비가용 시: 세마포어+kill-0.
   local PARENT_PID=$$
   local PARENT_STARTTIME; PARENT_STARTTIME="$(awk '{print $22}' /proc/$$/stat 2>/dev/null || true)"
+  # 세마포어 파일: EXIT trap 삭제 → SIGTERM 후 PID 재사용 시에도 heartbeat 가 정상 종료로 오인 없음.
+  # SIGKILL 시 EXIT trap 미실행으로 파일 잔존 가능 — 이 경우 kill-0 이 SIGKILL 감지를 보완한다.
+  PARENT_ALIVE_FILE="/tmp/execute-task-$$.alive"
+  touch "$PARENT_ALIVE_FILE" 2>/dev/null || PARENT_ALIVE_FILE=""
   ( fail=0
     while true; do
       # orphan 자가종료: 부모(execute-task 메인 프로세스)가 종료되면 heartbeat 도 즉시 종료.
-      # /proc 가용 시: 존재 + 시작 시간 비교(PID 재사용 구분). 비가용 시: kill -0 fallback.
+      # /proc 가용 시: 존재 + 시작 시간 비교(PID 재사용 구분). 비가용 시: 세마포어+kill-0 이중 확인.
       if [[ -n "$PARENT_STARTTIME" ]]; then
         if [[ -r "/proc/$PARENT_PID/stat" ]]; then
           [[ "$(awk '{print $22}' "/proc/$PARENT_PID/stat" 2>/dev/null)" == "$PARENT_STARTTIME" ]] || exit 0
@@ -140,6 +148,9 @@ et_start() {
           exit 0
         fi
       else
+        # 비-Linux: 세마포어 파일(SIGTERM+PID 재사용 방지) + kill-0(SIGKILL 감지) 이중 확인.
+        # 파일이 설정됐고 삭제됐으면 EXIT trap 실행됨(정상/SIGTERM 종료) → 자가종료.
+        if [[ -n "${PARENT_ALIVE_FILE:-}" && ! -f "$PARENT_ALIVE_FILE" ]]; then exit 0; fi
         kill -0 "$PARENT_PID" 2>/dev/null || exit 0
       fi
       if $ADAPTER_CMD renew_lease --task-id "$id" --owner "$owner" >/dev/null 2>&1; then fail=0

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -125,8 +125,13 @@ et_start() {
   $LOOP_CMD cleanup "$sp" --force >/dev/null 2>&1 || true
 
   # 백그라운드 heartbeat (lease 갱신). 연속 실패 시 lease 를 잃어 이중 실행 위험 → fail-fast 로 메인 중단.
+  # SIGKILL orphan 방지: 부모 PID 를 미리 캡처해 subshell 에서 생존 확인 후 자가종료.
+  local PARENT_PID=$$
   ( fail=0
     while true; do
+      # orphan 자가종료: 부모(execute-task 메인 프로세스)가 종료되면 heartbeat 도 즉시 종료.
+      # trap EXIT 는 SIGKILL 을 잡지 못하므로 주기적으로 부모 생존 여부를 확인한다.
+      kill -0 "$PARENT_PID" 2>/dev/null || exit 0
       if $ADAPTER_CMD renew_lease --task-id "$id" --owner "$owner" >/dev/null 2>&1; then fail=0
       else fail=$((fail+1)); if (( fail >= 3 )); then
         echo "execute-task: heartbeat lease 갱신 연속 실패 — 작업 중단($id)" >&2

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -125,13 +125,23 @@ et_start() {
   $LOOP_CMD cleanup "$sp" --force >/dev/null 2>&1 || true
 
   # 백그라운드 heartbeat (lease 갱신). 연속 실패 시 lease 를 잃어 이중 실행 위험 → fail-fast 로 메인 중단.
-  # SIGKILL orphan 방지: 부모 PID 를 미리 캡처해 subshell 에서 생존 확인 후 자가종료.
+  # SIGKILL orphan 방지: 부모 PID 와 시작 시간을 미리 캡처해 subshell 에서 생존 확인 후 자가종료.
+  # /proc 가용 시(Linux) 시작 시간도 비교해 PID 재사용으로 인한 orphan 재발을 방지한다.
   local PARENT_PID=$$
+  local PARENT_STARTTIME; PARENT_STARTTIME="$(awk '{print $22}' /proc/$$/stat 2>/dev/null || true)"
   ( fail=0
     while true; do
       # orphan 자가종료: 부모(execute-task 메인 프로세스)가 종료되면 heartbeat 도 즉시 종료.
-      # trap EXIT 는 SIGKILL 을 잡지 못하므로 주기적으로 부모 생존 여부를 확인한다.
-      kill -0 "$PARENT_PID" 2>/dev/null || exit 0
+      # /proc 가용 시: 존재 + 시작 시간 비교(PID 재사용 구분). 비가용 시: kill -0 fallback.
+      if [[ -n "$PARENT_STARTTIME" ]]; then
+        if [[ -r "/proc/$PARENT_PID/stat" ]]; then
+          [[ "$(awk '{print $22}' "/proc/$PARENT_PID/stat" 2>/dev/null)" == "$PARENT_STARTTIME" ]] || exit 0
+        else
+          exit 0
+        fi
+      else
+        kill -0 "$PARENT_PID" 2>/dev/null || exit 0
+      fi
       if $ADAPTER_CMD renew_lease --task-id "$id" --owner "$owner" >/dev/null 2>&1; then fail=0
       else fail=$((fail+1)); if (( fail >= 3 )); then
         echo "execute-task: heartbeat lease 갱신 연속 실패 — 작업 중단($id)" >&2

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -130,17 +130,17 @@ et_start() {
 
   # 백그라운드 heartbeat (lease 갱신). 연속 실패 시 lease 를 잃어 이중 실행 위험 → fail-fast 로 메인 중단.
   # SIGKILL orphan 방지: 부모 PID 와 시작 시간을 미리 캡처해 subshell 에서 생존 확인 후 자가종료.
-  # /proc 가용 시(Linux): 시작 시간 비교로 PID 재사용·SIGKILL 양쪽 감지. 비가용 시: 세마포어+kill-0.
+  # /proc 가용 시(Linux): 시작 시간 비교로 PID 재사용·SIGKILL 양쪽 감지. 비가용 시: 세마포어만 사용.
   local PARENT_PID=$$
   local PARENT_STARTTIME; PARENT_STARTTIME="$(awk '{print $22}' /proc/$$/stat 2>/dev/null || true)"
   # 세마포어 파일: EXIT trap 삭제 → SIGTERM 후 PID 재사용 시에도 heartbeat 가 정상 종료로 오인 없음.
-  # SIGKILL 시 EXIT trap 미실행으로 파일 잔존 가능 — 이 경우 kill-0 이 SIGKILL 감지를 보완한다.
+  # SIGKILL 시 EXIT trap 미실행으로 파일 잔존 가능(비-Linux 허용 한계; Linux 는 /proc 로 감지).
   PARENT_ALIVE_FILE="/tmp/execute-task-$$.alive"
   touch "$PARENT_ALIVE_FILE" 2>/dev/null || PARENT_ALIVE_FILE=""
   ( fail=0
     while true; do
       # orphan 자가종료: 부모(execute-task 메인 프로세스)가 종료되면 heartbeat 도 즉시 종료.
-      # /proc 가용 시: 존재 + 시작 시간 비교(PID 재사용 구분). 비가용 시: 세마포어+kill-0 이중 확인.
+      # /proc 가용 시: 존재 + 시작 시간 비교(PID 재사용 구분). 비가용 시: 세마포어(정상·SIGTERM 감지).
       if [[ -n "$PARENT_STARTTIME" ]]; then
         if [[ -r "/proc/$PARENT_PID/stat" ]]; then
           [[ "$(awk '{print $22}' "/proc/$PARENT_PID/stat" 2>/dev/null)" == "$PARENT_STARTTIME" ]] || exit 0
@@ -148,10 +148,10 @@ et_start() {
           exit 0
         fi
       else
-        # 비-Linux: 세마포어 파일(SIGTERM+PID 재사용 방지) + kill-0(SIGKILL 감지) 이중 확인.
-        # 파일이 설정됐고 삭제됐으면 EXIT trap 실행됨(정상/SIGTERM 종료) → 자가종료.
+        # 비-Linux: 세마포어 파일만 사용(정상/SIGTERM 종료 감지). kill -0 는 PID 재사용 시
+        # 다른 프로세스를 부모로 오인해 orphan 이 재발하므로 제외한다.
+        # SIGKILL 시 파일 잔존 → heartbeat 계속 실행(비-Linux SIGKILL 는 허용된 한계).
         if [[ -n "${PARENT_ALIVE_FILE:-}" && ! -f "$PARENT_ALIVE_FILE" ]]; then exit 0; fi
-        kill -0 "$PARENT_PID" 2>/dev/null || exit 0
       fi
       if $ADAPTER_CMD renew_lease --task-id "$id" --owner "$owner" >/dev/null 2>&1; then fail=0
       else fail=$((fail+1)); if (( fail >= 3 )); then

--- a/tests/autopilot/execute-task/test-execute-task-sigkill-heartbeat.sh
+++ b/tests/autopilot/execute-task/test-execute-task-sigkill-heartbeat.sh
@@ -3,8 +3,11 @@
 #   execute-task가 SIGKILL로 종료될 때, heartbeat subshell이 부모 생존 확인 후
 #   스스로 종료해야 한다(orphan으로 lease를 영구 갱신하는 버그 회귀 방지).
 #
-#   RED → SIGKILL 후 heartbeat가 orphan으로 살아남으면 FAIL.
-#   GREEN → fix 후 heartbeat가 HEARTBEAT_INTERVAL 내에 자가종료하면 PASS.
+#   TC1: SIGKILL 후 heartbeat orphan이 살아남으면 FAIL.
+#   TC2: 세마포어 파일(/tmp/execute-task-<PID>.alive)이 실행 중 존재하지 않으면 FAIL
+#         (PID 재사용 방지 메커니즘 부재 → 비-Linux에서 SIGTERM+PID재사용 시 orphan 재발).
+#
+#   GREEN → fix 후 TC1·TC2 모두 통과.
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
@@ -12,6 +15,7 @@ ADAPTER="$HERE/../../../plugins/autopilot/task-backend/adapter.sh"
 fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
 
 TMP="$(mktemp -d)"
+ET_PID=""
 HB_PID_FILE="$TMP/hb.pid"
 cleanup_test(){
   # 남은 백그라운드 프로세스 정리
@@ -20,6 +24,8 @@ cleanup_test(){
     [[ -n "$hbp" ]] && kill "$hbp" 2>/dev/null || true
   fi
   jobs -p 2>/dev/null | xargs -r kill 2>/dev/null || true
+  # 세마포어 파일 잔재 정리 (SIGKILL 시 EXIT trap 미실행으로 남을 수 있음)
+  [[ -n "$ET_PID" ]] && rm -f "/tmp/execute-task-${ET_PID}.alive" 2>/dev/null || true
   rm -rf "$TMP"
 }
 trap cleanup_test EXIT
@@ -67,7 +73,7 @@ LOOP_CMD="bash $TMP/bin/loop" \
 FORGE_CMD=":" \
 HEARTBEAT_INTERVAL=1 \
 bash "$ET" start "$id" &
-ET_PID=$!
+ET_PID=$!   # 세마포어 파일 경로 예측: /tmp/execute-task-${ET_PID}.alive
 
 # heartbeat가 첫 renew_lease 호출해 HB_PID_FILE에 기록될 때까지 대기(최대 5s)
 waited=0
@@ -88,6 +94,15 @@ if ! kill -0 "$HB_PID" 2>/dev/null; then
   bad "heartbeat PID $HB_PID 가 초기 실행 중이 아님 — 테스트 셋업 이상"
   kill "$ET_PID" 2>/dev/null || true
   echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail
+fi
+
+# TC2: 세마포어 파일 생성 확인 (PID 재사용 방지 메커니즘, fix 전 → FAIL)
+# execute-task 실행 중 /tmp/execute-task-${ET_PID}.alive 가 존재해야 한다.
+# 비-Linux fallback 에서 SIGTERM+PID재사용 시 heartbeat 가 오인하지 않도록 막는 역할.
+if [[ -f "/tmp/execute-task-${ET_PID}.alive" ]]; then
+  ok "세마포어 파일 생성됨 (/tmp/execute-task-${ET_PID}.alive)"
+else
+  bad "세마포어 파일 없음 — PID 재사용 방지 메커니즘 미구현 (kill-0 fallback만 있음)"
 fi
 
 # execute-task 메인 프로세스에 SIGKILL

--- a/tests/autopilot/execute-task/test-execute-task-sigkill-heartbeat.sh
+++ b/tests/autopilot/execute-task/test-execute-task-sigkill-heartbeat.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# test-execute-task-sigkill-heartbeat.sh — SIGKILL 후 heartbeat subshell orphan 자가종료 검증.
+#   execute-task가 SIGKILL로 종료될 때, heartbeat subshell이 부모 생존 확인 후
+#   스스로 종료해야 한다(orphan으로 lease를 영구 갱신하는 버그 회귀 방지).
+#
+#   RED → SIGKILL 후 heartbeat가 orphan으로 살아남으면 FAIL.
+#   GREEN → fix 후 heartbeat가 HEARTBEAT_INTERVAL 내에 자가종료하면 PASS.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
+ADAPTER="$HERE/../../../plugins/autopilot/task-backend/adapter.sh"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+
+TMP="$(mktemp -d)"
+HB_PID_FILE="$TMP/hb.pid"
+cleanup_test(){
+  # 남은 백그라운드 프로세스 정리
+  if [[ -s "$HB_PID_FILE" ]]; then
+    hbp="$(cat "$HB_PID_FILE" 2>/dev/null || true)"
+    [[ -n "$hbp" ]] && kill "$hbp" 2>/dev/null || true
+  fi
+  jobs -p 2>/dev/null | xargs -r kill 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup_test EXIT
+
+cd "$TMP"; git init -q; git config user.email t@t; git config user.name t
+bash "$ADAPTER" init --backend filesystem >/dev/null
+
+mkdir -p bin
+
+# mock adapter: renew_lease → PPID(=heartbeat PID)를 파일에 기록 후 정상 반환.
+# ADAPTER_EOF 미인용 → $TMP·$HB_PID_FILE 는 지금 치환, \$PPID 는 런타임에 치환.
+cat > bin/adapter <<ADAPTER_EOF
+#!/usr/bin/env bash
+case "\$1" in
+  materialize) echo '{"spec_path":"$TMP/spec.md"}';;
+  claim)       echo '{"claimed":"true"}';;
+  renew_lease) echo \$PPID > "$HB_PID_FILE"; exit 0;;
+  set_status|append_log|get_task) exit 0;;
+  *) exit 0;;
+esac
+ADAPTER_EOF
+chmod +x bin/adapter
+
+# mock loop: start → 영원히 블록(메인 프로세스가 kill되기 전까지 실행 중)
+cat > bin/loop <<'LOOP_EOF'
+#!/usr/bin/env bash
+case "$1" in
+  start)    sleep 999;;
+  cleanup)  exit 0;;
+  status)   echo '{"state":"terminal","signals":["DONE"]}';;
+  *)        exit 0;;
+esac
+LOOP_EOF
+chmod +x bin/loop
+
+# 더미 spec 파일(materialize 결과 경로)
+echo "# spec" > "$TMP/spec.md"
+
+# adapter create_task (실제 백엔드 사용)
+id="$(bash "$ADAPTER" create_task --title "T-hb-sigkill" --body $'## 목표\nx' | jq -r .task_id)"
+
+# execute-task 백그라운드 실행 (HEARTBEAT_INTERVAL=1 → 빠른 감지)
+ADAPTER_CMD="bash $TMP/bin/adapter" \
+LOOP_CMD="bash $TMP/bin/loop" \
+FORGE_CMD=":" \
+HEARTBEAT_INTERVAL=1 \
+bash "$ET" start "$id" &
+ET_PID=$!
+
+# heartbeat가 첫 renew_lease 호출해 HB_PID_FILE에 기록될 때까지 대기(최대 5s)
+waited=0
+while [[ ! -s "$HB_PID_FILE" ]] && (( waited < 25 )); do
+  sleep 0.2; waited=$((waited+1))
+done
+
+if [[ ! -s "$HB_PID_FILE" ]]; then
+  bad "heartbeat가 시작되지 않았음(HB_PID_FILE 비어있음)"
+  kill "$ET_PID" 2>/dev/null || true
+  echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail
+fi
+
+HB_PID="$(cat "$HB_PID_FILE")"
+
+# heartbeat가 실제로 실행 중인지 확인
+if ! kill -0 "$HB_PID" 2>/dev/null; then
+  bad "heartbeat PID $HB_PID 가 초기 실행 중이 아님 — 테스트 셋업 이상"
+  kill "$ET_PID" 2>/dev/null || true
+  echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail
+fi
+
+# execute-task 메인 프로세스에 SIGKILL
+kill -9 "$ET_PID" 2>/dev/null || true
+wait "$ET_PID" 2>/dev/null || true
+
+# heartbeat가 자가종료할 때까지 대기(최대 HEARTBEAT_INTERVAL*3=3s + 버퍼)
+waited_hb=0
+while kill -0 "$HB_PID" 2>/dev/null && (( waited_hb < 20 )); do
+  sleep 0.2; waited_hb=$((waited_hb+1))
+done
+
+if kill -0 "$HB_PID" 2>/dev/null; then
+  bad "heartbeat (PID $HB_PID) 가 SIGKILL 후에도 살아있음 — orphan lease 갱신 버그"
+else
+  ok "SIGKILL 후 heartbeat 자가종료 확인"
+fi
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail

--- a/tests/autopilot/execute-task/test-execute-task-sigkill-heartbeat.sh
+++ b/tests/autopilot/execute-task/test-execute-task-sigkill-heartbeat.sh
@@ -94,7 +94,7 @@ fi
 kill -9 "$ET_PID" 2>/dev/null || true
 wait "$ET_PID" 2>/dev/null || true
 
-# heartbeat가 자가종료할 때까지 대기(최대 HEARTBEAT_INTERVAL*3=3s + 버퍼)
+# heartbeat가 자가종료할 때까지 대기(최대 4s — HEARTBEAT_INTERVAL*3 + 여유)
 waited_hb=0
 while kill -0 "$HB_PID" 2>/dev/null && (( waited_hb < 20 )); do
   sleep 0.2; waited_hb=$((waited_hb+1))


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 506

## 요약


execute-task가 SIGKILL로 종료될 때 heartbeat subshell이 orphan이 되어 lease를 영구 갱신하는 문제를 수정한다. orphan heartbeat가 죽거나 gh 인증이 만료될 때까지 해당 태스크는 stale로 감지되지 않아 자동 회수가 불가능하다.
