### PR TITLE
🤖 [자동 리뷰] fix: create-task scope-coverage-map 중첩 참조 제거 — 경로 표기 관례 인라인

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### 변경(호환)
 - **공유 session-conventions 해체 — 규범을 각 SKILL.md에 용어 특화 인라인 (run 604)** — `skills/shared/session-conventions.md`를 제거하고 규범 5영역(호출 규약·세션 파일 규율·디스패치 공통 규범·중앙 리서치 공통 규범·공통 안전 경계)을 brainstorm(세션 파일, `.brainstorm/<session-id>.md`)·roundtable(회의 파일, `.roundtable/<meeting-id>.md`) 각 SKILL.md 본문에 각 스킬 용어로 자체 정의. `../shared/` 참조·위임 문구 제거(스킬 자기완결). 규범 의미·강도 불변.
 
+## autopilot 0.63.6
+
+### 변경(호환)
+- **create-task scope-coverage-map 자기완결화 (#608)** — `references/scope-coverage-map.md`가 `skills/loop/SKILL.md`를 경로 표기 관례의 단일 출처로 지시하던 중첩 참조(SKILL.md→references→타 스킬 SKILL.md)를 제거하고, 경고가 제시하는 경로의 수용 형식(후행 `/` 디렉토리 표기·파일 글롭)과 매칭 의미론(prefix 재귀 매칭)을 map 문서에 계약 수준으로 인라인. create-task 의 "다른 스킬 doc-link 금지" 자기 규칙과의 자기모순 해소. 매핑 규칙·`scope-coverage-check.sh` 동작 불변.
+
 ## autopilot 0.63.5
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.63.5",
+  "version": "0.63.6",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/create-task/references/scope-coverage-map.md
+++ b/plugins/autopilot/skills/create-task/references/scope-coverage-map.md
@@ -18,9 +18,18 @@
 `scope.include`의 항목 중 기대 테스트 경로를 **prefix-포함**하거나 **정확히 일치**하면 커버드로 본다.
 예: scope에 `tests/autopilot/` 이나 `tests/autopilot/test-create-task*.sh` 가 있으면 create-task 커버.
 
-이 검사가 누락 경고에 제시하는 디렉토리 경로(후행 `/`, 예 `tests/autopilot/<S>/`)는 loop scope 게이트가
-그대로 수용하는 형식이다 — 제시된 경로를 `scope.include` 에 그대로 넣으면 그 아래 파일 수정이 scope 밖으로
-오탐되지 않는다. 경로 표기 관례(수용 형식·매칭 의미론)의 단일 출처는 `skills/loop/SKILL.md` "Scope 경로 표기".
+## 경고가 제시하는 경로 표기
+
+이 검사가 누락 경고에 제시하는 경로는 SPEC frontmatter 의 `scope.include` 에 그대로 넣을 수 있는 형식이다 —
+제시된 경로를 붙여 넣으면 그 아래 파일 수정이 scope 밖으로 오탐되지 않는다.
+
+| 표기 | 예 | 매칭 |
+|---|---|---|
+| 디렉토리(후행 `/`) | `tests/autopilot/<S>/` | 그 디렉토리 하위 전체(깊이 무관) prefix 매칭 |
+| 파일 글롭 | `tests/autopilot/test-<S>*.sh` | bash 패턴 매칭 |
+
+디렉토리 표기는 **후행 `/` 가 붙은 항목에만** prefix 의미론이 적용된다. 후행 `/` 가 없으면 글롭·정확 경로로
+해석되므로, 디렉토리 전체를 덮으려면 후행 `/` 를 반드시 붙인다.
 
 ## 오탐 방지 조건
 

--- a/tests/autopilot/test-create-task-scope-coverage.sh
+++ b/tests/autopilot/test-create-task-scope-coverage.sh
@@ -114,5 +114,12 @@ grep -qE 'scope-coverage|기존 테스트.*등록|등록.*기존 테스트' "$SH
   || fail "T10: fix task-body-template에 scope-coverage(#498) 보완 언급 없음"
 ok "fix task-body-template: scope-coverage 보완 언급"
 
+# === T11: scope-coverage-map.md가 다른 스킬 문서를 doc-link하지 않음 (자기완결) ===
+echo "=== T11: map 문서 타 스킬 doc-link 부재 ==="
+foreign="$(grep -oE 'skills/[a-z0-9._-]+/' "$MAP_FILE" | grep -v '^skills/create-task/$' || true)"
+[[ -z "$foreign" ]] \
+  || fail "T11: scope-coverage-map.md가 타 스킬 문서를 참조함 (실제: '$foreign')"
+ok "scope-coverage-map.md: 타 스킬 doc-link 없음"
+
 echo ""
 echo "=== 모든 #498 scope-coverage 검증 테스트 통과 ==="


### PR DESCRIPTION
## 요약

create-task 소유 `references/scope-coverage-map.md`가 다른 스킬 문서 참조 없이 자기완결로 경로 표기 관례를 서술하는 상태. loop SKILL.md로의 doc-link가 제거되고, 그 링크가 위임하던 표기 관례 요지가 map 문서 안에 인라인된다.

## 작업 내용

create-task scope-coverage-map 중첩 참조 제거 완료 (commit 729dacc, autopilot 0.63.6).

- map.md: loop SKILL.md 단일-출처 지시 제거, "경고가 제시하는 경로 표기" 절로 수용 형식(후행 `/`
  디렉토리 표기·파일 글롭)과 매칭 의미론(prefix 재귀) 자체 서술.
- tests/autopilot/test-create-task-scope-coverage.sh: T11 타 스킬 doc-link 부재 가드 추가.
- plugin.json 0.63.6, CHANGELOG 항목 추가.

검증: bash tests/autopilot/test-create-task-scope-coverage.sh → exit 0 (T1–T11 통과).
