### PR TITLE
🤖 [자동 리뷰] .autopilot handoff 복원 후 자동 제거(잔여 archive 미보존)

### DIFF
--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/hooks/session-restore.sh
+++ b/plugins/autopilot/hooks/session-restore.sh
@@ -33,10 +33,8 @@ printf '%s\n' "이전 세션이 자동 컴팩션 경계에서 남긴 작업 핸�
 cat "$OUT" 2>/dev/null || true
 printf '\n%s\n' "</session-handoff>"
 
-# 복원 후 보관: 다음 세션이 stale 핸드오프를 다시 주입하지 않도록 archive 로 이동.
-ARCHIVE="$(handoff_dir "$PROJ")/restored"
-if mkdir -p "$ARCHIVE" 2>/dev/null; then
-  mv "$OUT" "$ARCHIVE/HANDOFF.last.md" 2>/dev/null || true
-fi
+# 복원 후 제거: 다음 세션이 stale 핸드오프를 다시 주입하지 않도록 활성 파일을 지운다.
+# 복원본을 별도 위치에 보관하지 않는다(무잔여). 제거 실패는 조용히 통과(비차단).
+rm -f "$OUT" 2>/dev/null || true
 
 exit 0

--- a/plugins/autopilot/hooks/tests/test-compaction-handoff.sh
+++ b/plugins/autopilot/hooks/tests/test-compaction-handoff.sh
@@ -128,6 +128,17 @@ echo "$OUT" | grep -q "pre-compact.sh" || fail "restore 출력에 만진 파일 
 pass "AC2 restore 주입"
 
 echo ""
+echo "=== 복원 후 활성 핸드오프 제거 + 영구 잔여물 부재 ==="
+[ ! -f "$HANDOFF" ] || fail "복원 후 활성 핸드오프 파일이 남음: $HANDOFF"
+[ ! -e "$PROJ/.autopilot/handoff/restored" ] || fail "복원본 archive 잔여물이 남음(무잔여 위반)"
+# 재주입 방지: 소비 후 두 번째 restore 는 빈 출력이어야 한다.
+OUT_2=$(jq -nc --arg c "$PROJ" \
+  '{session_id:"s4b",source:"compact",cwd:$c,hook_event_name:"SessionStart"}' \
+  | env CLAUDE_PROJECT_DIR="$PROJ" sh "$RESTORE_SH")
+[ -z "$OUT_2" ] || fail "복원 후 재주입됨(핸드오프가 소비되지 않음)"
+pass "복원 후 제거 + 무잔여 + 재주입 없음"
+
+echo ""
 echo "=== AC2: 핸드오프 부재 시 restore 무해(빈 출력, exit 0) ==="
 PROJ5="$TMP/proj5"; mkdir -p "$PROJ5"
 set +e


### PR DESCRIPTION
## 요약


autopilot 세션 핸드오프 복원 훅이 핸드오프 문서를 새 세션 컨텍스트로 주입한 뒤, 활성 위치의 핸드오프 파일을 자동으로 제거하도록 한다. 복원본을 별도 위치(예: `.autopilot/handoff/restored/`)에 영구 보관하지 않는다 — 복원 후에는 어떤 잔여 핸드오프 산출물도 사용자의 수동 정리를 요구하지 않아야 한다.

## 작업 내용

# DONE — #558 .autopilot handoff 복원 후 자동 제거

session-restore.sh 의 복원-후 처리를 archive 이동에서 활성 핸드오프 파일 `rm -f`
제거로 교체했다. 복원본을 별도 위치에 보관하지 않아 어떤 영구 잔여 산출물도
남기지 않는다(무잔여). 제거 실패는 비차단으로 조용히 통과(항상 exit 0).

## 완료 조건 대응
- 핸드오프 존재+새 세션 → 컨텍스트 주입: 기존 동작 유지(AC2 테스트).
- 복원 후 활성 파일 제거 → 재주입 방지: rm -f + 재주입 없음 단언 추가.
- 무잔여: restored/ archive 잔여물 부재 단언 추가.
- 핸드오프 부재/loop 헤드리스 → 비차단 통과: 기존 동작 유지(AC2 부재·AC4 테스트).
- 제거 실패 → 비차단(exit 0): `rm -f "$OUT" 2>/dev/null || true; exit 0`.

## 변경
- plugins/autopilot/hooks/session-restore.sh — archive→rm -f
- plugins/autopilot/hooks/tests/test-compaction-handoff.sh — 회귀 단언 3종
- plugins/autopilot/.claude-plugin/plugin.json — 0.61.7 → 0.61.8 (SoT PATCH)

## 검증
test-compaction-handoff.sh fresh 실행 exit 0 (모든 테스트 통과).
commit 631707d.
