### PR TITLE
🤖 [자동 리뷰] rules/version-control/git.md에 behind 브랜치 재동기화 지침 추가

### DIFF
--- a/rules/version-control/git.md
+++ b/rules/version-control/git.md
@@ -10,3 +10,4 @@
 - force push는 다른 사람이 받아 간 history를 무효화해 작업 손실·충돌을 일으키므로, 공유 브랜치에서는 예외 없이 막습니다.
 - 아직 공유되지 않은 본인 전용 토픽 브랜치의 정리(rebase 후 force push)가 불가피하면, 그 브랜치가 공유되지 않았음을 확인한 경우에만 허용하며 공유 브랜치에는 적용하지 않습니다.
 - 호스팅의 브랜치 보호(protected branch) 설정으로 기본 브랜치 force push를 차단하는 것을 권장합니다.
+- 공유 브랜치가 base보다 뒤처져 fast-forward 머지가 막히면, rebase 대신 base를 해당 브랜치로 **merge-in**해 재동기화합니다. merge-in은 history를 재작성하지 않는 **non-force push**입니다.


### PR DESCRIPTION
🤖 이 PR 은 execute-task 가 자동 생성했으며 자동 적대 리뷰를 거칩니다.

task-run: 551

## 요약

rules/version-control/git.md 의 force push 금지 섹션에, 공유 브랜치가 base보다 뒤처져 fast-forward 머지가 막힐 때의 재동기화 기법(rebase 대신 merge-in, non-force push)을 명시하는 짧은 안내를 추가한다.

## 작업 내용

rules/version-control/git.md의 force push 금지 섹션에 behind 브랜치 재동기화 지침(rebase 대신 merge-in, non-force push) 1줄을 추가했다. 완료 조건 3개(재동기화 기법 명시 / merge-in=non-force 명시 / 기존 본문 무손상) 모두 충족. 범위는 대상 파일 1개, 순수 추가(+1줄)만. versioning.md 워치 디렉토리(plugins)에 해당 없어 버전업 불필요. commit 33bea43(fix:root)로 반영.
