### PR TITLE
🤖 [자동 리뷰] 런타임 산출물 .task-work/ 를 .autopilot/runs/ 로 통합

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
       "name": "autopilot",
       "source": "./plugins/autopilot",
       "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
-      "version": "0.62.4",
+      "version": "0.63.0",
       "category": "automation",
       "tags": [
         "autonomous",

--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,11 @@ milestones/**/loops/**/.lock
 .fsd/
 # 업그레이드 전 conductor(구 이름) 런타임 상태 — 추적 노출 방지를 위해 유지
 .conductor/
-
-# task-centric family 런타임 산출물 (materialize 임시 spec, claim 락, run 상태)
-# .autopilot/task-backend.json(백엔드 선택 SoT)은 추적; 런타임만 무시
+# 업그레이드 전 .task-work(구 위치, #580 에서 .autopilot/runs/ 로 통합) 잔재 — 추적 노출 방지를 위해 유지
 .task-work/
+
+# task-centric family 런타임 산출물 (materialize 임시 spec, claim 락, run 상태 — .autopilot/runs/ 통합, #580)
+# .autopilot/task-backend.json(백엔드 선택 SoT)은 추적; 런타임만 무시
 .autopilot/runs/
 # review 스킬 런타임 상태 (태스크별 렌즈 산출물; done 시 execute-task 가 정리, #528)
 .review/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.63.0
+
+### 변경(호환)
+- **런타임 산출물 `.task-work/` 를 `.autopilot/runs/` 로 통합 (#580)** — 태스크 실행 런타임 산출물 디렉토리 `.task-work/` 를 폐지하고 기존 `.autopilot/runs/<태스크 id>/` 로 완전 통합했다. materialize 임시 SPEC(+파생 워크트리)은 `.autopilot/runs/<id>/SPEC.md` 에 생성되고(filesystem·github·beads 세 백엔드 동일), filesystem 백엔드의 claim 락은 `.autopilot/runs/.claims/<id>` 로 이동했다(`.claims` 는 `runs/` 아래 유일한 비-태스크-id 항목 — contract.md 명시). 태스크 하나의 런타임 상태가 디렉토리 하나에 모이고 최상위 런타임 dotdir 는 `.autopilot/` 하나가 된다. done 전이 시 `.autopilot/runs/<id>/`·`.review/tasks/<id>/` 정리, blocked·stop-at review 보존, done 선제 가드(잔존 정리 후 skip), PR 본문 임시 경로 비누출 동작은 새 경로 기준으로 유지된다(회귀 가드 갱신: test-filesystem·test-execute-task-lifecycle·forge integration selftest). 어댑터 공개 인터페이스(동사·JSON 스키마)는 불변(MINOR). 옛 `.task-work/` 잔재는 마이그레이션하지 않고 방치하며 `.gitignore` 에 레거시 잔재-보호 항목으로 유지한다.
+
 ## thinktank 1.0.0
 
 ### 변경(깨짐)

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.62.4",
+  "version": "0.63.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/forge/lib/integration.sh
+++ b/plugins/autopilot/forge/lib/integration.sh
@@ -980,14 +980,14 @@ SPECEOF
   body="$(in_pr_body "$specI")"
   case "$body" in *'Refs #43'*) ok "이슈 '#43' 표기 정규화";; *) bad "이슈 '#43' 표기 정규화";; esac
 
-  # ---- execute-task materialize 경로: 임시 materialize SPEC(.task-work/<id>/SPEC.md) 본문 ----
-  #   (a) .task-work/·절대 경로 누출 부재,
+  # ---- execute-task materialize 경로: 임시 materialize SPEC(.autopilot/runs/<id>/SPEC.md) 본문 ----
+  #   (a) .autopilot/runs/·절대 경로 누출 부재,
   #   (b) 자동생성 식별 줄·run 추적 줄 부재(#554), (c) 태스크 참조(Refs #n)·요약 보존. ----
-  local specET="$TMP/.task-work/777/SPEC.md"
-  mkdir -p "$TMP/.task-work/777"
+  local specET="$TMP/.autopilot/runs/777/SPEC.md"
+  mkdir -p "$TMP/.autopilot/runs/777"
   printf -- '---\nslug: et-body\nissue: 777\n---\n\n# ET 기능\n\n## 무엇을 만들 것인가\nET 요약 줄.\n' > "$specET"
   body="$(in_pr_body "$specET")"
-  case "$body" in *'.task-work/'*) bad "ET: .task-work 임시 경로 누출 부재";; *) ok "ET: .task-work 임시 경로 누출 부재";; esac
+  case "$body" in *'.autopilot/runs/'*) bad "ET: .autopilot/runs 임시 경로 누출 부재";; *) ok "ET: .autopilot/runs 임시 경로 누출 부재";; esac
   case "$body" in *"$specET"*) bad "ET: 절대 SPEC 경로 부재";; *) ok "ET: 절대 SPEC 경로 부재";; esac
   case "$body" in *'자동 생성'*) bad "ET: 자동생성 식별 줄 부재(#554)";; *) ok "ET: 자동생성 식별 줄 부재(#554)";; esac
   case "$body" in *'자동 적대 리뷰'*) bad "ET: 리뷰 식별 줄 부재(#554)";; *) ok "ET: 리뷰 식별 줄 부재(#554)";; esac
@@ -1006,8 +1006,8 @@ SPECEOF
 
   # ---- 작업 내용이 첫 요소(이슈·요약 부재)인 경우도 선행 공백 줄 없이 시작(#554) ----
   #   (basename 이 SPEC.md 라 위에서 채운 $LP/SPEC.md.logs 의 DONE 요약을 공유 — 의도적 재사용)
-  local specET2="$TMP/.task-work/778/SPEC.md"
-  mkdir -p "$TMP/.task-work/778"
+  local specET2="$TMP/.autopilot/runs/778/SPEC.md"
+  mkdir -p "$TMP/.autopilot/runs/778"
   printf -- '# ET 기능 2\n' > "$specET2"
   body="$(in_pr_body "$specET2")"
   case "$body" in '## 작업 내용'*) ok "본문 선두 작업 내용(선행 공백 줄 없음)";; *) bad "본문 선두 작업 내용(선행 공백 줄 없음)";; esac
@@ -1022,12 +1022,12 @@ SPECEOF
   body="$(in_pr_body "$specET")"
   case "$body" in *'## 작업 내용'*) bad "ET: DONE 신호 부재 → 작업 내용 섹션 생략";; *) ok "ET: DONE 신호 부재 → 작업 내용 섹션 생략";; esac
 
-  # ---- 단일 경로(#556): 발신 주체 구분 없음 — materialize 마커(.task-work) 없는 spec 경로도
+  # ---- 단일 경로(#556): 발신 주체 구분 없음 — materialize 마커(.autopilot/runs) 없는 spec 경로도
   #   DONE 요약이 있으면 '## 작업 내용' 섹션을 포함한다(#539 동작을 단일 경로로 유지).
   #   ($spec 의 basename 도 "SPEC.md" 라 같은 mock 로그 파일을 공유 — 의도적 재사용). ----
   printf '\n===== signals/DONE =====\n무엇을: Y\n' > "$LP/SPEC.md.logs"
   body="$(in_pr_body "$spec")"
-  case "$body" in *'## 작업 내용'*) ok "#556 단일 경로: 비-task-work spec 도 DONE 요약 → 작업 내용 포함";; *) bad "#556 단일 경로: 비-task-work spec 도 DONE 요약 → 작업 내용 포함";; esac
+  case "$body" in *'## 작업 내용'*) ok "#556 단일 경로: 비-materialize spec 도 DONE 요약 → 작업 내용 포함";; *) bad "#556 단일 경로: 비-materialize spec 도 DONE 요약 → 작업 내용 포함";; esac
   : > "$LP/SPEC.md.logs"
 
   # ---- PR 생성이 --body-file 로 멀티라인 본문을 forge 에 전달(줄바꿈 보존) ----

--- a/plugins/autopilot/skills/execute-task/SKILL.md
+++ b/plugins/autopilot/skills/execute-task/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools:
 등록된 **단일 태스크의 전체 생애**(구현→리뷰→머지→done)를 소유하는 실행기다. 결정적 드라이버
 `references/execute-task.sh`가 다음을 수행한다:
 
-1. `adapter materialize` — 태스크 본문을 임시 spec(`.task-work/<id>/SPEC.md`)으로 뜬다(본문=SPEC).
+1. `adapter materialize` — 태스크 본문을 임시 spec(`.autopilot/runs/<id>/SPEC.md`)으로 뜬다(본문=SPEC).
 2. `adapter set_status in_progress` + **백그라운드 heartbeat lease 갱신**(크래시·행 워커는 lease가 stale해져
    `list_ready`가 회수). 잔여 워커 자취(워크트리·lock)는 시작 전 정리(reclaim)한다.
 3. **loop 엔진**(랄프 루프)으로 포그라운드 구현. 반환 후 `status --json`으로 DONE/BLOCKED 분류.
@@ -54,7 +54,7 @@ bash "$EXEC" status|stop|logs <task-id>
 `blocked`로 끝난 태스크는 차단 원인을 해결한 뒤 **`start <task-id>`로 다시 실행하면 정상 파이프라인에
 재진입**한다(blocked 전이 시 claim 락이 풀려 재-claim이 성공한다). 재진입은 **막힌 지점부터 재개**한다 —
 loop 단계에서 막혔으면 loop을 재실행하고, forge 단계에서 막혔으면(`review_entered` 표지 존재) loop을 건너뛰고
-integrate부터 재개한다. 재진입이 merge까지 성공하면 `.task-work/<id>/`·`.autopilot/runs/<id>/` 잔재가
+integrate부터 재개한다. 재진입이 merge까지 성공하면 `.autopilot/runs/<id>/` 잔재가
 정리된다(성공 시에만 — blocked로 남아 있는 동안은 사후검시용으로 보존된다).
 
 재진입은 **사람의 명시적 재실행으로만** 일어난다. 자동 드레인(`workflow-task`/`list_ready`)은 blocked를

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -38,13 +38,13 @@ REVIEW_BOT_LOGINS_RE="${REVIEW_BOT_LOGINS_RE:-(\[bot\]$|^github-actions$|courtes
 
 die() { echo "execute-task: $*" >&2; exit 1; }
 
-# et_cleanup_dirs <task-work-dir> <run-dir> [<review-state-dir>] — 정리(멱등, 부재여도 무해).
+# et_cleanup_dirs <dir>... — 주어진 디렉토리들을 정리(멱등, 부재·중복이어도 무해).
 #   merge 성공 직후 정리와 done 선제 가드 정리(#541)가 공유하는 단일 출처.
-#   3번째 인자(리뷰 상태 <git-root>/.review/tasks/<id>, #528)는 주어질 때만 정리한다.
+#   대상: run-dir(.autopilot/runs/<id> — materialize SPEC·.worktree·run 상태, #580 통합),
+#   리뷰 상태(<git-root>/.review/tasks/<id>, #528).
 et_cleanup_dirs() {
-  rm -rf "$1" 2>/dev/null || true
-  rm -rf "$2" 2>/dev/null || true
-  [[ -n "${3:-}" ]] && rm -rf "$3" 2>/dev/null || true
+  local d
+  for d in "$@"; do rm -rf "$d" 2>/dev/null || true; done
 }
 
 # et_approval_gh <pr> — PR 호스팅 리뷰가 승인 상태면 0, 아니면 1.
@@ -130,13 +130,13 @@ et_start() {
   [[ -n "$id" ]] || die "start <task-id> [--stop-at review]"
 
   # done 선제 가드(#541): 백엔드 status 가 이미 done 이면 파이프라인을 재실행하지 않고 잔존
-  #   .task-work/<id>/·.autopilot/runs/<id>/ 만 멱등 정리 후 즉시 종료한다. materialize 는 디렉토리를
+  #   .autopilot/runs/<id>/ 만 멱등 정리 후 즉시 종료한다. materialize 는 디렉토리를
   #   재생성하므로 이 가드는 materialize/claim 호출 전에 와야 한다. 조회 실패(네트워크/백엔드 오류 등)는
   #   보수적으로 무시하고 기존 파이프라인 진행으로 폴백한다(오탐으로 정상 진행 중인 태스크를 막지 않음).
   local pre_status
   pre_status="$($ADAPTER_CMD get_task --task-id "$id" 2>/dev/null | jq -r '.status // empty' 2>/dev/null)" || pre_status=""
   if [[ "$pre_status" == "done" ]]; then
-    et_cleanup_dirs "$ROOT_DIR/.task-work/$id" "$ROOT_DIR/.autopilot/runs/$id" "$ROOT_DIR/.review/tasks/$id"
+    et_cleanup_dirs "$ROOT_DIR/.autopilot/runs/$id" "$ROOT_DIR/.review/tasks/$id"
     echo "execute-task: 이미 done — 정리 후 skip ($id)"
     return 0
   fi
@@ -292,7 +292,9 @@ et_start() {
   if $FORGE_CMD merge "$sp" "$run_dir" "$key" "$pr"; then
     $ADAPTER_CMD set_status --task-id "$id" --status done >/dev/null
     $ADAPTER_CMD append_log --task-id "$id" --marker handoff --text "merged ${branch:+($branch)}" >/dev/null
-    et_cleanup_dirs "$(dirname "$sp")" "$run_dir" "$ROOT_DIR/.review/tasks/$id"   # .task-work/<id>/·.autopilot/runs/<id>/·.review/tasks/<id>/ 정리
+    # .autopilot/runs/<id>/(materialize SPEC 포함)·.review/tasks/<id>/ 정리 — dirname sp 는 통상
+    # run_dir 와 동일(#580 통합)하나 TB_ROOT≠ROOT_DIR 환경 대비로 둘 다 전달(멱등이라 무해).
+    et_cleanup_dirs "$(dirname "$sp")" "$run_dir" "$ROOT_DIR/.review/tasks/$id"
     echo "execute-task: done ($id)"
   else
     $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "merge 실패" >/dev/null

--- a/plugins/autopilot/task-backend/beads.sh
+++ b/plugins/autopilot/task-backend/beads.sh
@@ -109,7 +109,7 @@ be_append_log() {
 
 be_materialize() {
   local id; id="$(_argval --task-id "$@")"
-  local dir="$TB_ROOT/.task-work/$id"; mkdir -p "$dir"; local sp="$dir/SPEC.md"
+  local dir="$TB_ROOT/.autopilot/runs/$id"; mkdir -p "$dir"; local sp="$dir/SPEC.md"
   local j; j="$(bd show "$id" --json 2>/dev/null)" || tb_die "bd show 실패: $id"
   { printf '# %s\n\n' "$(printf '%s' "$j" | jq -r .title)"; printf '%s\n' "$(printf '%s' "$j" | jq -r '.description//""')"; } > "$sp"
   jq -nc --arg id "$id" --arg p "$sp" '{task_id:$id, spec_path:$p}'

--- a/plugins/autopilot/task-backend/contract.md
+++ b/plugins/autopilot/task-backend/contract.md
@@ -112,7 +112,7 @@ scope:
 | `link_dependency` | `--task-id <id> --depends-on-id <id>` | `{"task_id","depends_on":[...]}` |
 | `list_ready` | (없음) | `[{"task_id","title"},...]` (depends_on 충족 + stale-lease in_progress) |
 | `append_log` | `--task-id <id> --marker decision|handoff|blocked --text <s>` | `{"task_id","logged":true}` |
-| `materialize` | `--task-id <id>` | `{"task_id","spec_path"}` (`.task-work/<id>/SPEC.md`) |
+| `materialize` | `--task-id <id>` | `{"task_id","spec_path"}` (`.autopilot/runs/<id>/SPEC.md`) |
 | `renew_lease` | `--task-id <id> [--owner <s>]` | `{"task_id","lease_renewed_at"}` |
 | `claim` | `--task-id <id> --owner <s>` | `{"task_id","claimed":true|false}` (stale 판정의 단일 진입점 — stale lease 탈취 + 신규 점유 원자적 게이트) |
 
@@ -126,8 +126,9 @@ scope:
 시 `claimed:true`(+ status를 in_progress로 전이, lease 초기화), 이미 신선한 lease로 점유 중이면
 `claimed:false`(실행자는 조용히 skip).
 
-- **filesystem**: `.task-work/.claims/<id>` 디렉토리 `mkdir`(원자적 CAS)로 게이트. 종단 상태(done/blocked/
-  cancelled) 전이 시 자동 해제.
+- **filesystem**: `.autopilot/runs/.claims/<id>` 디렉토리 `mkdir`(원자적 CAS)로 게이트. 종단 상태(done/blocked/
+  cancelled) 전이 시 자동 해제. `.claims` 는 `.autopilot/runs/` 아래 유일한 **비-태스크-id 항목**이다 —
+  `runs/` 를 태스크 id 로 순회하는 코드는 `.claims` 를 제외해야 한다.
 - **github-project/beads**: 공유 store 전반의 진정한 원자성은 원격 CAS가 필요하며 v1은 **단일 호스트 범위**의
   best-effort(현재 상태+lease 확인 후 전이). github의 stale 회수는 **로컬 lease 미러가 존재하고 stale일 때만**
   수행한다(미러 부재 시 회수하지 않음 — 타 체크아웃의 실행 중 태스크 오회수 방지).

--- a/plugins/autopilot/task-backend/filesystem.sh
+++ b/plugins/autopilot/task-backend/filesystem.sh
@@ -110,7 +110,7 @@ be_set_body() {
   jq -nc --arg id "$id" '{task_id:$id}'
 }
 
-fs_claim_dir() { printf '%s/.task-work/.claims' "$TB_ROOT"; }
+fs_claim_dir() { printf '%s/.autopilot/runs/.claims' "$TB_ROOT"; }
 fs_release_claim() { rm -rf "$(fs_claim_dir)/$1" 2>/dev/null || true; }
 
 be_set_status() {
@@ -195,7 +195,7 @@ be_append_log() {
 be_materialize() {
   local id; id="$(_argval --task-id "$@")"; fs_exists "$id" || tb_die "materialize: 없음 $id"
   local f; f="$(fs_file "$id")"
-  local dir="$TB_ROOT/.task-work/$id"; mkdir -p "$dir"
+  local dir="$TB_ROOT/.autopilot/runs/$id"; mkdir -p "$dir"
   local sp="$dir/SPEC.md"
   # 본문이 scope frontmatter 로 시작하면 그 블록 뒤에 제목을 주입(frontmatter-first + 제목, loop scope
   # 게이트 동작). 없으면 폴백으로 제목을 앞에 붙인다. (tb_emit_spec = adapter.sh 공통)

--- a/plugins/autopilot/task-backend/github.sh
+++ b/plugins/autopilot/task-backend/github.sh
@@ -167,7 +167,7 @@ be_append_log() {
 
 be_materialize() {
   local id; id="$(_argval --task-id "$@")"
-  local dir="$TB_ROOT/.task-work/$id"; mkdir -p "$dir"; local sp="$dir/SPEC.md"
+  local dir="$TB_ROOT/.autopilot/runs/$id"; mkdir -p "$dir"; local sp="$dir/SPEC.md"
   local title; title="$(gh issue view "$id" $(gh_repo_args) --json title -q .title)"
   # 내부 depends_on 마커는 spec 본문에서 제외(lease 는 본문이 아닌 전용 코멘트라 본문에 없음). 제목은
   # prepend 하지 않고 tb_emit_spec(adapter 공통)이 본문 frontmatter 뒤에 주입 → frontmatter-first.

--- a/plugins/autopilot/task-backend/tests/test-filesystem.sh
+++ b/plugins/autopilot/task-backend/tests/test-filesystem.sh
@@ -29,8 +29,9 @@ chk "ready=a" "$(bash "$A" list_ready | jq -r '.[].task_id' | tr '\n' ' ')" "$a 
 bash "$A" set_status --task-id "$a" --status done >/dev/null
 chk "a done 후 ready=b" "$(bash "$A" list_ready | jq -r '.[].task_id' | tr '\n' ' ')" "$b "
 
-# materialize 본문 + H1 title
+# materialize 본문 + H1 title (경로: .autopilot/runs/<id>/SPEC.md — #580 통합)
 sp="$(bash "$A" materialize --task-id "$b" | jq -r .spec_path)"
+chk "materialize 경로 .autopilot/runs" "$sp" "$TMP/.autopilot/runs/$b/SPEC.md"
 chk "materialize H1" "$(head -1 "$sp")" "# B"
 grep -q '## 목표' "$sp" && ok "materialize 본문 포함" || bad "materialize 본문 포함"
 
@@ -53,13 +54,14 @@ chk "set_body status 보존" "$(bash "$A" get_task --task-id "$e" | jq -r .statu
 chk "set_body depends_on 보존" "$(bash "$A" get_task --task-id "$e" | jq -r '.depends_on[0]')" "$a"
 chk "set_body title 보존" "$(bash "$A" get_body --task-id "$e" | jq -r .title)" "E"
 
-# 원자적 claim: 첫 획득 true, 신선 점유 중 재획득 false
+# 원자적 claim: 첫 획득 true, 신선 점유 중 재획득 false (락: .autopilot/runs/.claims/<id> — #580 통합)
 d="$(bash "$A" create_task --title D --body '## 목표'$'\n'디 | jq -r .task_id)"
 chk "claim 1회 true" "$(bash "$A" claim --task-id "$d" --owner w1 | jq -r .claimed)" "true"
+[[ -d "$TMP/.autopilot/runs/.claims/$d" ]] && ok "claim 락 .autopilot/runs/.claims" || bad "claim 락 .autopilot/runs/.claims"
 chk "claim 신선 점유 false" "$(bash "$A" claim --task-id "$d" --owner w2 | jq -r .claimed)" "false"
 chk "claim 후 in_progress" "$(bash "$A" get_task --task-id "$d" | jq -r .status)" "in_progress"
 bash "$A" set_status --task-id "$d" --status done >/dev/null
-[[ -d "$TMP/.task-work/.claims/$d" ]] && bad "done 시 claim 해제" || ok "done 시 claim 해제"
+[[ -d "$TMP/.autopilot/runs/.claims/$d" ]] && bad "done 시 claim 해제" || ok "done 시 claim 해제"
 
 # --- #471: 본문 frontmatter(scope) 보존 + frontmatter-first materialize ---
 fmbody=$'---\nscope:\n  include:\n    - src/**\n  exclude:\n    - rules/**\n---\n\n## 무엇을 만들 것인가\n바디 본문\n'

--- a/tests/autopilot/execute-task/test-execute-task-lifecycle.sh
+++ b/tests/autopilot/execute-task/test-execute-task-lifecycle.sh
@@ -58,7 +58,7 @@ id="$(bash "$ADAPTER" create_task --title "T1" --body '## 목표'$'\n'x | jq -r 
 mkdir -p "$TMP/.review/tasks/$id"
 MOCK_RESULT=DONE run start "$id" --stop-at review >/dev/null
 chk "stop-at review → review" "$(status_of "$id")" "review"
-[[ -d "$TMP/.task-work/$id" ]] && ok "1) stop-at: task-work 잔존" || bad "1) stop-at: task-work 잔존"
+[[ -f "$TMP/.autopilot/runs/$id/SPEC.md" ]] && ok "1) stop-at: run-dir(SPEC) 잔존" || bad "1) stop-at: run-dir(SPEC) 잔존"
 [[ -d "$TMP/.review/tasks/$id" ]] && ok "1) stop-at: review 상태 잔존" || bad "1) stop-at: review 상태 잔존"
 
 # 2) 전체 경로: DONE + forge 승인/머지 → done
@@ -66,7 +66,6 @@ id2="$(bash "$ADAPTER" create_task --title "T2" --body '## 목표'$'\n'y | jq -r
 mkdir -p "$TMP/.review/tasks/$id2" "$TMP/.review/tasks/other-keep"
 MOCK_RESULT=DONE run start "$id2" >/dev/null
 chk "전체 경로 → done" "$(status_of "$id2")" "done"
-[[ ! -d "$TMP/.task-work/$id2" ]] && ok "2) done: task-work 삭제" || bad "2) done: task-work 삭제"
 [[ ! -d "$TMP/.autopilot/runs/$id2" ]] && ok "2) done: run-dir 삭제" || bad "2) done: run-dir 삭제"
 [[ ! -d "$TMP/.review/tasks/$id2" ]] && ok "2) done: review 상태 삭제" || bad "2) done: review 상태 삭제"
 [[ -d "$TMP/.review/tasks/other-keep" ]] && ok "2) done: 다른 태스크 review 상태 보존" || bad "2) done: 다른 태스크 review 상태 보존"
@@ -76,56 +75,70 @@ id3="$(bash "$ADAPTER" create_task --title "T3" --body '## 목표'$'\n'z | jq -r
 mkdir -p "$TMP/.review/tasks/$id3"
 MOCK_RESULT=BLOCKED run start "$id3" >/dev/null 2>&1 || true
 chk "BLOCKED → blocked" "$(status_of "$id3")" "blocked"
-[[ -d "$TMP/.task-work/$id3" ]] && ok "3) blocked: task-work 잔존" || bad "3) blocked: task-work 잔존"
+[[ -f "$TMP/.autopilot/runs/$id3/SPEC.md" ]] && ok "3) blocked: run-dir(SPEC) 잔존" || bad "3) blocked: run-dir(SPEC) 잔존"
 [[ -d "$TMP/.review/tasks/$id3" ]] && ok "3) blocked: review 상태 잔존" || bad "3) blocked: review 상태 잔존"
 
-# 4) ROOT_DIR 회귀: 링크드 워크트리 안에서 호출해도 run_dir 이 메인 리포 루트에 생성됨
+# 4) ROOT_DIR 회귀: 링크드 워크트리(.autopilot/runs/<id>/.worktree — materialize 파생 실전 위치)
+#    안에서 호출해도 run_dir 이 메인 리포 루트에 생성되고 워크트리 내부에 중첩 생성이 없음.
+#    merge 실패 mock 으로 done-정리를 억제해 증거(review_entered·중첩 디렉토리)를 보존한 채 단정한다.
 T2="$(mktemp -d)"
 trap 'rm -rf "$TMP" "$T2"' EXIT
 git init -q "$T2"
 git -C "$T2" config user.email t@t
 git -C "$T2" config user.name t
 git -C "$T2" commit -q --allow-empty -m "init"
-git -C "$T2" worktree add -q "$T2/.task-work/wt" --detach
+git -C "$T2" worktree add -q "$T2/.autopilot/runs/wt_task/.worktree" --detach
 # 완전 목 어댑터 (git root 비의존 — adapter.sh 는 --show-toplevel 기반이어서 worktree 내에서 오동작)
 mkdir -p "$T2/bin"
 cat > "$T2/bin/adapter_wt" << AMOCK
 #!/usr/bin/env bash
 case "\$1" in
-  materialize) echo '{"spec_path":"$T2/.task-work/wt_task/SPEC.md"}';;
+  materialize) echo '{"spec_path":"$T2/.autopilot/runs/wt_task/SPEC.md"}';;
   claim)        echo '{"claimed":true}';;
   renew_lease|set_status|append_log) exit 0;;
   *) exit 0;;
 esac
 AMOCK
 chmod +x "$T2/bin/adapter_wt"
+# merge 실패 mock forge: blocked 로 끝나 정리가 없다 → run_dir 위치 증거 보존
+cat > "$T2/bin/forge_wt" <<'FMOCK'
+#!/usr/bin/env bash
+case "$1" in
+  integrate) echo "branch: feat/x"; echo "pr: 7"; exit 0;;
+  review) exit 20;;
+  merge) exit 1;;
+  *) exit 0;;
+esac
+FMOCK
+chmod +x "$T2/bin/forge_wt"
 touch "$T2/dummy.md"
 # 링크드 워크트리 안에서 execute-task.sh 실행 (run_dir 생성 지점까지 도달: --stop-at review 없음)
-(cd "$T2/.task-work/wt"
- ADAPTER_CMD="bash $T2/bin/adapter_wt" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+(cd "$T2/.autopilot/runs/wt_task/.worktree"
+ ADAPTER_CMD="bash $T2/bin/adapter_wt" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $T2/bin/forge_wt" \
  MOCK_RESULT=DONE HEARTBEAT_INTERVAL=1 APPROVAL_CHECK_CMD=true BLOCKING_CHECK_CMD=true SLEEP_CMD=: \
  bash "$ET" start wt_task >/dev/null 2>&1 || true)
-# done 후 run_dir(leaf) 삭제됐지만 parent 가 $T2 에 있으면 ROOT_DIR 이 올바르게 결정된 것
-[[ -d "$T2/.autopilot/runs" ]] \
+[[ -f "$T2/.autopilot/runs/wt_task/review_entered" ]] \
   && ok "4) worktree-내-호출 → run_dir 메인 루트 생성" \
   || bad "4) worktree-내-호출 → run_dir 메인 루트 생성"
+[[ ! -d "$T2/.autopilot/runs/wt_task/.worktree/.autopilot" ]] \
+  && ok "4) worktree-내-호출 → 워크트리 내부 중첩 미생성" \
+  || bad "4) worktree-내-호출 → 워크트리 내부 중첩 미생성"
 
-# 5) status=done 선제 가드: 잔존 .task-work/.autopilot 디렉토리 정리 + 파이프라인(loop) 미재실행(#541)
+# 5) status=done 선제 가드: 잔존 .autopilot/runs/<id> 디렉토리 정리 + 파이프라인(loop) 미재실행(#541)
 id5="$(bash "$ADAPTER" create_task --title "T5" --body '## 목표'$'\n'w | jq -r .task_id)"
 bash "$ADAPTER" set_status --task-id "$id5" --status done >/dev/null
-mkdir -p "$TMP/.task-work/$id5" "$TMP/.autopilot/runs/$id5" "$TMP/.review/tasks/$id5"
-touch "$TMP/.task-work/$id5/SPEC.md" "$TMP/.autopilot/runs/$id5/LOG.md"
+mkdir -p "$TMP/.autopilot/runs/$id5" "$TMP/.review/tasks/$id5"
+touch "$TMP/.autopilot/runs/$id5/SPEC.md" "$TMP/.autopilot/runs/$id5/LOG.md"
 rm -f "$TMP/loop.start.called"
 run start "$id5" >/dev/null
-[[ ! -d "$TMP/.task-work/$id5" ]] && ok "5) done 선제: task-work 정리" || bad "5) done 선제: task-work 정리"
 [[ ! -d "$TMP/.autopilot/runs/$id5" ]] && ok "5) done 선제: run-dir 정리" || bad "5) done 선제: run-dir 정리"
 [[ ! -d "$TMP/.review/tasks/$id5" ]] && ok "5) done 선제: review 상태 정리" || bad "5) done 선제: review 상태 정리"
 chk "5) done 선제: status 유지" "$(status_of "$id5")" "done"
 [[ ! -f "$TMP/loop.start.called" ]] && ok "5) done 선제: 파이프라인 미재실행(loop 미호출)" || bad "5) done 선제: 파이프라인 미재실행(loop 미호출)"
 
-# 6) 멱등: 두 디렉토리 모두 이미 없는 상태에서 재호출해도 에러·디렉토리 생성 없이 안전 종료
+# 6) 멱등: 디렉토리가 이미 없는 상태에서 재호출해도 에러·디렉토리 생성 없이 안전 종료
 run start "$id5" >/dev/null
-[[ ! -d "$TMP/.task-work/$id5" && ! -d "$TMP/.autopilot/runs/$id5" ]] \
+[[ ! -d "$TMP/.autopilot/runs/$id5" ]] \
   && ok "6) 멱등 재호출: 디렉토리 미생성" || bad "6) 멱등 재호출: 디렉토리 미생성"
 
 # 7) forge-단계 재진입 보존: review_entered 표지가 있으면 loop cleanup 을 건너뛴다(완료된 .worktree 보존)
@@ -143,5 +156,12 @@ id8="$(bash "$ADAPTER" create_task --title "T8" --body '## 목표'$'\n's | jq -r
 rm -f "$TMP/loop.cleanup.called"
 MOCK_RESULT=DONE run start "$id8" >/dev/null
 [[ -f "$TMP/loop.cleanup.called" ]] && ok "8) loop-단계: loop cleanup 정상 호출" || bad "8) loop-단계: loop cleanup 정상 호출"
+
+# 9) 레거시 경로 부재(#580): 플러그인 런타임 코드·계약 문서·스킬 문서에 .task-work 참조 없음
+if grep -rq '\.task-work' "$HERE/../../../plugins/autopilot"; then
+  bad "9) 플러그인 내 .task-work 참조 부재"; grep -rn '\.task-work' "$HERE/../../../plugins/autopilot" | head -5
+else
+  ok "9) 플러그인 내 .task-work 참조 부재"
+fi
 
 echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail


### PR DESCRIPTION
## 요약


태스크 실행 런타임 산출물 디렉토리 `.task-work/`를 폐지하고, 그 내용물을 기존
`.autopilot/runs/<태스크 id>/`로 완전 통합한다. materialize 임시 SPEC(+파생 워크트리)은
`.autopilot/runs/<태스크 id>/` 안에 생성되고, filesystem 백엔드의 claim 락은
`.autopilot/runs/.claims/<태스크 id>`로 이동한다. 결과적으로 태스크 하나의 런타임 상태가
디렉토리 하나에 모이고, 최상위 런타임 dotdir 는 `.autopilot/` 하나가 된다.

## 작업 내용

무엇을: 태스크 런타임 산출물 `.task-work/` 를 `.autopilot/runs/` 로 완전 통합 (#580, commit c9e49fa, autopilot 0.63.0)

왜: `.task-work/<id>/` 와 `.autopilot/runs/<id>/` 는 수명주기가 항상 쌍인데 별도 최상위 dotdir 로 존재해 쌍 정리 부기·gitignore 이중 항목·경로 산재를 만들었다 — 한 태스크의 런타임 상태를 디렉토리 하나로 모으고 최상위 런타임 dotdir 를 `.autopilot/` 하나로 단일화.

변경 요지:
- materialize 임시 SPEC → `.autopilot/runs/<id>/SPEC.md` (filesystem·github·beads 세 백엔드 동일)
- filesystem claim 락 → `.autopilot/runs/.claims/<id>` (원자적 mkdir CAS·종단 상태 해제 유지)
- execute-task: done 정리·done 선제 가드 새 경로 갱신, blocked/stop-at review 보존 유지
- contract.md: 경로 갱신 + `.claims` 는 runs/ 아래 유일한 비-태스크-id 항목 명시(향후 순회 코드 제외 근거)
- SKILL.md·forge integration selftest 경로 갱신, PR 본문 임시 경로 누출 단정을 `.autopilot/runs` 기준으로 전환
- .gitignore: `.task-work/` 레거시 잔재-보호 항목 유지(.conductor/ 패턴), CHANGELOG 기록
- 버전 0.63.0 (MINOR — 사용자 확정) plugin.json + marketplace.json 동일 커밋 동기화

검증(fresh, 0 exit): task-backend 테스트 2종 + execute-task 테스트 7종(sigkill 포함) + forge selftest + adapter selftest. RED→GREEN 준수(경로 단정 5건 선행 실패 확인). 플러그인 런타임·계약·스킬 문서 `.task-work` 참조 0 (grep 가드 테스트 케이스 9 신설). 적대 렌즈 3종(contrarian·minimalist·constraint-auditor) 발견 전부 SPEC 명시 결정 범위 내로 판정 — 미해결 의심 없음.

알려진 수용 리스크(SPEC 비-목표 소관): 업그레이드 전환기에 구 `.task-work/.claims` 락은 새 코드에 비가시 — 신선 lease 태스크는 list_ready 미노출이라 자동 드레인으로는 발동하지 않고, 실행 중 태스크의 수동 재시작에서만 성립(잔재 방치는 사용자 확정 결정).
