### PR TITLE
fix(execute-task): forge-단계 blocked 재진입 시 완료된 워크트리 보존 (0.62.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### 변경(호환)
 - **create-skill: description 작성 원칙을 WHEN(트리거) 중심으로 조정** — `description 완결성 원칙`과 `2. description 설계` 단계, `skill-template.md`를 갱신해 description의 무게중심을 "언제 호출되는가(WHEN·트리거·증상·오류 신호·동의어 키워드)"에 두도록 했다. WHAT은 동사-목적어 한 구절로 간결하게만 남긴다(생략은 rubric T-WHATWHEN 위반이라 유지). description은 호출 판단의 단일 출처이므로 트리거 매칭 정보를 우선한다는 취지.
 
+## autopilot 0.62.2
+
+### 버그 수정
+- **forge-단계 blocked 태스크 재진입 시 완료된 워크트리 보존** — `execute-task`가 재실행마다 무조건 호출하던 `loop cleanup --force`(내부적으로 `git worktree remove`)를 `review_entered` 표지가 없을 때(최초 실행·loop-단계 재진입)만 호출하도록 가드했다. forge(리뷰/머지) 단계에서 blocked로 끝난 태스크를 사람이 원인을 해결한 뒤 재실행하면, 이전엔 integrate 직전에 완료된 구현이 담긴 `.worktree`가 삭제돼 로컬 브랜치가 없는 케이스에서 `integrate 실패`로 다시 blocked에 떨어질 수 있었다. 이제 forge-단계 재진입은 워크트리를 보존한 채 integrate부터 정상 재개해 done·잔재 정리까지 도달한다. loop-단계 재진입/최초 실행의 죽은-워커 회수 정리는 그대로 유지. (자동 드레인·unblock 명령·잔재 GC는 도입하지 않음 — 재진입은 사람의 명시적 재실행으로만.)
+
 ## autopilot 0.62.0
 
 ### 변경(깨짐)

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.62.1",
+  "version": "0.62.2",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/execute-task/SKILL.md
+++ b/plugins/autopilot/skills/execute-task/SKILL.md
@@ -49,6 +49,17 @@ bash "$EXEC" status|stop|logs <task-id>
 > ```
 > status가 `blocked`이면 태스크 백엔드의 차단 사유·category를 확인하고 자가개선 절차를 밟는다.
 
+## blocked 재진입
+
+`blocked`로 끝난 태스크는 차단 원인을 해결한 뒤 **`start <task-id>`로 다시 실행하면 정상 파이프라인에
+재진입**한다(blocked 전이 시 claim 락이 풀려 재-claim이 성공한다). 재진입은 **막힌 지점부터 재개**한다 —
+loop 단계에서 막혔으면 loop을 재실행하고, forge 단계에서 막혔으면(`review_entered` 표지 존재) loop을 건너뛰고
+integrate부터 재개한다. 재진입이 merge까지 성공하면 `.task-work/<id>/`·`.autopilot/runs/<id>/` 잔재가
+정리된다(성공 시에만 — blocked로 남아 있는 동안은 사후검시용으로 보존된다).
+
+재진입은 **사람의 명시적 재실행으로만** 일어난다. 자동 드레인(`workflow-task`/`list_ready`)은 blocked를
+재실행 대상으로 잡지 않는다(무한 재시도 방지).
+
 ## 재사용 엔진 (런타임 호출, 그대로 둠)
 
 - **loop 엔진**(랄프 루프) — 격리 워크트리에서 RED→GREEN→검증 이터레이션.

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -153,8 +153,10 @@ et_start() {
   local reentry=0
   [[ -f "$run_dir/review_entered" ]] && reentry=1
 
-  # reclaim: 죽은 워커 잔재 정리(있으면) — loop 가 notes/worktree 로 이어받음
-  $LOOP_CMD cleanup "$sp" --force >/dev/null 2>&1 || true
+  # reclaim: 죽은 워커 잔재 정리(최초 실행/loop-단계 재진입). forge-단계 재진입(reentry=1)은 loop 가
+  #   이미 DONE 이라 회수할 워커가 없고, 완료된 .worktree 를 forge integrate 가 loop 결과(HEAD)로 읽으므로
+  #   cleanup(=git worktree remove)으로 지우면 integrate 가 재실패한다 → reentry 일 때는 건너뛴다.
+  (( reentry )) || $LOOP_CMD cleanup "$sp" --force >/dev/null 2>&1 || true
 
   # 백그라운드 heartbeat (lease 갱신). 연속 실패 시 lease 를 잃어 이중 실행 위험 → fail-fast 로 메인 중단.
   # SIGKILL orphan 방지: 부모 PID 와 시작 시간을 미리 캡처해 subshell 에서 생존 확인 후 자가종료.

--- a/tests/autopilot/execute-task/test-execute-task-lifecycle.sh
+++ b/tests/autopilot/execute-task/test-execute-task-lifecycle.sh
@@ -17,7 +17,7 @@ cat > bin/loop <<'EOF'
 #!/usr/bin/env bash
 case "$1" in
   start) touch loop.start.called 2>/dev/null; exit 0;;
-  cleanup) exit 0;;
+  cleanup) touch loop.cleanup.called 2>/dev/null; exit 0;;
   status) printf '{"state":"terminal","signals":["%s"]}\n' "${MOCK_RESULT:-DONE}";;
   *) exit 0;;
 esac
@@ -108,5 +108,21 @@ chk "5) done 선제: status 유지" "$(status_of "$id5")" "done"
 run start "$id5" >/dev/null
 [[ ! -d "$TMP/.task-work/$id5" && ! -d "$TMP/.autopilot/runs/$id5" ]] \
   && ok "6) 멱등 재호출: 디렉토리 미생성" || bad "6) 멱등 재호출: 디렉토리 미생성"
+
+# 7) forge-단계 재진입 보존: review_entered 표지가 있으면 loop cleanup 을 건너뛴다(완료된 .worktree 보존)
+#    → loop 미재실행 + integrate 부터 재개 → done. cleanup 이 호출되면 .worktree 가 삭제돼 integrate 가 깨진다.
+id7="$(bash "$ADAPTER" create_task --title "T7" --body '## 목표'$'\n'r | jq -r .task_id)"
+mkdir -p "$TMP/.autopilot/runs/$id7"; touch "$TMP/.autopilot/runs/$id7/review_entered"  # forge-단계 재진입 표지
+rm -f "$TMP/loop.cleanup.called" "$TMP/loop.start.called"
+run start "$id7" >/dev/null
+[[ ! -f "$TMP/loop.cleanup.called" ]] && ok "7) forge 재진입: loop cleanup 미호출(.worktree 보존)" || bad "7) forge 재진입: loop cleanup 미호출(.worktree 보존)"
+[[ ! -f "$TMP/loop.start.called" ]] && ok "7) forge 재진입: loop 미재실행(integrate 부터 재개)" || bad "7) forge 재진입: loop 미재실행(integrate 부터 재개)"
+chk "7) forge 재진입 → done" "$(status_of "$id7")" "done"
+
+# 8) loop-단계 재진입/최초 실행: review_entered 표지가 없으면 loop cleanup 을 정상 호출(회귀 방지)
+id8="$(bash "$ADAPTER" create_task --title "T8" --body '## 목표'$'\n's | jq -r .task_id)"
+rm -f "$TMP/loop.cleanup.called"
+MOCK_RESULT=DONE run start "$id8" >/dev/null
+[[ -f "$TMP/loop.cleanup.called" ]] && ok "8) loop-단계: loop cleanup 정상 호출" || bad "8) loop-단계: loop cleanup 정상 호출"
 
 echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail


### PR DESCRIPTION
## 배경

사용자 요청: "blocked가 해소될 때 정상 파이프라인으로 진입되도록 수정."

조사 결과 **수동 재진입 경로는 이미 대부분 동작**한다 — `execute-task start <blocked-id>`를 다시 부르면 정상 파이프라인에 재진입하고(blocked 전이 시 claim 락이 풀려 재-claim 성공, execute-task.sh:126 릴리즈), 실패 지점부터 재개한다(loop-단계 → loop 재실행, forge-단계 → `review_entered` 표지로 loop 건너뛰고 integrate부터). 성공 시 잔재도 정리된다(execute-task.sh:291).

사용자 결정(인터뷰): 트리거 = **사람이 원인 해결 후 재실행**(자동 드레인 아님), 재진입은 **실패 지점부터 재개**, 잔재는 **성공 재진입 시에만 정리**. 따라서 자동 드레인·unblock 명령·잔재 GC는 범위 밖.

## 결함

`execute-task.sh:157`의 `$LOOP_CMD cleanup "$sp" --force`는 주석("죽은 워커 잔재 정리")과 달리 실제로는 `git worktree remove --force`로 `.worktree`를 통째로 삭제한다(loop.sh:983-988). 이 호출이 `reentry` 값과 무관하게 **매 재실행마다 무조건** 실행되어, forge-단계 blocked(reentry=1) 재진입 시 **완료된 구현이 담긴 `.worktree`를 integrate 직전에 삭제**한다. 로컬 브랜치가 남아 있으면 forge의 멱등 처리로 넘어가지만, 그 브랜치가 없는 케이스(첫 integrate 도중 blocked, stale 잔여 정리로 브랜치 삭제)에서는 `in_loop_result_commit`이 삭제된 워크트리를 못 찾아 다시 `blocked("integrate 실패")`로 떨어진다.

## 변경 (외과적)

- **`references/execute-task.sh`** — `(( reentry )) || $LOOP_CMD cleanup ...` 가드. reentry=1(forge-단계)은 회수할 워커가 없고(loop 이미 DONE) 완료된 워크트리를 integrate가 읽어야 하므로 cleanup을 건너뛴다. reentry=0(최초/loop-단계)의 죽은-워커 회수는 그대로.
- **`SKILL.md`** — blocked 재진입 계약 문서화(계약 수준, 코드 중복 없음).
- **`test-execute-task-lifecycle.sh`** — 케이스 7(forge-단계 재진입: loop cleanup 미호출 → 워크트리 보존, integrate부터 재개 → done), 케이스 8(loop-단계: cleanup 정상 호출 회귀 방지).
- **`plugin.json` 0.62.1 → 0.62.2** (버그 수정, `rules/engineering/versioning.md` 워치 디렉토리 강제) + CHANGELOG.

## 검증

- 새 테스트가 결함을 판별: 수정 전 소스에서 케이스 7 FAIL, 수정 후 PASS 확인.
- `test-execute-task-lifecycle.sh` 전체 통과(공유 `/tmp` 경합으로 flaky했으나 `TMPDIR` 격리 시 3/3 안정 통과).

## ⚠️ 사전 실패 테스트 (이 변경과 무관)

`test-execute-task-review-reentry.sh`가 **base(main) HEAD에서도** 실패한다(내 변경을 되돌린 원본 소스에서 동일하게 3/3 실패로 확인). 근본 원인은 이 변경과 무관: 케이스 (a)가 **done 도달 후** `review_entered` 표지를 확인하는데, 0.59.1에서 추가된 done 자동 정리(execute-task.sh:291)가 merge 성공 시 run_dir을 통째로 삭제하므로 표지가 항상 사라진다(=done-cleanup 기능과 테스트 간 드리프트). 별도 후속 처리 대상으로 남긴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)