### PR TITLE
chore(autopilot): 버전 충돌 정상화 — #562를 0.62.3으로, #563 CHANGELOG backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@
 ### 변경(호환)
 - **create-skill: description 작성 원칙을 WHEN(트리거) 중심으로 조정** — `description 완결성 원칙`과 `2. description 설계` 단계, `skill-template.md`를 갱신해 description의 무게중심을 "언제 호출되는가(WHEN·트리거·증상·오류 신호·동의어 키워드)"에 두도록 했다. WHAT은 동사-목적어 한 구절로 간결하게만 남긴다(생략은 rubric T-WHATWHEN 위반이라 유지). description은 호출 판단의 단일 출처이므로 트리거 매칭 정보를 우선한다는 취지.
 
+## autopilot 0.62.3
+
+### 버그 수정
+- **forge-단계 blocked 태스크 재진입 시 완료된 워크트리 보존** — `execute-task`가 재실행마다 무조건 호출하던 `loop cleanup --force`(내부적으로 `git worktree remove`)를 `review_entered` 표지가 없을 때(최초 실행·loop-단계 재진입)만 호출하도록 가드했다. forge(리뷰/머지) 단계에서 blocked로 끝난 태스크를 사람이 원인을 해결한 뒤 재실행하면, 이전엔 integrate 직전에 완료된 구현이 담긴 `.worktree`가 삭제돼 로컬 브랜치가 없는 케이스에서 `integrate 실패`로 다시 blocked에 떨어질 수 있었다. 이제 forge-단계 재진입은 워크트리를 보존한 채 integrate부터 정상 재개해 done·잔재 정리까지 도달한다. loop-단계 재진입/최초 실행의 죽은-워커 회수 정리는 그대로 유지. (자동 드레인·unblock 명령·잔재 GC는 도입하지 않음 — 재진입은 사람의 명시적 재실행으로만.) (#562)
+
 ## autopilot 0.62.2
 
 ### 버그 수정
-- **forge-단계 blocked 태스크 재진입 시 완료된 워크트리 보존** — `execute-task`가 재실행마다 무조건 호출하던 `loop cleanup --force`(내부적으로 `git worktree remove`)를 `review_entered` 표지가 없을 때(최초 실행·loop-단계 재진입)만 호출하도록 가드했다. forge(리뷰/머지) 단계에서 blocked로 끝난 태스크를 사람이 원인을 해결한 뒤 재실행하면, 이전엔 integrate 직전에 완료된 구현이 담긴 `.worktree`가 삭제돼 로컬 브랜치가 없는 케이스에서 `integrate 실패`로 다시 blocked에 떨어질 수 있었다. 이제 forge-단계 재진입은 워크트리를 보존한 채 integrate부터 정상 재개해 done·잔재 정리까지 도달한다. loop-단계 재진입/최초 실행의 죽은-워커 회수 정리는 그대로 유지. (자동 드레인·unblock 명령·잔재 GC는 도입하지 않음 — 재진입은 사람의 명시적 재실행으로만.)
+- **execute-task done 시 리뷰 상태(`.review/tasks/<id>`) 정리 + `.review` gitignore화** — `.review/`를 git 추적에서 제외(gitignore)하고 우발적으로 커밋된 산출물을 추적 해제했다. 아울러 정리 단일 출처 `et_cleanup_dirs`에 리뷰 상태 경로(3번째 인자)를 추가해, 머지 성공 후 정리(`execute-task.sh:295`)와 done 선제 가드(`execute-task.sh:139`) 두 호출부가 `.review/tasks/<id>`까지 함께 치우도록 했다. done→삭제 / blocked·`--stop-at review`→잔존 / 다른 태스크 보존을 lifecycle 테스트로 가드한다. (#528, #563)
 
 ## autopilot 0.62.0
 

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.62.2",
+  "version": "0.62.3",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",


### PR DESCRIPTION
## 배경

PR #562(forge-단계 blocked 재진입 시 완료된 워크트리 보존)와 PR #563(execute-task done 시 리뷰 상태 정리, #528)이 **거의 동시에** main에 머지되면서 **둘 다 `plugin.json`을 0.62.1 → 0.62.2로 범프**했다. 값이 같아 텍스트 충돌 없이 머지됐지만, `rules/engineering/versioning.md`상 **각 base 머지는 버전을 올려야 한다** — 나중 머지된 #562는 0.62.3이어야 하므로 현재 main은 버전 규칙 위반 상태다(0.62.x 태그 미발행이라 무손실 정정 가능).

추가로 #563은 `plugin.json`만 올리고 **CHANGELOG 항목을 추가하지 않아** 0.62.2 이력에서 누락돼 있었다.

## 변경 (버전/문서만, 코드 무변경)

- **`plugin.json`** 0.62.2 → **0.62.3** (SoT 정상화).
- **`CHANGELOG.md`**: #562(워크트리 보존) 항목을 **0.62.3**으로 이동, 누락돼 있던 #563(#528, 리뷰 상태 정리 + `.review` gitignore) 항목을 **0.62.2**로 backfill. 결과 헤딩 순서: `0.62.3` → `0.62.2` → `0.62.0`.

## 검증

- `plugin.json` = `0.62.3` 확인.
- CHANGELOG 상단에 `## autopilot 0.62.3`(#562)·`## autopilot 0.62.2`(#563) 두 섹션 순서대로 존재.
- 코드 미변경 — main의 `execute-task.sh`에 #562 재진입 가드(line 161)와 #563 `et_cleanup_dirs` 3번째 인자(line 139·295)가 이미 충돌 없이 공존(diff는 2개 파일뿐).
- 워치 디렉토리(`plugins/`) 변경 = 버전 범프 자체이므로 자기정합, 추가 범프 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)