### PR TITLE
🤖 [자동 리뷰] fix(autopilot): fix/feature self-review·task-body-template에 test_sweep_paths 동시 선언 안내 누락

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.61.1
+
+### 버그 수정
+- **fix/feature self-review 축6·task-body-template에 `test_sweep_paths` 동시 선언 안내 누락 (#509)** — `scope.include`에 기존 테스트 파일 경로를 선언했으나 `test_sweep_paths`를 빠뜨리면 loop.sh의 테스트 약화 게이트가 HALT하는데, 이 의존 관계가 self-review와 task-body-template 어디에도 명시되지 않아 작성자가 누락을 잡을 수 없었다. fix/feature 양쪽 self-review 축6 끝에 "scope.include에 기존 테스트 파일 경로가 있으면 test_sweep_paths에도 선언됐는가(누락 시 loop의 테스트 약화 게이트 HALT)" 체크 항목을 추가하고, 양쪽 task-body-template 작성 규칙에 "test_sweep_paths 동시 선언" 규칙을 추가했다. 회귀 가드(`test-fix-skill.sh` S10c/S10d · `test-feature-skill.sh` S12/S13 · `test-feature-resume.sh` R9)가 각 문서의 규칙 존재를 단언한다.
+
 ## autopilot 0.61.0
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/feature/references/self-review.md
+++ b/plugins/autopilot/skills/feature/references/self-review.md
@@ -11,6 +11,8 @@
 6. **scope.include** — frontmatter `scope.include` 가 비어 있지 않고, 식별한 변경 대상을 합리적으로 덮는가
    (과좁으면 정당한 변경이 halt 되므로 불명확할 땐 보수적으로 넓게). 특히 완료 조건이 테스트(회귀 가드)를
    요구하면 그 테스트 경로가 `scope.include` 에 포함됐는가(누락 시 loop 이 RED 테스트를 scope 밖이라 halt).
+   또한 `scope.include`에 기존 테스트 파일 경로가 있으면 `test_sweep_paths`에도 선언됐는가(누락 시 loop의
+   테스트 약화 게이트 HALT).
 
 ## 규모 임계 시 적대 렌즈(가산)
 

--- a/plugins/autopilot/skills/feature/references/task-body-template.md
+++ b/plugins/autopilot/skills/feature/references/task-body-template.md
@@ -52,6 +52,9 @@ scope:
   loop 은 scope 밖 파일을 쓰면 halt 하므로, 완료 조건이 요구하는 산출물(특히 회귀 테스트)은 모두 scope 에 반영해야 RED 테스트를 작성할 수 있다.
   - **#483 (작성자 명시)**: 완료 조건이 요구하는 **새** 회귀 테스트 경로 — 작성자가 scope.include에 명시.
   - **scope-coverage (#498, 시스템 검증)**: scope 내 소스를 덮는 **기존** 테스트 경로 누락 — 등록 시 create-task가 자동 플래그.
+- **test_sweep_paths 동시 선언** — `scope.include`에 기존 테스트 파일 경로가 있으면 `test_sweep_paths`에도
+  선언한다(누락 시 loop.sh의 테스트 약화 게이트가 HALT — `scope.include`에 테스트를 넣되 `test_sweep_paths`를
+  빠뜨리면 loop이 기존 테스트 변경을 탐지해 실행을 중단한다).
 - **plugins/ 변경 시 버전 산출물 포함(권장)** — `plugins/` 를 바꾸는 SPEC 은 워커가 버전 안내(versioning)대로
   매니페스트를 올릴 수 있도록 `plugin.json`·`CHANGELOG.md` 도 `scope.include` 에 넣길 권장한다(강제 아님).
 - **WHAT/HOW 방어선** — 무엇을 만들 것인가·완료 조건에는 "무엇"만. 기술 선택·경로·라이브러리는 제약에.

--- a/plugins/autopilot/skills/fix/references/self-review.md
+++ b/plugins/autopilot/skills/fix/references/self-review.md
@@ -13,6 +13,8 @@
 6. **scope.include** — frontmatter `scope.include` 가 비어 있지 않고, 진단으로 식별한 변경 대상을 합리적으로
    덮는가(과좁으면 정당한 수정이 halt 되므로 불명확할 땐 보수적으로 넓게). 특히 완료 조건이 테스트(회귀 가드)를
    요구하면 그 테스트 경로가 `scope.include` 에 포함됐는가(누락 시 loop 이 RED 테스트를 scope 밖이라 halt).
+   또한 `scope.include`에 기존 테스트 파일 경로가 있으면 `test_sweep_paths`에도 선언됐는가(누락 시 loop의
+   테스트 약화 게이트 HALT).
 
 ## 진단 섹션 전용 점검 (fix 고유)
 

--- a/plugins/autopilot/skills/fix/references/task-body-template.md
+++ b/plugins/autopilot/skills/fix/references/task-body-template.md
@@ -69,6 +69,9 @@ scope:
   loop 은 scope 밖 파일을 쓰면 halt 하므로, 완료 조건이 요구하는 산출물(특히 회귀 테스트)은 모두 scope 에 반영해야 RED 테스트를 작성할 수 있다.
   - **#483 (작성자 명시)**: 완료 조건이 요구하는 **새** 회귀 테스트 경로 — 작성자가 scope.include에 명시.
   - **scope-coverage (#498, 시스템 검증)**: scope 내 소스를 덮는 **기존** 테스트 경로 누락 — 등록 시 create-task가 자동 플래그.
+- **test_sweep_paths 동시 선언** — `scope.include`에 기존 테스트 파일 경로가 있으면 `test_sweep_paths`에도
+  선언한다(누락 시 loop.sh의 테스트 약화 게이트가 HALT — `scope.include`에 테스트를 넣되 `test_sweep_paths`를
+  빠뜨리면 loop이 기존 테스트 변경을 탐지해 실행을 중단한다).
 - **plugins/ 변경 시 버전 산출물 포함(권장)** — `plugins/` 를 바꾸는 SPEC 은 워커가 버전 안내(versioning)대로
   매니페스트를 올릴 수 있도록 `plugin.json`·`CHANGELOG.md` 도 `scope.include` 에 넣길 권장한다(강제 아님).
 - **WHAT/HOW 방어선** — 무엇을 고칠지·완료 조건에는 "무엇"만. 기술 선택·경로·라이브러리는 제약/제안으로.

--- a/tests/autopilot/test-feature-resume.sh
+++ b/tests/autopilot/test-feature-resume.sh
@@ -83,5 +83,15 @@ grep -qE '거부|중단' "$CREATE" \
   || fail "R8: create-task 재개가 비-in_design 태스크를 거부/중단하지 않음(종단·진행 태스크 훼손 위험)"
 ok "create-task: 재개 진입 in_design 검증 + 비-in_design 거부"
 
+# === R9: feature 참조 — test_sweep_paths 동시 선언 규칙(#509) ===
+# 재개 경로도 동일 참조를 사용하므로 test_sweep_paths 규칙 존재를 확인한다.
+echo "=== R9: feature 참조 — test_sweep_paths 동시 선언 규칙 ==="
+FEATURE_DIR="$SKILLS/feature"
+grep -q 'test_sweep_paths' "$FEATURE_DIR/references/task-body-template.md" \
+  || fail "R9: feature task-body-template에 test_sweep_paths 동시 선언 규칙 없음"
+grep -q 'test_sweep_paths' "$FEATURE_DIR/references/self-review.md" \
+  || fail "R9: feature self-review에 test_sweep_paths 점검 항목 없음"
+ok "feature 참조: test_sweep_paths 동시 선언 규칙 존재"
+
 echo ""
 echo "=== 모든 #443/#461 in_design 재개 경로 계약 테스트 통과 ==="

--- a/tests/autopilot/test-feature-skill.sh
+++ b/tests/autopilot/test-feature-skill.sh
@@ -100,5 +100,19 @@ grep -qE '테스트.*scope\.include|scope\.include.*테스트' "$FEATURE/referen
   || fail "S11: feature self-review 축6에 테스트 경로 scope.include 점검 항목(한 줄) 없음"
 ok "feature self-review: DoD-요구 테스트 경로 점검 항목"
 
+# === S12: feature task-body-template — test_sweep_paths 동시 선언 규칙(#509) ===
+# scope.include에 기존 테스트 파일이 있으면 test_sweep_paths에도 선언해야 loop의
+# 테스트 약화 게이트(HALT)를 통과할 수 있다.
+echo "=== S12: feature 본문 템플릿 — test_sweep_paths 동시 선언 규칙 ==="
+grep -q 'test_sweep_paths' "$FEATURE/references/task-body-template.md" \
+  || fail "S12: feature task-body-template에 test_sweep_paths 동시 선언 규칙 없음"
+ok "feature task-body-template: test_sweep_paths 동시 선언 규칙"
+
+# === S13: feature self-review 축6 — test_sweep_paths 점검 항목(#509) ===
+echo "=== S13: feature self-review 축6 — test_sweep_paths 점검 항목 ==="
+grep -q 'test_sweep_paths' "$FEATURE/references/self-review.md" \
+  || fail "S13: feature self-review 축6에 test_sweep_paths 점검 항목 없음"
+ok "feature self-review: test_sweep_paths 점검 항목"
+
 echo ""
 echo "=== 모든 #445 작성/등록 분리 계약 테스트 통과 ==="

--- a/tests/autopilot/test-fix-skill.sh
+++ b/tests/autopilot/test-fix-skill.sh
@@ -106,6 +106,20 @@ grep -qE '테스트.*scope\.include|scope\.include.*테스트' "$FIX/references/
   || fail "S10b: fix self-review 축6에 테스트 경로 scope.include 점검 항목(한 줄) 없음"
 ok "fix self-review: DoD-요구 테스트 경로 점검 항목"
 
+# === S10c: fix task-body-template — test_sweep_paths 동시 선언 규칙(#509) ===
+# scope.include에 기존 테스트 파일이 있으면 test_sweep_paths에도 선언해야 loop의
+# 테스트 약화 게이트(HALT)를 통과할 수 있다.
+echo "=== S10c: fix 본문 템플릿 — test_sweep_paths 동시 선언 규칙 ==="
+grep -q 'test_sweep_paths' "$FIX/references/task-body-template.md" \
+  || fail "S10c: fix task-body-template에 test_sweep_paths 동시 선언 규칙 없음"
+ok "fix task-body-template: test_sweep_paths 동시 선언 규칙"
+
+# === S10d: fix self-review 축6 — test_sweep_paths 점검 항목(#509) ===
+echo "=== S10d: fix self-review 축6 — test_sweep_paths 점검 항목 ==="
+grep -q 'test_sweep_paths' "$FIX/references/self-review.md" \
+  || fail "S10d: fix self-review 축6에 test_sweep_paths 점검 항목 없음"
+ok "fix self-review: test_sweep_paths 점검 항목"
+
 # === S11: create-task 가 fix 를 작성자로 인지(짝 정합) ===
 echo "=== S11: create-task fix 짝 정합 ==="
 grep -q 'fix' "$CREATE/SKILL.md" \


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 525

## 요약


fix/feature의 self-review axis 6과 task-body-template DoD 섹션에 `test_sweep_paths` 동시 선언 안내를 추가한다. `scope.include`에 테스트 파일이 있으면 반드시 `test_sweep_paths`에도 선언해야 함을 작성자가 체크 단계에서 잡을 수 있도록 한다.
