### PR TITLE
🤖 [자동 리뷰] fix: create-task description WHEN-중심 재작성 (#560 컨벤션 정렬)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### 변경(호환)
 - **공유 session-conventions 해체 — 규범을 각 SKILL.md에 용어 특화 인라인 (run 604)** — `skills/shared/session-conventions.md`를 제거하고 규범 5영역(호출 규약·세션 파일 규율·디스패치 공통 규범·중앙 리서치 공통 규범·공통 안전 경계)을 brainstorm(세션 파일, `.brainstorm/<session-id>.md`)·roundtable(회의 파일, `.roundtable/<meeting-id>.md`) 각 SKILL.md 본문에 각 스킬 용어로 자체 정의. `../shared/` 참조·위임 문구 제거(스킬 자기완결). 규범 의미·강도 불변.
 
+## autopilot 0.63.6
+
+### 변경(호환)
+- **create-task description WHEN-중심 재작성 (#560 컨벤션 정렬)** — 소유권·아키텍처 경계 서술 위주였던 frontmatter description을 트리거(WHEN) 중심으로 재작성. "태스크로 등록해줘"·"백로그에 올려줘"·"태스크 만들어줘" 같은 실사용 표현과 `resume <task-id>` 재개 신호를 담고, WHAT은 "본문을 백엔드에 등록하고 등록-후 상태를 전이한다" 한 구절로 축약. 작성 로직 비소유·`set_body` 위임 등 경계 상세는 본문(「규칙」·워크플로)이 계속 소유한다(정보 손실 없음). 워크플로·동사 계약 불변.
+
 ## autopilot 0.63.5
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.63.5",
+  "version": "0.63.6",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/create-task/SKILL.md
+++ b/plugins/autopilot/skills/create-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-task
-description: 외부 작성자(feature·fix)가 만든 자기완결적 태스크 본문(=SPEC)을 받아 선택된 백엔드(filesystem/github-project/beads)에 태스크로 등록하려 할 때 사용하는 등록 프리미티브 — 등록과 등록-후 상태 전이(완성→backlog / 미해결 잔존→in_design)를 소유하고, 본문 갱신은 백엔드 set_body 동사에 위임한다. 인터뷰·정적분석 같은 작성 로직은 갖지 않는다(작성은 feature·fix가 소유). 본문이 곧 SPEC이며 별도 SPEC 파일은 만들지 않는다. 호출 'Skill(skill="create-task", args="<제목>\n\n<태스크 본문>")'.
+description: 완성된 태스크 본문(=SPEC)을 태스크 백엔드에 등록할 때 사용 — "이거 태스크로 등록해줘"·"백로그에 올려줘"·"태스크 만들어줘"·"이 스펙 등록해줘" 같은 직접 등록 요청, 작성자 feature·fix가 완성 본문을 넘겨 등록을 요청하는 경우, 그리고 'resume <task-id>'로 기존 in_design 태스크 본문을 갱신할 때. 받은 본문을 선택된 백엔드(filesystem/github-project/beads)에 등록하고 등록-후 상태(backlog/in_design)를 전이한다. 본문 작성이 아직 필요한 신호(새 기능 의도·버그 증상·실패 테스트)는 작성자 feature·fix가 먼저이므로 이 스킬을 직접 쓰지 않는다. 호출 'Skill(skill="create-task", args="<제목>\n\n<태스크 본문>")'.
 allowed-tools:
   - AskUserQuestion
   - Read

--- a/tests/autopilot/test-create-task-status-transition.sh
+++ b/tests/autopilot/test-create-task-status-transition.sh
@@ -42,4 +42,33 @@ grep -qF '[NEEDS CLARIFICATION' "$SKILL_MD" \
 ok "[NEEDS CLARIFICATION 마커 기준 명시"
 
 echo ""
+echo "=== TEST 5: description이 WHEN(트리거 표현) 중심 (#560 컨벤션) ==="
+DESC="$(grep -m1 '^description:' "$SKILL_MD")"
+BODY="$(awk 'NR>1 && /^---$/{f=1;next} f' "$SKILL_MD")"
+echo "$DESC" | grep -qE '등록해줘|백로그에 올려|태스크 만들어줘' \
+  || fail "description에 사용자 직접 등록 요청 표현(트리거 동의어)이 없음"
+ok "description: 직접 등록 요청 트리거 표현 포함"
+
+echo ""
+echo "=== TEST 6: description에 소유권·경계 상세 서술 부재 (본문 소관) ==="
+if echo "$DESC" | grep -qE '작성 로직|set_body'; then
+  fail "description에 경계 상세 서술(작성 로직/set_body 위임)이 잔존 — 본문으로 이동해야 함"
+fi
+ok "description: 경계 상세 서술 부재"
+
+echo ""
+echo "=== TEST 7: 옮겨진 경계 서술이 본문에 보존됨 (정보 손실 없음) ==="
+echo "$BODY" | grep -q 'set_body' \
+  || fail "본문에 set_body 위임 서술이 없음"
+echo "$BODY" | grep -qE '작성.*(feature|fix).*소유|소유.*작성' \
+  || fail "본문에 작성 소유권(feature/fix) 서술이 없음"
+ok "본문: 경계 서술 보존"
+
+echo ""
+echo "=== TEST 8: description에 오발동 방지 배제 조항 존재 (작성 신호는 feature·fix) ==="
+echo "$DESC" | grep -qE '(feature.*fix).*(먼저|아니)' \
+  || fail "description에 작성 신호는 feature·fix가 먼저라는 배제 조항이 없음"
+ok "description: 배제 조항 존재"
+
+echo ""
 echo "=== 모든 create-task 등록-후 상태 전이 조건부화 테스트 통과 ==="


### PR DESCRIPTION
## 요약

create-task SKILL.md frontmatter description이 WHEN(트리거 상황·사용자 표현 동의어) 중심으로 재작성된 상태. WHAT은 간결한 한 구절, 소유권·경계 상세는 본문으로 이동.

## 작업 내용

create-task description WHEN-중심 재작성 완료 (commit 48f3f5d, autopilot 0.63.6)

수용 기준 대응:
- WHEN 중심 + WHAT 한 구절: description 재작성 (SKILL.md:3) — 실사용 트리거 표현·resume 신호 포함.
- 정보 손실 없음: 경계 서술(작성 로직 비소유·set_body 위임·본문=SPEC)은 본문 「규칙」·워크플로가 계속 소유, TEST 7로 가드.
- 규칙 검사기 17항목: rule_checker.py → grade S, 실패 0.
- 기존 계약 테스트: test-create-task-status-transition.sh(TEST 1~8) / test-create-task-scope-coverage.sh(T1~T10) 전부 PASS.

버전 표면: plugin.json 0.63.5 → 0.63.6, CHANGELOG 항목 추가.
