### PR TITLE
🤖 [자동 리뷰] fix: create-task 등록-후 전이 이중 허용 문구 단일화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### 변경(호환)
 - **공유 session-conventions 해체 — 규범을 각 SKILL.md에 용어 특화 인라인 (run 604)** — `skills/shared/session-conventions.md`를 제거하고 규범 5영역(호출 규약·세션 파일 규율·디스패치 공통 규범·중앙 리서치 공통 규범·공통 안전 경계)을 brainstorm(세션 파일, `.brainstorm/<session-id>.md`)·roundtable(회의 파일, `.roundtable/<meeting-id>.md`) 각 SKILL.md 본문에 각 스킬 용어로 자체 정의. `../shared/` 참조·위임 문구 제거(스킬 자기완결). 규범 의미·강도 불변.
 
+## autopilot 0.63.6
+
+### 변경(호환)
+- **create-task 등록-후 상태 전이 문구 단일화 (run 611)** — 마커 없음 분기가 "전이를 생략하거나 명시적으로 `set_status --status backlog` 를 호출한다"로 두 갈래를 허용해 실행 세션마다 동사 시퀀스가 달라지던 비결정성을 제거. 이제 초기 상태 `backlog` 유지라는 단일 행동만 지시한다(추가 전이 호출 없음). 전이 의미론(backlog/in_design 기준)·재개 경로 불변. 회귀 가드: `tests/autopilot/test-create-task-status-transition.sh` TEST 5.
+
 ## autopilot 0.63.5
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.63.5",
+  "version": "0.63.6",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/create-task/SKILL.md
+++ b/plugins/autopilot/skills/create-task/SKILL.md
@@ -91,8 +91,7 @@ auto-merge, 없으면 로컬 메인 merge. `.autopilot/` 는 워치 디렉토리
    ```
 5. **등록-후 상태 전이 (소유)** — 등록 직후 본문의 `[NEEDS CLARIFICATION` 마커 유무로 최종 상태를 분기한다.
    이 전이는 이 등록 프리미티브가 소유한다:
-   - 마커가 **없으면**(완성 SPEC) 초기 상태 `backlog`를 유지한다 — 전이를 생략하거나 명시적으로
-     `bash "$ADAPTER" set_status --task-id <id> --status backlog` 를 호출한다.
+   - 마커가 **없으면**(완성 SPEC) 초기 상태 `backlog`를 유지한다 — 추가 전이 호출을 하지 않는다.
    - 마커가 **남아 있으면**(미해결 잔존) `bash "$ADAPTER" set_status --task-id <id> --status in_design` 로
      상태를 전이한다.
 6. **본문 갱신은 set_body에 위임** — 등록된 태스크의 본문을 나중에 갱신해야 하면(예: `in_design` 태스크의

--- a/tests/autopilot/test-create-task-status-transition.sh
+++ b/tests/autopilot/test-create-task-status-transition.sh
@@ -42,4 +42,19 @@ grep -qF '[NEEDS CLARIFICATION' "$SKILL_MD" \
 ok "[NEEDS CLARIFICATION 마커 기준 명시"
 
 echo ""
+echo "=== TEST 5: 상태 전이 이중 허용 문구 부재 (negative) ==="
+# 과거 §5: "전이를 생략하거나 명시적으로 set_status ... --status backlog 를 호출한다"
+# 두 갈래 허용은 세션마다 다른 동사 시퀀스를 만든다 — 단일 행동만 지시해야 한다.
+if grep -qE '생략하거나' "$SKILL_MD"; then
+  fail "SKILL.md에 전이 이중 허용 문구('…생략하거나…')가 잔존"
+fi
+# 등록-후 전이(5단계) 블록 한정 — resume 경로의 in_design → backlog 전이는 정당하므로 제외한다.
+STEP5=$(awk '/^5\. \*\*등록-후 상태 전이/{flag=1} /^6\. \*\*본문 갱신/{flag=0} flag' "$SKILL_MD")
+[[ -n "$STEP5" ]] || fail "SKILL.md에서 등록-후 상태 전이(5단계) 블록을 찾지 못함"
+if grep -qE 'set_status .*--status backlog' <<<"$STEP5"; then
+  fail "SKILL.md 5단계에 backlog 유지 분기의 중복 set_status 호출 지시가 잔존"
+fi
+ok "상태 전이 이중 허용 문구 부재"
+
+echo ""
 echo "=== 모든 create-task 등록-후 상태 전이 조건부화 테스트 통과 ==="


### PR DESCRIPTION
## 요약

등록-후 상태 전이(마커 없음 분기)의 지시가 단일 행동으로 서술된 SKILL.md: 마커가 없으면 초기 상태 `backlog`를 유지한다(중복 `set_status` 호출 지시 제거). "전이를 생략하거나 명시적으로 호출한다"의 이중 허용 문구가 사라진다.

## 작업 내용

create-task 등록-후 상태 전이 문구 단일화 완료 (commit 6f88c42, autopilot 0.63.6)

완료 조건:
- 마커 없음 분기 = 단일 행동("초기 상태 backlog 유지 — 추가 전이 호출 없음")
- 상태 전이 이중 허용 문구("…생략하거나…") SKILL.md 에서 제거
- 회귀 가드 TEST 5 추가·통과 (이중 허용 문구 부재 + §5 블록 한정 중복 set_status 부재)
- 기존 TEST 1–4 통과 (test-create-task-status-transition.sh 0 exit)

주의(후속): .claude-plugin/marketplace.json 의 autopilot 버전이 0.63.5 로 남음 —
SPEC scope.include 밖이라 미수정. 파생 표면 동기화 후속 필요.
