### PR TITLE
🤖 [자동 리뷰] fix: execute-task가 워크트리 내부에서 호출되면 중첩 .task-work/ 생성

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.59.1
+
+### 버그 수정
+- **execute-task가 링크드 워크트리 안에서 호출될 때 중첩 .task-work/ 경로 생성 (#520)** — `execute-task.sh`의 `ROOT_DIR` 결정 로직이 `git rev-parse --show-toplevel`만 사용해, 링크드 워크트리(`.task-work/<id>/.worktree`) 안에서 호출하면 워크트리 자신의 루트를 메인 리포 루트로 잘못 판정했다. 이로 인해 `.task-work/<id>/.worktree/.task-work/<id>/.worktree` 같은 중첩 경로와 `.autopilot/runs/`의 잘못된 위치 생성이 발생했다. 이제 `git worktree list --porcelain`의 첫 항목(항상 메인 워크트리)을 파싱해 `ROOT_DIR`을 메인 리포 루트로 고정하고, 구버전 git(< 2.7) 또는 git 미설치 환경은 기존 `--show-toplevel` 폴백으로 처리한다. 이로써 호출 위치와 무관하게 `.task-work/`와 `.autopilot/runs/`가 항상 메인 리포 루트 기준으로 생성된다. 회귀 가드(`test-execute-task-lifecycle.sh` 케이스 4)가 링크드 워크트리에서 호출 시 `run_dir`이 메인 리포 루트에 생성됨을 단언한다.
+
 ## autopilot 0.59.0
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -11,7 +11,11 @@
 # 모킹: ADAPTER_CMD / LOOP_CMD / FORGE_CMD 환경변수로 엔진 치환(테스트).
 set -euo pipefail
 
-ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+# 링크드 워크트리 안에서 호출할 때 --show-toplevel 은 워크트리 루트를 반환해 중첩 경로가 생긴다.
+# worktree list --porcelain 의 첫 항목(항상 메인 워크트리)으로 메인 리포 루트를 확정하고,
+# 구버전 git(< 2.7) 또는 git 미설치 환경은 --show-toplevel 으로 폴백한다.
+ROOT_DIR="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10); exit}')" || true
+[[ -n "$ROOT_DIR" ]] || ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 PLUGIN="$ROOT_DIR/plugins/autopilot"
 # 플러그인 자신이 소비처가 아닐 때(설치형): 스크립트 위치 기준으로도 해석
 [[ -d "$PLUGIN" ]] || PLUGIN="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"

--- a/tests/autopilot/execute-task/test-execute-task-lifecycle.sh
+++ b/tests/autopilot/execute-task/test-execute-task-lifecycle.sh
@@ -56,4 +56,35 @@ id3="$(bash "$ADAPTER" create_task --title "T3" --body '## 목표'$'\n'z | jq -r
 MOCK_RESULT=BLOCKED run start "$id3" >/dev/null 2>&1 || true
 chk "BLOCKED → blocked" "$(status_of "$id3")" "blocked"
 
+# 4) ROOT_DIR 회귀: 링크드 워크트리 안에서 호출해도 run_dir 이 메인 리포 루트에 생성됨
+T2="$(mktemp -d)"
+trap 'rm -rf "$TMP" "$T2"' EXIT
+git init -q "$T2"
+git -C "$T2" config user.email t@t
+git -C "$T2" config user.name t
+git -C "$T2" commit -q --allow-empty -m "init"
+git -C "$T2" worktree add -q "$T2/.task-work/wt" --detach
+# 완전 목 어댑터 (git root 비의존 — adapter.sh 는 --show-toplevel 기반이어서 worktree 내에서 오동작)
+mkdir -p "$T2/bin"
+cat > "$T2/bin/adapter_wt" << AMOCK
+#!/usr/bin/env bash
+case "\$1" in
+  materialize) echo '{"spec_path":"$T2/dummy.md"}';;
+  claim)        echo '{"claimed":true}';;
+  renew_lease|set_status|append_log) exit 0;;
+  *) exit 0;;
+esac
+AMOCK
+chmod +x "$T2/bin/adapter_wt"
+touch "$T2/dummy.md"
+# 링크드 워크트리 안에서 execute-task.sh 실행 (run_dir 생성 지점까지 도달: --stop-at review 없음)
+(cd "$T2/.task-work/wt"
+ ADAPTER_CMD="bash $T2/bin/adapter_wt" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+ MOCK_RESULT=DONE HEARTBEAT_INTERVAL=1 APPROVAL_CHECK_CMD=true BLOCKING_CHECK_CMD=true SLEEP_CMD=: \
+ bash "$ET" start wt_task >/dev/null 2>&1 || true)
+# run_dir 이 메인 리포 루트($T2)에 생성됐으면 ROOT_DIR 이 올바르게 결정된 것
+[[ -d "$T2/.autopilot/runs/wt_task" ]] \
+  && ok "4) worktree-내-호출 → run_dir 메인 루트 생성" \
+  || bad "4) worktree-내-호출 → run_dir 메인 루트 생성"
+
 echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 520

## 요약


`execute-task.sh`를 링크드 워크트리(`.task-work/<id>/.worktree`) 안에서 호출했을 때 `ROOT_DIR`이 메인 리포 루트가 아닌 워크트리 자신의 루트로 결정되는 버그를 수정한다. 이로 인해 `.task-work/<id>/.worktree/.task-work/<id>/.worktree`처럼 중첩 워크트리가 생성된다.
