### PR TITLE
🤖 [자동 리뷰] fix: 리뷰 CI self thread-resolve fallback이 증분 범위 밖 blocking 지적을 오해소

### DIFF
--- a/.github/scripts/diff-anchor-filter.js
+++ b/.github/scripts/diff-anchor-filter.js
@@ -78,10 +78,11 @@ function parseDiffRightLines(patch) {
   return map;
 }
 
-// Resolve the RIGHT-side file path from a `+++ ` header value (the part after
-// "+++ "). Returns null for /dev/null (deleted file). Strips the conventional
-// `b/` prefix and unwraps git's C-quoted paths for names with special chars.
-function parseNewPath(raw) {
+// Resolve the file path from a `+++ `/`--- ` header value (the part after the
+// four-char prefix). Returns null for /dev/null (added/deleted side). Strips
+// the conventional side prefix (`b/` or `a/`) and unwraps git's C-quoted
+// paths for names with special chars.
+function parseDiffSidePath(raw, sidePrefix) {
   let p = raw;
   // git may append a trailing tab + timestamp in some diff variants; cut it.
   const tab = p.indexOf('\t');
@@ -92,8 +93,12 @@ function parseNewPath(raw) {
     // Minimal C-style unquote for git's quoted paths.
     try { p = JSON.parse(p); } catch { p = p.slice(1, -1); }
   }
-  if (p.startsWith('b/')) p = p.slice(2);
+  if (p.startsWith(sidePrefix)) p = p.slice(sidePrefix.length);
   return p;
+}
+
+function parseNewPath(raw) {
+  return parseDiffSidePath(raw, 'b/');
 }
 
 // Compute the anchor line(s) the workflow will submit for a finding, mirroring
@@ -216,6 +221,46 @@ function parseContextRightLineMap(contextText) {
   return map;
 }
 
+// Collect the file paths that appear in a model-facing context's unified diff
+// (after the first `Unified diff:` marker line) — the set of files actually
+// handed to this review chunk. Both diff sides are included: the new
+// (`+++ b/`) path and the old (`--- a/`) path, so renamed and deleted files
+// still count as part of the reviewed scope. Header lines inside hunk bodies
+// (e.g. a removed line whose content starts with `-- `) are not parsed as
+// paths. Returns a Set of paths; no marker → empty set (conservative).
+//
+// Used by the review workflows' self thread-resolve FALLBACK tier: a finding
+// whose anchor file is NOT in this round's reviewed scope is simply not
+// re-reportable this round — its absence from the findings set means nothing,
+// so its thread must not be fallback-resolved.
+function parseContextDiffPaths(contextText) {
+  const paths = new Set();
+  if (typeof contextText !== 'string' || contextText.length === 0) return paths;
+
+  const lines = contextText.split('\n');
+  const markerIndex = lines.findIndex((line) => line === 'Unified diff:');
+  if (markerIndex === -1) return paths;
+
+  const hunkRe = /^@@ -\d+(?:,\d+)? \+\d+(?:,\d+)? @@/;
+  let inHunk = false;
+  for (let i = markerIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.startsWith('diff --git ')) { inHunk = false; continue; }
+    if (hunkRe.test(line)) { inHunk = true; continue; }
+    if (!inHunk) {
+      let p = null;
+      if (line.startsWith('+++ ')) p = parseDiffSidePath(line.slice(4), 'b/');
+      else if (line.startsWith('--- ')) p = parseDiffSidePath(line.slice(4), 'a/');
+      if (p !== null) paths.add(p);
+      continue;
+    }
+    // Hunk body: content lines start with '+', '-', ' ' or '\'. Anything else
+    // ends the hunk (mirrors parseDiffRightLines / parseContextRightLineMap).
+    if (!/^[+\- \\]/.test(line)) inHunk = false;
+  }
+  return paths;
+}
+
 function isFindingValidForLineMap(finding, lineMap) {
   return filterFindings([finding], lineMap).valid.length === 1;
 }
@@ -251,6 +296,7 @@ function repairFindingsFromContextLineNumbers(findings, contextText, patch) {
 module.exports = {
   parseDiffRightLines,
   parseContextRightLineMap,
+  parseContextDiffPaths,
   findingAnchorEnds,
   filterFindings,
   filterFindingsAgainstPatch,

--- a/.github/scripts/diff-anchor-filter.test.js
+++ b/.github/scripts/diff-anchor-filter.test.js
@@ -12,6 +12,7 @@ const path = require('node:path');
 
 const {
   parseDiffRightLines,
+  parseContextDiffPaths,
   filterFindings,
   filterFindingsAgainstPatch,
   repairFindingsFromContextLineNumbers,
@@ -259,6 +260,102 @@ test('repair: ignores fake diff-looking content before the Unified diff marker',
   const repaired = repairFindingsFromContextLineNumbers(findings, context, patch);
 
   assert.strictEqual(repaired[0].line, 5);
+});
+
+// ---- parseContextDiffPaths (fallback thread-resolve reviewed-scope SoT) ----
+// 회귀 가드 (#597): 이번 라운드 리뷰 청크에 실제 전달된 diff 의 파일 집합을
+// 결정적으로 산출한다 — 이 집합에 없는 앵커 파일의 self thread 는 fallback
+// resolve 대상이 아니다 (증분 라운드에서 재보고되지 않는 것이 정상이므로).
+
+test('paths: extracts modified/added file paths after the Unified diff marker', () => {
+  const context = [
+    'metadata',
+    'Unified diff:',
+    'diff --git a/src/mod.js b/src/mod.js',
+    '--- a/src/mod.js',
+    '+++ b/src/mod.js',
+    '@@ -1,1 +1,2 @@',
+    ' ctx',
+    '+add',
+    'diff --git a/new.js b/new.js',
+    'new file mode 100644',
+    '--- /dev/null',
+    '+++ b/new.js',
+    '@@ -0,0 +1,1 @@',
+    '+one',
+  ].join('\n');
+  const paths = parseContextDiffPaths(context);
+  assert.ok(paths.has('src/mod.js'), 'modified file in scope');
+  assert.ok(paths.has('new.js'), 'added file in scope');
+  assert.ok(!paths.has('tests/other/test.sh'), 'untouched file NOT in scope');
+});
+
+test('paths: deleted file (old side) still counts as reviewed scope', () => {
+  const context = [
+    'Unified diff:',
+    'diff --git a/gone.js b/gone.js',
+    'deleted file mode 100644',
+    '--- a/gone.js',
+    '+++ /dev/null',
+    '@@ -1,1 +0,0 @@',
+    '-bye',
+  ].join('\n');
+  const paths = parseContextDiffPaths(context);
+  assert.ok(paths.has('gone.js'), 'deleted file path from --- a/ side');
+});
+
+test('paths: rename includes both old and new path', () => {
+  const context = [
+    'Unified diff:',
+    'diff --git a/old/name.js b/new/name.js',
+    'similarity index 90%',
+    'rename from old/name.js',
+    'rename to new/name.js',
+    '--- a/old/name.js',
+    '+++ b/new/name.js',
+    '@@ -1,1 +1,1 @@',
+    '-x',
+    '+y',
+  ].join('\n');
+  const paths = parseContextDiffPaths(context);
+  assert.ok(paths.has('old/name.js'), 'old side');
+  assert.ok(paths.has('new/name.js'), 'new side');
+});
+
+test('paths: no marker → empty set (conservative: nothing in scope)', () => {
+  const context = [
+    'diff --git a/x.js b/x.js',
+    '--- a/x.js',
+    '+++ b/x.js',
+    '@@ -1,1 +1,1 @@',
+    '-a',
+    '+b',
+  ].join('\n');
+  assert.strictEqual(parseContextDiffPaths(context).size, 0);
+});
+
+test('paths: ignores diff-looking content before the marker and inside hunks', () => {
+  const context = [
+    '+++ b/fake-header-before-marker.js',
+    'Unified diff:',
+    'diff --git a/real.js b/real.js',
+    '--- a/real.js',
+    '+++ b/real.js',
+    '@@ -1,2 +1,3 @@',
+    ' ctx',
+    '--- removed line whose content starts with dashes',
+    '+++ added line whose content starts with pluses',
+  ].join('\n');
+  const paths = parseContextDiffPaths(context);
+  assert.ok(paths.has('real.js'));
+  assert.ok(!paths.has('fake-header-before-marker.js'), 'pre-marker header ignored');
+  assert.strictEqual(paths.size, 1, 'hunk content lines not parsed as headers');
+});
+
+test('paths: non-string / empty input → empty set', () => {
+  assert.strictEqual(parseContextDiffPaths('').size, 0);
+  assert.strictEqual(parseContextDiffPaths(null).size, 0);
+  assert.strictEqual(parseContextDiffPaths(undefined).size, 0);
 });
 
 console.log(`\nALL ${passed} CHECKS PASSED`);

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -825,8 +825,9 @@ jobs:
               try { fs.accessSync('.claude-review/result.json'); resultFiles = ['.claude-review/result.json']; } catch {}
             }
             let repairFindingsFromContextLineNumbers = null;
+            let parseContextDiffPaths = null;
             try {
-              ({ repairFindingsFromContextLineNumbers } =
+              ({ repairFindingsFromContextLineNumbers, parseContextDiffPaths } =
                 require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/diff-anchor-filter.js`));
             } catch (e) {
               core.warning(`Shared context-line anchor repair unavailable in trusted-base checkout (${e.message}); findings will use model-provided anchors.`);
@@ -844,6 +845,9 @@ jobs:
                 const chunkMatch = p.match(/result\.chunk-(\d+)\.json$/);
                 const chunk = chunkMatch ? chunkMatch[1] : '0';
                 const contextPath = `.claude-review/context.chunk-${chunk}.md`;
+                // Remembered so the thread-resolve fallback tier can derive the
+                // reviewed-scope file set from the exact context this chunk saw.
+                result.__contextPath = contextPath;
                 if (repairFindingsFromContextLineNumbers && anchorPatch && Array.isArray(result.findings)) {
                   let contextText = '';
                   try { contextText = fs.readFileSync(contextPath, 'utf8'); }
@@ -1158,7 +1162,9 @@ jobs:
             // duplicate. Two tiers:
             //   (1) primary  — fingerprints the model listed in resolved_threads;
             //   (2) fallback — self threads whose fingerprint is absent from this
-            //                   round's MERGED findings set (no longer reported).
+            //                   round's MERGED findings set (no longer reported)
+            //                   AND whose anchor file was part of this round's
+            //                   reviewed scope (see reviewedPaths below).
             // A self thread whose fingerprint is still in the findings set (and not
             // in resolved_threads) is left untouched. Only self-owned threads are
             // touched; threads whose marker has no extractable fingerprint are left
@@ -1173,6 +1179,32 @@ jobs:
             // (workflow-computed, not model-supplied) — the fallback tier resolves
             // any self thread whose fingerprint is absent from this set.
             const findingFingerprints = new Set(findings.map((f) => computeFingerprint(f)));
+            // Reviewed-scope gate for the fallback tier (#597). An incremental
+            // review round only reviews the incremental diff, so a finding whose
+            // anchor file was NOT part of this round's reviewed chunks is simply
+            // not re-reportable this round — its absence from the findings set
+            // means "not looked at", not "resolved". The scope SoT is the file
+            // list actually handed to the review chunks (each reviewed chunk's
+            // context file). If the scope cannot be derived (older trusted-base
+            // module, unreadable context), the set stays empty and the fallback
+            // tier is conservatively disabled for this run — the resolved_threads
+            // tier is unaffected.
+            const reviewedPaths = new Set();
+            if (typeof parseContextDiffPaths === 'function') {
+              for (const r of reviewedResults) {
+                if (!r.__contextPath) continue;
+                try {
+                  for (const p of parseContextDiffPaths(fs.readFileSync(r.__contextPath, 'utf8'))) reviewedPaths.add(p);
+                } catch (e) {
+                  core.warning(`Could not read ${r.__contextPath} for the fallback resolve scope (${e.message}).`);
+                }
+              }
+            } else {
+              core.warning('parseContextDiffPaths unavailable in trusted-base checkout; expected on the PR that introduces or modifies it.');
+            }
+            if (reviewedPaths.size === 0) {
+              core.warning('No reviewed-scope paths derived; fallback thread resolve disabled this run (resolved_threads tier unaffected).');
+            }
             try {
               const threadResp = await github.graphql(`
                 query($owner:String!, $repo:String!, $pr:Int!) {
@@ -1182,6 +1214,7 @@ jobs:
                         nodes {
                           id
                           isResolved
+                          path
                           comments(first: 1) {
                             nodes { author { login } body }
                           }
@@ -1206,7 +1239,7 @@ jobs:
                 const fp = m && m[1];
                 if (!fp) continue; // legacy/markerless thread — leave untouched
                 const byModel = resolvedFingerprints.has(fp);
-                const byFallback = !byModel && !findingFingerprints.has(fp);
+                const byFallback = !byModel && !findingFingerprints.has(fp) && reviewedPaths.has(t.path);
                 if (!byModel && !byFallback) continue; // still reported — leave
                 try {
                   await github.graphql(`

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -679,8 +679,9 @@ jobs:
               try { fs.accessSync('.codex-review/result.json'); resultFiles = ['.codex-review/result.json']; } catch {}
             }
             let repairFindingsFromContextLineNumbers = null;
+            let parseContextDiffPaths = null;
             try {
-              ({ repairFindingsFromContextLineNumbers } =
+              ({ repairFindingsFromContextLineNumbers, parseContextDiffPaths } =
                 require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/diff-anchor-filter.js`));
             } catch (e) {
               core.warning(`Shared context-line anchor repair unavailable in trusted-base checkout (${e.message}); findings will use model-provided anchors.`);
@@ -704,6 +705,9 @@ jobs:
                 // it — not a never-generated context.chunk file — is what the anchor
                 // repair must read. Restored into .codex-review/ via codex-review-prep.
                 const contextPath = `.codex-review/prompt.chunk-${chunk}.md`;
+                // Remembered so the thread-resolve fallback tier can derive the
+                // reviewed-scope file set from the exact context this chunk saw.
+                result.__contextPath = contextPath;
                 if (repairFindingsFromContextLineNumbers && anchorPatch && Array.isArray(result.findings)) {
                   let contextText = '';
                   try { contextText = fs.readFileSync(contextPath, 'utf8'); }
@@ -1010,7 +1014,9 @@ jobs:
             // duplicate. Two tiers:
             //   (1) primary  — fingerprints the model listed in resolved_threads;
             //   (2) fallback — self threads whose fingerprint is absent from this
-            //                   round's MERGED findings set (no longer reported).
+            //                   round's MERGED findings set (no longer reported)
+            //                   AND whose anchor file was part of this round's
+            //                   reviewed scope (see reviewedPaths below).
             // A self thread whose fingerprint is still in the findings set (and not
             // in resolved_threads) is left untouched. Only self-owned threads are
             // touched; threads whose marker has no extractable fingerprint are left
@@ -1025,6 +1031,32 @@ jobs:
             // (workflow-computed, not model-supplied) — the fallback tier resolves
             // any self thread whose fingerprint is absent from this set.
             const findingFingerprints = new Set(findings.map((f) => computeFingerprint(f)));
+            // Reviewed-scope gate for the fallback tier (#597). An incremental
+            // review round only reviews the incremental diff, so a finding whose
+            // anchor file was NOT part of this round's reviewed chunks is simply
+            // not re-reportable this round — its absence from the findings set
+            // means "not looked at", not "resolved". The scope SoT is the file
+            // list actually handed to the review chunks (each reviewed chunk's
+            // context file). If the scope cannot be derived (older trusted-base
+            // module, unreadable context), the set stays empty and the fallback
+            // tier is conservatively disabled for this run — the resolved_threads
+            // and supersede tiers are unaffected.
+            const reviewedPaths = new Set();
+            if (typeof parseContextDiffPaths === 'function') {
+              for (const r of reviewedResults) {
+                if (!r.__contextPath) continue;
+                try {
+                  for (const p of parseContextDiffPaths(fs.readFileSync(r.__contextPath, 'utf8'))) reviewedPaths.add(p);
+                } catch (e) {
+                  core.warning(`Could not read ${r.__contextPath} for the fallback resolve scope (${e.message}).`);
+                }
+              }
+            } else {
+              core.warning('parseContextDiffPaths unavailable in trusted-base checkout; expected on the PR that introduces or modifies it.');
+            }
+            if (reviewedPaths.size === 0) {
+              core.warning('No reviewed-scope paths derived; fallback thread resolve disabled this run (resolved_threads tier unaffected).');
+            }
             // Supersede tier — fingerprints we ACTUALLY posted as inline comments
             // this round. Only populated when a submission really happened
             // (submitOk): if the submit was skipped as a duplicate or failed, no
@@ -1054,6 +1086,7 @@ jobs:
                         nodes {
                           id
                           isResolved
+                          path
                           comments(first: 1) {
                             nodes { databaseId author { login } body }
                           }
@@ -1104,7 +1137,7 @@ jobs:
                 const fp = m && m[1];
                 if (!fp) continue; // legacy/markerless thread — leave untouched
                 const byModel = resolvedFingerprints.has(fp);
-                const byFallback = !byModel && !findingFingerprints.has(fp);
+                const byFallback = !byModel && !findingFingerprints.has(fp) && reviewedPaths.has(t.path);
                 // Supersede: this is an OLDER duplicate of a fingerprint we just
                 // re-posted (a newer open thread for it survives). Resolve it so
                 // stale [blocking] threads don't accumulate. The finding itself

--- a/tests/claude/test-claude-review-workflow.sh
+++ b/tests/claude/test-claude-review-workflow.sh
@@ -342,6 +342,19 @@ grep -qF 'findings.map((f) => computeFingerprint(f))' "$WORKFLOW" \
 ok "check 7d: 결정론적 fingerprint(file+perspective+title), 줄번호 비의존"
 
 echo ""
+echo "=== check 7e: fallback resolve 는 이번 라운드 검토 범위(reviewedPaths)로 게이트된다 (#597 회귀 가드) ==="
+# 증분 리뷰 라운드는 증분 diff 만 검토하므로, diff 에 앵커 파일이 없는 기존 지적은
+# 재보고되지 않는 것이 정상이다. "이번 라운드 findings 에 지문 없음"만으로 resolve
+# 하면 유효 blocking 지적이 수정·반박 없이 오해소된다 (PR #594 실사고).
+grep -qF 'const byFallback = !byModel && !findingFingerprints.has(fp) && reviewedPaths.has(t.path);' "$WORKFLOW" \
+  || fail "fallback 판정이 reviewedPaths.has(t.path) 로 게이트되지 않음 — 범위 밖 지문 오해소 회귀 (#597)"
+grep -qF 'parseContextDiffPaths' "$WORKFLOW" \
+  || fail "리뷰 청크 컨텍스트(SoT)에서 검토 파일 집합을 산출하는 parseContextDiffPaths 소비 부재 (#597)"
+grep -A5 'reviewThreads(first: 100)' "$WORKFLOW" | grep -qE '^\s+path$' \
+  || fail "GraphQL reviewThreads 조회가 thread 앵커 파일 경로(path)를 가져오지 않음 (#597)"
+ok "check 7e: fallback resolve 검토 범위 게이트 (reviewedPaths + thread path)"
+
+echo ""
 echo "=== check 8: prompt captures token and confidence policies ==="
 grep -q '토큰 최적화 정책' "$PROMPT" \
   || fail "prompt 토큰 최적화 정책 부재"

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -330,6 +330,19 @@ grep -qF 'findings.map((f) => computeFingerprint(f))' "$WORKFLOW" \
 ok "check 16b: 결정론적 fingerprint(file+perspective+title), 줄번호 비의존"
 
 echo ""
+echo "=== check 16c: fallback resolve 는 이번 라운드 검토 범위(reviewedPaths)로 게이트된다 (#597 회귀 가드) ==="
+# 증분 리뷰 라운드는 증분 diff 만 검토하므로, diff 에 앵커 파일이 없는 기존 지적은
+# 재보고되지 않는 것이 정상이다. "이번 라운드 findings 에 지문 없음"만으로 resolve
+# 하면 유효 blocking 지적이 수정·반박 없이 오해소된다 (PR #594 실사고).
+grep -qF 'const byFallback = !byModel && !findingFingerprints.has(fp) && reviewedPaths.has(t.path);' "$WORKFLOW" \
+  || fail "fallback 판정이 reviewedPaths.has(t.path) 로 게이트되지 않음 — 범위 밖 지문 오해소 회귀 (#597)"
+grep -qF 'parseContextDiffPaths' "$WORKFLOW" \
+  || fail "리뷰 청크 컨텍스트(SoT)에서 검토 파일 집합을 산출하는 parseContextDiffPaths 소비 부재 (#597)"
+grep -A5 'reviewThreads(first: 100)' "$WORKFLOW" | grep -qE '^\s+path$' \
+  || fail "GraphQL reviewThreads 조회가 thread 앵커 파일 경로(path)를 가져오지 않음 (#597)"
+ok "check 16c: fallback resolve 검토 범위 게이트 (reviewedPaths + thread path)"
+
+echo ""
 echo "=== check 17: GitHub App 설치 토큰 발급 + 동적 봇 식별 + graceful degradation (AC1/AC2/AC3/AC5/제약) ==="
 # App 설치 토큰 발급 스텝이 SHA 고정 actions/create-github-app-token 으로 존재.
 grep -qE 'uses: actions/create-github-app-token@[0-9a-f]{40}' "$WORKFLOW" \

--- a/tests/codex/test-codex-review-workflow.sh
+++ b/tests/codex/test-codex-review-workflow.sh
@@ -34,14 +34,15 @@ grep -qF '도구가 표시하는 컨텍스트 파일 줄 번호는 소스 파일
 [[ -f "$SCHEMA" ]] || fail "$SCHEMA 부재"
 
 echo "=== check 1: 모델 호출은 공식 openai/codex-action 으로 이뤄진다 (AC1) ==="
-# 1차/2차(needs_context follow-up) 모두 동일한 SHA 고정 action 으로 실행.
+# 1차/2차(needs_context follow-up) 리뷰 + auth-refresh 워밍업(회전 토큰 write-back용
+# 트리비얼 호출) 3곳 모두 동일한 SHA 고정 action 으로 실행.
 codex_action_count="$(grep -cE 'uses: openai/codex-action@[0-9a-f]{40}' "$WORKFLOW")"
-[[ "$codex_action_count" == "2" ]] \
-  || fail "openai/codex-action SHA 고정 호출이 1차/2차 2곳에 없음 (현재 $codex_action_count)"
+[[ "$codex_action_count" == "3" ]] \
+  || fail "openai/codex-action SHA 고정 호출이 1차/2차/auth-refresh 3곳에 없음 (현재 $codex_action_count)"
 if grep -qE 'uses: openai/codex-action@v[0-9.]+' "$WORKFLOW"; then
   fail "openai/codex-action 이 mutable version tag 로 참조됨 — SHA 고정 필요"
 fi
-ok "check 1: openai/codex-action SHA 고정 호출 2곳"
+ok "check 1: openai/codex-action SHA 고정 호출 3곳 (1차/2차/auth-refresh)"
 
 echo ""
 echo "=== check 2: 셸 직접 codex CLI 호출·설치 스텝이 존재하지 않는다 (AC1) ==="
@@ -59,15 +60,18 @@ ok "check 2: codex CLI 직접 호출·설치 스텝 부재"
 echo ""
 echo "=== check 3: codex CLI 버전이 action 버전 입력으로 고정된다 (제약) ==="
 codex_version_count="$(count "codex-version: '0.132.0'" "$WORKFLOW")"
-[[ "$codex_version_count" == "2" ]] \
-  || fail "codex-version 입력이 1차/2차 action 호출 양쪽에 0.132.0 으로 고정되지 않음 (현재 $codex_version_count)"
+[[ "$codex_version_count" == "3" ]] \
+  || fail "codex-version 입력이 1차/2차/auth-refresh action 호출 3곳에 0.132.0 으로 고정되지 않음 (현재 $codex_version_count)"
 ok "check 3: codex-version 입력으로 codex CLI 0.132.0 고정"
 
 echo ""
 echo "=== check 4: ChatGPT auth.json codex-home 부트스트랩 (AC2/제약) ==="
+# 정확히 3곳: review 매트릭스 부트스트랩 env + auth-refresh 부트스트랩 env +
+# write-back 비교용 OLD_AUTH env. 전부 전용 부트스트랩/write-back 스텝의 env 이며
+# 모델 호출 스텝에는 노출되지 않는다.
 secret_count="$(count 'secrets.CODEX_AUTH_JSON' "$WORKFLOW")"
-[[ "$secret_count" == "1" ]] \
-  || fail "secrets.CODEX_AUTH_JSON 참조가 정확히 1곳(부트스트랩 env)이어야 함 — 모델 호출 스텝 노출 금지 (현재 $secret_count) (제약)"
+[[ "$secret_count" == "3" ]] \
+  || fail "secrets.CODEX_AUTH_JSON 참조가 정확히 3곳(부트스트랩 env×2 + write-back OLD_AUTH)이어야 함 — 모델 호출 스텝 노출 금지 (현재 $secret_count) (제약)"
 grep -q 'CODEX_AUTH_JSON:.*secrets\.CODEX_AUTH_JSON' "$WORKFLOW" \
   || fail "CODEX_AUTH_JSON secret env 매핑 부재 (AC2)"
 grep -q 'printf .*> "\$codex_home/auth\.json"' "$WORKFLOW" \
@@ -77,8 +81,8 @@ grep -q 'chmod 600 "\$codex_home/auth\.json"' "$WORKFLOW" \
 grep -q 'codex-home: ${{ env\.CODEX_HOME_DIR }}' "$WORKFLOW" \
   || fail "codex-home 디렉터리를 action 의 codex-home 입력으로 전달하지 않음 (AC2/제약)"
 codex_home_input_count="$(count 'codex-home: ${{ env.CODEX_HOME_DIR }}' "$WORKFLOW")"
-[[ "$codex_home_input_count" == "2" ]] \
-  || fail "codex-home 입력이 1차/2차 action 호출 양쪽에 전달되지 않음 (현재 $codex_home_input_count)"
+[[ "$codex_home_input_count" == "3" ]] \
+  || fail "codex-home 입력이 1차/2차/auth-refresh action 호출 3곳에 전달되지 않음 (현재 $codex_home_input_count)"
 # Placeholder server-info seed: the action's "Read server info" step fires on
 # prompt presence but the proxy that writes that file only runs with an API
 # key. Without the seed the job dies on "Failed to read server info". The seed


### PR DESCRIPTION
## 요약


리뷰 CI(claude-review.yml·codex-review.yml)의 self 인라인 스레드 fallback resolve가, 이번 라운드
리뷰 범위(diff)에 앵커 파일이 포함되지 않은 지적을 "더 이상 보고되지 않음"으로 오판해 resolve하지
않도록 고친다.

## 작업 내용

완료 요약 — fix: 리뷰 CI self thread-resolve fallback이 증분 범위 밖 blocking 지적을 오해소 (#597)

root cause fix (a2008d2): 두 리뷰 워크플로의 fallback resolve 티어를 "앵커 파일이 이번 라운드
검토 범위(diff)에 포함"으로 게이트. 범위 SoT는 리뷰 청크에 실제 전달된 컨텍스트 파일이며,
공용 스크립트 diff-anchor-filter.js의 신규 parseContextDiffPaths로 산출. GraphQL reviewThreads에
path 추가, byFallback = !byModel && !findingFingerprints.has(fp) && reviewedPaths.has(t.path)
(두 워크플로 동일, 드리프트 없음). 범위 산출 불가 시 fallback만 보수적 비활성 —
resolved_threads 1차 티어·codex supersede 티어 무영향(데드락 방지 목적 보존).

수용 기준 5/5 충족:
1. 범위 밖 지적 fallback resolve 금지 ✓ (게이트)
2. resolved_threads 명시 보고 resolve 보존 ✓ (byModel 무변경)
3. 범위 내 + findings 소멸 → 정당한 fallback 보존 ✓
4. 회귀 가드 테스트 ✓ — 단위 6케이스(경로 추출·rename/delete·마커 없음·hunk 오인 방지) +
   계약 check 16c(codex)/7e(claude): 게이트 식·parseContextDiffPaths 소비·path 조회
5. tests/codex/·tests/claude/ 전체 통과 ✓ (fresh 0 exit)

부수 교정 (a2a2698, test:): codex 계약 스위트가 HEAD에서 사전 존재 red — auth-refresh 잡 도입
후 stale해진 개수 단언(2·2·2·1)을 실제(3·3·3·3)로 교정. 단언 강도 유지(약화 아님).

검증: 4-Level Verifier(existence/substantive/wired/runtime) + Self-Review + 적대 렌즈
(contrarian·minimalist·constraint-auditor, 발견 3건 검토·전부 수정 불요) 통과.
비고: tests/review-context/ 실패는 베이스라인 동일(사전 존재, DoD 대상 아님).
