### PR TITLE
🤖 [자동 리뷰] fix: scope-coverage 매핑 repo-특정 하드코딩 제거 — 프로젝트 설정 공급화

### DIFF
--- a/.autopilot/scope-coverage-map.json
+++ b/.autopilot/scope-coverage-map.json
@@ -1,0 +1,17 @@
+{
+  "rules": [
+    {
+      "source": "plugins/autopilot/skills/<name>/",
+      "tests": [
+        "tests/autopilot/<name>/",
+        "tests/autopilot/test-<name>*.sh"
+      ]
+    },
+    {
+      "source": "plugins/autopilot/lib/task-backend/",
+      "tests": [
+        "plugins/autopilot/lib/task-backend/tests/"
+      ]
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### 변경(호환)
 - **공유 session-conventions 해체 — 규범을 각 SKILL.md에 용어 특화 인라인 (run 604)** — `skills/shared/session-conventions.md`를 제거하고 규범 5영역(호출 규약·세션 파일 규율·디스패치 공통 규범·중앙 리서치 공통 규범·공통 안전 경계)을 brainstorm(세션 파일, `.brainstorm/<session-id>.md`)·roundtable(회의 파일, `.roundtable/<meeting-id>.md`) 각 SKILL.md 본문에 각 스킬 용어로 자체 정의. `../shared/` 참조·위임 문구 제거(스킬 자기완결). 규범 의미·강도 불변.
 
+## autopilot 0.64.0
+
+### 변경(호환)
+- **scope-coverage 매핑을 컨슈밍 프로젝트 설정으로 공급 (#609)** — `scope-coverage-check.sh`에 하드코딩돼 있던 이 저장소 전용 소스→테스트 매핑(`plugins/autopilot/skills/<S>` → `tests/autopilot/…`)을 제거하고, 프로젝트가 `<repo-root>/.autopilot/scope-coverage-map.json`으로 매핑 규칙(`rules[].source` prefix + `<name>` 세그먼트 캡처, `rules[].tests` 디렉토리·글롭)을 공급하는 구조로 전환. 설정이 없는 프로젝트는 검사가 경고 없이 exit 0으로 통과(등록 비차단 계약 불변). `references/scope-coverage-map.md`는 매핑 표가 아니라 설정 스키마 규약 문서로 갱신. 이 저장소는 자체 `.autopilot/scope-coverage-map.json`을 제공해 기존 검사 동작 유지. 플러그인이 컨슈밍 프로젝트 정책을 내장하던 계층 역전 해소(#482 계열).
+
 ## autopilot 0.63.6
 
 ### 변경(호환)

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.63.6",
+  "version": "0.64.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/create-task/SKILL.md
+++ b/plugins/autopilot/skills/create-task/SKILL.md
@@ -72,7 +72,9 @@ auto-merge, 없으면 로컬 메인 merge. `.autopilot/` 는 워치 디렉토리
    영속화」 헬퍼를 실행해 config를 메인까지 영속화한다(멱등).
 3. **scope-coverage 검증** — 등록 전에 scope-coverage 검증을 수행한다. 본문 frontmatter의
    `scope.include`에서 소스 경로를 읽어, 그 소스를 덮는 **기존** 테스트 경로가 scope.include에 함께 있는지
-   확인한다. 매핑 관례의 단일 출처는 `references/scope-coverage-map.md`다:
+   확인한다. 소스→테스트 매핑은 **컨슈밍 프로젝트가 `.autopilot/scope-coverage-map.json`으로 공급**하며,
+   그 설정 스키마의 단일 출처는 `references/scope-coverage-map.md`다. 설정이 없는 프로젝트에서는 검사가
+   경고 없이 통과한다:
    ```
    CHECKER="${CLAUDE_PLUGIN_ROOT}/skills/create-task/references/scope-coverage-check.sh"
    echo "<본문>" | bash "$CHECKER"

--- a/plugins/autopilot/skills/create-task/references/scope-coverage-check.sh
+++ b/plugins/autopilot/skills/create-task/references/scope-coverage-check.sh
@@ -2,8 +2,9 @@
 # scope-coverage-check.sh — SPEC 본문의 scope.include 소스 경로를 덮는
 # 기존 테스트 경로가 scope.include에 함께 있는지 검증한다 (#498).
 #
-# 매핑 관례의 단일 출처: references/scope-coverage-map.md
-# 항상 0 exit — 등록을 막지 않고 누락만 플래그한다.
+# 소스→테스트 매핑은 컨슈밍 프로젝트가 `.autopilot/scope-coverage-map.json` 으로 공급한다.
+# 설정 스키마의 단일 출처: references/scope-coverage-map.md
+# 설정이 없으면 검사하지 않고 통과한다. 항상 0 exit — 등록을 막지 않고 누락만 플래그한다.
 #
 # Usage:
 #   bash scope-coverage-check.sh [--body-file <path>]
@@ -36,7 +37,7 @@ fi
 
 # Python으로 파싱 + 검증 (stdin = 스크립트, argv = 파일경로)
 python3 - "$body_path" "$REPO_ROOT" <<'PYEOF'
-import sys, re, os
+import sys, re, os, json, glob
 
 body_path = sys.argv[1]
 repo_root = sys.argv[2]
@@ -72,6 +73,17 @@ def parse_includes(body):
                 in_include = in_scope = False
     return includes
 
+def load_rules(repo_root):
+    """프로젝트가 공급한 매핑 규칙 목록. 설정이 없거나 불량이면 빈 목록."""
+    cfg = os.path.join(repo_root, '.autopilot', 'scope-coverage-map.json')
+    if not os.path.isfile(cfg):
+        return []
+    try:
+        with open(cfg) as f:
+            return json.load(f).get('rules', [])
+    except Exception:
+        return []
+
 def is_covered(test_path, includes):
     """테스트 경로가 includes의 항목 중 하나로 커버되는지 확인.
 
@@ -86,51 +98,53 @@ def is_covered(test_path, includes):
 
 try:
     includes = parse_includes(body)
-    if not includes:
+    rules = load_rules(repo_root)
+    if not includes or not rules:
         sys.exit(0)
 
     missing = []
     checked = set()
 
-    for inc in includes:
-        # 매핑 규칙 1: plugins/autopilot/skills/<S>/...
-        m = re.match(r'^plugins/autopilot/skills/([^/]+)/', inc)
-        if m:
-            skill = m.group(1)
-            if skill in checked:
-                continue
-            checked.add(skill)
-
-            expected = []
-
-            # 1a) tests/autopilot/<S>/ 디렉터리
-            dir_test = f'tests/autopilot/{skill}/'
-            if os.path.isdir(os.path.join(repo_root, dir_test)):
-                expected.append(dir_test)
-
-            # 1b) tests/autopilot/test-<S>*.sh 파일
-            test_dir = os.path.join(repo_root, 'tests/autopilot')
-            if os.path.isdir(test_dir):
-                for f in sorted(os.listdir(test_dir)):
-                    if f.startswith(f'test-{skill}') and f.endswith('.sh'):
-                        expected.append(f'tests/autopilot/{f}')
-
-            # 기존 테스트 없는 신규 소스 → 오탐 방지, 통과
-            if not expected:
-                continue
-
-            if not any(is_covered(exp, includes) for exp in expected):
-                rep = expected[0] + (', ...' if len(expected) > 1 else '')
-                missing.append(f'[{skill}] {rep}')
+    for rule in rules:
+        source = rule.get('source', '')
+        tests = rule.get('tests', [])
+        if not source or not tests:
             continue
 
-        # 매핑 규칙 2: plugins/autopilot/lib/task-backend/...
-        if inc.startswith('plugins/autopilot/lib/task-backend/') and 'task-backend' not in checked:
-            checked.add('task-backend')
-            tb_dir = 'plugins/autopilot/lib/task-backend/tests/'
-            if os.path.isdir(os.path.join(repo_root, tb_dir)):
-                if not is_covered(tb_dir, includes):
-                    missing.append(f'[task-backend] {tb_dir}')
+        # source 의 <name> 은 경로 세그먼트 1개를 캡처한다.
+        if '<name>' in source:
+            pre, post = source.split('<name>', 1)
+            pattern = '^' + re.escape(pre) + r'([^/]+)' + re.escape(post)
+        else:
+            pattern = '^' + re.escape(source)
+
+        for inc in includes:
+            m = re.match(pattern, inc)
+            if not m:
+                continue
+            name = m.group(1) if m.groups() else ''
+            key = (source, name)
+            if key in checked:
+                continue
+            checked.add(key)
+
+            # 실제로 존재하는 기대 테스트 경로만 수집 (신규 소스 오탐 방지)
+            existing = []
+            for t in tests:
+                expected = t.replace('<name>', name)
+                if expected.endswith('/'):
+                    if os.path.isdir(os.path.join(repo_root, expected)):
+                        existing.append(expected)
+                else:
+                    for p in sorted(glob.glob(os.path.join(repo_root, expected), recursive=True)):
+                        existing.append(os.path.relpath(p, repo_root))
+
+            if not existing:
+                continue
+
+            if not any(is_covered(exp, includes) for exp in existing):
+                rep = existing[0] + (', ...' if len(existing) > 1 else '')
+                missing.append(f'[{name or source}] {rep}')
 
     if missing:
         print('SCOPE_COVERAGE_WARNING: 아래 소스를 덮는 기존 테스트 경로가 scope.include에 없습니다.')

--- a/plugins/autopilot/skills/create-task/references/scope-coverage-map.md
+++ b/plugins/autopilot/skills/create-task/references/scope-coverage-map.md
@@ -1,41 +1,63 @@
-# scope-coverage 매핑 관례 (create-task 자체 소유 단일 출처)
+# scope-coverage 매핑 설정 스키마 (create-task 자체 소유 단일 출처)
 
-`scope-coverage-check.sh`가 소스 경로 → 프로젝트 테스트 경로를 매핑할 때 따르는 관례.
-구현체는 `scope-coverage-check.sh`이며, 이 문서는 인간 가독 규약 문서다.
+소스 경로 → 기대 테스트 경로 매핑은 **컨슈밍 프로젝트의 소유물**이다. 플러그인은 매핑을 내장하지 않고,
+프로젝트가 공급한 설정을 읽어 검사한다. 구현체는 `scope-coverage-check.sh`이며, 이 문서는 그 설정
+스키마의 규약 문서다.
 
-## 매핑 규칙
+## 설정 위치
 
-| 소스 패턴 | 기대 테스트 경로 |
+`<repo-root>/.autopilot/scope-coverage-map.json` (벤더-중립 `.autopilot/` 관례).
+
+설정 파일이 없거나 파싱에 실패하면 **검사하지 않고 경고 없이 통과**한다. 등록은 어떤 경우에도 막지 않는다.
+
+## 스키마
+
+```json
+{
+  "rules": [
+    {
+      "source": "<소스 경로 prefix, 선택적 <name> 플레이스홀더>",
+      "tests": ["<기대 테스트 경로>", "..."]
+    }
+  ]
+}
+```
+
+| 필드 | 의미 |
 |---|---|
-| `plugins/autopilot/skills/<S>/...` | `tests/autopilot/test-<S>*.sh` (파일 glob) |
-| `plugins/autopilot/skills/<S>/...` | `tests/autopilot/<S>/` (디렉터리, 있으면) |
-| `plugins/autopilot/lib/task-backend/...` | `plugins/autopilot/lib/task-backend/tests/` |
+| `source` | `scope.include` 항목의 **prefix**로 매칭한다. `<name>` 은 경로 세그먼트 **1개**를 캡처한다. |
+| `tests` | 그 소스를 덮을 것으로 기대되는 테스트 경로 목록. `<name>` 은 캡처된 값으로 치환된다. |
 
-`<S>`는 스킬 이름(예: `create-task`, `loop`, `execute-task`, `feature`, `fix`).
+`tests` 항목 표기:
+
+| 표기 | 매칭 | 존재 판정 |
+|---|---|---|
+| 디렉토리(후행 `/`) | 그 디렉토리 하위 전체(깊이 무관) prefix 매칭 | 디렉토리 존재 |
+| 파일 글롭 | glob 패턴 매칭 | 매칭 파일 1개 이상 |
+
+여기 제시되는 경로는 SPEC frontmatter 의 `scope.include` 에 그대로 넣을 수 있는 형식이다 — 경고가 제시한
+경로를 붙여 넣으면 그 아래 파일 수정이 scope 밖으로 오탐되지 않는다. 디렉토리 전체를 덮으려면 후행 `/` 를
+반드시 붙인다(후행 `/` 없으면 글롭·정확 경로로 해석된다).
+
+## 예
+
+```json
+{
+  "rules": [
+    { "source": "src/modules/<name>/", "tests": ["spec/modules/<name>/", "spec/modules/<name>_spec.rb"] },
+    { "source": "lib/adapter/", "tests": ["lib/adapter/tests/"] }
+  ]
+}
+```
 
 ## 커버드(covered) 판정
 
 `scope.include`의 항목 중 기대 테스트 경로를 **prefix-포함**하거나 **정확히 일치**하면 커버드로 본다.
-예: scope에 `tests/autopilot/` 이나 `tests/autopilot/test-create-task*.sh` 가 있으면 create-task 커버.
-
-## 경고가 제시하는 경로 표기
-
-이 검사가 누락 경고에 제시하는 경로는 SPEC frontmatter 의 `scope.include` 에 그대로 넣을 수 있는 형식이다 —
-제시된 경로를 붙여 넣으면 그 아래 파일 수정이 scope 밖으로 오탐되지 않는다.
-
-| 표기 | 예 | 매칭 |
-|---|---|---|
-| 디렉토리(후행 `/`) | `tests/autopilot/<S>/` | 그 디렉토리 하위 전체(깊이 무관) prefix 매칭 |
-| 파일 글롭 | `tests/autopilot/test-<S>*.sh` | bash 패턴 매칭 |
-
-디렉토리 표기는 **후행 `/` 가 붙은 항목에만** prefix 의미론이 적용된다. 후행 `/` 가 없으면 글롭·정확 경로로
-해석되므로, 디렉토리 전체를 덮으려면 후행 `/` 를 반드시 붙인다.
 
 ## 오탐 방지 조건
 
 - **기존 테스트 없는 신규 소스**: 매핑된 테스트 경로가 파일시스템에 존재하지 않으면 검사하지 않는다. 존재 확인이 전제다.
-- **테스트-only 경로**: `plugins/autopilot/` 외 경로(예: `tests/`, `CHANGELOG.md`, `rules/`)는 소스로 취급하지 않는다.
-- **문서-only 경로**: `rules/**`, `CHANGELOG.md`, `*.md` 등은 소스 취급 안 함.
+- **규칙에 없는 경로**: 어떤 `source` prefix에도 매칭되지 않는 항목(문서·설정·테스트 경로 등)은 소스로 취급하지 않는다.
 
 ## #483과 역할 분담
 

--- a/tests/autopilot/test-create-task-scope-coverage.sh
+++ b/tests/autopilot/test-create-task-scope-coverage.sh
@@ -121,5 +121,34 @@ foreign="$(grep -oE 'skills/[a-z0-9._-]+/' "$MAP_FILE" | grep -v '^skills/create
   || fail "T11: scope-coverage-map.md가 타 스킬 문서를 참조함 (실제: '$foreign')"
 ok "scope-coverage-map.md: 타 스킬 doc-link 없음"
 
+# === T12: 플러그인 파일에 repo-특정 매핑 리터럴 부재 (#609 회귀 가드) ===
+echo "=== T12: 플러그인 파일 repo-특정 매핑 리터럴 부재 ==="
+for f in "$CHECKER" "$MAP_FILE"; do
+  hit="$(grep -nE 'tests/autopilot|plugins/autopilot/skills/[a-z]|plugins/autopilot/lib/task-backend' "$f" || true)"
+  [[ -z "$hit" ]] \
+    || fail "T12: $(basename "$f") 에 repo-특정 매핑 리터럴 잔존 (실제: '$hit')"
+done
+ok "플러그인 파일: repo-특정 매핑 리터럴 없음"
+
+# === T13: 프로젝트 설정 없으면 경고 없이 통과 ===
+echo "=== T13: 매핑 설정 없는 프로젝트 → 무경고 통과 ==="
+TMP_REPO="$(mktemp -d)"
+trap 'rm -rf "$TMP_REPO"' EXIT
+git -C "$TMP_REPO" init -q
+mkdir -p "$TMP_REPO/plugins/autopilot/skills/create-task" "$TMP_REPO/tests/autopilot"
+touch "$TMP_REPO/tests/autopilot/test-create-task-scope-coverage.sh"
+out5="$(cd "$TMP_REPO" && echo "$BODY_MISSING" | bash "$CHECKER")"
+[[ -z "$out5" ]] \
+  || fail "T13: 매핑 설정 없는 프로젝트에서 경고 발생 (실제: '$out5')"
+ok "매핑 설정 없음 → 무경고 통과"
+
+# === T14: 이 저장소가 자체 매핑 설정을 제공 ===
+echo "=== T14: 저장소 매핑 설정 존재 ==="
+PROJECT_MAP="$REPO_ROOT/.autopilot/scope-coverage-map.json"
+[[ -f "$PROJECT_MAP" ]] || fail "T14: .autopilot/scope-coverage-map.json 부재"
+python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d["rules"], "rules 비어 있음"' "$PROJECT_MAP" \
+  || fail "T14: scope-coverage-map.json 파싱 실패 또는 rules 비어 있음"
+ok "저장소 매핑 설정 존재"
+
 echo ""
 echo "=== 모든 #498 scope-coverage 검증 테스트 통과 ==="


### PR DESCRIPTION
## 요약

scope-coverage 검증의 소스→테스트 경로 매핑이 플러그인 하드코딩이 아니라 컨슈밍 프로젝트 측 설정에서 공급되는 구조. 설정이 없는 프로젝트에서는 검사가 명시적 no-op로 통과한다(현행 유지), 설정이 있으면 그 매핑으로 기존 테스트 경로 누락을 플래그한다.

## 작업 내용

scope-coverage 매핑 repo-특정 하드코딩 제거 — 프로젝트 설정 공급화 (#609, autopilot 0.64.0)

commit bf92f84

## 완료 조건 충족
- 플러그인 파일(scope-coverage-check.sh·scope-coverage-map.md)에 repo-특정 매핑 리터럴 없음 (T12)
- 프로젝트 설정 공급 시 그 매핑으로 누락을 SCOPE_COVERAGE_WARNING 플래그 (T4)
- 설정 없는 프로젝트는 경고 없이 exit 0 (T13)
- 이 저장소 .autopilot/scope-coverage-map.json 제공, 기존 기능 케이스 T4–T8 계속 통과
- 회귀 가드 T12–T14 통과

## 검증 (fresh, 0 exit)
- tests/autopilot/test-create-task-scope-coverage.sh
- tests/autopilot/test-create-task-status-transition.sh

## 변경 표면
config 신규 .autopilot/scope-coverage-map.json / checker 매핑 로직 설정 구동화 /
map 문서 = 설정 스키마 규약 / SKILL.md 서술 / plugin.json 0.63.6→0.64.0 / CHANGELOG
