### PR TITLE
🤖 [자동 리뷰] project-init hook-standard — 소비 프로젝트 훅 구조 표준 + 결정적 검사기

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "project-init",
       "source": "./plugins/project-init",
       "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
-      "version": "0.24.7",
+      "version": "0.25.0",
       "category": "scaffold",
       "tags": [
         "scaffold",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## project-init 0.25.0
+
+### 새 기능
+- **소비 프로젝트 훅 구조 표준 + 결정적 검사기 신설 (run 616)** — `shared/hook-standard/` 추가. `standard.md`가 소비 프로젝트 `.claude/hooks/`의 2계층 레이아웃(직속=이벤트명 kebab-case 핸들러, `lib/<command>/`=기능별 디렉터리)·역할 분리(핸들러는 디스패처, 로직은 lib)·스크립트 계약(POSIX sh·jq 우선 sed 폴백·비차단 exit 0·차단 exit 2·실행권한·`${CLAUDE_PROJECT_DIR}` 등록)을 단일 출처로 정의하고, 검사기 판정 10항목과 모델 판정 5항목을 분리된 절로 둔다. `hook_checker.py`(Python3 표준 라이브러리 전용)가 레이아웃·파일명·실행권한·셔뱅·settings↔핸들러 정합·lib 구조를 판정해 항목별 severity+evidence JSON을 stdout으로 내며, 결함이 있어도 평가 성공이면 exit 0. `checker-invocation.md`가 호출 계약(절대경로 고정·실행 형식·결과 해석)을 정의하고, `tests/`가 통과·위반 5종 픽스처로 판정을 검증한다. 후속 `create-hook`·`repair-hook` 스킬이 공유할 기준선(`shared/rubric`이 create-skill·repair-skill에 하는 역할과 대칭).
+
 ## thinktank 1.0.2
 
 ### 변경(호환)

--- a/plugins/project-init/.claude-plugin/plugin.json
+++ b/plugins/project-init/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.24.7",
+  "version": "0.25.0",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",

--- a/plugins/project-init/.codex-plugin/plugin.json
+++ b/plugins/project-init/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-init",
-  "version": "0.24.7",
+  "version": "0.25.0",
   "description": "새 프로젝트 시작 시 필요한 기본 지침과 도구를 자동으로 설정해주는 플러그인",
   "author": {
     "name": "예의상",

--- a/plugins/project-init/shared/bootstrap/tests/codex-parity-contract.test.sh
+++ b/plugins/project-init/shared/bootstrap/tests/codex-parity-contract.test.sh
@@ -31,8 +31,8 @@ check "Codex marketplace has required policy and category" bash -c \
 check "Codex marketplace omits plugin version" bash -c \
   "[ \"\$(jq -r '.plugins[0] | has(\"version\")' '$CODEX_MARKETPLACE')\" = false ]"
 
-check "project-init release surfaces are version 0.24.7" bash -c \
-  "[ \"\$(jq -r .version '$CODEX_MANIFEST')\" = 0.24.7 ] && [ \"\$(jq -r .version '$CLAUDE_MANIFEST')\" = 0.24.7 ] && [ \"\$(jq -r '.plugins[] | select(.name == \"project-init\") | .version' '$CLAUDE_MARKETPLACE')\" = 0.24.7 ]"
+check "project-init release surfaces are version 0.25.0" bash -c \
+  "[ \"\$(jq -r .version '$CODEX_MANIFEST')\" = 0.25.0 ] && [ \"\$(jq -r .version '$CLAUDE_MANIFEST')\" = 0.25.0 ] && [ \"\$(jq -r '.plugins[] | select(.name == \"project-init\") | .version' '$CLAUDE_MARKETPLACE')\" = 0.25.0 ]"
 check "Codex manifest uses default plugin hook discovery without override" bash -c \
   "[ \"\$(jq -r 'has(\"hooks\")' '$CODEX_MANIFEST')\" = false ]"
 

--- a/plugins/project-init/shared/hook-standard/checker-invocation.md
+++ b/plugins/project-init/shared/hook-standard/checker-invocation.md
@@ -1,0 +1,15 @@
+# hook_checker 호출 계약 (단일 출처)
+
+스킬(`create-hook`·`repair-hook`)이 훅 구조 표준의 결정적 검사기 `hook_checker.py`를 호출할 때의 공통 계약이다. 각 스킬은 이 문서를 참조하고 사본을 두지 않는다.
+
+- **절대경로 고정.** `git rev-parse --show-toplevel`로 저장소 루트의 절대경로를 구하고, 검사기 경로와 평가 대상 훅 디렉터리 경로 모두 절대경로로 조합한다 — Bash 실행 시 현재 작업 디렉터리에 대한 가정을 하지 않으며, 상대경로(`../../` 등)는 Read로 단일 문서를 읽을 때만 쓰고 Bash 실행 인자에는 쓰지 않는다.
+- **실행 형식.**
+
+  ```
+  python3 <repo_root>/plugins/project-init/shared/hook-standard/hook_checker.py <소비 프로젝트의 .claude/hooks 절대경로>
+  ```
+
+  settings 정합 검사는 인자로 받은 훅 디렉터리의 **부모**에서 `settings.json`·`settings.local.json`을 읽는다 — 별도 인자가 없다.
+
+- **결과 해석.** 평가 자체가 성공하면 결함이 발견되어도 종료 코드 0과 함께 stdout JSON을 낸다 — 결함은 종료 코드가 아니라 JSON의 `grade`·`*_count`·`checks`(결정적 10항목, `check_type: "rule"`)에 담긴다. 각 항목의 `evidence`가 위반의 구체 근거(파일명·등록 경로)를 담는다. 종료 코드가 0이 아니면(경로 오류 등) 오류를 알리고 중단한다.
+- **모델 판정 항목은 검사기 밖.** `standard.md`의 모델 판정 절 5항목은 이 JSON에 포함되지 않는다 — 스킬을 실행하는 에이전트가 스크립트를 읽고 채운다.

--- a/plugins/project-init/shared/hook-standard/hook_checker.py
+++ b/plugins/project-init/shared/hook-standard/hook_checker.py
@@ -174,13 +174,15 @@ def evaluate(hooks_dir):
                         f"셔뱅이 '{SHEBANG}' 가 아닌 스크립트: {bad_shebang}" if bad_shebang
                         else f"모든 스크립트 셔뱅 {SHEBANG}")
 
-    # settings 정합
-    registered = {_command_basename(c) for _, c in regs}
+    # settings 정합 — 등록은 (이벤트, 핸들러 파일명) 쌍으로 비교한다: 같은 파일명이라도
+    # 다른 이벤트에 등록된 것은 정합이 아니다(훅은 등록된 이벤트에서만 실행된다).
+    registered = {(e, _command_basename(c)) for e, c in regs}
     unregistered = [os.path.basename(p) for p in top
-                    if os.path.basename(p) not in registered]
+                    if (HANDLER_NAMES.get(os.path.basename(p)),
+                        os.path.basename(p)) not in registered]
     res["G-REGISTERED"] = (not unregistered,
-                           f"settings 에 등록 없는 핸들러: {unregistered}" if unregistered
-                           else f"핸들러 {len(top)}개 모두 등록됨")
+                           f"settings 에 자기 이벤트로 등록 없는 핸들러: {unregistered}" if unregistered
+                           else f"핸들러 {len(top)}개 모두 자기 이벤트로 등록됨")
     existing = {os.path.basename(p) for p in top}
     missing = sorted({_command_basename(c) for _, c in regs
                       if _command_basename(c) not in existing})

--- a/plugins/project-init/shared/hook-standard/hook_checker.py
+++ b/plugins/project-init/shared/hook-standard/hook_checker.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""project-init: 소비 프로젝트 훅 구조 표준 검사기 (결정적 10항목).
+
+`shared/hook-standard/standard.md`가 정의하는 2계층 레이아웃·스크립트 계약 중
+결정적으로 판정 가능한 항목(레이아웃·파일명·실행권한·셔뱅·settings 정합·lib 구조)을
+파일시스템과 settings JSON 만으로 검사한다. 의미적 판정 항목(비차단 원칙 위배 소지,
+과광 matcher, 위험 명령 등)은 이 도구가 다루지 않고 `standard.md`의 모델 판정 절을
+기준으로 훅 스킬(create-hook/repair-hook)을 실행하는 에이전트가 채운다.
+
+이 스크립트는 project-init 플러그인의 자체 자산이며 Python3 표준 라이브러리만 쓴다.
+
+사용법:
+    python3 hook_checker.py <소비 프로젝트의 .claude/hooks 디렉터리>
+
+평가에 성공하면 stdout 에 JSON 을 내고 exit code 0 으로 끝난다. 발견된 결함은
+종료 코드가 아니라 결과의 grade·blocker_count·major_count·minor_count 에 담긴다.
+입력 오류(디렉터리 없음·읽기 불가)는 exit code 4.
+"""
+
+import datetime
+import json
+import os
+import re
+import sys
+
+SCHEMA_VERSION = "1.0"
+
+# Claude Code 훅 이벤트 — 핸들러 파일명은 이벤트명의 kebab-case + .sh.
+EVENTS = [
+    "PreToolUse", "PostToolUse", "UserPromptSubmit", "Notification",
+    "Stop", "SubagentStop", "PreCompact", "SessionStart", "SessionEnd",
+]
+SHEBANG = "#!/bin/sh"
+PLACEHOLDER = "${CLAUDE_PROJECT_DIR}"
+SETTINGS_FILES = ("settings.json", "settings.local.json")
+
+# (id, section, item, severity)
+RULE_META = [
+    ("L-EVENT-NAME", "레이아웃", "직속 파일은 이벤트명 kebab-case 핸들러", "BLOCKER"),
+    ("S-EXEC-HANDLER", "스크립트 계약", "핸들러 실행권한", "BLOCKER"),
+    ("G-REGISTERED", "settings 정합", "핸들러 파일마다 등록 존재", "BLOCKER"),
+    ("G-FILE-EXISTS", "settings 정합", "등록된 핸들러 파일 실재", "BLOCKER"),
+    ("L-NO-STRAY-SCRIPT", "레이아웃", "기능 스크립트는 lib/<command>/ 안", "MAJOR"),
+    ("S-SHEBANG", "스크립트 계약", "모든 스크립트 셔뱅 #!/bin/sh", "MAJOR"),
+    ("S-EXEC-LIB", "스크립트 계약", "lib 스크립트 실행권한", "MAJOR"),
+    ("G-PLACEHOLDER", "settings 정합", "등록 경로 ${CLAUDE_PROJECT_DIR} 사용", "MAJOR"),
+    ("G-ONE-HANDLER", "settings 정합", "이벤트당 핸들러 1개", "MAJOR"),
+    ("L-LIB-STRUCTURE", "레이아웃", "lib/<command>/ 에 스크립트 존재", "MINOR"),
+]
+
+
+def kebab(event):
+    return re.sub(r"(?<!^)(?=[A-Z])", "-", event).lower()
+
+
+HANDLER_NAMES = {kebab(e) + ".sh": e for e in EVENTS}
+
+
+def _scan(hooks_dir):
+    """hooks 디렉터리를 (핸들러 후보, lib 스크립트, stray 스크립트, lib 디렉터리) 로 나눈다."""
+    top, lib_scripts, stray, lib_dirs = [], [], [], []
+    for root, dirs, files in os.walk(hooks_dir):
+        dirs.sort()
+        rel_root = os.path.relpath(root, hooks_dir)
+        parts = [] if rel_root == "." else rel_root.split(os.sep)
+        if len(parts) == 1 and parts[0] == "lib":
+            lib_dirs.extend(os.path.join(root, d) for d in dirs)
+        for name in sorted(files):
+            path = os.path.join(root, name)
+            if not parts:
+                # 직속의 비스크립트 파일(README 등)은 핸들러 판정 대상이 아니다.
+                if name.endswith(".sh"):
+                    top.append(path)
+            elif len(parts) == 2 and parts[0] == "lib":
+                lib_scripts.append(path)
+            elif parts[0] == "lib":
+                # lib/<command>/ 보다 깊은 위치의 스크립트만 위반으로 본다(참조 파일은 허용).
+                if name.endswith(".sh"):
+                    stray.append(path)
+            elif name.endswith(".sh"):
+                stray.append(path)
+    return top, lib_scripts, stray, lib_dirs
+
+
+def _read_settings(hooks_dir):
+    """hooks 디렉터리의 부모에서 settings 를 읽어 (이벤트, 명령) 등록 목록을 만든다.
+
+    settings.json 과 settings.local.json 을 **둘 다** 읽되 병합 우선순위는 구현하지
+    않는다 — "어느 파일에도 등록이 없음"만 위반으로 보아 과판정을 피한다.
+    """
+    parent = os.path.dirname(os.path.abspath(hooks_dir))
+    regs = []
+    for fname in SETTINGS_FILES:
+        path = os.path.join(parent, fname)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            continue
+        hooks = data.get("hooks") if isinstance(data, dict) else None
+        if not isinstance(hooks, dict):
+            continue
+        for event, matchers in hooks.items():
+            if not isinstance(matchers, list):
+                continue
+            for matcher in matchers:
+                if not isinstance(matcher, dict):
+                    continue
+                for entry in matcher.get("hooks", []) or []:
+                    if isinstance(entry, dict) and isinstance(entry.get("command"), str):
+                        regs.append((event, entry["command"]))
+    return regs
+
+
+def _command_basename(command):
+    """등록 명령 문자열에서 참조하는 핸들러 스크립트 파일명을 뽑는다.
+
+    인용부호와 인터프리터 접두(`sh "<path>"`)를 견딘다 — `.sh` 로 끝나는 마지막
+    토큰을 우선 쓰고, 없으면 첫 토큰의 basename 으로 폴백한다.
+    """
+    tokens = [t.strip("'\"") for t in command.strip().split()]
+    if not tokens:
+        return ""
+    sh_tokens = [t for t in tokens if t.endswith(".sh")]
+    return os.path.basename(sh_tokens[-1] if sh_tokens else tokens[0])
+
+
+def _first_line(path):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return f.readline().rstrip("\n")
+    except OSError:
+        return ""
+
+
+def evaluate(hooks_dir):
+    top, lib_scripts, stray, lib_dirs = _scan(hooks_dir)
+    regs = _read_settings(hooks_dir)
+    res = {}
+
+    # 레이아웃
+    bad_names = [os.path.basename(p) for p in top
+                 if os.path.basename(p) not in HANDLER_NAMES]
+    res["L-EVENT-NAME"] = (not bad_names,
+                           f"이벤트명이 아닌 직속 파일: {bad_names}" if bad_names
+                           else f"핸들러 {len(top)}개 모두 이벤트명 kebab-case")
+    rel_stray = [os.path.relpath(p, hooks_dir) for p in stray]
+    res["L-NO-STRAY-SCRIPT"] = (not rel_stray,
+                                f"lib/<command>/ 밖 기능 스크립트: {rel_stray}" if rel_stray
+                                else "기능 스크립트가 모두 lib/<command>/ 안에 있음")
+    empty_libs = [os.path.basename(d) for d in lib_dirs
+                  if not any(os.path.dirname(s) == d and s.endswith(".sh")
+                             for s in lib_scripts)]
+    res["L-LIB-STRUCTURE"] = (not empty_libs,
+                              f"스크립트 없는 lib command: {empty_libs}" if empty_libs
+                              else f"lib command {len(lib_dirs)}개 스크립트 보유")
+
+    # 스크립트 계약
+    no_exec_top = [os.path.basename(p) for p in top if not os.access(p, os.X_OK)]
+    res["S-EXEC-HANDLER"] = (not no_exec_top,
+                             f"실행권한 없는 핸들러: {no_exec_top}" if no_exec_top
+                             else "핸들러 실행권한 충족")
+    no_exec_lib = [os.path.relpath(p, hooks_dir) for p in lib_scripts
+                   if p.endswith(".sh") and not os.access(p, os.X_OK)]
+    res["S-EXEC-LIB"] = (not no_exec_lib,
+                         f"실행권한 없는 lib 스크립트: {no_exec_lib}" if no_exec_lib
+                         else "lib 스크립트 실행권한 충족")
+    bad_shebang = [os.path.relpath(p, hooks_dir)
+                   for p in top + lib_scripts + stray
+                   if p.endswith(".sh") and _first_line(p).strip() != SHEBANG]
+    res["S-SHEBANG"] = (not bad_shebang,
+                        f"셔뱅이 '{SHEBANG}' 가 아닌 스크립트: {bad_shebang}" if bad_shebang
+                        else f"모든 스크립트 셔뱅 {SHEBANG}")
+
+    # settings 정합
+    registered = {_command_basename(c) for _, c in regs}
+    unregistered = [os.path.basename(p) for p in top
+                    if os.path.basename(p) not in registered]
+    res["G-REGISTERED"] = (not unregistered,
+                           f"settings 에 등록 없는 핸들러: {unregistered}" if unregistered
+                           else f"핸들러 {len(top)}개 모두 등록됨")
+    existing = {os.path.basename(p) for p in top}
+    missing = sorted({_command_basename(c) for _, c in regs
+                      if _command_basename(c) not in existing})
+    res["G-FILE-EXISTS"] = (not missing,
+                            f"등록됐으나 파일 부재: {missing}" if missing
+                            else f"등록 {len(regs)}건 모두 파일 실재")
+    no_ph = sorted({c for _, c in regs if PLACEHOLDER not in c})
+    res["G-PLACEHOLDER"] = (not no_ph,
+                            f"{PLACEHOLDER} 미사용 등록: {no_ph}" if no_ph
+                            else f"등록 경로 모두 {PLACEHOLDER} 사용")
+    per_event = {}
+    for event, command in regs:
+        per_event.setdefault(event, set()).add(_command_basename(command))
+    multi = sorted(f"{e}: {sorted(v)}" for e, v in per_event.items() if len(v) > 1)
+    res["G-ONE-HANDLER"] = (not multi,
+                            f"이벤트당 핸들러 2개 이상: {multi}" if multi
+                            else "이벤트당 핸들러 1개")
+
+    checks = []
+    for cid, section, item, severity in RULE_META:
+        passed, evidence = res[cid]
+        checks.append({
+            "id": cid, "section": section, "item": item,
+            "check_type": "rule", "severity": severity,
+            "passed": bool(passed), "evidence": evidence,
+        })
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "evaluated_at": datetime.datetime.now(datetime.timezone.utc)
+                                 .strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "hooks_dir": os.path.abspath(hooks_dir),
+        "checks": checks,
+        **_grade(checks),
+    }
+
+
+def _grade(checks):
+    b = sum(1 for c in checks if not c["passed"] and c["severity"] == "BLOCKER")
+    mj = sum(1 for c in checks if not c["passed"] and c["severity"] == "MAJOR")
+    mn = sum(1 for c in checks if not c["passed"] and c["severity"] == "MINOR")
+    if b >= 1:
+        grade = "F"
+    elif mj == 0:
+        grade = "S"
+    elif mj <= 2:
+        grade = "A"
+    elif mj <= 4:
+        grade = "B"
+    else:
+        grade = "C"
+    return {"grade": grade, "blocker_count": b, "major_count": mj, "minor_count": mn}
+
+
+def main(argv):
+    if not argv:
+        sys.stderr.write("usage: hook_checker.py <.claude/hooks 디렉터리>\n")
+        return 4
+    hooks_dir = argv[0]
+    if not os.path.isdir(hooks_dir) or not os.access(hooks_dir, os.R_OK):
+        sys.stderr.write(f"error: 디렉터리가 없거나 읽을 수 없습니다: {hooks_dir}\n")
+        return 4
+    print(json.dumps(evaluate(hooks_dir), ensure_ascii=False, indent=2))
+    return 0  # 평가 성공. 발견된 결함은 grade·*_count 에 있다(종료 코드 아님).
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/plugins/project-init/shared/hook-standard/standard.md
+++ b/plugins/project-init/shared/hook-standard/standard.md
@@ -1,0 +1,80 @@
+# 소비 프로젝트 훅 구조 표준 (단일 출처)
+
+소비 프로젝트의 `.claude/hooks/` 훅 구조·품질 기준이다. 훅을 작성·수리하는 스킬(`create-hook`·`repair-hook`)이 이 문서를 참조하고 사본을 두지 않는다.
+
+이 표준은 **스킬 산출물의 계약**이다 — 소비 프로젝트에 정책을 강제하는 게이트가 아니다. 플러그인 자신의 `hooks/`(hooks.json) 표면에는 적용되지 않는다.
+
+## 등급 기준
+
+| 등급 | 조건 |
+|---|---|
+| F | BLOCKER ≥ 1 |
+| S | BLOCKER 0, MAJOR 0 |
+| A | BLOCKER 0, MAJOR ≤ 2 |
+| B | BLOCKER 0, MAJOR ≤ 4 |
+| C | BLOCKER 0, MAJOR ≥ 5 |
+
+MINOR 는 등급에 영향을 주지 않는다.
+
+## 1. 2계층 레이아웃
+
+```
+.claude/hooks/
+├── pre-tool-use.sh          # 이벤트 핸들러 (PreToolUse)
+├── session-start.sh         # 이벤트 핸들러 (SessionStart)
+└── lib/
+    └── <command>/           # 기능(command)별 디렉터리
+        ├── <command>.sh     # 기능 스크립트
+        └── <참조 파일>       # 그 기능이 쓰는 데이터·템플릿
+```
+
+- **핸들러 계층** — `.claude/hooks/` 직속. 등록된 이벤트당 파일 1개, 파일명은 이벤트명의 kebab-case + `.sh`(`PreToolUse` → `pre-tool-use.sh`, `UserPromptSubmit` → `user-prompt-submit.sh`).
+- **기능 계층** — `.claude/hooks/lib/<command>/`. 기능별 디렉터리 하나에 스크립트와 그 기능이 쓰는 참조 파일을 응집시킨다.
+
+이벤트명: `PreToolUse` · `PostToolUse` · `UserPromptSubmit` · `Notification` · `Stop` · `SubagentStop` · `PreCompact` · `SessionStart` · `SessionEnd`.
+
+## 2. 역할 분리
+
+- 핸들러는 **디스패처**다. stdin JSON 을 **1회** 읽어(`input="$(cat)"`) 변수에 담고, 자기 이벤트에 속한 lib command 들을 호출하며 그 결과를 종합한다.
+- 실제 로직은 **lib command 스크립트에만** 둔다. 핸들러에 로직을 인라인하지 않는다.
+- stdin 은 한 번만 읽을 수 있으므로, 여러 command 에 넘길 때는 읽어 둔 변수를 전달한다.
+
+## 3. 스크립트 계약
+
+- **POSIX sh** — 모든 스크립트 셔뱅은 `#!/bin/sh`. bash 전용 문법(배열, `[[ ]]`)을 쓰지 않는다.
+- **jq 우선·sed 폴백** — JSON 파싱은 jq 를 쓰되, jq 부재 환경에서 sed/grep 폴백으로 동작을 이어간다.
+- **비차단 이벤트는 항상 exit 0** — 실패·파싱 불가·의존 도구 부재는 graceful passthrough 한다(세션을 막지 않는다).
+- **차단 의도는 exit 2 + stderr 사유** — 차단은 명시적 의도일 때만, 사유를 stderr 로 남긴다.
+- **실행권한** — 모든 `.sh` 에 `chmod +x`.
+- **settings 등록** — `.claude/settings.json`(또는 `settings.local.json`)에 이벤트당 핸들러 1개를 `${CLAUDE_PROJECT_DIR}` placeholder 경로로 등록한다(절대경로·상대경로 하드코딩 금지).
+
+## 4. 검사기 판정 항목 (결정적 10)
+
+`hook_checker.py` 가 파일시스템과 settings JSON 만으로 판정한다. 호출 방법은 `checker-invocation.md`.
+
+| id | 섹션 | 항목 | severity |
+|---|---|---|---|
+| L-EVENT-NAME | 레이아웃 | 직속 파일은 이벤트명 kebab-case 핸들러 | BLOCKER |
+| S-EXEC-HANDLER | 스크립트 계약 | 핸들러 실행권한 | BLOCKER |
+| G-REGISTERED | settings 정합 | 핸들러 파일마다 등록 존재 | BLOCKER |
+| G-FILE-EXISTS | settings 정합 | 등록된 핸들러 파일 실재 | BLOCKER |
+| L-NO-STRAY-SCRIPT | 레이아웃 | 기능 스크립트는 `lib/<command>/` 안 | MAJOR |
+| S-SHEBANG | 스크립트 계약 | 모든 스크립트 셔뱅 `#!/bin/sh` | MAJOR |
+| S-EXEC-LIB | 스크립트 계약 | lib 스크립트 실행권한 | MAJOR |
+| G-PLACEHOLDER | settings 정합 | 등록 경로 `${CLAUDE_PROJECT_DIR}` 사용 | MAJOR |
+| G-ONE-HANDLER | settings 정합 | 이벤트당 핸들러 1개 | MAJOR |
+| L-LIB-STRUCTURE | 레이아웃 | `lib/<command>/` 에 스크립트 존재 | MINOR |
+
+settings 정합은 `settings.json` 과 `settings.local.json` 을 **둘 다** 읽되 병합 우선순위는 구현하지 않는다 — "어느 파일에도 등록이 없음"만 위반으로 본다(과판정 회피).
+
+## 5. 모델 판정 항목 (의미적 5)
+
+검사기로 판정할 수 없는 항목이다. `create-hook`·`repair-hook` 을 실행하는 에이전트가 스크립트 내용을 읽고 판정한다.
+
+| id | 항목 | severity | 판정 기준 |
+|---|---|---|---|
+| M-NONBLOCKING | 비차단 원칙 준수 | BLOCKER | 비차단 이벤트 핸들러가 오류·의존 부재 상황에서 0 이 아닌 코드로 끝날 경로가 없는가. `set -e`, 파이프 실패, 미검증 명령 실패가 세션을 막지 않는가. |
+| M-DESTRUCTIVE | 위험 명령 부재 | BLOCKER | `rm -rf`, `git push --force`, `dd`, 자격증명 유출 등 되돌릴 수 없는 명령을 실행하지 않는가. |
+| M-MATCHER-SCOPE | matcher 범위 적정 | MAJOR | settings 의 matcher 가 필요한 도구만 걸러내는가. 전체 도구를 잡아 놓고 스크립트 안에서 걸러내는 과광(over-broad) 패턴이 아닌가. |
+| M-DISPATCH | 디스패처 역할 준수 | MAJOR | 핸들러가 stdin 을 1회 읽고 lib command 로 위임하는가. 로직이 핸들러에 인라인돼 있지 않은가. |
+| M-JQ-FALLBACK | jq 폴백 실효성 | MINOR | jq 부재 시 폴백 경로가 실제로 같은 값을 뽑는가(주석만 있고 미구현이 아닌가). |

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/good/hooks/lib/rtk-rewrite/rewrite.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/good/hooks/lib/rtk-rewrite/rewrite.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# rtk-rewrite command: 명령을 rtk 프록시로 재작성한다.
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/good/hooks/pre-tool-use.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/good/hooks/pre-tool-use.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# PreToolUse 이벤트 핸들러 — stdin JSON 을 1회 읽어 lib command 로 위임한다.
+input="$(cat)"
+printf %s "$input" >/dev/null
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/good/hooks/session-start.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/good/hooks/session-start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# SessionStart 이벤트 핸들러 — stdin JSON 을 1회 읽어 lib command 로 위임한다.
+input="$(cat)"
+printf %s "$input" >/dev/null
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/good/settings.json
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/good/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [ { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-tool-use.sh" } ] }
+    ],
+    "SessionStart": [
+      { "hooks": [ { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh" } ] }
+    ]
+  }
+}

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-bad-name/hooks/my-hook.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-bad-name/hooks/my-hook.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# PreToolUse 이벤트 핸들러 — stdin JSON 을 1회 읽어 lib command 로 위임한다.
+input="$(cat)"
+printf %s "$input" >/dev/null
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-bad-name/settings.json
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-bad-name/settings.json
@@ -1,0 +1,1 @@
+{ "hooks": { "PreToolUse": [ { "hooks": [ { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/my-hook.sh" } ] } ] } }

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-no-exec/hooks/pre-tool-use.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-no-exec/hooks/pre-tool-use.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# PreToolUse 이벤트 핸들러 — stdin JSON 을 1회 읽어 lib command 로 위임한다.
+input="$(cat)"
+printf %s "$input" >/dev/null
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-no-exec/settings.json
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-no-exec/settings.json
@@ -1,0 +1,1 @@
+{ "hooks": { "PreToolUse": [ { "hooks": [ { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-tool-use.sh" } ] } ] } }

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-settings-mismatch/hooks/pre-tool-use.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-settings-mismatch/hooks/pre-tool-use.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# PreToolUse 이벤트 핸들러 — stdin JSON 을 1회 읽어 lib command 로 위임한다.
+input="$(cat)"
+printf %s "$input" >/dev/null
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-settings-mismatch/settings.json
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-settings-mismatch/settings.json
@@ -1,0 +1,1 @@
+{ "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/stop.sh" } ] } ] } }

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-shebang/hooks/pre-tool-use.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-shebang/hooks/pre-tool-use.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# 셔뱅이 POSIX sh 가 아닌 핸들러 — 표준 위반.
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-shebang/settings.json
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-shebang/settings.json
@@ -1,0 +1,1 @@
+{ "hooks": { "PreToolUse": [ { "hooks": [ { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-tool-use.sh" } ] } ] } }

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-stray-script/hooks/helpers/util.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-stray-script/hooks/helpers/util.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# lib/<command>/ 밖에 놓인 기능 스크립트 — 표준 위반.
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-stray-script/hooks/lib/note/note.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-stray-script/hooks/lib/note/note.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# note command 스크립트.
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-stray-script/hooks/pre-tool-use.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-stray-script/hooks/pre-tool-use.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# PreToolUse 이벤트 핸들러 — stdin JSON 을 1회 읽어 lib command 로 위임한다.
+input="$(cat)"
+printf %s "$input" >/dev/null
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-stray-script/settings.json
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-stray-script/settings.json
@@ -1,0 +1,1 @@
+{ "hooks": { "PreToolUse": [ { "hooks": [ { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-tool-use.sh" } ] } ] } }

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-wrong-event/hooks/pre-tool-use.sh
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-wrong-event/hooks/pre-tool-use.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# PreToolUse 이벤트 핸들러 — stdin JSON 을 1회 읽어 lib command 로 위임한다.
+input="$(cat)"
+printf %s "$input" >/dev/null
+exit 0

--- a/plugins/project-init/shared/hook-standard/tests/fixtures/violation-wrong-event/settings.json
+++ b/plugins/project-init/shared/hook-standard/tests/fixtures/violation-wrong-event/settings.json
@@ -1,0 +1,1 @@
+{ "hooks": { "Stop": [ { "hooks": [ { "type": "command", "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-tool-use.sh" } ] } ] } }

--- a/plugins/project-init/shared/hook-standard/tests/hook-checker.test.sh
+++ b/plugins/project-init/shared/hook-standard/tests/hook-checker.test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# shared/hook-standard: hook_checker.py 단위 테스트.
+# 소비 프로젝트 .claude/hooks/ 구조 표준의 결정적 검사기 판정·등급·exit code를 검증한다.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CHECKER="$DIR/hook_checker.py"
+FIXTURES="$DIR/tests/fixtures"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "OK: $*"; }
+
+run() {
+  EC=0
+  python3 "$CHECKER" "$@" > "$tmp/out.json" 2> "$tmp/err.txt" || EC=$?
+}
+
+ASSERT="$tmp/assert.py"
+cat > "$ASSERT" <<'PY'
+import json, sys
+r = json.load(open(sys.argv[1]))
+checks = {c["id"]: c for c in r["checks"]}
+for a in sys.argv[2:]:
+    k, v = a.split("=", 1)
+    if k == "grade":
+        got = r["grade"]
+    elif k in ("blocker", "major", "minor"):
+        got = str(r[k + "_count"])
+    elif k.startswith("pass:"):
+        got = str(checks[k[5:]]["passed"]).lower()
+    elif k.startswith("evidence:"):
+        cid = k[len("evidence:"):]
+        got = "nonempty" if checks[cid]["evidence"].strip() else "empty"
+    else:
+        raise SystemExit("unknown assert key: " + k)
+    if str(got) != v:
+        raise SystemExit(f"  {k}: expected '{v}' got '{got}'")
+PY
+
+assert_json() {
+  local label="$1"; shift
+  python3 "$ASSERT" "$tmp/out.json" "$@" || fail "$label"
+}
+
+[ -f "$CHECKER" ] || fail "hook_checker.py 부재"
+[ -f "$DIR/standard.md" ] || fail "standard.md 부재"
+[ -f "$DIR/checker-invocation.md" ] || fail "checker-invocation.md 부재"
+ok "필수 산출물 존재"
+
+# 표준 문서가 검사기 항목과 모델 판정 항목을 분리된 절로 정의한다
+grep -q '^## .*모델 판정' "$DIR/standard.md" || fail "standard.md 모델 판정 절 부재"
+grep -q '^## .*검사기' "$DIR/standard.md" || fail "standard.md 검사기 항목 절 부재"
+ok "standard.md: 검사기 항목·모델 판정 항목 분리 절"
+
+# 픽스처의 실행권한은 git mode 로 보존되지만, 체크아웃 환경 차이를 배제하기 위해 명시 부여.
+chmod +x "$FIXTURES"/good/hooks/*.sh "$FIXTURES"/good/hooks/lib/*/*.sh
+chmod +x "$FIXTURES"/violation-bad-name/hooks/*.sh
+chmod +x "$FIXTURES"/violation-settings-mismatch/hooks/*.sh
+chmod +x "$FIXTURES"/violation-stray-script/hooks/*.sh "$FIXTURES"/violation-stray-script/hooks/helpers/*.sh
+chmod +x "$FIXTURES"/violation-shebang/hooks/*.sh
+chmod -x "$FIXTURES"/violation-no-exec/hooks/pre-tool-use.sh
+
+run "$FIXTURES/good/hooks"
+[ "$EC" -eq 0 ] || fail "good exit code 0 기대(실제 $EC): $(cat "$tmp/err.txt")"
+assert_json "good 픽스처는 BLOCKER·MAJOR 0" grade=S blocker=0 major=0
+ok "good: 표준 준수 → BLOCKER·MAJOR 0"
+
+run "$FIXTURES/violation-bad-name/hooks"
+[ "$EC" -eq 0 ] || fail "결함 존재는 실패가 아님 — exit 0 기대(실제 $EC)"
+assert_json "비이벤트명 핸들러는 L-EVENT-NAME FAIL" grade=F pass:L-EVENT-NAME=false evidence:L-EVENT-NAME=nonempty
+ok "violation-bad-name: L-EVENT-NAME BLOCKER → F"
+
+run "$FIXTURES/violation-no-exec/hooks"
+[ "$EC" -eq 0 ] || fail "violation-no-exec exit 0 기대(실제 $EC)"
+assert_json "실행권한 없음은 S-EXEC-HANDLER FAIL" grade=F pass:S-EXEC-HANDLER=false evidence:S-EXEC-HANDLER=nonempty
+ok "violation-no-exec: S-EXEC-HANDLER BLOCKER → F"
+
+run "$FIXTURES/violation-settings-mismatch/hooks"
+[ "$EC" -eq 0 ] || fail "violation-settings-mismatch exit 0 기대(실제 $EC)"
+assert_json "등록↔파일 불일치는 양방향 FAIL" grade=F pass:G-REGISTERED=false pass:G-FILE-EXISTS=false \
+  evidence:G-REGISTERED=nonempty evidence:G-FILE-EXISTS=nonempty
+ok "violation-settings-mismatch: G-REGISTERED·G-FILE-EXISTS BLOCKER → F"
+
+run "$FIXTURES/violation-stray-script/hooks"
+[ "$EC" -eq 0 ] || fail "violation-stray-script exit 0 기대(실제 $EC)"
+assert_json "lib 밖 기능 스크립트는 L-NO-STRAY-SCRIPT FAIL" blocker=0 pass:L-NO-STRAY-SCRIPT=false \
+  evidence:L-NO-STRAY-SCRIPT=nonempty
+ok "violation-stray-script: L-NO-STRAY-SCRIPT MAJOR"
+
+run "$FIXTURES/violation-shebang/hooks"
+[ "$EC" -eq 0 ] || fail "violation-shebang exit 0 기대(실제 $EC)"
+assert_json "셔뱅 불일치는 S-SHEBANG FAIL" blocker=0 pass:S-SHEBANG=false evidence:S-SHEBANG=nonempty
+ok "violation-shebang: S-SHEBANG MAJOR"
+
+# settings.local.json 에만 등록돼도 위반이 아니다(과판정 회피).
+cp -r "$FIXTURES/good" "$tmp/local-only"
+mv "$tmp/local-only/settings.json" "$tmp/local-only/settings.local.json"
+run "$tmp/local-only/hooks"
+assert_json "settings.local.json 등록도 인정" pass:G-REGISTERED=true
+ok "settings.local.json 단독 등록: 과판정 없음"
+
+# 인용부호·인터프리터 접두 명령도 핸들러 참조로 인식한다(과판정 회피).
+cp -r "$FIXTURES/good" "$tmp/quoted-cmd"
+cat > "$tmp/quoted-cmd/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      { "hooks": [ { "type": "command", "command": "\"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-tool-use.sh\"" } ] }
+    ],
+    "SessionStart": [
+      { "hooks": [ { "type": "command", "command": "sh \"${CLAUDE_PROJECT_DIR}/.claude/hooks/session-start.sh\"" } ] }
+    ]
+  }
+}
+JSON
+run "$tmp/quoted-cmd/hooks"
+assert_json "인용·인터프리터 접두 등록도 정합" grade=S blocker=0 major=0
+ok "인용부호·인터프리터 접두 명령: 과판정 없음"
+
+# 훅 디렉터리 직속의 비스크립트 파일(README 등)은 핸들러 판정 대상이 아니다.
+cp -r "$FIXTURES/good" "$tmp/with-readme"
+echo '# hooks' > "$tmp/with-readme/hooks/README.md"
+run "$tmp/with-readme/hooks"
+assert_json "직속 README.md 는 핸들러 위반이 아님" grade=S blocker=0 major=0 \
+  pass:L-EVENT-NAME=true pass:S-EXEC-HANDLER=true pass:G-REGISTERED=true
+ok "직속 비스크립트 파일: 과판정 없음"
+
+run "$FIXTURES/__does-not-exist__/hooks"
+[ "$EC" -eq 4 ] || fail "존재하지 않는 경로는 exit 4 기대(실제 $EC)"
+ok "존재하지 않는 경로: 입력 오류 exit 4"
+
+echo "ALL CHECKS PASSED"

--- a/plugins/project-init/shared/hook-standard/tests/hook-checker.test.sh
+++ b/plugins/project-init/shared/hook-standard/tests/hook-checker.test.sh
@@ -59,6 +59,7 @@ ok "standard.md: 검사기 항목·모델 판정 항목 분리 절"
 chmod +x "$FIXTURES"/good/hooks/*.sh "$FIXTURES"/good/hooks/lib/*/*.sh
 chmod +x "$FIXTURES"/violation-bad-name/hooks/*.sh
 chmod +x "$FIXTURES"/violation-settings-mismatch/hooks/*.sh
+chmod +x "$FIXTURES"/violation-wrong-event/hooks/*.sh
 chmod +x "$FIXTURES"/violation-stray-script/hooks/*.sh "$FIXTURES"/violation-stray-script/hooks/helpers/*.sh
 chmod +x "$FIXTURES"/violation-shebang/hooks/*.sh
 chmod -x "$FIXTURES"/violation-no-exec/hooks/pre-tool-use.sh
@@ -83,6 +84,13 @@ run "$FIXTURES/violation-settings-mismatch/hooks"
 assert_json "등록↔파일 불일치는 양방향 FAIL" grade=F pass:G-REGISTERED=false pass:G-FILE-EXISTS=false \
   evidence:G-REGISTERED=nonempty evidence:G-FILE-EXISTS=nonempty
 ok "violation-settings-mismatch: G-REGISTERED·G-FILE-EXISTS BLOCKER → F"
+
+# 같은 파일명이라도 다른 이벤트에 등록되면 정합이 아니다 — (이벤트, 파일명) 쌍 비교.
+run "$FIXTURES/violation-wrong-event/hooks"
+[ "$EC" -eq 0 ] || fail "violation-wrong-event exit 0 기대(실제 $EC)"
+assert_json "다른 이벤트 등록은 G-REGISTERED FAIL" grade=F pass:G-REGISTERED=false \
+  pass:G-FILE-EXISTS=true evidence:G-REGISTERED=nonempty
+ok "violation-wrong-event: 이벤트↔핸들러 불일치 G-REGISTERED BLOCKER → F"
 
 run "$FIXTURES/violation-stray-script/hooks"
 [ "$EC" -eq 0 ] || fail "violation-stray-script exit 0 기대(실제 $EC)"


### PR DESCRIPTION
## 요약

소비 프로젝트 `.claude/hooks/` 훅 구조 표준의 단일 출처(표준 문서)와 그 준수를 결정적으로 판정하는 검사기.

표준이 정의하는 것:
- 2계층 레이아웃 — `.claude/hooks/` 직속 = 이벤트 핸들러(등록 이벤트당 1개, 이벤트명 kebab-case 파일명, 예: PreToolUse → pre-tool-use.sh), `.claude/hooks/lib/<command>/` = 기능(command)별 디렉토리(스크립트 + 참조 파일 응집).
- 역할 분리 — 핸들러는 디스패처: stdin JSON 을 1회 읽어 자기 이벤트의 lib command 들을 호출하고 결과를 종합한다. 실제 로직은 lib command 스크립트에만 둔다.
- 스크립트 계약 — POSIX sh(`#!/bin/sh`), jq 우선·부재 시 sed 폴백, 비차단 이벤트 항상 exit 0(graceful passthrough), 차단 의도는 exit 2 + stderr 사유, 실행권한(chmod +x), settings.json 등록은 `${CLAUDE_PROJECT_DIR}` placeholder 경로로 이벤트당 핸들러 1개.
- 검사기(결정적) — 레이아웃·파일명·실행권한·셔뱅·settings.json↔핸들러 파일 정합(등록된 핸들러 파일 존재, 핸들러 파일마다 등록 존재)·lib 구조를 판정하고 항목별 severity(BLOCKER/MAJOR/MINOR)+evidence 를 JSON 으로 stdout 출력.
- 모델 판정 항목(의미적) — 검사기로 판정 불가한 항목(비차단 원칙 위배 소지, 과광 matcher, 위험 명령 포함 등)을 표준 문서의 분리된 절로 정의(create-hook/repair-hook 이 소비).

## 작업 내용

project-init hook-standard 완료 (0.25.0, commit c8fb495)

산출물 — plugins/project-init/shared/hook-standard/
- standard.md — 2계층 레이아웃(직속=이벤트명 kebab-case 핸들러, lib/<command>/=기능
  디렉터리), 역할 분리(핸들러=디스패처, 로직은 lib), 스크립트 계약(POSIX sh·jq 우선
  sed 폴백·비차단 exit 0·차단 exit 2+stderr·chmod +x·${CLAUDE_PROJECT_DIR} 등록),
  등급 규칙(BLOCKER≥1→F, MAJOR 수로 S/A/B/C), 검사기 판정 10항목 절, 모델 판정
  5항목 절(분리).
- hook_checker.py — Python3 표준 라이브러리 전용. 레이아웃·파일명·실행권한·셔뱅·
  settings↔핸들러 정합·lib 구조를 판정해 항목별 severity+evidence JSON stdout 출력.
  결함 존재해도 exit 0, 입력 오류만 exit 4.
- checker-invocation.md — 절대경로 고정·실행 형식·결과 해석.
- tests/hook-checker.test.sh + fixtures — 통과 1종 + 위반 5종(비이벤트명 핸들러·
  실행권한 없음·settings 등록↔파일 불일치·lib 밖 기능 스크립트·셔뱅 불일치).

버전 — 0.24.7 → 0.25.0, 표면 4곳(marketplace.json, claude/codex plugin.json,
codex-parity-contract.test.sh 릴리스 핀) 동기화 + CHANGELOG 최상단 항목 추가.

검증 — plugins/project-init/shared/*/tests/*.test.sh 4개 전부 통과(sweep exit 0).
4-Level Verifier 통과, Self-Review·적대 렌즈 3종 완료(발견 6건 중 4건 수정,
2건 비채택 사유는 .loop/notes.md 기록).
