### PR TITLE
fix(execute-task): start는 run_in_background 필수 명시 (0.61.4)

### DIFF
--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.61.3",
+  "version": "0.61.4",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/execute-task/SKILL.md
+++ b/plugins/autopilot/skills/execute-task/SKILL.md
@@ -31,11 +31,23 @@ allowed-tools:
 
 ```
 EXEC="$(git rev-parse --show-toplevel)/plugins/autopilot/skills/execute-task/references/execute-task.sh"
-bash "$EXEC" start <task-id> [--stop-at review]
+bash "$EXEC" start <task-id> [--stop-at review]   # ← run_in_background: true 필수 (아래 참고)
 bash "$EXEC" status|stop|logs <task-id>
 ```
 
 `status|stop|logs`는 task-id를 spec 경로로 해석해 loop 엔진에 위임한다.
+
+> **`start`는 반드시 `run_in_background: true`(또는 동등한 비동기 실행 메커니즘)로 호출한다.**
+> `start`는 구현 루프 + 리뷰 승인 폴링(`APPROVAL_WAIT_MAX` 기본 360 s) + 머지를 직렬 실행하므로
+> 정상 경로도 10분을 초과할 수 있다. 동기 실행 시 런타임 도구의 타임아웃에 걸려 PR 생성·머지 단계가
+> 중단된다. `status`·`stop`·`logs`는 단명(短命) 조회이므로 동기 호출로 무방하다.
+>
+> background 완료 notification 수신 후 결과를 확인한다:
+> ```
+> bash "$EXEC" logs <task-id>          # 상세 실행 로그
+> bash "$EXEC" status <task-id>        # DONE / BLOCKED / 진행 중 요약
+> ```
+> status가 `blocked`이면 태스크 백엔드의 차단 사유·category를 확인하고 자가개선 절차를 밟는다.
 
 ## 재사용 엔진 (런타임 호출, 그대로 둠)
 


### PR DESCRIPTION
## Summary

- `execute-task start`는 구현 루프 + `APPROVAL_WAIT_MAX`(360s) + 머지를 직렬 실행하므로 정상 경로도 10분을 초과할 수 있음
- 에이전트가 Bash tool로 동기 실행하면 10분 hard timeout에 걸려 PR 생성·머지 단계가 중단되는 버그
- SKILL.md 호출 섹션에 `run_in_background: true` 필수 지시와 완료 후 `logs`/`status` 확인 절차를 명시
- workflow-task는 shell subprocess 경로(`workflow-task.sh → flow.sh → execute-task.sh`)를 사용하므로 이 변경에 무관

## Test plan

- [ ] execute-task를 `run_in_background: true`로 호출 → 10분 초과 작업도 완료됨 확인
- [ ] background 완료 notification 후 `logs <id>` / `status <id>` 로 결과 확인 가능
- [ ] workflow-task drain 정상 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDyMJNRAxwUDZCQZZbT2Xc