### PR TITLE
🤖 [자동 리뷰] fix: 통합이 stale 로컬 브랜치를 재사용해 루프 결과 커밋을 유실

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### 버그 수정
 - **통합이 stale 로컬 브랜치를 재사용해 루프 결과 커밋을 유실 (task 605)** — `in_ensure_work_branch`가 동명의 로컬 작업 브랜치 존재만으로 멱등 판정해, 재실행 시 낡은 시도의 브랜치를 그대로 push하고 루프의 최신 결과 커밋을 조용히 버렸다(관측: 진부한 구현이 되살아나 `plugin.json` 버전 되감김). 이제 기존 브랜치가 loop 결과 커밋을 조상으로 포함할 때만 멱등 통과하고, 미포함(stale)이면 정리 안내(로컬 브랜치 삭제 후 재실행)와 함께 차단한다. force 재배치는 계속 금지. 결과 커밋 미판독(loop 워크트리 이상)도 조용히 통과하지 않고 차단한다(terminal=done 은 워크트리 존재를 전제 — 정리 후 재진입은 pending 으로 빠져 이 경로에 오지 않음). 회귀 가드 `test-integration-stale-branch.sh` 추가.
 
+## project-init 0.25.0
+
+### 새 기능
+- **소비 프로젝트 훅 구조 표준 + 결정적 검사기 신설 (run 616)** — `shared/hook-standard/` 추가. `standard.md`가 소비 프로젝트 `.claude/hooks/`의 2계층 레이아웃(직속=이벤트명 kebab-case 핸들러, `lib/<command>/`=기능별 디렉터리)·역할 분리(핸들러는 디스패처, 로직은 lib)·스크립트 계약(POSIX sh·jq 우선 sed 폴백·비차단 exit 0·차단 exit 2·실행권한·`${CLAUDE_PROJECT_DIR}` 등록)을 단일 출처로 정의하고, 검사기 판정 10항목과 모델 판정 5항목을 분리된 절로 둔다. `hook_checker.py`(Python3 표준 라이브러리 전용)가 레이아웃·파일명·실행권한·셔뱅·settings↔핸들러 정합·lib 구조를 판정해 항목별 severity+evidence JSON을 stdout으로 내며, 결함이 있어도 평가 성공이면 exit 0. `checker-invocation.md`가 호출 계약(절대경로 고정·실행 형식·결과 해석)을 정의하고, `tests/`가 통과·위반 5종 픽스처로 판정을 검증한다. 후속 `create-hook`·`repair-hook` 스킬이 공유할 기준선(`shared/rubric`이 create-skill·repair-skill에 하는 역할과 대칭).
+
 ## thinktank 1.0.2
 
 ### 변경(호환)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
-## project-init 0.25.0
+## autopilot 0.64.3
 
-### 새 기능
-- **소비 프로젝트 훅 구조 표준 + 결정적 검사기 신설 (run 616)** — `shared/hook-standard/` 추가. `standard.md`가 소비 프로젝트 `.claude/hooks/`의 2계층 레이아웃(직속=이벤트명 kebab-case 핸들러, `lib/<command>/`=기능별 디렉터리)·역할 분리(핸들러는 디스패처, 로직은 lib)·스크립트 계약(POSIX sh·jq 우선 sed 폴백·비차단 exit 0·차단 exit 2·실행권한·`${CLAUDE_PROJECT_DIR}` 등록)을 단일 출처로 정의하고, 검사기 판정 10항목과 모델 판정 5항목을 분리된 절로 둔다. `hook_checker.py`(Python3 표준 라이브러리 전용)가 레이아웃·파일명·실행권한·셔뱅·settings↔핸들러 정합·lib 구조를 판정해 항목별 severity+evidence JSON을 stdout으로 내며, 결함이 있어도 평가 성공이면 exit 0. `checker-invocation.md`가 호출 계약(절대경로 고정·실행 형식·결과 해석)을 정의하고, `tests/`가 통과·위반 5종 픽스처로 판정을 검증한다. 후속 `create-hook`·`repair-hook` 스킬이 공유할 기준선(`shared/rubric`이 create-skill·repair-skill에 하는 역할과 대칭).
+### 버그 수정
+- **통합이 stale 로컬 브랜치를 재사용해 루프 결과 커밋을 유실 (task 605)** — `in_ensure_work_branch`가 동명의 로컬 작업 브랜치 존재만으로 멱등 판정해, 재실행 시 낡은 시도의 브랜치를 그대로 push하고 루프의 최신 결과 커밋을 조용히 버렸다(관측: 진부한 구현이 되살아나 `plugin.json` 버전 되감김). 이제 기존 브랜치가 loop 결과 커밋을 조상으로 포함할 때만 멱등 통과하고, 미포함(stale)이면 정리 안내(로컬 브랜치 삭제 후 재실행)와 함께 차단한다. force 재배치는 계속 금지. 결과 커밋 미판독(loop 워크트리 이상)도 조용히 통과하지 않고 차단한다(terminal=done 은 워크트리 존재를 전제 — 정리 후 재진입은 pending 으로 빠져 이 경로에 오지 않음). 회귀 가드 `test-integration-stale-branch.sh` 추가.
 
 ## thinktank 1.0.2
 

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/lib/forge/lib/integration.sh
+++ b/plugins/autopilot/lib/forge/lib/integration.sh
@@ -153,15 +153,25 @@ in_loop_result_commit() {
 }
 
 # in_ensure_work_branch <branch> <spec> — 작업 브랜치 보장(없으면 loop 결과 커밋에서 생성).
-#   이미 있으면 그대로 사용(재실행 멱등). 어떤 경로에서도 force 로 옮기지 않는다.
+#   이미 있으면 loop 결과 커밋을 조상으로 포함할 때만 그대로 사용(재실행 멱등) — 포함하지
+#   않으면(낡은 시도의 stale 브랜치, task 605) 조용히 재사용해 결과 커밋을 유실하는 대신
+#   불일치를 표면화해 차단한다. 어떤 경로에서도 force 로 옮기지 않는다.
 #   forge·direct 서브모드가 공유하는 단일 진입(브랜치 이식 중복 방지).
 in_ensure_work_branch() {
   local branch="$1" spec="$2"
+  # 결과 커밋은 브랜치 존재 여부와 무관하게 필수 — terminal=done 은 loop 워크트리 존재를
+  # 전제하므로(status 는 <WT>/.loop/signals 로 판정), 미판독은 정상 재진입이 아니라 이상이다.
+  # 조용한 통과 대신 표면화한다(in_loop_result_commit 이 in_die 로 사유를 낸다).
+  local commit; commit="$(in_loop_result_commit "$spec")" || return 1
   # shellcheck disable=SC2086
   if $GIT_CMD rev-parse --verify --quiet "refs/heads/$branch" >/dev/null 2>&1; then
-    return 0   # 이미 존재 — 멱등, force 재배치 안 함.
+    # shellcheck disable=SC2086
+    if $GIT_CMD merge-base --is-ancestor "$commit" "refs/heads/$branch" 2>/dev/null; then
+      return 0   # 결과 커밋 포함 — 멱등, force 재배치 안 함.
+    fi
+    in_die "stale 작업 브랜치: $branch 가 loop 결과 커밋($commit)을 포함하지 않음 — 조용한 재사용은 결과를 유실하므로 차단(force 재배치 금지). 정리: 로컬 브랜치 삭제(git branch -D $branch, 원격 동명 브랜치·열린 PR 도 정리) 후 재실행하세요."
+    return 1
   fi
-  local commit; commit="$(in_loop_result_commit "$spec")" || return 1
   # shellcheck disable=SC2086
   $GIT_CMD branch "$branch" "$commit" \
     || { in_die "작업 브랜치 생성 실패: $branch ← $commit"; return 1; }

--- a/plugins/autopilot/lib/forge/lib/tests/test-integration-remote-ahead.sh
+++ b/plugins/autopilot/lib/forge/lib/tests/test-integration-remote-ahead.sh
@@ -58,6 +58,7 @@ mock_git() {
         *origin/*)                       return 1 ;;  # base(origin/main) 전진 — 브랜치 조상 아님.
         *"remotetip localcommit"*)       return 1 ;;  # 원격 tip 은 로컬의 조상 아님(원격이 더 많음).
         *"localcommit remotetip"*)       return 0 ;;  # 로컬은 원격 tip 의 조상 = 원격-앞섬.
+        *"localcommit refs/heads/"*)     return 0 ;;  # loop 결과 커밋 = 브랜치 tip — 자기 자신은 조상.
         *) return 1 ;;
       esac ;;
     branch) printf '%s\n' "$2" >> "$BRANCHES"; return 0 ;;

--- a/plugins/autopilot/lib/forge/lib/tests/test-integration-stale-branch.sh
+++ b/plugins/autopilot/lib/forge/lib/tests/test-integration-stale-branch.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# test-integration-stale-branch.sh — stale 로컬 작업 브랜치 재사용 회귀 가드 (task 605 관측).
+#   시나리오: 재실행 시 동명의 로컬 작업 브랜치가 남아 있는데, 그 브랜치가 loop 의 최신 결과
+#   커밋을 조상으로 포함하지 않는다(낡은 시도의 커밋).
+#   기대: 통합이 stale 브랜치를 조용히 재사용해 push 하지 않고 불일치를 표면화(차단)한다.
+#     - 루프 결과 커밋이 유실되지 않는다(낡은 커밋 push·PR 미수행).
+#     - 브랜치가 결과 커밋을 이미 담고 있으면 기존대로 멱등 통과.
+#     - 어떤 경로에서도 force 미사용.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
+
+# integration.sh 를 source (하단 BASH_SOURCE 가드로 main 미실행).
+# shellcheck disable=SC1091
+. "$HERE/../integration.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+RD="$TMP/.autopilot/runs/20260721T000000-run605"; mkdir -p "$RD"
+SPEC="$TMP/SPEC.md"
+printf '# stale branch feature x\n\n## 무엇\n...\n' > "$SPEC"
+BRANCH="feat/20260721T000000-run605-stale-branch-feature-x"
+
+# ---- mock loop: 종료=DONE, paths 는 결과 워크트리 ----
+LOOPWT="$TMP/loopwt"; mkdir -p "$LOOPWT"
+mock_loop() {
+  case "$1" in
+    status) printf '{"state":"terminal","signals":["DONE"]}\n' ;;
+    logs)   : ;;
+    paths)  printf 'SPEC_PATH   %s\nWT          %s\nLOOP_DIR    %s\n' "$2" "$LOOPWT" "$LOOPWT/.loop" ;;
+    cleanup) return 0 ;;
+  esac
+}
+LOOP_CMD=mock_loop
+
+# ---- mock git ----
+#   로컬 브랜치 존재(tip=stalecommit) / loop 결과 커밋 = resultcommit.
+#   ANCESTOR: 브랜치가 결과 커밋을 포함하는가(1=stale, 0=포함) — 케이스별 토글.
+GITLOG="$TMP/gitlog" PUSHLOG="$TMP/pushlog" BRANCHES="$TMP/branches"
+: > "$GITLOG"; : > "$PUSHLOG"; printf '%s\n' "$BRANCH" > "$BRANCHES"
+ANCESTOR=1
+mock_git() {
+  if [[ "$1" == "-C" ]]; then shift 2; fi
+  local a; for a in "$@"; do case "$a" in *force*|-f) echo "FORCE USED" >&2; exit 99;; esac; done
+  printf '%s\n' "$*" >> "$GITLOG"
+  case "$1" in
+    fetch|rebase|worktree) return 0 ;;
+    ls-remote) return 0 ;;   # 원격 브랜치 미존재(원격을 지워도 재현 — SPEC 재현 맥락).
+    rev-parse)
+      case "$*" in
+        *--verify*refs/heads/*) grep -Fxq "$BRANCH" "$BRANCHES" 2>/dev/null; return $? ;;
+        *--absolute-git-dir*) printf '%s/gitdir\n' "$TMP"; return 0 ;;
+        *refs/heads/*) grep -Fxq "$BRANCH" "$BRANCHES" 2>/dev/null && { echo "stalecommit"; return 0; } || return 1 ;;
+        *HEAD*) echo "resultcommit"; return 0 ;;
+      esac ;;
+    merge-base)
+      # --is-ancestor <A> <B>: A 가 B 의 조상인가.
+      case "$*" in
+        *"resultcommit refs/heads/"*) return "$ANCESTOR" ;;  # 결과 커밋 ⊂ 브랜치?
+        *"origin/main"*)              return 0 ;;            # base 는 브랜치 조상(동기화 불필요).
+        *) return 1 ;;
+      esac ;;
+    branch) printf '%s\n' "$2" >> "$BRANCHES"; return 0 ;;
+    push) printf '%s\n' "$*" >> "$PUSHLOG"; return 0 ;;
+  esac
+  return 0
+}
+GIT_CMD=mock_git
+
+# ---- mock forge ----
+PRLOG="$TMP/prlog"; : > "$PRLOG"
+mock_forge() {
+  case "$1 $2" in
+    "pr list")   : ;;                                        # open PR 없음.
+    "pr create") printf '%s\n' "$*" >> "$PRLOG"; echo created ;;
+  esac
+  return 0
+}
+FORGE_CMD=mock_forge
+DEFAULT_BRANCH=main
+
+# ---- 케이스 A: stale 브랜치(결과 커밋 미포함) → 차단·표면화, 유실 없음 ----
+ANCESTOR=1
+rc=0; err="$(in_integrate "$SPEC" "$RD" "run605-key" 2>&1 >/dev/null)" || rc=$?
+chk "A1: stale 브랜치 → integrate 차단(rc=4)" "$rc" "4"
+chk "A2: phase=blocked" "$(int_get_phase "$RD" "run605-key")" "blocked"
+[[ ! -s "$PUSHLOG" ]] && ok "A3: 낡은 브랜치 push 안 함(결과 커밋 유실 방지)" || bad "A3: 낡은 브랜치 push 안 함 (pushlog: $(tr '\n' ';' < "$PUSHLOG"))"
+[[ ! -s "$PRLOG" ]] && ok "A4: PR 미생성" || bad "A4: PR 미생성"
+printf '%s' "$err" | grep -q "resultcommit" && ok "A5: 불일치 표면화(결과 커밋 명시)" || bad "A5: 불일치 표면화(결과 커밋 명시) (err: $err)"
+
+# ---- 케이스 B: 브랜치가 결과 커밋 포함 → 기존대로 멱등 통과 ----
+ANCESTOR=0
+rc=0; in_ensure_work_branch "$BRANCH" "$SPEC" 2>/dev/null || rc=$?
+chk "B1: 결과 커밋 포함 브랜치 → 멱등 통과(rc=0)" "$rc" "0"
+
+# ---- 케이스 C: 브랜치 미존재 → 결과 커밋에서 생성(기존 동작) ----
+printf '' > "$BRANCHES"
+rc=0; in_ensure_work_branch "$BRANCH" "$SPEC" 2>/dev/null || rc=$?
+chk "C1: 브랜치 미존재 → 생성(rc=0)" "$rc" "0"
+grep -Fxq "$BRANCH" "$BRANCHES" && ok "C2: 결과 커밋에서 브랜치 생성" || bad "C2: 결과 커밋에서 브랜치 생성"
+
+# ---- 케이스 E: 결과 커밋 미판독(loop 워크트리 이상) + 브랜치 존재 → 조용한 통과 아님(차단) ----
+#   terminal=done 은 loop 워크트리 존재를 전제하므로 미판독은 정상 재진입이 아니라 이상.
+printf '%s\n' "$BRANCH" > "$BRANCHES"
+mock_loop_nowt() {
+  case "$1" in
+    status) printf '{"state":"terminal","signals":["DONE"]}\n' ;;
+    paths)  : ;;   # WT 경로 미제공 — 결과 커밋 판독 불가.
+    *) : ;;
+  esac
+}
+LOOP_CMD=mock_loop_nowt
+rc=0; in_ensure_work_branch "$BRANCH" "$SPEC" 2>/dev/null || rc=$?
+[[ "$rc" != "0" ]] && ok "E1: 결과 커밋 미판독 → 조용한 통과 아님(rc!=0)" || bad "E1: 결과 커밋 미판독 → 조용한 통과 아님(rc!=0)"
+LOOP_CMD=mock_loop
+
+# ---- 공통: force 미사용 ----
+if grep -qiE 'force|(^| )-f( |$)' "$GITLOG"; then bad "D1: force 미사용"; else ok "D1: force 미사용"; fi
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || { echo "FAILURES present"; exit 1; }


### PR DESCRIPTION
## 요약


통합 단계가 작업 브랜치를 보장할 때, 기존 로컬 브랜치가 루프의 최신 결과 커밋을 담고 있지 않으면 그 사실을 감지해 처리한다. 검증된 구현이 조용히 버려지고 낡은 커밋이 PR에 올라가는 일이 없어야 한다.

## 작업 내용

통합 stale 로컬 브랜치 재사용 유실 fix 완료 (task 605, autopilot 0.64.3).

무엇을: in_ensure_work_branch(integration.sh)가 브랜치 존재만으로 멱등 판정하던 것을,
기존 브랜치가 loop 결과 커밋을 조상으로 포함할 때만 멱등 통과하도록 보강. 미포함(stale)·
결과 커밋 미판독은 정리 안내(로컬 브랜치 삭제 후 재실행)와 함께 차단 — 낡은 커밋의
조용한 push·PR 을 막아 결과 커밋 유실을 방지. force 재배치 금지 불변.

왜: 재실행 시 이전 시도의 로컬 브랜치가 그대로 push 돼 검증된 구현이 버려지고 낡은
커밋이 머지 후보가 되는 관측(task 605, plugin.json 버전 되감김) 차단.

검증: 회귀 가드 test-integration-stale-branch.sh 신설(stale 차단·멱등 통과·생성·
미판독 차단·force 미사용) + 기존 remote-ahead(mock 충실도 1줄 보정, 단언 무변경)·
merge-serverside 포함 lib/tests 3종 fresh ALL PASS 0-exit.

커밋: e81ed92 fix:root (integration.sh, tests 2, plugin.json 0.64.3, CHANGELOG).
