### PR TITLE
🤖 [자동 리뷰] fix: claude-review.yml needs_context follow-up 패스 — review job에 PR head fetch 추가

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -421,6 +421,14 @@ jobs:
         with:
           name: claude-review-prep
 
+      - name: Fetch PR head for follow-up context
+        if: ${{ needs.prep.outputs.claude_workflow_changed != 'true' }}
+        env:
+          PR_NUMBER: ${{ needs.prep.outputs.pr_number }}
+        run: |
+          git fetch --no-tags --depth=1 origin \
+            "+refs/pull/$PR_NUMBER/head:refs/remotes/pull/$PR_NUMBER/head"
+
       - name: Load chunk prompt
         id: load-prompt
         if: ${{ needs.prep.outputs.claude_workflow_changed != 'true' }}


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 533

## 요약


`.github/workflows/claude-review.yml`의 `review` 잡에 PR head fetch 스텝 1개를 추가한다.
