### PR TITLE
🤖 [자동 리뷰] fix: claude-review.yml Fetch PR head 스텝 if 조건에 pr_number 빈값 가드 추가

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -422,7 +422,7 @@ jobs:
           name: claude-review-prep
 
       - name: Fetch PR head for follow-up context
-        if: ${{ needs.prep.outputs.claude_workflow_changed != 'true' }}
+        if: ${{ needs.prep.outputs.claude_workflow_changed != 'true' && needs.prep.outputs.pr_number != '' }}
         env:
           PR_NUMBER: ${{ needs.prep.outputs.pr_number }}
         run: |


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 536

## 요약


"Fetch PR head for follow-up context" 스텝의 `if:` 조건에 `pr_number` 빈값 가드를 추가한다.
