### PR TITLE
🤖 [자동 리뷰] fix: forge 리뷰 approve-후-blocking-스레드 교착 + execute-task blocked category 누락

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
       "name": "autopilot",
       "source": "./plugins/autopilot",
       "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
-      "version": "0.63.4",
+      "version": "0.63.5",
       "category": "automation",
       "tags": [
         "autonomous",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.63.5
+
+### 버그 수정
+- **forge 리뷰 approve-후-blocking-스레드 교착 해소 (#600)** — approve 판정 기록 후 같은 head 에 신뢰봇 미해결 스레드가 승인을 가리는데(#493) 현재 head 공식 재리뷰 증거가 없어 판정이 pending(#549)인 조합에서, 리뷰 루프가 폴링 상한(~10분)까지 무행동 대기(rc=20 반복)만 하다 blocked 로 종착하던 3자 교착(승인 가림·재작업 금지·새 커밋 주체 없음)을 근거 있는 에스컬레이션(rc=10)으로 유한 시간 내 종착하도록 수정. `rl_review_fetch_gh` 가 승인 가림 상태를 `blocked: 1` 로 표면화하고 `rl_round` 같은-head 게이트가 이를 식별한다. 기존 가드(#493 승인 가림·#549 증거 없는 재작업 금지·#571 같은 head 1회 재평가)는 시맨틱 불변.
+- **execute-task forge 단계 blocked category 표면화 (#600)** — integrate/review/merge 실패 blocked 로그 텍스트 선두에 `category:` 를 싣는다(자가개선 seam 소비용). 기계적 매핑: 환경 차단(integrate/merge 실패)→`environment-gap`, 리뷰 수렴·판정 문제(진전 불가·미승인·폴링 상한)→`other`.
+
 ## autopilot 0.63.4
 
 ### 변경(호환)

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.63.4",
+  "version": "0.63.5",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/lib/forge/lib/review-loop.sh
+++ b/plugins/autopilot/lib/forge/lib/review-loop.sh
@@ -133,6 +133,9 @@ query($owner:String!,$name:String!,$pr:Int!,$endCursor:String){
   # 현재 head 미해결 스레드의 전체 인라인 지적(타당성 판단은 워커가 change-adoption 으로 — 원천만 평탄화).
   findings="$(printf '%s\n' "$comments" | awk -F'\t' -v h="$head" '$2==h{print $3}' \
        | sed -E 's/<!--[^>]*-->//g' | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  # #600: 신뢰봇 미해결 스레드의 실재를 verdict 와 별도로 표면화 — rl_round 같은-head 게이트가
+  #   pending 교착(그곳 주석 참조)을 식별하는 신호.
+  [[ "$blocking" == "1" ]] && echo "blocked: 1"
   if [[ -n "$approve" && -z "$blocking" ]]; then
     echo "verdict: approve"
   elif [[ "$blocking" == "FETCH_FAILED" ]]; then
@@ -306,9 +309,20 @@ rl_round() {
     #   request_changes 로 바꾸므로 같은 head 재평가는 1회로 수렴하고, 무한 라운드는 기존 세 가드
     #   (라운드 상한·무진전·핑퐁)에 귀속된다. pending(#549 재매핑 추정)과 조회 실패 합성 changes
     #   (fetchfail — 실재 증거 아님)는 그대로 대기.
-    if [[ "$(int_get_verdict "$rd" "$key")" == "approve" && "$(rl_review_verdict "$pr")" == "changes" \
+    local rec_verdict gate_verdict=""
+    rec_verdict="$(int_get_verdict "$rd" "$key")"
+    [[ "$rec_verdict" == "approve" ]] && gate_verdict="$(rl_review_verdict "$pr")"
+    if [[ "$rec_verdict" == "approve" && "$gate_verdict" == "changes" \
           && -z "$(rl_review_field "$pr" fetchfail)" ]]; then
       int_log "$rd" "$key" "head 동일($head)이나 approve 기록 후 미해결 신뢰봇 스레드 도착 — 재평가(재작업 진입)"
+    # #600: approve 기록 후 같은 head 에 신뢰봇 미해결 스레드가 승인을 가리는데(blocked=1, #493) 현재
+    #   head 공식 재리뷰 증거가 없어 판정이 pending(#549 — 재작업 채택 금지)인 조합은, 승인·재작업·새
+    #   커밋 모두 막힌 3자 교착이다. 폴링 상한까지 무행동 대기(rc=20 반복) 대신 근거 있는 에스컬레이션
+    #   으로 유한 시간 내 종착한다 — #493(승인 가림)·#549(증거 없는 재작업 금지)는 그대로 보존.
+    elif [[ "$rec_verdict" == "approve" && "$gate_verdict" == "pending" \
+          && "$(rl_review_field "$pr" blocked)" == "1" ]]; then
+      rl_escalate "$rd" "$key" "approve 기록 후 같은 head($head)의 신뢰봇 미해결 스레드가 승인을 가리나 현재 head 재리뷰 증거 없음(#549) — 재작업·머지 모두 불가 교착, 스레드 해소·수동 개입 필요"
+      return 10
     else
       int_log "$rd" "$key" "head 동일($head) — 새 커밋 없음, 라운드 미시작"
       return 20
@@ -653,6 +667,17 @@ rl_selftest() {
   rl_round "$rd" "$kL3" "$base" 111 "feat/run1-l3"; chk "#571 approve 기록+조회 실패 changes → 대기(rc=20, 합성 finding 재작업 금지)" "$?" "20"
   [[ ! -s "$IMPLLOG" ]] && ok "#571 조회 실패 시 재작업 미실행" || bad "#571 조회 실패 시 재작업 미실행"
 
+  # ---- #600: approve 기록+pending+blocked(3자 교착 — rl_round 게이트 주석 참조) → 에스컬레이션 ----
+  local kL4="l4-lll8"; : > "$IMPLLOG"
+  forge_review sha-L4 approve > "$RV/112.review"
+  rl_round "$rd" "$kL4" "$base" 112 "feat/run1-l4" >/dev/null
+  printf 'state: NONE\nauthor: \nhead: sha-L4\nblocked: 1\nverdict: pending\n' > "$RV/112.review"
+  out="$(rl_round "$rd" "$kL4" "$base" 112 "feat/run1-l4")"; rc=$?
+  chk "#600 approve 기록+pending+blocked → 에스컬레이션(rc=10, 무행동 대기 아님)" "$rc" "10"
+  chk "#600 phase=escalated" "$(int_get_phase "$rd" "$kL4")" "escalated"
+  case "$out" in *교착*) ok "#600 교착 사유 표면화";; *) bad "#600 교착 사유 표면화 (out='$out')";; esac
+  [[ ! -s "$IMPLLOG" ]] && ok "#600 증거 없는 스레드 재작업 미실행(#549 보존)" || bad "#600 증거 없는 스레드 재작업 미실행(#549 보존)"
+
   # ---- pending(승인X·지적X) → 대기(rc=20), 로컬 review 미호출 ----
   local kPd="pd-ppp0"
   forge_review sha-PD pending > "$RV/110.review"
@@ -834,6 +859,11 @@ rl_selftest() {
     "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_API_FAIL=1 rvg)" "changes"
   out="$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_API_FAIL=1 rl_review_fetch_gh 205 2>/dev/null)"
   case "$out" in *조회\ 실패*|*default-deny*) ok "AC5 조회 실패 finding 표면화";; *) bad "AC5 조회 실패 finding 표면화";; esac
+  # #600: 승인 가림 pending 에 blocked=1 표면화(교착 식별 신호 — rl_round 게이트 주석 참조).
+  chk "#600 approve 가림+증거 없음 → pending 에 blocked=1 표면화" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$GBLK" rl_review_fetch_gh 206 2>/dev/null | grep -c '^blocked: 1')" "1"
+  chk "#600 스레드 없는 pending 은 blocked 미표면화" \
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_REVIEWS="$MARK_OLD2" SC_THREADS="$GEMPTY" rl_review_fetch_gh 207 2>/dev/null | grep -c '^blocked: 1')" "0"
   unset -f gh
 
   # ---- force 미사용 (mock_git force 보면 exit99; 여기 도달했으면 미사용) ----

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -42,6 +42,11 @@ die() { echo "execute-task: $*" >&2; exit 1; }
 #   integrate/merge 실패 사유가 stderr 로만 흘러 유실되는 무로그 blocked 방지(run 592).
 et_reason_excerpt() { printf '%s\n' "$1" | tail -n 20 | tr '\n' ' '; }
 
+# forge 단계 blocked 의 category 표면화(#600) — 자가개선 seam(using-autopilot 카테고리→행동 매핑)이
+#   소비할 값을 blocked 로그 선두에 싣는다. 사유별 기계적 규칙(사이트 고정, 임의 판단 없음):
+#     원격·브랜치·머지 게이트 등 환경 차단(integrate/merge 실패) → environment-gap
+#     리뷰 수렴·판정 문제(review 진전 불가/미승인·폴링 상한)     → other (진단 후 분류)
+
 # et_cleanup_dirs <dir>... — 주어진 디렉토리들을 정리(멱등, 부재·중복이어도 무해).
 #   merge 성공 직후 정리와 done 선제 가드 정리(#541)가 공유하는 단일 출처.
 #   대상: run-dir(.autopilot/runs/<id> — materialize SPEC·.worktree·run 상태, #580 통합),
@@ -236,7 +241,7 @@ et_start() {
   local iout branch pr=""
   iout="$($FORGE_CMD integrate "$sp" "$run_dir" "$key" 2>&1)" || {
     $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "integrate 실패" >/dev/null
-    $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "integrate 실패: $(et_reason_excerpt "$iout")" >/dev/null
+    $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "category: environment-gap — integrate 실패: $(et_reason_excerpt "$iout")" >/dev/null
     echo "$iout" >&2; return 1; }
   branch="$(printf '%s' "$iout" | sed -n 's/^branch:[[:space:]]*//p' | head -1)"
   pr="$(printf '%s' "$iout" | sed -n 's/^pr:[[:space:]]*//p' | head -1)"
@@ -271,13 +276,13 @@ et_start() {
           waited=$((waited + APPROVAL_POLL_INTERVAL)) ;;
         *)                         # 10(에스컬레이션/라운드상한/핑퐁) 등 진전 불가 → 빠른 실패
           $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "리뷰 진전 불가(리워크로 해소 불가, rl_round rc=$rrc) — 폴링 상한 대기 생략" >/dev/null
-          $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "review 진전 불가(rc=$rrc) — 즉시 종료($rounds 라운드)" >/dev/null
+          $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "category: other — review 진전 불가(rc=$rrc) — 즉시 종료($rounds 라운드)" >/dev/null
           return 1 ;;
       esac
     done
     if (( ! approved )); then
       $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "리뷰 미승인(승인 폴링 상한 ${APPROVAL_WAIT_MAX}s 초과)" >/dev/null
-      $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "review 승인 미게시 — 폴링 상한 초과($rounds 라운드)" >/dev/null
+      $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "category: other — review 승인 미게시 — 폴링 상한 초과($rounds 라운드)" >/dev/null
       return 1
     fi
   else
@@ -290,7 +295,7 @@ et_start() {
     done
     if (( ! approved )); then
       $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "리뷰 미승인(에스컬레이션/가드)" >/dev/null
-      $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "review 미승인 ($n 라운드)" >/dev/null
+      $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "category: other — review 미승인 ($n 라운드)" >/dev/null
       return 1
     fi
   fi
@@ -307,7 +312,7 @@ et_start() {
     echo "execute-task: done ($id)"
   else
     $ADAPTER_CMD set_status --task-id "$id" --status blocked --reason "merge 실패" >/dev/null
-    $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "merge 실패: $(et_reason_excerpt "$mout")" >/dev/null
+    $ADAPTER_CMD append_log --task-id "$id" --marker blocked --text "category: environment-gap — merge 실패: $(et_reason_excerpt "$mout")" >/dev/null
     echo "$mout" >&2
     return 1
   fi

--- a/tests/autopilot/execute-task/test-execute-task-blocked-category.sh
+++ b/tests/autopilot/execute-task/test-execute-task-blocked-category.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# test-execute-task-blocked-category.sh — forge 단계 blocked 신호의 category 표면화 회귀 가드 (#600).
+#   결함: execute-task 의 forge 단계 blocked 로그(integrate/review/merge 실패)에 `category:` 필드가
+#   없어, 자가개선 seam(using-autopilot 카테고리→행동 매핑)이 소비할 정보가 유실된다.
+#   기대: forge 단계 blocked append_log 텍스트가 `category:` 값으로 시작한다 — 사유별 기계적 규칙:
+#     원격·브랜치·머지 게이트 등 환경 차단(integrate/merge 실패) → environment-gap
+#     리뷰 수렴·판정 문제(review 진전 불가/미승인·폴링 상한)     → other
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
+ADAPTER="$HERE/../../../plugins/autopilot/lib/task-backend/adapter.sh"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"; git init -q; git config user.email t@t; git config user.name t
+bash "$ADAPTER" init --backend filesystem >/dev/null
+
+mkdir -p bin
+cat > bin/loop <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  status) printf '{"state":"terminal","signals":["DONE"]}\n';;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/loop
+
+# mock forge: FORGE_MODE 로 blocked 지점 선택.
+cat > bin/forge <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  integrate)
+    if [[ "${FORGE_MODE:-}" == "integrate-fail" ]]; then
+      echo "integration: push 실패(non-fast-forward)" >&2; exit 4
+    fi
+    echo "branch: feat/x"
+    [[ "${FORGE_MODE:-}" == "direct-unapproved" ]] || echo "pr: 7"   # direct 경로 = PR 없음
+    exit 0;;
+  review)
+    case "${FORGE_MODE:-}" in
+      review-stuck)     exit 10;;   # rl_round 계약: 10=에스컬레이션(진전 불가)
+      review-wait)      exit 20;;   # 20=대기(비동기 승인 폴링)
+      direct-unapproved) exit 1;;   # direct 경로 리뷰 미승인
+      merge-fail|*)     exit 30;;   # 30=approve
+    esac;;
+  merge)
+    if [[ "${FORGE_MODE:-}" == "merge-fail" ]]; then
+      echo "merge: 승인 차단 — 미해결 리뷰 스레드" >&2; exit 1
+    fi
+    exit 0;;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/forge
+
+cat > bin/adapter_norenew << EOF
+#!/usr/bin/env bash
+[[ "\$1" == renew_lease ]] && { echo '{"task_id":"noop"}'; exit 0; }
+exec bash "$ADAPTER" "\$@"
+EOF
+chmod +x bin/adapter_norenew
+
+run() { ADAPTER_CMD="bash $TMP/bin/adapter_norenew" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+        HEARTBEAT_INTERVAL=1 APPROVAL_WAIT_MAX=0 APPROVAL_CHECK_CMD=false BLOCKING_CHECK_CMD=false SLEEP_CMD=: \
+        bash "$ET" "$@"; }
+task_file(){ printf '%s/.tasks/%s.md' "$TMP" "$1"; }
+# blocked 로그 라인이 category 로 시작하는지: `[blocked] category: <값> — ...`
+has_cat(){ grep -q "\[blocked\] category: $2" "$(task_file "$1")"; }
+
+# ---- 1: integrate 실패 → category: environment-gap ----
+id1="$(bash "$ADAPTER" create_task --title T1 --body '## 목표'$'\n'x | jq -r .task_id)"
+FORGE_MODE=integrate-fail run start "$id1" >/dev/null 2>&1 || true
+has_cat "$id1" environment-gap && ok "1: integrate 실패 category=environment-gap" \
+  || { bad "1: integrate 실패 category=environment-gap"; sed -n '$p' "$(task_file "$id1")"; }
+
+# ---- 2: review 진전 불가(rc=10) → category: other ----
+id2="$(bash "$ADAPTER" create_task --title T2 --body '## 목표'$'\n'x | jq -r .task_id)"
+FORGE_MODE=review-stuck run start "$id2" >/dev/null 2>&1 || true
+has_cat "$id2" other && ok "2: review 진전 불가 category=other" \
+  || { bad "2: review 진전 불가 category=other"; sed -n '$p' "$(task_file "$id2")"; }
+
+# ---- 3: review 승인 폴링 상한 초과 → category: other ----
+id3="$(bash "$ADAPTER" create_task --title T3 --body '## 목표'$'\n'x | jq -r .task_id)"
+FORGE_MODE=review-wait run start "$id3" >/dev/null 2>&1 || true
+has_cat "$id3" other && ok "3: 폴링 상한 초과 category=other" \
+  || { bad "3: 폴링 상한 초과 category=other"; sed -n '$p' "$(task_file "$id3")"; }
+
+# ---- 4: merge 실패 → category: environment-gap ----
+id4="$(bash "$ADAPTER" create_task --title T4 --body '## 목표'$'\n'x | jq -r .task_id)"
+FORGE_MODE=merge-fail run start "$id4" >/dev/null 2>&1 || true
+has_cat "$id4" environment-gap && ok "4: merge 실패 category=environment-gap" \
+  || { bad "4: merge 실패 category=environment-gap"; sed -n '$p' "$(task_file "$id4")"; }
+
+# ---- 5: direct(PR 없음) 경로 review 미승인 → category: other ----
+id6="$(bash "$ADAPTER" create_task --title T6 --body '## 목표'$'\n'x | jq -r .task_id)"
+FORGE_MODE=direct-unapproved run start "$id6" >/dev/null 2>&1 || true
+has_cat "$id6" other && ok "5: direct review 미승인 category=other" \
+  || { bad "5: direct review 미승인 category=other"; sed -n '$p' "$(task_file "$id6")"; }
+
+# ---- 6: 성공 경로 회귀 없음(blocked/category 마커 미기록) ----
+id5="$(bash "$ADAPTER" create_task --title T5 --body '## 목표'$'\n'x | jq -r .task_id)"
+run start "$id5" >/dev/null 2>&1 || true
+grep -q '\[blocked\]' "$(task_file "$id5")" \
+  && bad "6: 성공 경로에 blocked 마커 없음" || ok "6: 성공 경로에 blocked 마커 없음"
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || { echo "FAILURES present"; exit 1; }


### PR DESCRIPTION
## 요약


forge 리뷰 루프의 approve-후-blocking-스레드 교착을 해소하고, execute-task의 forge 단계 blocked 신호에 `category:` 필드를 싣는다. 두 수정 지점 모두 같은 blocked 경로에서 한 사건(#600/PR #601)으로 드러났다.

## 작업 내용

run 602 완료 — fix:root 42f0042 (0.63.5)

1) forge 리뷰 approve-후-blocking-스레드 3자 교착(#600) 해소: rl_review_fetch_gh 가 승인 가림을 `blocked: 1` 로 표면화, rl_round 같은-head 게이트가 approve기록+pending+blocked=1 조합을 rl_escalate(rc=10) 로 유한 시간 내 종착 — 폴링 상한 무행동 대기 제거. 가드 #493/#549/#571 시맨틱 불변.
2) execute-task forge 단계 blocked 5개 사이트 로그 선두에 `category:` 표면화 — integrate/merge 실패=environment-gap, review 수렴·판정=other(기계적 매핑).
3) 회귀 테스트: rl_selftest #600 4건 + fetch 2건 + test-execute-task-blocked-category.sh 5건(RED→GREEN). 교착 mock 재현에서 무한 대기 미관찰(즉시 rc=10).
4) 스위프 40/40 실질 통과 — test-loop-sh 1건 실패는 세션 env `CLAUDE_PID` 상속 환경 요인으로 확정(`env -u CLAUDE_PID` 36/36 통과, 이번 diff 무관, scope 밖 별도 결함 후보로 노트 기록).
5) 버전 표면 0.63.5 동기(plugin.json·marketplace.json·CHANGELOG).

4-Level Verifier·Self-Review·적대 렌즈(비자명 변경) 통과 — 상세 .loop/notes.md.
