### PR TITLE
🤖 [자동 리뷰] fix: execute-task 재진입 경로에서 set_status review 미호출 — forge 구간 stale TTL 300s 오적용

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.61.2
+
+### 버그 수정
+- **execute-task 재진입 경로에서 `set_status review` 미호출 — forge 구간 stale TTL 300s 오적용 수정 (#527)** — PR #522(review 상태 crash 회수)에서 도입된 reentry else 블록이 `set_status review` 호출을 누락해, 재진입 forge 구간이 `in_progress` 상태(TTL=300s)로 진행됐다. heartbeat가 ~300s 동안 갱신을 멈추면 `be_list_ready`가 false positive stale 판정으로 다른 워커가 태스크를 재탈취할 수 있었다. reentry else 블록 내 forge 진입 직전에 `set_status review` 한 줄을 추가해 정상 경로와 동일하게 TTL=1800s(`TB_REVIEW_TTL`)가 적용되도록 수정했다. 회귀 가드(`test-execute-task-review-reentry.sh`)에 `(b) 재진입: set_status review 호출됨` 단언과 `MOCK_STATUS_LOG` append 추적을 추가해 재진입 경로의 상태 전이 순서를 검증한다.
+
 ## autopilot 0.61.1
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.61.1",
+  "version": "0.61.2",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -198,6 +198,7 @@ et_start() {
     if [[ "$stop_at" == "review" ]]; then echo "execute-task: review 단계 정지 ($id)"; return 0; fi
   else
     echo "execute-task: review 재진입 — forge 단계부터 재시작 ($id)" >&2
+    $ADAPTER_CMD set_status --task-id "$id" --status review >/dev/null
   fi
 
   # forge: integrate → review(승인까지 반복, 가드) → merge (origin 라우팅)

--- a/tests/autopilot/execute-task/test-execute-task-review-reentry.sh
+++ b/tests/autopilot/execute-task/test-execute-task-review-reentry.sh
@@ -41,6 +41,7 @@ EOF
 chmod +x bin/forge
 
 # mock adapter: claim 항상 true, set_status 결과를 MOCK_STATUS_FILE 에 기록.
+# MOCK_STATUS_LOG 가 설정되면 모든 set_status 호출의 상태값을 줄 단위로 append.
 cat > bin/adapter_mock << 'EOF'
 #!/usr/bin/env bash
 case "$1" in
@@ -56,6 +57,7 @@ case "$1" in
       i=$((i+1))
     done
     if [[ -n "$s" && -n "${MOCK_STATUS_FILE:-}" ]]; then printf '%s' "$s" > "$MOCK_STATUS_FILE"; fi
+    if [[ -n "$s" && -n "${MOCK_STATUS_LOG:-}" ]]; then printf '%s\n' "$s" >> "$MOCK_STATUS_LOG"; fi
     printf '{"task_id":"X","status":"%s"}\n' "$s";;
   renew_lease|append_log)
     printf '{"task_id":"X"}\n';;
@@ -90,14 +92,17 @@ chk "(a) loop.start 1회" "$(awk '/^start$/{c++}END{print c+0}' "$clog_a")" "1"
 
 # --- (b) 재진입: review_entered 존재 → loop.start 미호출 → forge → done ---
 # 완전 mock adapter: claim 항상 true (filesystem claim lock 우회)
-st_b="$TMP/st_b"
+st_b="$TMP/st_b"; slog_b="$TMP/sl_b"
 mkdir -p "$TMP/.autopilot/runs/Xb"
 touch "$TMP/.autopilot/runs/Xb/review_entered"
 clog_b="$TMP/loop_b.log"; : > "$clog_b"
-MOCK_WD="$TMP" MOCK_STATUS_FILE="$st_b" LOOP_CALL_LOG="$clog_b" \
+MOCK_WD="$TMP" MOCK_STATUS_FILE="$st_b" MOCK_STATUS_LOG="$slog_b" LOOP_CALL_LOG="$clog_b" \
   run_mock start Xb >/dev/null 2>&1 || true
 chk "(b) 재진입 → done" "$(cat "$st_b" 2>/dev/null || echo '')" "done"
 chk "(b) 재진입: loop.start 미호출" "$(awk '/^start$/{c++}END{print c+0}' "$clog_b")" "0"
+grep -qx "review" "$slog_b" 2>/dev/null \
+  && ok "(b) 재진입: set_status review 호출됨" \
+  || bad "(b) 재진입: set_status review 호출됨"
 
 # --- (c) --stop-at review: review_entered 미생성, forge 미진입 ---
 st_c="$TMP/st_c"


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 527

## 요약


`execute-task.sh`의 reentry else 블록에 `$ADAPTER_CMD set_status --task-id "$id" --status review >/dev/null` 한 줄을 추가한다. 재진입 시 forge 단계 진입 전에 상태를 `review`로 전이해 `be_list_ready`의 `review)` 케이스(TTL=1800s)가 적용되도록 한다.
