### PR TITLE
🤖 [자동 리뷰] shared/rubric 테스트 회귀 커버리지 이식 — #568 삭제 스위트의 BLOCKER 픽스처·파싱 엣지 케이스

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "project-init",
       "source": "./plugins/project-init",
       "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
-      "version": "0.24.4",
+      "version": "0.24.5",
       "category": "scaffold",
       "tags": [
         "scaffold",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## project-init 0.24.5
+
+### 변경(호환)
+- **shared/rubric 테스트 회귀 커버리지 이식 (#572)** — #568(skill-rubric 플러그인 제거)에서 삭제된 구 `tests/skill-rubric/test-rubric-checker.sh` 스위트에만 있던 회귀 커버리지를 `shared/rubric/tests/`로 이식했다. BLOCKER 픽스처 2종(`blocker-no-yaml`: S-YAML FAIL→F, `blocker-secret`: SEC-SECRET FAIL→F)과 런타임 생성 케이스 5종(`long-body`: C-LENGTH FAIL, `attr-xml`: 속성 있는 XML 태그 S-NO-XML FAIL→F, `bad-quote`: 닫히지 않은 따옴표 S-YAML FAIL, `inline-comment`: 인라인 주석 S-YAML PASS, `trailing-garbage`: 트레일링 가비지 S-YAML FAIL)을 현 스위트 관례로 재작성 통합. `rule_checker.py` 판정 로직은 변경 없음(이식 케이스 전부 현 검사기에서 PASS — 실제 회귀 없음 확인).
+
 ## autopilot 0.62.4
 
 ### 버그 수정

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",

--- a/plugins/project-init/.codex-plugin/plugin.json
+++ b/plugins/project-init/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.24.4",
+  "version": "0.24.5",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",

--- a/plugins/project-init/shared/bootstrap/tests/codex-parity-contract.test.sh
+++ b/plugins/project-init/shared/bootstrap/tests/codex-parity-contract.test.sh
@@ -31,8 +31,8 @@ check "Codex marketplace has required policy and category" bash -c \
 check "Codex marketplace omits plugin version" bash -c \
   "[ \"\$(jq -r '.plugins[0] | has(\"version\")' '$CODEX_MARKETPLACE')\" = false ]"
 
-check "project-init release surfaces are version 0.24.4" bash -c \
-  "[ \"\$(jq -r .version '$CODEX_MANIFEST')\" = 0.24.4 ] && [ \"\$(jq -r .version '$CLAUDE_MANIFEST')\" = 0.24.4 ] && [ \"\$(jq -r '.plugins[] | select(.name == \"project-init\") | .version' '$CLAUDE_MARKETPLACE')\" = 0.24.4 ]"
+check "project-init release surfaces are version 0.24.5" bash -c \
+  "[ \"\$(jq -r .version '$CODEX_MANIFEST')\" = 0.24.5 ] && [ \"\$(jq -r .version '$CLAUDE_MANIFEST')\" = 0.24.5 ] && [ \"\$(jq -r '.plugins[] | select(.name == \"project-init\") | .version' '$CLAUDE_MARKETPLACE')\" = 0.24.5 ]"
 check "Codex manifest uses default plugin hook discovery without override" bash -c \
   "[ \"\$(jq -r 'has(\"hooks\")' '$CODEX_MANIFEST')\" = false ]"
 

--- a/plugins/project-init/shared/rubric/tests/fixtures/blocker-no-yaml/SKILL.md
+++ b/plugins/project-init/shared/rubric/tests/fixtures/blocker-no-yaml/SKILL.md
@@ -1,0 +1,4 @@
+# blocker-no-yaml
+
+이 파일은 frontmatter 펜스가 없다. 첫 줄이 `---`가 아니므로 S-YAML BLOCKER가 발생해야 한다.
+이름·설명도 파싱되지 않으므로 여러 구조 BLOCKER가 함께 잡히고 등급은 F가 된다.

--- a/plugins/project-init/shared/rubric/tests/fixtures/blocker-secret/SKILL.md
+++ b/plugins/project-init/shared/rubric/tests/fixtures/blocker-secret/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: blocker-secret
+description: 규칙 검사기 blocker-secret 픽스처 — 본문에 평문 시크릿이 있어 SEC-SECRET이 FAIL해야 할 때 사용한다.
+allowed-tools:
+  - Read
+---
+
+# blocker-secret
+
+이 픽스처는 본문에 하드코딩된 시크릿을 포함한다.
+
+```
+api_key = "abcd1234efgh5678ijkl"
+```
+
+이 평문 시크릿 때문에 SEC-SECRET BLOCKER가 발생하고 등급이 F가 되어야 한다.

--- a/plugins/project-init/shared/rubric/tests/rule-checker.test.sh
+++ b/plugins/project-init/shared/rubric/tests/rule-checker.test.sh
@@ -58,9 +58,94 @@ assert_json "blocker-xml-tag는 F + S-NO-XML FAIL" grade=F pass:S-NO-XML=false
 [ "$EC" -eq 0 ] || fail "blocker-xml-tag exit code 0 기대(결함은 JSON에, 실제 $EC)"
 ok "blocker-xml-tag: S-NO-XML BLOCKER → F"
 
+run "$FIXTURES/blocker-no-yaml/SKILL.md"
+assert_json "blocker-no-yaml는 F + S-YAML FAIL" grade=F pass:S-YAML=false
+ok "blocker-no-yaml: S-YAML BLOCKER → F"
+
+run "$FIXTURES/blocker-secret/SKILL.md"
+assert_json "blocker-secret는 F + SEC-SECRET FAIL" grade=F pass:SEC-SECRET=false
+ok "blocker-secret: SEC-SECRET BLOCKER → F"
+
 run "$FIXTURES/major-unknown-key/SKILL.md"
 assert_json "major-unknown-key는 A + S-ALLOWED-KEYS FAIL" grade=A blocker=0 major=1 pass:S-ALLOWED-KEYS=false
 ok "major-unknown-key: S-ALLOWED-KEYS MAJOR → A"
+
+# 런타임 생성 케이스: 본문 길이 초과 → C-LENGTH FAIL
+mkdir -p "$tmp/long-body"
+{
+  echo '---'
+  echo 'name: long-body'
+  echo 'description: "본문이 500줄을 넘어 C-LENGTH MINOR를 유발하는 픽스처 — 길이 검사 확인용으로 사용한다."'
+  echo 'allowed-tools:'
+  echo '  - Read'
+  echo '---'
+  echo '# long-body'
+  for i in $(seq 1 520); do echo "본문 줄 $i"; done
+} > "$tmp/long-body/SKILL.md"
+run "$tmp/long-body/SKILL.md"
+assert_json "long-body는 C-LENGTH FAIL" pass:C-LENGTH=false
+ok "long-body: C-LENGTH MINOR 검출"
+
+# 런타임 생성 케이스: 속성 있는 XML 태그 → S-NO-XML BLOCKER
+mkdir -p "$tmp/attr-xml"
+{
+  echo '---'
+  echo 'name: attr-xml'
+  echo 'description: "속성 있는 XML 태그가 본문에 있을 때 S-NO-XML이 잡는지 확인하는 픽스처로 사용한다."'
+  echo 'allowed-tools:'
+  echo '  - Read'
+  echo '---'
+  echo '# attr-xml'
+  echo '<IMPORTANT level="high">속성 있는 태그</IMPORTANT>'
+} > "$tmp/attr-xml/SKILL.md"
+run "$tmp/attr-xml/SKILL.md"
+assert_json "속성 XML 태그는 S-NO-XML FAIL" grade=F pass:S-NO-XML=false
+ok "속성 있는 XML 태그 검출(S-NO-XML)"
+
+# 런타임 생성 케이스: 닫히지 않은 따옴표 → S-YAML BLOCKER
+mkdir -p "$tmp/bad-quote"
+{
+  echo '---'
+  echo 'name: bad-quote'
+  printf 'description: "%s\n' '따옴표가 닫히지 않은 값'
+  echo 'allowed-tools:'
+  echo '  - Read'
+  echo '---'
+  echo '# bad-quote'
+} > "$tmp/bad-quote/SKILL.md"
+run "$tmp/bad-quote/SKILL.md"
+assert_json "닫히지 않은 따옴표는 S-YAML FAIL" pass:S-YAML=false
+ok "닫히지 않은 따옴표 검출(S-YAML)"
+
+# 런타임 생성 케이스: 닫힌 따옴표 뒤 인라인 주석 → S-YAML PASS(거짓 실패 금지)
+mkdir -p "$tmp/inline-comment"
+{
+  echo '---'
+  echo 'name: inline-comment'
+  printf 'description: "%s" # %s\n' '인라인 주석이 있어도 정상 파싱되는지 확인할 때 사용하는 픽스처입니다.' '인라인 주석'
+  echo 'allowed-tools:'
+  echo '  - Read'
+  echo '---'
+  echo '# inline-comment'
+} > "$tmp/inline-comment/SKILL.md"
+run "$tmp/inline-comment/SKILL.md"
+assert_json "인라인 주석 있는 정상 YAML은 S-YAML PASS" pass:S-YAML=true
+ok "인라인 주석 포함 YAML: S-YAML 통과"
+
+# 런타임 생성 케이스: 닫는 따옴표 뒤 비주석 토큰 → S-YAML FAIL(잘못된 YAML)
+mkdir -p "$tmp/trailing-garbage"
+{
+  echo '---'
+  echo 'name: trailing-garbage'
+  printf 'description: "%s" %s\n' '닫는 따옴표 뒤에 주석이 아닌 토큰이 붙은 잘못된 값입니다 사용.' '잘못된-토큰'
+  echo 'allowed-tools:'
+  echo '  - Read'
+  echo '---'
+  echo '# trailing-garbage'
+} > "$tmp/trailing-garbage/SKILL.md"
+run "$tmp/trailing-garbage/SKILL.md"
+assert_json "닫는 따옴표 뒤 비주석 토큰은 S-YAML FAIL" pass:S-YAML=false
+ok "닫는 따옴표 뒤 비주석 토큰 검출(S-YAML)"
 
 run "$FIXTURES/__does-not-exist__/SKILL.md"
 [ "$EC" -eq 4 ] || fail "존재하지 않는 경로는 exit 4 기대(실제 $EC)"


### PR DESCRIPTION
## 요약


shared/rubric 테스트 스위트(`plugins/project-init/shared/rubric/tests/`)가, #568(skill-rubric 플러그인 제거)에서 삭제된 구 `tests/skill-rubric/test-rubric-checker.sh` 스위트에만 존재하던 회귀 커버리지를 포함하는 상태로 만든다. 이식 대상 커버리지:

- **BLOCKER 픽스처 2종**: `blocker-no-yaml`(YAML frontmatter 부재 → S-YAML FAIL → F), `blocker-secret`(시크릿 포함 → SEC-SECRET FAIL → F). 구 스위트에선 `tests/skill-rubric/fixtures/` 하위 디렉터리 픽스처였다(git 히스토리 `3e75d5d` 시점에서 복원 가능).
- **런타임 생성 케이스 5종**: `long-body`(본문 길이 초과 → C-LENGTH FAIL), `attr-xml`(속성 있는 XML 태그 → S-NO-XML FAIL → F), `bad-quote`(닫히지 않은 따옴표 → S-YAML), `inline-comment`·`trailing-garbage`(YAML 파싱 엣지). 구 스위트의 TEST 5·11~14에 해당한다.

이식은 현 스위트의 구조·단언 관례에 맞춰 통합한다(구 코드 원형 복원이 아니라 재작성 통합). 현 스위트가 이미 동등하게 커버하는 시나리오는 중복 추가하지 않는다.

## 작업 내용

#572 shared/rubric 테스트 회귀 커버리지 이식 완료.

- BLOCKER 픽스처 2종(blocker-no-yaml→S-YAML F, blocker-secret→SEC-SECRET F) + 런타임 5종(long-body C-LENGTH, attr-xml S-NO-XML F, bad-quote/inline-comment/trailing-garbage S-YAML 엣지)을 현 스위트 관례로 rule-checker.test.sh에 통합.
- 완료조건 1~4: 각 케이스 단언 통과(구 스위트 3e75d5d와 동등 판정). 5: 스윕 2종(rule-checker 13케이스·codex-parity) 전부 PASS exit 0. 6: 기존 항목과 판정 대상 불겹침 근거 커밋 메시지·노트에 기록.
- 검사기(rule_checker.py) 무변경 — 이식 케이스 전부 현 검사기 PASS(실제 회귀 없음).
- 버전 3표면 0.24.5 동일 + parity 하드코딩 일치, CHANGELOG 항목 추가.
- 4-Level Verifier·Self-Review·적대 렌즈 3종(발견 없음) 통과. commit 455fc59.
