### PR TITLE
🤖 [자동 리뷰] autopilot: scope-coverage 검증 매핑을 비-autopilot 플러그인(thinktank)으로 일반화

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
       "name": "autopilot",
       "source": "./plugins/autopilot",
       "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
-      "version": "0.63.5",
+      "version": "0.63.6",
       "category": "automation",
       "tags": [
         "autonomous",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.63.6
+
+### 변경(호환)
+- **create-task scope-coverage 검증을 플러그인-불문으로 일반화 (run 605)** — 기존 테스트 경로 누락 플래그가 autopilot 소스만 매핑하던 것을 `plugins/<P>/skills/<S>/` → `tests/<P>/` 관례로 일반화. thinktank 등 비-autopilot 플러그인 SPEC도 등록 시 `SCOPE_COVERAGE_WARNING`을 받는다(태스크 604의 실행-단계 spec-gap BLOCKED를 등록 시점으로 앞당김). 기존 autopilot 매핑 의미론·오탐 방지 존재-확인 전제·경고-비차단(항상 0 exit) 계약 불변.
+
 ## thinktank 1.0.2
 
 ### 변경(호환)

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.63.5",
+  "version": "0.63.6",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/create-task/references/scope-coverage-check.sh
+++ b/plugins/autopilot/skills/create-task/references/scope-coverage-check.sh
@@ -93,27 +93,28 @@ try:
     checked = set()
 
     for inc in includes:
-        # 매핑 규칙 1: plugins/autopilot/skills/<S>/...
-        m = re.match(r'^plugins/autopilot/skills/([^/]+)/', inc)
+        # 매핑 규칙 1: plugins/<P>/skills/<S>/...
+        m = re.match(r'^plugins/([^/]+)/skills/([^/]+)/', inc)
         if m:
-            skill = m.group(1)
-            if skill in checked:
+            plugin, skill = m.group(1), m.group(2)
+            key = (plugin, skill)
+            if key in checked:
                 continue
-            checked.add(skill)
+            checked.add(key)
 
             expected = []
 
-            # 1a) tests/autopilot/<S>/ 디렉터리
-            dir_test = f'tests/autopilot/{skill}/'
+            # 1a) tests/<P>/<S>/ 디렉터리
+            dir_test = f'tests/{plugin}/{skill}/'
             if os.path.isdir(os.path.join(repo_root, dir_test)):
                 expected.append(dir_test)
 
-            # 1b) tests/autopilot/test-<S>*.sh 파일
-            test_dir = os.path.join(repo_root, 'tests/autopilot')
+            # 1b) tests/<P>/test-<S>*.sh 파일
+            test_dir = os.path.join(repo_root, f'tests/{plugin}')
             if os.path.isdir(test_dir):
                 for f in sorted(os.listdir(test_dir)):
                     if f.startswith(f'test-{skill}') and f.endswith('.sh'):
-                        expected.append(f'tests/autopilot/{f}')
+                        expected.append(f'tests/{plugin}/{f}')
 
             # 기존 테스트 없는 신규 소스 → 오탐 방지, 통과
             if not expected:

--- a/plugins/autopilot/skills/create-task/references/scope-coverage-map.md
+++ b/plugins/autopilot/skills/create-task/references/scope-coverage-map.md
@@ -7,11 +7,12 @@
 
 | 소스 패턴 | 기대 테스트 경로 |
 |---|---|
-| `plugins/autopilot/skills/<S>/...` | `tests/autopilot/test-<S>*.sh` (파일 glob) |
-| `plugins/autopilot/skills/<S>/...` | `tests/autopilot/<S>/` (디렉터리, 있으면) |
+| `plugins/<P>/skills/<S>/...` | `tests/<P>/test-<S>*.sh` (파일 glob) |
+| `plugins/<P>/skills/<S>/...` | `tests/<P>/<S>/` (디렉터리, 있으면) |
 | `plugins/autopilot/lib/task-backend/...` | `plugins/autopilot/lib/task-backend/tests/` |
 
-`<S>`는 스킬 이름(예: `create-task`, `loop`, `execute-task`, `feature`, `fix`).
+`<P>`는 플러그인 이름(예: `autopilot`, `thinktank`), `<S>`는 스킬 이름(예: `create-task`, `loop`, `brainstorm`).
+스킬 매핑은 플러그인-불문 관례(`plugins/<P>/skills/<S>/` → `tests/<P>/`)이며, `task-backend` 규칙만 autopilot 전용이다.
 
 ## 커버드(covered) 판정
 

--- a/tests/autopilot/test-create-task-scope-coverage.sh
+++ b/tests/autopilot/test-create-task-scope-coverage.sh
@@ -114,5 +114,65 @@ grep -qE 'scope-coverage|기존 테스트.*등록|등록.*기존 테스트' "$SH
   || fail "T10: fix task-body-template에 scope-coverage(#498) 보완 언급 없음"
 ok "fix task-body-template: scope-coverage 보완 언급"
 
+# === T11: 비-autopilot 플러그인(thinktank) 소스 + 테스트 누락 → 경고 ===
+echo "=== T11: thinktank 소스 + 테스트 누락 → SCOPE_COVERAGE_WARNING ==="
+BODY_TT_MISSING="---
+scope:
+  include:
+    - plugins/thinktank/skills/brainstorm/**
+    - CHANGELOG.md
+---
+
+## 무엇을 만들 것인가
+thinktank 소스만 포함한 샘플 본문.
+"
+out5="$(echo "$BODY_TT_MISSING" | bash "$CHECKER")"
+echo "$out5" | grep -q 'SCOPE_COVERAGE_WARNING' \
+  || fail "T11: thinktank 소스 테스트 누락 시 SCOPE_COVERAGE_WARNING 없음 (실제: '$out5')"
+echo "$out5" | grep -q 'tests/thinktank/' \
+  || fail "T11: 누락 경로 목록에 tests/thinktank/ 없음 (실제: '$out5')"
+ok "thinktank 소스 테스트 누락 → SCOPE_COVERAGE_WARNING"
+
+# === T12: thinktank 소스 + 테스트 경로 모두 포함 → 경고 없음 ===
+echo "=== T12: thinktank 소스+테스트 모두 포함 → 경고 없음 ==="
+BODY_TT_COVERED="---
+scope:
+  include:
+    - plugins/thinktank/skills/brainstorm/**
+    - tests/thinktank/
+    - CHANGELOG.md
+---
+
+## 무엇을 만들 것인가
+thinktank 소스+테스트 모두 포함 샘플 본문.
+"
+out6="$(echo "$BODY_TT_COVERED" | bash "$CHECKER")"
+[[ -z "$out6" ]] \
+  || fail "T12: thinktank 소스+테스트 모두 포함 시 경고 발생 (실제: '$out6')"
+ok "thinktank 소스+테스트 모두 포함 → 경고 없음"
+
+# === T13: 기존 테스트 없는 플러그인 소스 → 검사 생략 (오탐 방지) ===
+echo "=== T13: 기존 테스트 없는 플러그인 소스 → 검사 생략 ==="
+BODY_NO_TESTS="---
+scope:
+  include:
+    - plugins/project-init/skills/bootstrap/**
+    - CHANGELOG.md
+---
+
+## 무엇을 만들 것인가
+매핑된 테스트 경로가 없는 플러그인 소스 샘플.
+"
+out7="$(echo "$BODY_NO_TESTS" | bash "$CHECKER")"
+[[ -z "$out7" ]] \
+  || fail "T13: 기존 테스트 없는 소스에서 오탐 발생 (실제: '$out7')"
+ok "기존 테스트 없는 플러그인 소스 → 검사 생략"
+
+# === T14: scope-coverage-map.md에 일반화 규칙 반영 ===
+echo "=== T14: map 문서 일반화 규칙 반영 ==="
+grep -qE 'plugins/<P>/skills/<S>|tests/<P>/' "$MAP_FILE" \
+  || fail "T14: scope-coverage-map.md에 일반화 매핑 규칙 없음"
+ok "scope-coverage-map.md: 일반화 매핑 규칙 반영"
+
 echo ""
 echo "=== 모든 #498 scope-coverage 검증 테스트 통과 ==="


### PR DESCRIPTION
## 요약


create-task의 scope-coverage 검증(#498)이 autopilot 외 플러그인 소스에 대해서도 기존 테스트 경로 누락을 플래그하도록 매핑을 일반화한다. 최소 대상: `plugins/thinktank/skills/<S>/` 소스 ↔ `tests/thinktank/` 기존 테스트. 매핑 규약 문서(scope-coverage-map.md)도 일반화된 규칙을 반영한다.

## 작업 내용

run 605 완료 — scope-coverage 매핑 플러그인-불문 일반화

commit: 53fc33d feat: scope-coverage 매핑을 플러그인-불문으로 일반화 (run 605, 0.63.6)

수용 기준 대응:
1. thinktank 소스 + tests/thinktank/ 누락 → SCOPE_COVERAGE_WARNING + 누락 경로 출력 (T11)
2. 매핑된 테스트 경로 포함 시 무경고 (T12)
3. 매핑 테스트 파일시스템 부재 시 검사 생략 (T13)
4. 기존 autopilot 매핑 회귀 유지 (T4/T5/T6 + status-transition PASS)
5. scope-coverage-map.md 매핑 규칙 표 일반화 반영 (T14)
6. 회귀 가드 T11~T14 추가·통과
7. autopilot 0.63.5 → 0.63.6 (plugin.json·marketplace.json) + CHANGELOG 항목

fresh verify: tests/autopilot/test-create-task-scope-coverage.sh exit 0 (T1~T14 전부 OK)
