### PR TITLE
🤖 [자동 리뷰] execute-task review-reentry 테스트 스테일 단정 수정 — done-정리 기능과 정합

### DIFF
--- a/tests/autopilot/execute-task/test-execute-task-lifecycle.sh
+++ b/tests/autopilot/execute-task/test-execute-task-lifecycle.sh
@@ -36,9 +36,20 @@ esac
 EOF
 chmod +x bin/forge
 
+# renew_lease 만 no-op 하고 나머지는 실제 fs adapter 로 패스스루하는 래퍼.
+# 백그라운드 heartbeat 의 renew_lease(fs_fm_set)가 메인 흐름 set_status 와 같은 태스크 파일에
+# 동시 기록하면 공유 $f.tmp 클로버로 status 소실·파일 truncation 플레이크가 난다(케이스 7에서 관측).
+# 이 테스트의 단정은 lease 를 검증하지 않으므로(heartbeat 는 전용 테스트 별도) 동시 기록자만 제거한다.
+cat > bin/adapter_norenew << EOF
+#!/usr/bin/env bash
+[[ "\$1" == renew_lease ]] && { echo '{"task_id":"noop"}'; exit 0; }
+exec bash "$ADAPTER" "\$@"
+EOF
+chmod +x bin/adapter_norenew
+
 # 승인 게이트는 실제 PR 승인 상태로 판정한다(review rc 아님). 해피패스 = 즉시 승인(true) +
 # 미해결 [blocking] 인라인 없음(BLOCKING_CHECK_CMD=true=clear). blocking 가산 차단은 별도 테스트.
-run() { ADAPTER_CMD="bash $ADAPTER" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+run() { ADAPTER_CMD="bash $TMP/bin/adapter_norenew" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
         HEARTBEAT_INTERVAL=1 APPROVAL_CHECK_CMD=true BLOCKING_CHECK_CMD=true SLEEP_CMD=: bash "$ET" "$@"; }
 status_of(){ bash "$ADAPTER" get_task --task-id "$1" | jq -r .status; }
 

--- a/tests/autopilot/execute-task/test-execute-task-review-reentry.sh
+++ b/tests/autopilot/execute-task/test-execute-task-review-reentry.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # test-execute-task-review-reentry.sh — review 상태 crash 후 forge 단계 재진입 검증.
-#   (a) 정상 경로: review_entered 미존재 → loop.start 1회 → review_entered 생성 → forge → done
-#   (b) 재진입 경로: review_entered 존재 → loop.start 미호출 → forge → done
+#   (a) 정상 경로: review_entered 미존재 → loop.start 1회 → forge 진입 시점 마커 존재 → done 후 runs/ 정리
+#   (b) 재진입 경로: review_entered 존재 → loop.start 미호출 → forge → done 후 runs/ 정리
 #   (c) --stop-at review: forge 미진입 → review_entered 미생성
+# done 전이는 et_cleanup_dirs 로 dirname(spec_path)·runs/<id>/ 를 정리하므로(의도된 기능),
+# 마커 존재는 done 이전(forge integrate 시점, mock forge 가 기록)에 검증한다.
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
@@ -29,10 +31,15 @@ EOF
 chmod +x bin/loop
 
 # mock forge: integrate→branch+pr, review→rc20(승인폴링 대기), merge→rc0
+# integrate 시점($3=run_dir; 호출 계약 integrate <sp> <run_dir> <key>)에 review_entered
+# 존재 여부를 FORGE_MARKER_LOG 에 기록 — done-정리가 마커를 지우기 전, forge 진입 시점의
+# 마커 생성을 검증하기 위함.
 cat > bin/forge << 'EOF'
 #!/usr/bin/env bash
 case "$1" in
-  integrate) echo "branch: feat/x"; echo "pr: 7"; exit 0;;
+  integrate)
+    [[ -f "$3/review_entered" ]] && echo "marker" >> "${FORGE_MARKER_LOG:-/dev/null}"
+    echo "branch: feat/x"; echo "pr: 7"; exit 0;;
   review) exit 20;;
   merge) exit 0;;
   *) exit 0;;
@@ -67,11 +74,24 @@ esac
 EOF
 chmod +x bin/adapter_mock
 
-touch "$TMP/dummy.md"
+# renew_lease 만 no-op 하고 나머지는 실제 fs adapter 로 패스스루하는 래퍼(run_fs 용).
+# 백그라운드 heartbeat 의 renew_lease 가 메인 흐름 set_status 와 같은 태스크 파일에 동시
+# 기록(fs_fm_set 공유 $f.tmp)하면 status 소실·truncation 플레이크가 난다. 이 테스트의 단정은
+# lease 를 검증하지 않으므로(heartbeat 는 전용 테스트 별도) 동시 기록자만 제거한다.
+cat > bin/adapter_norenew << EOF
+#!/usr/bin/env bash
+[[ "\$1" == renew_lease ]] && { echo '{"task_id":"noop"}'; exit 0; }
+exec bash "$ADAPTER" "\$@"
+EOF
+chmod +x bin/adapter_norenew
+
+# mock materialize 용 spec 배치: done-정리가 dirname(spec_path) 를 제거하므로
+# 테스트 루트($TMP)가 아닌 케이스별 하위 디렉터리에 둔다(루트 삭제 방지).
+mkdir -p "$TMP/wd_b" "$TMP/wd_c"; touch "$TMP/wd_b/dummy.md" "$TMP/wd_c/dummy.md"
 status_of(){ bash "$ADAPTER" get_task --task-id "$1" | jq -r .status; }
 
-run_fs() {  # 실제 filesystem adapter
-  ADAPTER_CMD="bash $ADAPTER" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+run_fs() {  # 실제 filesystem adapter (renew_lease 만 no-op — 위 래퍼 주석 참조)
+  ADAPTER_CMD="bash $TMP/bin/adapter_norenew" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
   HEARTBEAT_INTERVAL=999 APPROVAL_CHECK_CMD=true BLOCKING_CHECK_CMD=true SLEEP_CMD=: \
   bash "$ET" "$@"
 }
@@ -81,34 +101,39 @@ run_mock() {  # 완전 mock adapter (claim 항상 true)
   bash "$ET" "$@"
 }
 
-# --- (a) 정상 경로: review_entered 미존재 → loop.start 1회 → review_entered 생성 → done ---
+# --- (a) 정상 경로: loop.start 1회 → forge 진입 시점 review_entered 존재 → done 후 runs/ 정리 ---
 id_a="$(bash "$ADAPTER" create_task --title "A" --body '## 목표'$'\n'x | jq -r .task_id)"
 clog_a="$TMP/loop_a.log"; : > "$clog_a"
-LOOP_CALL_LOG="$clog_a" run_fs start "$id_a" >/dev/null 2>&1 || true
+mlog_a="$TMP/marker_a.log"; : > "$mlog_a"
+LOOP_CALL_LOG="$clog_a" FORGE_MARKER_LOG="$mlog_a" run_fs start "$id_a" >/dev/null 2>&1 || true
 chk "(a) 정상 경로 → done" "$(status_of "$id_a")" "done"
 chk "(a) loop.start 1회" "$(awk '/^start$/{c++}END{print c+0}' "$clog_a")" "1"
-[[ -f "$TMP/.autopilot/runs/$id_a/review_entered" ]] \
-  && ok "(a) review_entered 생성됨" || bad "(a) review_entered 생성됨"
+grep -qx "marker" "$mlog_a" 2>/dev/null \
+  && ok "(a) forge 진입 시점 review_entered 존재" || bad "(a) forge 진입 시점 review_entered 존재"
+[[ ! -d "$TMP/.autopilot/runs/$id_a" ]] \
+  && ok "(a) done 후 runs 디렉터리 정리됨" || bad "(a) done 후 runs 디렉터리 정리됨"
 
-# --- (b) 재진입: review_entered 존재 → loop.start 미호출 → forge → done ---
+# --- (b) 재진입: review_entered 존재 → loop.start 미호출 → forge → done 후 runs/ 정리 ---
 # 완전 mock adapter: claim 항상 true (filesystem claim lock 우회)
 st_b="$TMP/st_b"; slog_b="$TMP/sl_b"
 mkdir -p "$TMP/.autopilot/runs/Xb"
 touch "$TMP/.autopilot/runs/Xb/review_entered"
 clog_b="$TMP/loop_b.log"; : > "$clog_b"
-MOCK_WD="$TMP" MOCK_STATUS_FILE="$st_b" MOCK_STATUS_LOG="$slog_b" LOOP_CALL_LOG="$clog_b" \
+MOCK_WD="$TMP/wd_b" MOCK_STATUS_FILE="$st_b" MOCK_STATUS_LOG="$slog_b" LOOP_CALL_LOG="$clog_b" \
   run_mock start Xb >/dev/null 2>&1 || true
 chk "(b) 재진입 → done" "$(cat "$st_b" 2>/dev/null || echo '')" "done"
 chk "(b) 재진입: loop.start 미호출" "$(awk '/^start$/{c++}END{print c+0}' "$clog_b")" "0"
 grep -qx "review" "$slog_b" 2>/dev/null \
   && ok "(b) 재진입: set_status review 호출됨" \
   || bad "(b) 재진입: set_status review 호출됨"
+[[ ! -d "$TMP/.autopilot/runs/Xb" ]] \
+  && ok "(b) done 후 runs 디렉터리 정리됨" || bad "(b) done 후 runs 디렉터리 정리됨"
 
 # --- (c) --stop-at review: review_entered 미생성, forge 미진입 ---
 st_c="$TMP/st_c"
 mkdir -p "$TMP/.autopilot/runs/Xc"
 clog_c="$TMP/loop_c.log"; : > "$clog_c"
-MOCK_WD="$TMP" MOCK_STATUS_FILE="$st_c" LOOP_CALL_LOG="$clog_c" \
+MOCK_WD="$TMP/wd_c" MOCK_STATUS_FILE="$st_c" LOOP_CALL_LOG="$clog_c" \
   run_mock start Xc --stop-at review >/dev/null 2>&1 || true
 chk "(c) stop-at review → review 상태" "$(cat "$st_c" 2>/dev/null || echo '')" "review"
 [[ ! -f "$TMP/.autopilot/runs/Xc/review_entered" ]] \


### PR DESCRIPTION
## 요약


`tests/autopilot/execute-task/test-execute-task-review-reentry.sh`의 스테일 단정을 재설계해 base HEAD에서 통과하게 만든다. 검증 의도(blocked 재진입 시 forge 단계 재개 마커 동작)는 보존하고, 단정 시점과 mock 배치만 바로잡는다. **제품 코드(execute-task.sh)는 변경하지 않는다** — done-정리는 의도된 기능이다.

## 작업 내용

#575 완료 — review-reentry 테스트 스테일 단정 재설계 + lifecycle 선재 플레이크 결정화 (commit af18bb6)

## 완료 조건 충족
- test-execute-task-review-reentry.sh: main(67549ff) 기준 통과. 재설계 — 마커 존재는 forge 진입
  시점(mock forge integrate가 run_dir($3)의 review_entered를 기록)에 검증, done 전이 후에는
  마커·runs 디렉터리 정리됨을 검증(단정 삭제·skip 아님, 시점 재설계). mock materialize spec_path는
  $TMP 하위 디렉터리(wd_b/wd_c) 배치로 done-정리의 루트 삭제 방지.
- plugins/** 무변경(버전 범프 불요). 제품 코드 무변경.
- tests/autopilot/ 전 스위트 33/33 통과(exit 0). 대상 테스트 16회 반복 0실패.

## 추가 해소(같은 scope 내)
- lifecycle 케이스 7 선재 플레이크(base에서 캡처 실행 시 4/8 재현): 제품 fs_fm_set 공유 $f.tmp
  동시 기록 레이스(heartbeat renew_lease vs set_status)가 원인 — 테스트 측에서 renew_lease만
  no-op하는 실제-adapter 패스스루 래퍼로 결정화(단정 약화 없음, lease는 전용 테스트가 검증).
  review-reentry의 실제-adapter 경로에도 동일 적용. 각 16회 반복 0실패.

## 발견 — 후속 태스크 후보(제품, 이번 scope 밖)
1. plugins/autopilot/task-backend/filesystem.sh fs_fm_set: 공유 $f.tmp 비원자 read-modify-write →
   동시 기록자(heartbeat renew_lease vs 메인 set_status) 간 lost update·0바이트 truncation
   (최소 재현 30/30). 프로덕션 기본 interval 60에서도 t≈0 창 존재. fix 후보: per-writer temp
   ($f.tmp.$$)+원자 mv 또는 flock.
2. plugins/autopilot/skills/execute-task/references/execute-task.sh cleanup_hb: HB 서브셸만 kill,
   sleep 자식이 고아로 상속 fd(stderr 등)를 점유 — 큰 HEARTBEAT_INTERVAL이면 호출측 파이프
   캡처가 sleep 만료까지 블록.
