### PR TITLE
🤖 [자동 리뷰] fix: review 상태 중 crash 시 자동 회수 경로 없음 — 영구 고착

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.61.0
+
+### 버그 수정
+- **execute-task가 `review` 상태에서 crash 되면 영구 고착 — 자동 회수 경로 없음 수정 (#507)** — `execute-task.sh`가 `set_status review` 를 호출하고 forge 단계(integrate→review→merge)에 진입한 뒤 crash 되면, `github.sh`의 `be_list_ready`가 `review` 상태를 반환하지 않고 lease도 없어 수동 개입 없이는 회수가 불가능했다. 두 곳을 수정했다. (1) `github.sh` — `be_set_status`가 `review` 전이 시 `gh_set_lease(owner="review")`로 진입 시각을 lease에 기록하고, `be_list_ready`에 `review)` 케이스를 추가해 `TB_REVIEW_TTL`(기본 1800초) 초과 시 stale로 판정해 회수한다(lease 미기록 구버전 호환: lease=0 → 회수하지 않는 보수적 default-deny). (2) `execute-task.sh` — forge 진입 직전 `run_dir/review_entered` 마커를 찍는다. 재진입 시(마커 존재) loop 단계를 건너뛰고 forge 단계부터 이어받는다(구현 재실행 방지). `--stop-at review` 경로는 forge 미진입이므로 마커를 찍지 않아 재진입 경로로 오전환되지 않는다. 기존 `in_progress` stale 감지 동작에 회귀 없음. 회귀 가드(`tests/autopilot/execute-task/test-execute-task-review-reentry.sh`)가 (a) 정상 경로에서 `review_entered` 생성과 loop.start 1회를 단언, (b) 재진입 경로에서 loop.start 미호출과 done 도달을 단언, (c) `--stop-at review` 경로에서 마커 미생성을 단언한다.
+
 ## autopilot 0.60.0
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -129,6 +129,11 @@ et_start() {
   local claimed; claimed="$($ADAPTER_CMD claim --task-id "$id" --owner "$owner" | jq -r '.claimed // false')"
   if [[ "$claimed" != "true" ]]; then echo "execute-task: 이미 다른 실행자가 점유 — skip ($id)"; return 0; fi
 
+  # review 재진입 감지: 이전 실행이 forge 단계 진입 전에 review_entered 마커를 찍었으면 loop 생략.
+  local run_dir="$ROOT_DIR/.autopilot/runs/$id"
+  local reentry=0
+  [[ -f "$run_dir/review_entered" ]] && reentry=1
+
   # reclaim: 죽은 워커 잔재 정리(있으면) — loop 가 notes/worktree 로 이어받음
   $LOOP_CMD cleanup "$sp" --force >/dev/null 2>&1 || true
 
@@ -171,28 +176,34 @@ et_start() {
     done ) &
   HB_PID=$!
 
-  # 구현 (포그라운드 블로킹)
-  $LOOP_CMD start "$sp" || true
+  if (( ! reentry )); then
+    # 구현 (포그라운드 블로킹)
+    $LOOP_CMD start "$sp" || true
 
-  # 분류
-  local sj signals; sj="$($LOOP_CMD status --json "$sp" 2>/dev/null || echo '{}')"
-  # loop status --json 은 JSON 계약 → 필수 의존성 jq 로 읽는다(미선언 yq 회피).
-  signals="$(printf '%s' "$sj" | jq -r '.signals[]?' 2>/dev/null || true)"
-  if printf '%s\n' "$signals" | grep -Fxq BLOCKED; then
-    $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "loop BLOCKED" >/dev/null
-    $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "loop BLOCKED" >/dev/null
-    return 1
-  fi
-  if ! printf '%s\n' "$signals" | grep -Fxq DONE; then
-    $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "loop 미완(DONE 신호 없음)" >/dev/null
-    return 1
-  fi
+    # 분류
+    local sj signals; sj="$($LOOP_CMD status --json "$sp" 2>/dev/null || echo '{}')"
+    # loop status --json 은 JSON 계약 → 필수 의존성 jq 로 읽는다(미선언 yq 회피).
+    signals="$(printf '%s' "$sj" | jq -r '.signals[]?' 2>/dev/null || true)"
+    if printf '%s\n' "$signals" | grep -Fxq BLOCKED; then
+      $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "loop BLOCKED" >/dev/null
+      $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "loop BLOCKED" >/dev/null
+      return 1
+    fi
+    if ! printf '%s\n' "$signals" | grep -Fxq DONE; then
+      $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "loop 미완(DONE 신호 없음)" >/dev/null
+      return 1
+    fi
 
-  $ADAPTER_CMD set_status --task-id "$id" --status review >/dev/null
-  if [[ "$stop_at" == "review" ]]; then echo "execute-task: review 단계 정지 ($id)"; return 0; fi
+    $ADAPTER_CMD set_status --task-id "$id" --status review >/dev/null
+    if [[ "$stop_at" == "review" ]]; then echo "execute-task: review 단계 정지 ($id)"; return 0; fi
+  else
+    echo "execute-task: review 재진입 — forge 단계부터 재시작 ($id)" >&2
+  fi
 
   # forge: integrate → review(승인까지 반복, 가드) → merge (origin 라우팅)
-  local run_dir="$ROOT_DIR/.autopilot/runs/$id"; mkdir -p "$run_dir"
+  # crash 후 재진입 경로 표지: forge 진입 직전에 찍어, 이후 crash 시 다음 실행이 loop 를 재실행하지 않도록 한다.
+  mkdir -p "$run_dir"
+  touch "$run_dir/review_entered" 2>/dev/null || true
   local key="$id"
   local iout branch pr=""
   iout="$($FORGE_CMD integrate "$sp" "$run_dir" "$key" 2>&1)" || {

--- a/plugins/autopilot/task-backend/github.sh
+++ b/plugins/autopilot/task-backend/github.sh
@@ -94,6 +94,8 @@ be_set_status() {
   [[ -n "$old" ]] && gh issue edit "$id" $(gh_repo_args) --remove-label "status:$old" >/dev/null 2>&1 || true
   gh issue edit "$id" $(gh_repo_args) --add-label "status:$s" >/dev/null 2>&1 || tb_die "라벨 status:$s 설정 실패(라벨 존재 필요)"
   if [[ "$s" == "in_progress" ]]; then gh_set_lease "$id" "$(tb_now_epoch)" "$(_argval --owner "$@")"; fi
+  # review 진입 시각을 lease 에 기록(owner="review"). heartbeat 없는 forge 단계의 crash 감지에 사용.
+  if [[ "$s" == "review" ]]; then gh_set_lease "$id" "$(tb_now_epoch)" "review"; fi
   [[ "$s" == "done" ]] && gh issue close "$id" $(gh_repo_args) >/dev/null 2>&1 || true
   jq -nc --arg id "$id" --arg s "$s" '{task_id:$id, status:$s}'
 }
@@ -142,6 +144,14 @@ be_list_ready() {
         # 어느 호스트든 회수 가능.
         local lr; lr="$(gh_get_lease "$id")"; [[ -n "$lr" ]] || lr=0
         (( now - lr > ttl )) && ready=1
+        ;;
+      review)
+        # forge 단계(heartbeat 없음)에서 crash 되면 lease 가 stale 해진다. TTL 초과 시 회수.
+        # be_set_status review 에서 gh_set_lease(owner="review") 로 진입 시각을 기록하므로
+        # lease 가 없으면(진입 시각 미기록 = 구버전 호환) 회수하지 않는다(보수적 default-deny).
+        local rt="${TB_REVIEW_TTL:-1800}"
+        local lr; lr="$(gh_get_lease "$id")"; [[ -n "$lr" ]] || lr=0
+        [[ "$lr" -gt 0 ]] && (( now - lr > rt )) && ready=1
         ;;
     esac
     (( ready )) && out="$(printf '%s' "$out" | jq -c --arg id "$id" --arg t "$title" '. + [{task_id:$id, title:$t}]')"

--- a/tests/autopilot/execute-task/test-execute-task-review-reentry.sh
+++ b/tests/autopilot/execute-task/test-execute-task-review-reentry.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# test-execute-task-review-reentry.sh — review 상태 crash 후 forge 단계 재진입 검증.
+#   (a) 정상 경로: review_entered 미존재 → loop.start 1회 → review_entered 생성 → forge → done
+#   (b) 재진입 경로: review_entered 존재 → loop.start 미호출 → forge → done
+#   (c) --stop-at review: forge 미진입 → review_entered 미생성
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
+ADAPTER="$HERE/../../../plugins/autopilot/task-backend/adapter.sh"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"; git init -q; git config user.email t@t; git config user.name t
+bash "$ADAPTER" init --backend filesystem >/dev/null
+
+mkdir -p bin
+
+# mock loop: 호출 기록 + DONE 신호. LOOP_CALL_LOG 파일에 verb 기록.
+cat > bin/loop << 'EOF'
+#!/usr/bin/env bash
+echo "$1" >> "${LOOP_CALL_LOG:-/dev/null}"
+case "$1" in
+  start|cleanup) exit 0;;
+  status) printf '{"state":"terminal","signals":["DONE"]}\n';;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/loop
+
+# mock forge: integrate→branch+pr, review→rc20(승인폴링 대기), merge→rc0
+cat > bin/forge << 'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  integrate) echo "branch: feat/x"; echo "pr: 7"; exit 0;;
+  review) exit 20;;
+  merge) exit 0;;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/forge
+
+# mock adapter: claim 항상 true, set_status 결과를 MOCK_STATUS_FILE 에 기록.
+cat > bin/adapter_mock << 'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  materialize)
+    printf '{"spec_path":"%s/dummy.md"}\n' "${MOCK_WD:-.}";;
+  claim)
+    printf '{"task_id":"X","claimed":true}\n';;
+  set_status)
+    s=""; i=2
+    while [[ $i -le $# ]]; do
+      a="${!i}"
+      if [[ "$a" == "--status" ]]; then j=$((i+1)); s="${!j}"; break; fi
+      i=$((i+1))
+    done
+    if [[ -n "$s" && -n "${MOCK_STATUS_FILE:-}" ]]; then printf '%s' "$s" > "$MOCK_STATUS_FILE"; fi
+    printf '{"task_id":"X","status":"%s"}\n' "$s";;
+  renew_lease|append_log)
+    printf '{"task_id":"X"}\n';;
+  *)
+    printf '{"task_id":"X"}\n';;
+esac
+EOF
+chmod +x bin/adapter_mock
+
+touch "$TMP/dummy.md"
+status_of(){ bash "$ADAPTER" get_task --task-id "$1" | jq -r .status; }
+
+run_fs() {  # 실제 filesystem adapter
+  ADAPTER_CMD="bash $ADAPTER" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+  HEARTBEAT_INTERVAL=999 APPROVAL_CHECK_CMD=true BLOCKING_CHECK_CMD=true SLEEP_CMD=: \
+  bash "$ET" "$@"
+}
+run_mock() {  # 완전 mock adapter (claim 항상 true)
+  ADAPTER_CMD="bash $TMP/bin/adapter_mock" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+  HEARTBEAT_INTERVAL=999 APPROVAL_CHECK_CMD=true BLOCKING_CHECK_CMD=true SLEEP_CMD=: \
+  bash "$ET" "$@"
+}
+
+# --- (a) 정상 경로: review_entered 미존재 → loop.start 1회 → review_entered 생성 → done ---
+id_a="$(bash "$ADAPTER" create_task --title "A" --body '## 목표'$'\n'x | jq -r .task_id)"
+clog_a="$TMP/loop_a.log"; : > "$clog_a"
+LOOP_CALL_LOG="$clog_a" run_fs start "$id_a" >/dev/null 2>&1 || true
+chk "(a) 정상 경로 → done" "$(status_of "$id_a")" "done"
+chk "(a) loop.start 1회" "$(awk '/^start$/{c++}END{print c+0}' "$clog_a")" "1"
+[[ -f "$TMP/.autopilot/runs/$id_a/review_entered" ]] \
+  && ok "(a) review_entered 생성됨" || bad "(a) review_entered 생성됨"
+
+# --- (b) 재진입: review_entered 존재 → loop.start 미호출 → forge → done ---
+# 완전 mock adapter: claim 항상 true (filesystem claim lock 우회)
+st_b="$TMP/st_b"
+mkdir -p "$TMP/.autopilot/runs/Xb"
+touch "$TMP/.autopilot/runs/Xb/review_entered"
+clog_b="$TMP/loop_b.log"; : > "$clog_b"
+MOCK_WD="$TMP" MOCK_STATUS_FILE="$st_b" LOOP_CALL_LOG="$clog_b" \
+  run_mock start Xb >/dev/null 2>&1 || true
+chk "(b) 재진입 → done" "$(cat "$st_b" 2>/dev/null || echo '')" "done"
+chk "(b) 재진입: loop.start 미호출" "$(awk '/^start$/{c++}END{print c+0}' "$clog_b")" "0"
+
+# --- (c) --stop-at review: review_entered 미생성, forge 미진입 ---
+st_c="$TMP/st_c"
+mkdir -p "$TMP/.autopilot/runs/Xc"
+clog_c="$TMP/loop_c.log"; : > "$clog_c"
+MOCK_WD="$TMP" MOCK_STATUS_FILE="$st_c" LOOP_CALL_LOG="$clog_c" \
+  run_mock start Xc --stop-at review >/dev/null 2>&1 || true
+chk "(c) stop-at review → review 상태" "$(cat "$st_c" 2>/dev/null || echo '')" "review"
+[[ ! -f "$TMP/.autopilot/runs/Xc/review_entered" ]] \
+  && ok "(c) stop-at review: review_entered 미생성" \
+  || bad "(c) stop-at review: review_entered 미생성"
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 507

## 요약


execute-task가 `review` 상태로 전이한 뒤 crash되면 해당 태스크가 영구 고착되는 문제를 수정한다. `list_ready`가 `review` 상태를 반환하지 않고, lease 만료 여부와 무관하게 자동 회수 경로가 없다.
