### PR TITLE
🤖 [자동 리뷰] fix: forge integrate 원격-앞섬 브랜치 non-ff 실패 + execute-task 무로그 blocked

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
       "name": "autopilot",
       "source": "./plugins/autopilot",
       "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
-      "version": "0.63.2",
+      "version": "0.63.3",
       "category": "automation",
       "tags": [
         "autonomous",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.63.3
+
+### 버그 수정
+- **forge integrate 원격-앞섬 브랜치 non-ff 실패 + execute-task 무로그 blocked (run 592)** — 원격 작업 브랜치가 로컬 브랜치 ref보다 앞선 상태(리뷰 수정 푸시 등 정당한 전진)에서 integrate가 stale 로컬 ref를 push해 non-ff 거부로 반복 실패하고, 원격-앞섬을 stale 잔여로 오판해 PR close·원격 브랜치 삭제(리뷰 커밋 파괴)까지 갈 수 있던 문제를 고쳤다. `in_push_branch`는 판정 직전 원격 ref를 fetch해 로컬 ref가 원격 tip의 조상이면 push를 생략하고(원격이 이미 모든 커밋 보유, force 없음), `in_remote_ff_incompatible`은 원격-앞섬을 비-stale(보존)로 판정한다. 또한 execute-task의 integrate/merge 실패 분기가 `set_status blocked`만 하고 백엔드 로그를 남기지 않아 실패 사유가 stderr로 유실되던 무로그 blocked를 고쳐, 두 분기 모두 `append_log`에 blocked 마커와 실패 사유 발췌(마지막 20줄 평탄화)를 남긴다. 회귀 가드: `plugins/autopilot/forge/lib/tests/test-integration-remote-ahead.sh`, `tests/autopilot/execute-task/test-execute-task-failure-log-markers.sh`.
+
 ## thinktank 1.0.1
 
 ### 변경(호환)

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.63.2",
+  "version": "0.63.3",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/forge/lib/integration.sh
+++ b/plugins/autopilot/forge/lib/integration.sh
@@ -296,8 +296,24 @@ _in_base_sync_core() {
 }
 
 in_push_branch() {
+  # 원격-앞섬 정합(run 592): 로컬 ref 가 원격 tip 의 조상이면(리뷰 수정 푸시 등 정당한 전진으로
+  # 원격이 앞섬) 원격이 이미 모든 로컬 커밋을 보유 — push 는 불필요하고 non-ff 로 거부만 되므로
+  # 건너뛴다. fetch 시점 레이스 완화를 위해 판정 직전에 원격 ref 를 fetch 한다. force 금지 유지.
+  local branch="$1" tip local_commit
+  tip="$(in_remote_tip "$branch")"
+  if [[ -n "$tip" ]]; then
+    # shellcheck disable=SC2086
+    $GIT_CMD fetch origin "$branch" >/dev/null 2>&1 || true
+    # shellcheck disable=SC2086
+    local_commit="$($GIT_CMD rev-parse "refs/heads/$branch" 2>/dev/null)"
+    # shellcheck disable=SC2086
+    if [[ -n "$local_commit" ]] && $GIT_CMD merge-base --is-ancestor "$local_commit" "$tip" 2>/dev/null; then
+      echo "integration: push 생략 — 원격 브랜치가 로컬 ref 를 이미 포함(원격-앞섬): $branch" >&2
+      return 0
+    fi
+  fi
   # shellcheck disable=SC2086
-  $GIT_CMD push origin "$1" || { in_die "push 실패(force 금지): $1"; return 1; }
+  $GIT_CMD push origin "$branch" || { in_die "push 실패(force 금지): $branch"; return 1; }
 }
 
 # =====================================================================
@@ -327,6 +343,11 @@ in_remote_ff_incompatible() {
   $GIT_CMD fetch origin "$branch" >/dev/null 2>&1 || true
   # shellcheck disable=SC2086
   $GIT_CMD merge-base --is-ancestor "$tip" "$local_commit" 2>/dev/null && return 1
+  # 원격-앞섬(로컬이 원격 tip 의 조상): 원격이 이미 로컬 커밋을 모두 보유(리뷰 수정 푸시 등
+  # 정당한 전진) — stale 잔여가 아니라 건강한 상태이므로 보존한다(push 는 in_push_branch 가
+  # 원격-앞섬을 감지해 생략 → non-ff 문제 없음). run 592 회귀: 오판 시 리뷰 커밋 파괴.
+  # shellcheck disable=SC2086
+  $GIT_CMD merge-base --is-ancestor "$local_commit" "$tip" 2>/dev/null && return 1
   return 0
 }
 

--- a/plugins/autopilot/forge/lib/tests/test-integration-remote-ahead.sh
+++ b/plugins/autopilot/forge/lib/tests/test-integration-remote-ahead.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# test-integration-remote-ahead.sh — 원격-앞섬 브랜치 통합 회귀 가드 (run 592 관측).
+#   시나리오: 원격 작업 브랜치가 로컬 브랜치 ref 보다 앞서 있고(로컬이 원격 tip 의 조상 —
+#   리뷰 수정 푸시 등 정당한 전진) open PR 이 존재.
+#   기대: integrate 가 push 실패 없이 완료(rc=0, phase=review, PR 재사용). force 금지 유지.
+#     - stale ref push 를 시도하지 않는다(원격이 이미 모든 로컬 커밋 보유 → push 불필요).
+#     - 원격-앞섬을 stale 잔여로 오판해 PR close·원격 브랜치 삭제로 파괴하지 않는다.
+#   mock git 은 실제 git 처럼 원격-앞섬 브랜치로의 non-ff push 를 거부한다(회귀 재현 조건).
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
+
+# integration.sh 를 source (하단 BASH_SOURCE 가드로 main 미실행).
+# shellcheck disable=SC1091
+. "$HERE/../integration.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+RD="$TMP/.autopilot/runs/20260714T000000-run592"; mkdir -p "$RD"
+SPEC="$TMP/SPEC.md"
+printf '# remote ahead feature x\n\n## 무엇\n...\n' > "$SPEC"
+BRANCH="feat/20260714T000000-run592-remote-ahead-feature-x"
+
+# ---- mock loop: 종료=DONE, paths 는 결과 워크트리 ----
+LOOPWT="$TMP/loopwt"; mkdir -p "$LOOPWT"
+mock_loop() {
+  case "$1" in
+    status) printf '{"state":"terminal","signals":["DONE"]}\n' ;;
+    logs)   : ;;
+    paths)  printf 'SPEC_PATH   %s\nWT          %s\nLOOP_DIR    %s\n' "$2" "$LOOPWT" "$LOOPWT/.loop" ;;
+    cleanup) return 0 ;;
+  esac
+}
+LOOP_CMD=mock_loop
+
+# ---- mock git: 원격-앞섬 상태를 실제처럼 모사 ----
+#   로컬 ref = localcommit / 원격 tip = remotetip / localcommit ⊂ remotetip (원격이 앞섬).
+#   stale 로컬 ref 의 브랜치명 push 는 실제 git 처럼 non-ff 로 거부한다.
+GITLOG="$TMP/gitlog" PUSHLOG="$TMP/pushlog" BRANCHES="$TMP/branches"
+: > "$GITLOG"; : > "$PUSHLOG"; printf '%s\n' "$BRANCH" > "$BRANCHES"
+mock_git() {
+  if [[ "$1" == "-C" ]]; then shift 2; fi
+  local a; for a in "$@"; do case "$a" in *force*|-f) echo "FORCE USED" >&2; exit 99;; esac; done
+  printf '%s\n' "$*" >> "$GITLOG"
+  case "$1" in
+    fetch|rebase) return 0 ;;
+    ls-remote) printf 'remotetip\trefs/heads/%s\n' "$BRANCH" ;;
+    rev-parse)
+      case "$*" in
+        *--verify*refs/heads/*) grep -Fxq "$BRANCH" "$BRANCHES" 2>/dev/null; return $? ;;
+        *--absolute-git-dir*) printf '%s/gitdir\n' "$TMP"; return 0 ;;
+        *refs/heads/*) grep -Fxq "$BRANCH" "$BRANCHES" 2>/dev/null && { echo "localcommit"; return 0; } || return 1 ;;
+        *HEAD*) echo "localcommit"; return 0 ;;
+      esac ;;
+    merge-base)
+      # --is-ancestor <A> <B>: A 가 B 의 조상인가.
+      case "$*" in
+        *origin/*)                       return 1 ;;  # base(origin/main) 전진 — 브랜치 조상 아님.
+        *"remotetip localcommit"*)       return 1 ;;  # 원격 tip 은 로컬의 조상 아님(원격이 더 많음).
+        *"localcommit remotetip"*)       return 0 ;;  # 로컬은 원격 tip 의 조상 = 원격-앞섬.
+        *) return 1 ;;
+      esac ;;
+    branch) printf '%s\n' "$2" >> "$BRANCHES"; return 0 ;;
+    push)
+      printf '%s\n' "$*" >> "$PUSHLOG"
+      case "$*" in
+        *--delete*) return 0 ;;
+        *)
+          # 실제 git 재현: 원격이 앞선 브랜치로의 브랜치명/HEAD push 는 non-ff 거부.
+          echo "! [rejected] $BRANCH -> $BRANCH (non-fast-forward)" >&2
+          return 1 ;;
+      esac ;;
+    worktree) return 0 ;;
+  esac
+  return 0
+}
+GIT_CMD=mock_git
+
+# ---- mock forge: open PR #91 존재(autopilot 소유 신호 포함 — 오판 시 파괴 경로 노출) ----
+PRCLOSELOG="$TMP/prclose" PRLOG="$TMP/prlog"; : > "$PRCLOSELOG"; : > "$PRLOG"
+mock_forge() {
+  case "$1 $2" in
+    "pr list")  echo "91" ;;
+    "pr view")
+      case "$*" in
+        *"--json author"*)  echo "courtesy-bot" ;;
+        *"--json reviews"*) printf 'courtesy-bot\t<!-- claude-formal-review head_sha=x verdict=approve -->\n' ;;
+      esac ;;
+    "pr close") printf '%s\n' "$3" >> "$PRCLOSELOG" ;;
+    "pr create") printf '%s\n' "$*" >> "$PRLOG"; echo created ;;
+  esac
+  return 0
+}
+FORGE_CMD=mock_forge
+DEFAULT_BRANCH=main
+
+# ---- 실행 ----
+rc=0; in_integrate "$SPEC" "$RD" "run592-key" >/dev/null 2>&1 || rc=$?
+
+# ---- 단언 ----
+chk "1: 원격-앞섬+open PR → integrate rc=0(push 실패 없음)" "$rc" "0"
+chk "2: phase=review" "$(int_get_phase "$RD" "run592-key")" "review"
+chk "3: open PR 재사용(pr=91)" "$(int_get_pr "$RD" "run592-key")" "91"
+[[ ! -s "$PRLOG" ]] && ok "4: 새 PR 미생성(재사용)" || bad "4: 새 PR 미생성(재사용)"
+[[ ! -s "$PRCLOSELOG" ]] && ok "5: 원격-앞섬을 stale 로 오판해 PR close 안 함" || bad "5: 원격-앞섬 PR close 안 함"
+grep -q -- '--delete' "$PUSHLOG" && bad "6: 원격 브랜치 삭제 안 함(리뷰 커밋 보존)" || ok "6: 원격 브랜치 삭제 안 함(리뷰 커밋 보존)"
+[[ ! -s "$PUSHLOG" ]] && ok "7: stale 로컬 ref push 시도 없음(원격이 이미 보유)" || bad "7: stale 로컬 ref push 시도 없음 (pushlog: $(cat "$PUSHLOG" 2>/dev/null | tr '\n' ';'))"
+grep -qE "^fetch origin $BRANCH" "$GITLOG" && ok "8: 판정 직전 원격 브랜치 fetch(레이스 완화)" || bad "8: 판정 직전 원격 브랜치 fetch(레이스 완화)"
+if grep -qiE 'force|(^| )-f( |$)' "$GITLOG"; then bad "9: force 미사용"; else ok "9: force 미사용"; fi
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || { echo "FAILURES present"; exit 1; }

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -38,6 +38,10 @@ REVIEW_BOT_LOGINS_RE="${REVIEW_BOT_LOGINS_RE:-(\[bot\]$|^github-actions$|courtes
 
 die() { echo "execute-task: $*" >&2; exit 1; }
 
+# et_reason_excerpt <text> — 실패 출력에서 백엔드 로그용 사유 발췌(마지막 20줄, 한 줄 평탄화).
+#   integrate/merge 실패 사유가 stderr 로만 흘러 유실되는 무로그 blocked 방지(run 592).
+et_reason_excerpt() { printf '%s\n' "$1" | tail -n 20 | tr '\n' ' '; }
+
 # et_cleanup_dirs <dir>... — 주어진 디렉토리들을 정리(멱등, 부재·중복이어도 무해).
 #   merge 성공 직후 정리와 done 선제 가드 정리(#541)가 공유하는 단일 출처.
 #   대상: run-dir(.autopilot/runs/<id> — materialize SPEC·.worktree·run 상태, #580 통합),
@@ -231,7 +235,9 @@ et_start() {
   local key="$id"
   local iout branch pr=""
   iout="$($FORGE_CMD integrate "$sp" "$run_dir" "$key" 2>&1)" || {
-    $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "integrate 실패" >/dev/null; echo "$iout" >&2; return 1; }
+    $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "integrate 실패" >/dev/null
+    $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "integrate 실패: $(et_reason_excerpt "$iout")" >/dev/null
+    echo "$iout" >&2; return 1; }
   branch="$(printf '%s' "$iout" | sed -n 's/^branch:[[:space:]]*//p' | head -1)"
   pr="$(printf '%s' "$iout" | sed -n 's/^pr:[[:space:]]*//p' | head -1)"
 
@@ -289,7 +295,10 @@ et_start() {
     fi
   fi
 
-  if $FORGE_CMD merge "$sp" "$run_dir" "$key" "$pr"; then
+  # merge 출력을 캡처해 실패 시 사유를 백엔드 로그에 남긴다(무로그 blocked 방지, run 592).
+  local mout
+  if mout="$($FORGE_CMD merge "$sp" "$run_dir" "$key" "$pr" 2>&1)"; then
+    if [[ -n "$mout" ]]; then printf '%s\n' "$mout"; fi
     $ADAPTER_CMD set_status --task-id "$id" --status done >/dev/null
     $ADAPTER_CMD append_log --task-id "$id" --marker handoff --text "merged ${branch:+($branch)}" >/dev/null
     # .autopilot/runs/<id>/(materialize SPEC 포함)·.review/tasks/<id>/ 정리 — dirname sp 는 통상
@@ -298,6 +307,8 @@ et_start() {
     echo "execute-task: done ($id)"
   else
     $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "merge 실패" >/dev/null
+    $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "merge 실패: $(et_reason_excerpt "$mout")" >/dev/null
+    echo "$mout" >&2
     return 1
   fi
 }

--- a/tests/autopilot/execute-task/test-execute-task-failure-log-markers.sh
+++ b/tests/autopilot/execute-task/test-execute-task-failure-log-markers.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# test-execute-task-failure-log-markers.sh — integrate/merge 실패 시 무로그 blocked 회귀 가드 (run 592 관측).
+#   결함: integrate/merge 실패 분기가 set_status blocked 만 호출하고 append_log 마커를 남기지 않아,
+#   실패 사유가 stderr 로만 흘러 백그라운드 실행에서 유실(무로그 blocked → 수동 포렌식 필요).
+#   기대: 두 분기 모두 백엔드 로그에 [blocked] 마커 + 원인 식별 가능한 실패 사유 텍스트를 남긴다.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
+ADAPTER="$HERE/../../../plugins/autopilot/task-backend/adapter.sh"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"; git init -q; git config user.email t@t; git config user.name t
+bash "$ADAPTER" init --backend filesystem >/dev/null
+
+mkdir -p bin
+cat > bin/loop <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  start|cleanup) exit 0;;
+  status) printf '{"state":"terminal","signals":["DONE"]}\n';;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/loop
+
+# mock forge: FORGE_MODE 로 실패 지점 선택.
+#   integrate-fail → integrate 가 non-ff push 거부 사유를 출력하고 rc4.
+#   merge-fail     → integrate/review 정상(즉시 approve), merge 가 사유 출력 후 rc1.
+cat > bin/forge <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  integrate)
+    if [[ "${FORGE_MODE:-}" == "integrate-fail" ]]; then
+      echo "integration: push 실패(force 금지): feat/x" >&2
+      echo "! [rejected] feat/x -> feat/x (non-fast-forward)" >&2
+      exit 4
+    fi
+    echo "branch: feat/x"; echo "pr: 7"; exit 0;;
+  review) exit 30;;  # rl_round 계약: 30=approve → 머지 진행
+  merge)
+    if [[ "${FORGE_MODE:-}" == "merge-fail" ]]; then
+      echo "merge: ff-only 게이트 실패 — base 전진(재동기화 필요)" >&2
+      exit 1
+    fi
+    exit 0;;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/forge
+
+# renew_lease 동시 기록자 제거 래퍼(lifecycle 테스트와 동일 이유 — 상태 파일 클로버 방지).
+cat > bin/adapter_norenew << EOF
+#!/usr/bin/env bash
+[[ "\$1" == renew_lease ]] && { echo '{"task_id":"noop"}'; exit 0; }
+exec bash "$ADAPTER" "\$@"
+EOF
+chmod +x bin/adapter_norenew
+
+run() { ADAPTER_CMD="bash $TMP/bin/adapter_norenew" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+        HEARTBEAT_INTERVAL=1 APPROVAL_CHECK_CMD=true BLOCKING_CHECK_CMD=true SLEEP_CMD=: bash "$ET" "$@"; }
+status_of(){ bash "$ADAPTER" get_task --task-id "$1" | jq -r .status; }
+task_file(){ printf '%s/.tasks/%s.md' "$TMP" "$1"; }
+
+# ---- 1: integrate 실패 → blocked 마커 + 실패 사유 텍스트가 백엔드 로그에 남는다 ----
+id1="$(bash "$ADAPTER" create_task --title "T-int" --body '## 목표'$'\n'x | jq -r .task_id)"
+rc=0; FORGE_MODE=integrate-fail run start "$id1" >/dev/null 2>&1 || rc=$?
+chk "1: integrate 실패 rc=1" "$rc" "1"
+chk "1: status=blocked" "$(status_of "$id1")" "blocked"
+grep -q '\[blocked\].*integrate' "$(task_file "$id1")" \
+  && ok "1: [blocked] 마커(integrate) 기록" || bad "1: [blocked] 마커(integrate) 기록"
+grep -q 'non-fast-forward' "$(task_file "$id1")" \
+  && ok "1: 실패 사유 텍스트(non-fast-forward) 기록" || bad "1: 실패 사유 텍스트(non-fast-forward) 기록"
+
+# ---- 2: merge 실패 → blocked 마커 + 실패 사유 텍스트가 백엔드 로그에 남는다 ----
+id2="$(bash "$ADAPTER" create_task --title "T-mrg" --body '## 목표'$'\n'y | jq -r .task_id)"
+rc=0; FORGE_MODE=merge-fail run start "$id2" >/dev/null 2>&1 || rc=$?
+chk "2: merge 실패 rc=1" "$rc" "1"
+chk "2: status=blocked" "$(status_of "$id2")" "blocked"
+grep -q '\[blocked\].*merge' "$(task_file "$id2")" \
+  && ok "2: [blocked] 마커(merge) 기록" || bad "2: [blocked] 마커(merge) 기록"
+grep -q 'ff-only 게이트 실패' "$(task_file "$id2")" \
+  && ok "2: 실패 사유 텍스트(ff-only) 기록" || bad "2: 실패 사유 텍스트(ff-only) 기록"
+
+# ---- 3: 정상 경로 회귀 없음(성공 시 blocked 마커 미기록, done 전이 유지) ----
+id3="$(bash "$ADAPTER" create_task --title "T-ok" --body '## 목표'$'\n'z | jq -r .task_id)"
+run start "$id3" >/dev/null 2>&1 || true
+chk "3: 성공 경로 status=done" "$(status_of "$id3")" "done"
+grep -q '\[blocked\]' "$(task_file "$id3")" \
+  && bad "3: 성공 경로에 blocked 마커 없음" || ok "3: 성공 경로에 blocked 마커 없음"
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || { echo "FAILURES present"; exit 1; }


### PR DESCRIPTION
## 요약


execute-task/forge integrate 경로가 (a) 원격 작업 브랜치가 로컬 브랜치 ref보다 앞선 상태(리뷰 수정
푸시·수동 충돌 해결 등 정당한 경로로 발생)를 견디고, (b) integrate/merge 실패 시 백엔드 로그에
사유를 남기도록 고친다.

## 작업 내용

무엇을: forge integrate의 원격-앞섬 브랜치 non-ff 실패와 execute-task의 무로그 blocked를 근본 수정했다(run 592 관측). integration.sh의 in_push_branch가 판정 직전 원격 ref를 fetch해 로컬 ref가 원격 tip의 조상이면 push를 생략하고(force 없음), in_remote_ff_incompatible이 원격-앞섬을 stale 잔여가 아닌 보존 대상으로 판정해 PR close·원격 브랜치 삭제(리뷰 커밋 파괴) 오작동을 차단한다. execute-task.sh의 integrate/merge 실패 분기는 이제 append_log에 blocked 마커와 실패 사유 발췌(마지막 20줄 평탄화)를 남기며, merge 출력을 캡처해 사유를 확보한다. 회귀 가드 테스트 2종 신규(test-integration-remote-ahead.sh, test-execute-task-failure-log-markers.sh), 버전 0.63.3 동기(plugin.json·marketplace) + CHANGELOG.

왜: 원격 작업 브랜치가 리뷰 수정 푸시 등으로 로컬 ref보다 앞서면 integrate가 stale ref push의 non-ff 거부를 무한 반복하고, 실패 사유가 백엔드 로그에 전혀 남지 않아 드레인 자동화가 막히고 수동 포렌식이 필요했다. 4-Level Verifier·Self-Review·적대 렌즈 3종 통과, 전체 스위트(신규 2 + 기존 execute-task 8종·forge lib·selftest) 0 exit.
