### PR TITLE
🤖 [자동 리뷰] fix: adapter.sh help에 claim 누락 + contract.md claim 설명이 stale 판정 역할을 전면에 드러내지 않음

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.61.3
+
+### 버그 수정
+- **adapter.sh help에 claim 동사 누락 + contract.md claim 설명에서 stale 판정 역할이 묻힘 (#508)** — `adapter.sh` help 출력에 `claim --task-id ID --owner S`와 "stale 판정 + 실행권 획득의 단일 진입점 (GitHub 공유 lease 기반)" 설명을 추가했다(라우팅에는 존재하나 help에 없어 인터페이스 탐색 시 발견 불가). `contract.md` 동사 표의 `claim` 항에 "(stale 판정의 단일 진입점 — stale lease 탈취 + 신규 점유 원자적 게이트)" 부제를 추가하고, claim 섹션 제목을 "stale 판정 + 실행권 획득의 단일 진입점"으로, 섹션 본문을 stale 판정 역할을 첫 문장에 내세우도록 재서술했다. `tb_selftest`에 help 출력 `claim` 포함 회귀 가드를 추가했다.
+
 ## autopilot 0.61.2
 
 ### 새 기능

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.61.2",
+  "version": "0.61.3",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/task-backend/adapter.sh
+++ b/plugins/autopilot/task-backend/adapter.sh
@@ -111,6 +111,7 @@ usage: adapter.sh <verb> [args]
   set_status --task-id ID --status S [--reason R]
   link_dependency --task-id ID --depends-on-id ID
   append_log --task-id ID --marker decision|handoff|blocked --text T
+  claim --task-id ID --owner S         # stale 판정 + 실행권 획득의 단일 진입점 (GitHub 공유 lease 기반)
   list_ready | backend | selftest
 EOF
       exit 2;;
@@ -147,6 +148,9 @@ tb_selftest() {
   local mr; mr="$(cd "$TMP" && bash "$A" materialize --task-id "$id2")"
   local sp; sp="$(printf '%s' "$mr" | jq -r .spec_path)"
   [[ -f "$TMP/$sp" || -f "$sp" ]] && ok "materialize 파일 생성" || bad "materialize 파일 생성 ($sp)"
+  # help 출력에 claim 동사 포함 확인 (회귀 가드)
+  local help_out; help_out="$(bash "$A" help 2>&1 || true)"
+  [[ "$help_out" == *"claim"* ]] && ok "help에 claim 포함" || bad "help에 claim 미포함"
   echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"
   rm -rf "$TMP"
   return $fail

--- a/plugins/autopilot/task-backend/contract.md
+++ b/plugins/autopilot/task-backend/contract.md
@@ -114,16 +114,17 @@ scope:
 | `append_log` | `--task-id <id> --marker decision|handoff|blocked --text <s>` | `{"task_id","logged":true}` |
 | `materialize` | `--task-id <id>` | `{"task_id","spec_path"}` (`.task-work/<id>/SPEC.md`) |
 | `renew_lease` | `--task-id <id> [--owner <s>]` | `{"task_id","lease_renewed_at"}` |
-| `claim` | `--task-id <id> --owner <s>` | `{"task_id","claimed":true|false}` |
+| `claim` | `--task-id <id> --owner <s>` | `{"task_id","claimed":true|false}` (stale 판정의 단일 진입점 — stale lease 탈취 + 신규 점유 원자적 게이트) |
 
 관리 동사: `init`(config 생성/갱신), `selftest`(계약 자체 검증), `backend`(현재 백엔드 출력).
 
-### claim (원자적 실행권 획득 — 중복 실행 방지)
+### claim (stale 판정 + 실행권 획득의 단일 진입점)
 
-`list_ready` 조회와 in_progress 전이 사이의 경쟁으로 같은 태스크가 이중 실행되는 것을 막기 위해, 실행자는
-구현 시작 **전에 `claim` 으로 원자적으로 실행권을 획득**한다(단순 `set_status in_progress` 금지). 성공 시
-`claimed:true`(+ status를 in_progress로 전이, lease 초기화), 이미 신선한 lease로 점유 중이면 `claimed:false`
-(실행자는 조용히 skip). lease가 **stale**이면 탈취한다(크래시 워커 회수).
+`claim` 은 **stale 판정의 단일 진입점**이다 — lease가 **stale**(크래시·행 워커)이면 자동으로 탈취해 실행권을
+획득하고, 신선한 점유가 없으면 신규로 원자적 점유한다. `list_ready` 조회와 in_progress 전이 사이의 경쟁도
+차단하므로, 실행자는 구현 시작 **전에 반드시 `claim` 을 호출**한다(단순 `set_status in_progress` 금지). 성공
+시 `claimed:true`(+ status를 in_progress로 전이, lease 초기화), 이미 신선한 lease로 점유 중이면
+`claimed:false`(실행자는 조용히 skip).
 
 - **filesystem**: `.task-work/.claims/<id>` 디렉토리 `mkdir`(원자적 CAS)로 게이트. 종단 상태(done/blocked/
   cancelled) 전이 시 자동 해제.


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 508

## 요약


`adapter.sh` help 출력에 `claim` 동사를 추가하고, `contract.md`의 `claim` 설명을 "stale 판정 + 실행권 획득의 단일 진입점"으로 전면에 드러낸다. 설명의 완성도로 올바른 사용법을 자연스럽게 유도한다(금지 규칙 없이).
