### PR TITLE
🤖 [자동 리뷰] loop scope 게이트가 scope-coverage 검사의 디렉토리 표기 경로를 거부해 false HALT — 경로 의미론 일치

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
-## project-init 0.24.6
+## autopilot 0.63.1
 
-### 변경(호환)
-- **version-control-rule-creator: SKILL.md 슬림화 — references 분리·결정적 스크립트화 (#586)** — 백엔드 판별·입력 치환의 상세 산문을 SKILL.md 인라인에서 걷어내 `references/backend-detection.md`·`references/input-substitution.md`로 위임하고, 파일명 파싱·git 계열 분류·옵션 값 집계를 결정적 스크립트 `references/template_tools.py`(`parse-name`·`git-family`·`aggregate`) 단일 출처로 일원화했다. git 계열 멤버십(`github`·`gitlab`)은 이제 스크립트의 `GIT_FAMILY` 집합이 유일한 정의처이며 SKILL.md 산문과 이중 기술하지 않는다. 사람 대상 `README.md`를 추가하고 동작 명세 단일 출처로 SKILL.md를 가리킨다. 스킬 외부 동작(트리거·호출 인터페이스·생성 파일 경로·내용 계약)은 불변(문서·구조 리팩터, PATCH). 스킬 내부 구조 테스트 2종(git-common-force-push·review-approval-merge-method)에 references 구조·위임 계약 단정을 더하고, 스크립트 회귀 테스트 `template_tools.test.sh`를 추가했다. (codex-plugin.json 버전 동기는 본 변경 scope 밖이라 후속으로 처리 — versioning.md parity 예외.)
+### 버그 수정
+- **loop scope 게이트가 후행 `/` 디렉토리 표기를 수용 (#584)** — SPEC frontmatter 경로 필드의 표기 의미론을 정합화했다. `diff_vs_scope` 의 include/exclude 판정이 bash 글롭(`[[ $file == $inc ]]`)이라 후행 `/` 디렉토리 표기(`dir/`)가 `dir/file` 과 매치되지 않아, create-task 의 scope-coverage 검사가 제안한 디렉토리 경로를 그대로 `scope.include` 에 넣으면 그 아래 파일 수정이 false scope-violation HALT 를 일으켰다(#580 실행에서 관찰). 이제 include/exclude 판정에서 후행 `/` 항목만 prefix(디렉토리 하위 전체) 매칭하고 그 외 표기(글롭 `**`·정확 경로)는 기존 동작을 유지한다 — `test_sweep_paths`(git pathspec)·scope-coverage(prefix)와 표기 의미론이 일치한다. 경로 표기 관례(수용 형식·매칭 의미론)의 단일 출처는 `skills/loop/SKILL.md` "Scope 경로 표기" 이고, scope-coverage-map·feature/fix 본문 템플릿이 이를 가리킨다. 회귀 가드는 `tests/autopilot/loop/test-loop-scope-dir-notation.sh`.
 
 ## autopilot 0.63.0
 

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/create-task/references/scope-coverage-map.md
+++ b/plugins/autopilot/skills/create-task/references/scope-coverage-map.md
@@ -18,6 +18,10 @@
 `scope.include`의 항목 중 기대 테스트 경로를 **prefix-포함**하거나 **정확히 일치**하면 커버드로 본다.
 예: scope에 `tests/autopilot/` 이나 `tests/autopilot/test-create-task*.sh` 가 있으면 create-task 커버.
 
+이 검사가 누락 경고에 제시하는 디렉토리 경로(후행 `/`, 예 `tests/autopilot/<S>/`)는 loop scope 게이트가
+그대로 수용하는 형식이다 — 제시된 경로를 `scope.include` 에 그대로 넣으면 그 아래 파일 수정이 scope 밖으로
+오탐되지 않는다. 경로 표기 관례(수용 형식·매칭 의미론)의 단일 출처는 `skills/loop/SKILL.md` "Scope 경로 표기".
+
 ## 오탐 방지 조건
 
 - **기존 테스트 없는 신규 소스**: 매핑된 테스트 경로가 파일시스템에 존재하지 않으면 검사하지 않는다. 존재 확인이 전제다.

--- a/plugins/autopilot/skills/feature/references/task-body-template.md
+++ b/plugins/autopilot/skills/feature/references/task-body-template.md
@@ -48,7 +48,7 @@ scope:
 
 - **frontmatter-first** — 본문 첫 줄은 `---`(여는 frontmatter). `scope.include` 는 step 1 인터뷰에서 식별한
   변경 대상 glob 으로 채운다. 불명확하면 보수적으로 넓게 잡고 **위험**에 명시한다.
-- **DoD-요구 테스트 경로 포함** — 완료 조건이 회귀 가드 테스트 추가/수정을 요구하면, 그 테스트 파일·디렉터리 경로를 `scope.include` 에 포함한다.
+- **DoD-요구 테스트 경로 포함** — 완료 조건이 회귀 가드 테스트 추가/수정을 요구하면, 그 테스트 파일·디렉터리 경로를 `scope.include` 에 포함한다(디렉터리는 후행 `/` 표기 — 예 `tests/autopilot/<S>/` — 로 하위 전체를 넣는다; loop scope 게이트가 그 표기를 prefix 로 수용하므로 scope-coverage 가 제시하는 형식을 그대로 써도 된다).
   loop 은 scope 밖 파일을 쓰면 halt 하므로, 완료 조건이 요구하는 산출물(특히 회귀 테스트)은 모두 scope 에 반영해야 RED 테스트를 작성할 수 있다.
   - **#483 (작성자 명시)**: 완료 조건이 요구하는 **새** 회귀 테스트 경로 — 작성자가 scope.include에 명시.
   - **scope-coverage (#498, 시스템 검증)**: scope 내 소스를 덮는 **기존** 테스트 경로 누락 — 등록 시 create-task가 자동 플래그.

--- a/plugins/autopilot/skills/fix/references/task-body-template.md
+++ b/plugins/autopilot/skills/fix/references/task-body-template.md
@@ -65,7 +65,7 @@ scope:
 
 - **frontmatter-first** — 본문 첫 줄은 `---`(여는 frontmatter). `scope.include` 는 step 2 정적 진단에서 식별한
   변경 대상 glob 으로 채운다. 불명확하면 보수적으로 넓게 잡고 **위험**에 명시한다.
-- **DoD-요구 테스트 경로 포함** — 완료 조건이 회귀 가드 테스트 추가/수정을 요구하면, 그 테스트 파일·디렉터리 경로를 `scope.include` 에 포함한다.
+- **DoD-요구 테스트 경로 포함** — 완료 조건이 회귀 가드 테스트 추가/수정을 요구하면, 그 테스트 파일·디렉터리 경로를 `scope.include` 에 포함한다(디렉터리는 후행 `/` 표기 — 예 `tests/autopilot/<S>/` — 로 하위 전체를 넣는다; loop scope 게이트가 그 표기를 prefix 로 수용하므로 scope-coverage 가 제시하는 형식을 그대로 써도 된다).
   loop 은 scope 밖 파일을 쓰면 halt 하므로, 완료 조건이 요구하는 산출물(특히 회귀 테스트)은 모두 scope 에 반영해야 RED 테스트를 작성할 수 있다.
   - **#483 (작성자 명시)**: 완료 조건이 요구하는 **새** 회귀 테스트 경로 — 작성자가 scope.include에 명시.
   - **scope-coverage (#498, 시스템 검증)**: scope 내 소스를 덮는 **기존** 테스트 경로 누락 — 등록 시 create-task가 자동 플래그.

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -61,6 +61,20 @@ driver 동작: 검증 → lock 획득 → 작업 공간 준비(헌법을 `CLAUDE
 
 driver 인터페이스의 self-emit 단일 출처: `loop.sh env`(환경 변수) · `loop.sh gates`(객관 게이트) · `loop.sh paths <spec>`(계산된 경로) · `loop.sh deps`(의존성 + 설치 상태). 지침은 본문에 중복 열거하지 않고 이 subcommand 를 가리킨다.
 
+## Scope 경로 표기 (표기 관례 단일 출처)
+
+SPEC frontmatter 의 경로 필드(`scope.include`·`scope.exclude`·`test_sweep_paths`)가 수용하는 표기와 매칭 의미론의 단일 출처다. driver(`loop.sh`)의 scope 게이트가 이 관례로 변경 파일을 판정한다.
+
+| 표기 | 예 | 매칭 |
+|---|---|---|
+| 글롭 | `app/**`, `**/*.py` | bash 패턴 매칭(`*` 는 `/` 포함 임의 문자열) |
+| 정확 경로 | `lib/beta.py` | 그 파일 하나 |
+| 디렉토리(후행 `/`) | `pkg/tests/` | 그 디렉토리 하위 전체(깊이 무관) prefix 매칭 |
+
+- 세 필드 모두 위 표기를 동일하게 해석한다 — 디렉토리 표기는 하위 파일을 재귀 포함한다(`test_sweep_paths` 는 git pathspec 로 동일 결과).
+- `scope.include`·`scope.exclude` 의 디렉토리 표기는 **후행 `/` 가 붙은 항목에만** prefix 의미론을 적용한다. 후행 `/` 가 없으면 글롭·정확 경로로 해석해 기존 표기 동작을 바꾸지 않는다.
+- create-task 의 scope-coverage 검사가 누락 경고에 제시하는 디렉토리 경로(후행 `/`)를 그대로 `scope.include` 에 넣으면 이 게이트가 수용한다.
+
 ## references
 
 | 파일 | 역할 |

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -424,6 +424,20 @@ resolve_base_ref() {
   git -C "$repo" rev-parse HEAD
 }
 
+# scope 경로 표기 매칭. 표기 관례 SoT: skills/loop/SKILL.md "Scope 경로 표기".
+#   - 후행 '/' 항목: prefix(디렉토리 하위 전체) 매칭 — `dir/` 가 `dir/a/b` 를 매치.
+#   - 그 외: bash 글롭 매칭(기존 동작 유지) — `**`·`*`·정확 경로.
+# 반환: 매치 0, 비매치 1.
+path_matches_pattern() {
+  local file="$1" pat="$2"
+  if [[ "$pat" == */ ]]; then
+    [[ "$file" == "$pat"* ]]
+  else
+    # shellcheck disable=SC2053
+    [[ "$file" == $pat ]]
+  fi
+}
+
 # 변경 파일이 scope.include 안인지 검사. 위반 파일 목록 출력(있으면).
 diff_vs_scope() {
   local base_sha="$1"
@@ -442,8 +456,7 @@ diff_vs_scope() {
     local excluded=0
     while IFS= read -r exc; do
       [[ -z "$exc" ]] && continue
-      # shellcheck disable=SC2053
-      if [[ "$file" == $exc ]]; then
+      if path_matches_pattern "$file" "$exc"; then
         out_of_scope+="$file (excluded by $exc)\n"; excluded=1; break
       fi
     done <<< "$exclude_patterns"
@@ -452,8 +465,7 @@ diff_vs_scope() {
     local matched=0
     while IFS= read -r inc; do
       [[ -z "$inc" ]] && continue
-      # shellcheck disable=SC2053
-      if [[ "$file" == $inc ]]; then matched=1; break; fi
+      if path_matches_pattern "$file" "$inc"; then matched=1; break; fi
     done <<< "$include_patterns"
     [[ $matched -eq 0 ]] && out_of_scope+="$file (not in include)\n"
   done <<< "$changed"

--- a/tests/autopilot/loop/test-loop-scope-dir-notation.sh
+++ b/tests/autopilot/loop/test-loop-scope-dir-notation.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# test-loop-scope-dir-notation.sh
+#
+# 회귀 가드 (#584): loop scope 게이트가 후행 '/' 디렉토리 표기 include/exclude 항목을
+# prefix(디렉토리 하위 전체) 매칭으로 수용해야 한다. 그래야 scope-coverage 검사가 제안하는
+# 디렉토리 표기(`plugins/autopilot/task-backend/tests/` 등)를 그대로 scope.include 에 넣어도
+# 그 아래 파일 수정이 false scope-violation HALT 를 내지 않는다.
+#
+# 동시에 기존 표기(글롭 `**`·정확 파일 경로)의 판정 동작은 회귀 없이 유지되어야 한다.
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOOP_SH="$SCRIPT_DIR/../../../plugins/autopilot/skills/loop/references/loop.sh"
+
+command -v git >/dev/null 2>&1 || { echo "SKIP: git 미설치"; exit 0; }
+command -v yq  >/dev/null 2>&1 || { echo "SKIP: yq 미설치"; exit 0; }
+
+# loop.sh 를 source 해 함수만 사용 (dispatcher 는 BASH_SOURCE guard 로 비실행).
+# shellcheck source=../../../plugins/autopilot/skills/loop/references/loop.sh
+source "$LOOP_SH"
+set +e   # loop.sh 가 켠 errexit 해제 — 테스트가 조건 분기를 직접 제어
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# --- Part A: path_matches_pattern 단위 판정 -------------------------------------
+# in(0)/out(1) 판정을 문자열로 단정.
+check() {
+  local file="$1" pat="$2" want="$3" desc="$4"
+  path_matches_pattern "$file" "$pat"; local got=$?
+  [[ "$got" -eq "$want" ]] || fail "$desc — path_matches_pattern '$file' '$pat' = $got, 기대 $want"
+}
+
+# 후행 '/' 디렉토리 표기: 직속·하위 깊이 파일 모두 매치.
+check "plugins/autopilot/task-backend/tests/test-filesystem.sh" "plugins/autopilot/task-backend/tests/" 0 "디렉토리 직속 파일"
+check "tests/autopilot/execute-task/sub/deep.sh"                "tests/autopilot/execute-task/"          0 "디렉토리 하위 깊이 파일"
+# 후행 '/' 디렉토리는 접두 문자열만 같은 형제 경로를 매치하지 않음.
+check "tests-foo/x.sh"                                          "tests/"                                 1 "형제 디렉토리 비매치"
+check "tests"                                                  "tests/"                                 1 "디렉토리명 자체(파일 아님) 비매치"
+
+# 기존 글롭 표기 회귀: '**' 는 하위 매치, 비매치는 out.
+check "app/main.py"        "app/**" 0 "글롭 ** 하위 매치"
+check "other/main.py"      "app/**" 1 "글롭 ** 범위 밖 비매치"
+# 기존 정확 파일 경로 회귀.
+check "lib/beta.py"        "lib/beta.py" 0 "정확 경로 매치"
+check "lib/other.py"       "lib/beta.py" 1 "정확 경로 비매치"
+
+echo "PASS(A): path_matches_pattern 디렉토리 표기 prefix + 글롭·정확경로 회귀"
+
+# --- Part B: diff_vs_scope 통합 — 디렉토리 표기 include 아래 커밋은 위반 아님 ------
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+repo="$tmp/repo"
+mkdir -p "$repo"
+( cd "$repo"
+  git init -q
+  git config user.email t@e.com
+  git config user.name T
+  mkdir -p pkg/tests
+  echo "base" > README.md
+  git add README.md
+  git commit -q -m "base" --no-verify
+) || fail "repo 셋업 실패"
+
+base_sha="$(cd "$repo" && git rev-parse HEAD)"
+
+SPEC_PATH="$tmp/spec.md"
+cat > "$SPEC_PATH" <<'SPEC'
+---
+scope:
+  include:
+    - pkg/tests/
+  exclude:
+    - rules/**
+---
+# 제목
+SPEC
+
+# diff_vs_scope 가 참조하는 워크트리 전역.
+WT="$repo"
+
+# 디렉토리 표기 include 아래 파일을 커밋 → in-scope 여야 함(위반 출력 없음).
+( cd "$repo"
+  echo "print('x')" > pkg/tests/test_x.py
+  git add pkg/tests/test_x.py
+  git commit -q -m "feat: in-dir file" --no-verify
+) || fail "in-scope 커밋 실패"
+
+_SCOPE_YAML_KEY=""   # 캐시 무효화
+viol="$(diff_vs_scope "$base_sha")"
+[[ -z "$viol" ]] || fail "디렉토리 표기 include 아래 파일이 scope 위반으로 오탐: [$viol]"
+
+echo "PASS(B): diff_vs_scope 디렉토리 표기 include 아래 파일 in-scope"
+echo "PASS: #584 scope 게이트 디렉토리 표기 수용"


### PR DESCRIPTION
## 요약


SPEC frontmatter 경로 필드들의 표기 의미론을 일치시킨다. scope-coverage 검사가 제안하는 경로
형식을 그대로 `scope.include`에 넣으면 loop의 scope 게이트가 그 형식을 수용해, 디렉토리 표기
항목 아래 파일 수정이 false scope-violation HALT를 일으키지 않게 한다. 경로 표기 관례는 한
문서에 단일 정의된다.

## 작업 내용

#584 완료: loop scope 게이트가 후행 '/' 디렉토리 표기를 수용하도록 표기 의미론 정합화.

변경:
- loop.sh: path_matches_pattern 헬퍼 추가 — 후행 '/' 항목만 prefix 매칭, 그 외 글롭·정확
  경로는 기존 동작 유지. diff_vs_scope include/exclude 판정에 적용.
- loop/SKILL.md: "Scope 경로 표기" — 세 경로 필드(include/exclude/test_sweep_paths) 표기
  관례 단일 출처.
- scope-coverage-map.md·feature/fix 본문 템플릿: SoT 참조로 정합화, 디렉토리 표기 수용 명시.
- CHANGELOG + plugin.json 0.63.0→0.63.1 (fix=PATCH).
- 회귀 가드: tests/autopilot/loop/test-loop-scope-dir-notation.sh (RED→GREEN).

검증: 전체 테스트 스윕 16개 + loop frontmatter 테스트 모두 0 exit. 변경 8파일 전부 scope 내.
완료 조건 5개 전부 충족. 4-Level Verifier·Self-Review·적대 렌즈 통과.
