### PR TITLE
🤖 [자동 리뷰] execute-task PR 본문에 태스크 정보·실제 작업 내용 포함

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.61.5
+
+### 새 기능
+- **execute-task PR 본문에 실제 작업 내용 섹션 추가 (#539)** — execute-task 가 자동 생성하는 PR 본문에는 태스크 추적성(task-run·Refs)과 SPEC 의도(요약)는 있었으나, 실제로 무엇을 했는지(diff 기반 작업 내용)가 없어 리뷰어가 PR 만 보고 작업 내용을 파악할 수 없었다. `forge/lib/integration.sh`에 `in_done_summary`를 추가해 loop 의 공개 인터페이스(`loop logs`)에서 워커가 `signals/DONE`에 남긴 완료 요약을 읽고(내부 signals 파일 직접 열람 없음), `in_pr_body`가 execute-task 발신 PR(`.task-work/<id>/SPEC.md` 경로)에 한해 `## 작업 내용` 섹션으로 포함한다. DONE 요약이 비어있거나 없으면 섹션을 생략한다. dispatch 발신 PR 본문은 회귀 없이 그대로다.
+
 ## autopilot 0.61.3
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.61.4",
+  "version": "0.61.5",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/forge/lib/integration.sh
+++ b/plugins/autopilot/forge/lib/integration.sh
@@ -457,18 +457,36 @@ in_spec_issue() {
   ' "$1"
 }
 
+# in_done_summary <spec_path> — loop 공개 logs 인터페이스(`loop logs`)에서 워커가 signals/DONE
+#   에 남긴 완료 요약(diff 기반 무엇을·왜) 본문을 추출한다. DONE 신호가 없거나 본문이 비어 있으면
+#   빈 출력(호출자가 '## 작업 내용' 섹션을 생략). 내부 signals 파일을 직접 열지 않고, `logs` 출력의
+#   "===== signals/DONE =====" 섹션만 골라낸다(다음 "===== " 섹션 경계에서 닫음, in_pr_summary 와
+#   동일 패턴).
+in_done_summary() {
+  # shellcheck disable=SC2086
+  $LOOP_CMD logs "$1" 2>/dev/null | awk '
+    /^===== signals\/DONE =====$/ { insec = 1; next }
+    insec && /^===== / { exit }
+    insec { print }
+  '
+}
+
 # in_pr_body <spec_path> <run-id> — 구조화 PR 본문(결정적) stdout. dispatch·execute-task 공용.
 #   자동 리뷰 식별 줄(주체별 자동 생성 표기 + "자동 적대 리뷰") + 추적성 + 실행 컨텍스트(run-id)
-#   + 조건부 이슈 cross-reference(Refs #n, rules/context.md 형식) + 요약(SPEC 의도 섹션, 없으면 생략).
+#   + 조건부 이슈 cross-reference(Refs #n, rules/context.md 형식) + 요약(SPEC 의도 섹션, 없으면 생략)
+#   + execute-task 한정 작업 내용(loop DONE 완료 요약, 없으면 생략; #539).
 #   originator 판정은 spec 경로의 임시 materialize 마커(execute-task 의 .task-work/<id>/SPEC.md
 #   컨벤션)로 한다:
 #     - execute-task: 임시 SPEC 경로는 리뷰어에게 무의미·로컬 레이아웃 누출이라 박지 않고(생략),
 #       주체를 정확히 표기(execute-task)하며 추적성은 task-run·이슈 참조(Refs #n)로 표현한다.
-#     - dispatch: 실제 repo SPEC 경로(추적 가치 있음)·dispatch-run 으로 기존 표현을 회귀 없이 유지.
+#       실제로 무엇을 했는지는 loop DONE 완료 요약을 '## 작업 내용' 섹션으로 추가한다.
+#     - dispatch: 실제 repo SPEC 경로(추적 가치 있음)·dispatch-run 으로 기존 표현을 회귀 없이 유지
+#       ('## 작업 내용' 섹션은 추가하지 않는다 — execute-task 발신 PR 한정).
 in_pr_body() {
-  local spec="$1" rid="$2"
+  local spec="$1" rid="$2" is_execute_task=0
   case "$spec" in
     *"/.task-work/"*|".task-work/"*)
+      is_execute_task=1
       printf '🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.\n\n'
       printf 'task-run: %s\n' "$rid"
       ;;
@@ -483,6 +501,12 @@ in_pr_body() {
   local summary; summary="$(in_pr_summary "$spec")"
   if [[ -n "${summary//[$' \t\n']/}" ]]; then
     printf '\n## 요약\n\n%s\n' "$summary"
+  fi
+  if [[ "$is_execute_task" == "1" ]]; then
+    local done_summary; done_summary="$(in_done_summary "$spec")"
+    if [[ -n "${done_summary//[$' \t\n']/}" ]]; then
+      printf '\n## 작업 내용\n\n%s\n' "$done_summary"
+    fi
   fi
 }
 
@@ -990,11 +1014,37 @@ SPECEOF
   case "$body" in *'task-run: 777'*) ok "ET: 태스크 run 추적성";; *) bad "ET: 태스크 run 추적성";; esac
   case "$body" in *'ET 요약 줄.'*) ok "ET: 요약 섹션 보존";; *) bad "ET: 요약 섹션 보존";; esac
 
+  # ---- AC(#539): execute-task DONE 작업 내용 — loop 공개 logs(signals/DONE 섹션)에서 워커
+  #   완료 요약을 읽어 '## 작업 내용' 섹션으로 포함한다(내부 signals 파일 직접 열람 아님,
+  #   $LOOP_CMD logs 경유). specET 의 basename 이 "SPEC.md" 라 mock_loop 의 logs 는
+  #   $LP/SPEC.md.logs 를 읽는다(mock 의 basename-키 컨벤션). ----
+  printf '\n===== signals/DONE =====\n무엇을: X 함수 수정\n왜: 버그 수정\n' > "$LP/SPEC.md.logs"
+  body="$(in_pr_body "$specET" "777")"
+  case "$body" in *'## 작업 내용'*) ok "ET: DONE 요약 있음 → 작업 내용 섹션 포함";; *) bad "ET: DONE 요약 있음 → 작업 내용 섹션 포함";; esac
+  case "$body" in *'무엇을: X 함수 수정'*'왜: 버그 수정'*) ok "ET: 작업 내용 섹션에 DONE 요약 본문 보존";; *) bad "ET: 작업 내용 섹션에 DONE 요약 본문 보존";; esac
+
+  # ---- AC(#539): DONE 신호는 있으나 본문이 비어있음 → 작업 내용 섹션 생략 ----
+  printf '\n===== signals/DONE =====\n' > "$LP/SPEC.md.logs"
+  body="$(in_pr_body "$specET" "777")"
+  case "$body" in *'## 작업 내용'*) bad "ET: DONE 요약 비어있음 → 작업 내용 섹션 생략";; *) ok "ET: DONE 요약 비어있음 → 작업 내용 섹션 생략";; esac
+
+  # ---- AC(#539): DONE 신호 자체가 없음 → 작업 내용 섹션 생략 ----
+  : > "$LP/SPEC.md.logs"
+  body="$(in_pr_body "$specET" "777")"
+  case "$body" in *'## 작업 내용'*) bad "ET: DONE 신호 부재 → 작업 내용 섹션 생략";; *) ok "ET: DONE 신호 부재 → 작업 내용 섹션 생략";; esac
+
   # ---- originator=dispatch 회귀 가드: 기존 본문 표현(라벨·SPEC 경로·dispatch-run) 유지 ----
   body="$(in_pr_body "$specB" "ridDG")"
   case "$body" in *'dispatch 가 자동 생성'*) ok "회귀: dispatch 라벨 유지";; *) bad "회귀: dispatch 라벨 유지";; esac
   case "$body" in *'dispatch-run: ridDG'*) ok "회귀: dispatch-run 유지";; *) bad "회귀: dispatch-run 유지";; esac
   case "$body" in *"SPEC: $specB"*) ok "회귀: dispatch SPEC 경로 유지";; *) bad "회귀: dispatch SPEC 경로 유지";; esac
+
+  # ---- 회귀(#539): dispatch 경로는 DONE 요약이 있어도 '## 작업 내용' 섹션을 추가하지 않는다
+  #   ($spec 의 basename 도 "SPEC.md" 라 같은 mock 로그 파일을 공유 — 의도적 재사용). ----
+  printf '\n===== signals/DONE =====\n무엇을: Y\n' > "$LP/SPEC.md.logs"
+  body="$(in_pr_body "$spec" "ridDG2")"
+  case "$body" in *'## 작업 내용'*) bad "회귀: dispatch 경로 작업 내용 섹션 미추가(DONE 요약 있어도)";; *) ok "회귀: dispatch 경로 작업 내용 섹션 미추가(DONE 요약 있어도)";; esac
+  : > "$LP/SPEC.md.logs"
 
   # ---- PR 생성이 --body-file 로 멀티라인 본문을 forge 에 전달(줄바꿈 보존) ----
   local kB="x-bbb0000"; : > "$PRLOG"; : > "$PRBODY"; : > "$PUSHLOG"


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 539

## 요약

execute-task 가 자동 생성하는 PR 본문에, 해당 태스크가 실제로 무엇을 했는지를 보여주는 작업 내용 섹션을 추가한다. 소스는 loop 워커가 완료 신호(signals/DONE)에 남기는 완료 요약(diff 기반 무엇을·왜 바꿨는지)이며, loop 의 공개 인터페이스(`loop logs`)로만 읽는다(내부 signals 파일 직접 열람 금지).
