### PR TITLE
🤖 [자동 리뷰] autopilot review-loop 신뢰봇 게이트 — 실리뷰봇 미인식(blocked 비가시·approve 합성) + 같은-head approve/approve 무한 대기

### DIFF
--- a/.autopilot/review-bot-logins
+++ b/.autopilot/review-bot-logins
@@ -1,0 +1,3 @@
+# forge review-loop 신뢰 리뷰봇 allowlist — 한 줄당 GitHub 로그인 정확일치. `#` 주석.
+# GitHub App 이 아닌 머신유저 리뷰봇만 여기에 명시 등록한다(임의 `*-bot` 자동 신뢰 금지).
+courtesy-bot

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
       "name": "autopilot",
       "source": "./plugins/autopilot",
       "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
-      "version": "0.63.5",
+      "version": "0.64.3",
       "category": "automation",
       "tags": [
         "autonomous",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 ### 변경(호환)
 - **공유 session-conventions 해체 — 규범을 각 SKILL.md에 용어 특화 인라인 (run 604)** — `skills/shared/session-conventions.md`를 제거하고 규범 5영역(호출 규약·세션 파일 규율·디스패치 공통 규범·중앙 리서치 공통 규범·공통 안전 경계)을 brainstorm(세션 파일, `.brainstorm/<session-id>.md`)·roundtable(회의 파일, `.roundtable/<meeting-id>.md`) 각 SKILL.md 본문에 각 스킬 용어로 자체 정의. `../shared/` 참조·위임 문구 제거(스킬 자기완결). 규범 의미·강도 불변.
 
+## autopilot 0.64.3
+
+### 버그 수정
+- **forge review-loop 신뢰봇 게이트 — 머신유저 리뷰봇 미인식 + 같은-head approve/approve 무한 대기 (#627)** — (1) `REVIEW_BOT_LOGIN_RE` 기본값에 `-bot$` 접미 관례를 추가해 GitHub App 이 아닌 머신유저 리뷰봇 계정(예: courtesy-bot)을 세 게이트(승인 마커·현재-head 재리뷰 증거·미해결 스레드 차단)가 인식한다 — 미인식 시 blocking 스레드가 비가시(blocked=0·reviewed=0)라 approve 가 합성돼 승인 가림(#493)이 무력화되던 결함 수정. 접미 앵커로 오포섭을 최소화하고 배제 방향(비접미 계정 비신뢰)을 selftest 로 검증. (2) 같은-head 분기에서 기록 approve+판정 approve 인데 phase 가 강등된 상태(머지 게이트 차단 후 재진입이 phase=review 로 재설정)가 rc=20 무한 반복하던 경로를 approved 재전이(머지 복귀)로 종착시킨다. phase=approved 정상 멱등(rc=20)과 기존 가드(#493/#549/#571/#600, 라운드 상한·무진전·핑퐁)는 selftest 로 회귀 없이 보존. marketplace.json 의 stale autopilot 버전(0.63.5)도 SoT(plugin.json)와 동기화.
+
 ## autopilot 0.64.2
 
 ### 변경(호환)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 ### 변경(호환)
 - **공유 session-conventions 해체 — 규범을 각 SKILL.md에 용어 특화 인라인 (run 604)** — `skills/shared/session-conventions.md`를 제거하고 규범 5영역(호출 규약·세션 파일 규율·디스패치 공통 규범·중앙 리서치 공통 규범·공통 안전 경계)을 brainstorm(세션 파일, `.brainstorm/<session-id>.md`)·roundtable(회의 파일, `.roundtable/<meeting-id>.md`) 각 SKILL.md 본문에 각 스킬 용어로 자체 정의. `../shared/` 참조·위임 문구 제거(스킬 자기완결). 규범 의미·강도 불변.
 
+## autopilot 0.64.3
+
+### 버그 수정
+- **forge review-loop 신뢰봇 게이트 — 머신유저 리뷰봇 미인식 + 같은-head approve/approve 무한 대기 (#627)** — (1) `REVIEW_BOT_LOGIN_RE` 기본값에 `-bot$` 접미 관례를 추가해 GitHub App 이 아닌 머신유저 리뷰봇 계정(예: courtesy-bot)을 세 게이트(승인 마커·현재-head 재리뷰 증거·미해결 스레드 차단)가 인식한다 — 미인식 시 blocking 스레드가 비가시(blocked=0·reviewed=0)라 approve 가 합성돼 승인 가림(#493)이 무력화되던 결함 수정. 접미 앵커로 오포섭을 최소화하고 배제 방향(비접미 계정 비신뢰)을 selftest 로 검증. (2) 같은-head 분기에서 기록 approve+판정 approve 인데 phase 가 강등된 상태(머지 게이트 차단 후 재진입이 phase=review 로 재설정)가 rc=20 무한 반복하던 경로를 approved 재전이(머지 복귀)로 종착시킨다. phase=approved 정상 멱등(rc=20)과 기존 가드(#493/#549/#571/#600, 라운드 상한·무진전·핑퐁)는 selftest 로 회귀 없이 보존. marketplace.json 의 stale autopilot 버전(0.63.5)도 SoT(plugin.json)와 동기화.
+
 ## autopilot 0.64.2
 
 ### 변경(호환)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## autopilot 0.64.3
 
 ### 버그 수정
-- **forge review-loop 신뢰봇 게이트 — 머신유저 리뷰봇 미인식 + 같은-head approve/approve 무한 대기 (#627)** — (1) `REVIEW_BOT_LOGIN_RE` 기본값에 `-bot$` 접미 관례를 추가해 GitHub App 이 아닌 머신유저 리뷰봇 계정(예: courtesy-bot)을 세 게이트(승인 마커·현재-head 재리뷰 증거·미해결 스레드 차단)가 인식한다 — 미인식 시 blocking 스레드가 비가시(blocked=0·reviewed=0)라 approve 가 합성돼 승인 가림(#493)이 무력화되던 결함 수정. 접미 앵커로 오포섭을 최소화하고 배제 방향(비접미 계정 비신뢰)을 selftest 로 검증. (2) 같은-head 분기에서 기록 approve+판정 approve 인데 phase 가 강등된 상태(머지 게이트 차단 후 재진입이 phase=review 로 재설정)가 rc=20 무한 반복하던 경로를 approved 재전이(머지 복귀)로 종착시킨다. phase=approved 정상 멱등(rc=20)과 기존 가드(#493/#549/#571/#600, 라운드 상한·무진전·핑퐁)는 selftest 로 회귀 없이 보존. marketplace.json 의 stale autopilot 버전(0.63.5)도 SoT(plugin.json)와 동기화.
+- **forge review-loop 신뢰봇 게이트 — 머신유저 리뷰봇 미인식 + 같은-head approve/approve 무한 대기 (#627)** — (1) 저장소 관리 allowlist(`<repo>/.autopilot/review-bot-logins`, 한 줄당 로그인 정확일치)를 신뢰봇 판별 기본값에 합성해 GitHub App 이 아닌 머신유저 리뷰봇 계정(예: courtesy-bot)을 세 게이트(승인 마커·현재-head 재리뷰 증거·미해결 스레드 차단)가 인식한다 — 미인식 시 blocking 스레드가 비가시(blocked=0·reviewed=0)라 approve 가 합성돼 승인 가림(#493)이 무력화되던 결함 수정. 기본값 자체는 플랫폼 보장 식별자만 유지한다 — 접미 관례(`-bot$`) 기본 신뢰는 임의 계정의 승인 마커 위조를 허용하므로 채택하지 않음(리뷰 반영). 포함(allowlist 등록)·배제(미등록 계정 비신뢰) 양방향을 selftest 로 검증. (2) 같은-head 분기에서 기록 approve+판정 approve 인데 phase 가 강등된 상태(머지 게이트 차단 후 재진입이 phase=review 로 재설정)가 rc=20 무한 반복하던 경로를 approved 재전이(머지 복귀)로 종착시킨다. phase=approved 정상 멱등(rc=20)과 기존 가드(#493/#549/#571/#600, 라운드 상한·무진전·핑퐁)는 selftest 로 회귀 없이 보존. marketplace.json 의 stale autopilot 버전(0.63.5)도 SoT(plugin.json)와 동기화.
 
 ## autopilot 0.64.2
 

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/lib/forge/lib/review-loop.sh
+++ b/plugins/autopilot/lib/forge/lib/review-loop.sh
@@ -50,7 +50,10 @@ set +e
 set -uo pipefail
 
 REVIEW_ROUNDS_MAX="${REVIEW_ROUNDS_MAX:-3}"
-REVIEW_BOT_LOGIN_RE="${REVIEW_BOT_LOGIN_RE:-(\[bot\]$|claude|github-actions)}"
+# 신뢰봇 로그인 판별(세 게이트 공용: 승인 마커·현재-head 재리뷰 증거·미해결 스레드 차단).
+#   `-bot$`: GitHub App 이 아닌 머신유저 리뷰봇 계정의 접미 관례(예: courtesy-bot) — #627.
+#   접미 앵커라 임의 계정 오포섭을 최소화한다. 저장소별 커스텀은 env override 로.
+REVIEW_BOT_LOGIN_RE="${REVIEW_BOT_LOGIN_RE:-(\[bot\]$|-bot$|claude|github-actions)}"
 
 REVIEW_FETCH_CMD="${REVIEW_FETCH_CMD:-rl_review_fetch_gh}"
 REVIEW_PRODUCE_CMD="${REVIEW_PRODUCE_CMD:-rl_produce_review_skill}"
@@ -323,6 +326,16 @@ rl_round() {
           && "$(rl_review_field "$pr" blocked)" == "1" ]]; then
       rl_escalate "$rd" "$key" "approve 기록 후 같은 head($head)의 신뢰봇 미해결 스레드가 승인을 가리나 현재 head 재리뷰 증거 없음(#549) — 재작업·머지 모두 불가 교착, 스레드 해소·수동 개입 필요"
       return 10
+    # #627: 머지 게이트 차단(phase=blocked) 후 재진입은 integration 이 phase 를 review 로 재설정한다.
+    #   이때 head 불변+판정 approve 조합이 else(rc=20) 로 떨어지면 approved 재전이 경로가 없어 폴링
+    #   상한까지 무행동 대기 — approved 로 재전이해 머지로 복귀시킨다(유한 종착). phase==review 로
+    #   좁혀 의도한 강등 시나리오만 겨냥한다 — approved 정상 멱등(rc=20)을 보존하고, merged/merging
+    #   등에서의 직접 재호출이 phase 를 역행시키지 않는다.
+    elif [[ "$rec_verdict" == "approve" && "$gate_verdict" == "approve" \
+          && "$(int_get_phase "$rd" "$key")" == "review" ]]; then
+      int_set_phase "$rd" "$key" approved
+      int_log "$rd" "$key" "head 동일($head)·판정 approve 인데 phase 강등 상태 — approved 재전이(머지 복귀, #627)"
+      return 30
     else
       int_log "$rd" "$key" "head 동일($head) — 새 커밋 없음, 라운드 미시작"
       return 20
@@ -678,6 +691,24 @@ rl_selftest() {
   case "$out" in *교착*) ok "#600 교착 사유 표면화";; *) bad "#600 교착 사유 표면화 (out='$out')";; esac
   [[ ! -s "$IMPLLOG" ]] && ok "#600 증거 없는 스레드 재작업 미실행(#549 보존)" || bad "#600 증거 없는 스레드 재작업 미실행(#549 보존)"
 
+  # ---- #627: approve 기록+같은 head+판정 approve 인데 phase 가 강등된 상태 → approved 재전이 ----
+  #   머지 게이트 차단(phase=blocked) 후 재진입하면 integration 이 phase=review 로 재설정한다.
+  #   이때 head 불변+판정 approve 조합이 rc=20 무한 반복하면 머지 복귀가 영구 불가 — 재전이로 종착.
+  local kM="m-mmm3"; : > "$IMPLLOG"
+  forge_review sha-M approve > "$RV/113.review"
+  rl_round "$rd" "$kM" "$base" 113 "feat/run1-m"; chk "#627 선행 approve(rc=30)" "$?" "30"
+  int_set_phase "$rd" "$kM" review   # 머지 게이트 차단 후 재진입이 phase 를 review 로 강등한 상황 모사
+  rl_round "$rd" "$kM" "$base" 113 "feat/run1-m"; rc=$?
+  chk "#627 같은 head approve/approve+phase 강등 → approved 재전이(rc=30, rc=20 반복 아님)" "$rc" "30"
+  chk "#627 재전이 후 phase=approved" "$(int_get_phase "$rd" "$kM")" "approved"
+  [[ ! -s "$IMPLLOG" ]] && ok "#627 재전이 시 구현 미위임" || bad "#627 재전이 시 구현 미위임"
+  # phase=approved 정상 상태의 같은 head 재호출은 기존 멱등 유지(rc=20) — kB 케이스와 동일 계약.
+  rl_round "$rd" "$kM" "$base" 113 "feat/run1-m"; chk "#627 재전이 후 재호출 멱등(rc=20)" "$?" "20"
+  # 재전이는 phase==review 강등 시나리오만 겨냥 — merged 등 다른 phase 를 approved 로 역행시키지 않는다.
+  int_set_phase "$rd" "$kM" merged
+  rl_round "$rd" "$kM" "$base" 113 "feat/run1-m"; chk "#627 phase=merged 재호출 → 역행 없이 대기(rc=20)" "$?" "20"
+  chk "#627 phase=merged 유지(approved 역행 안 함)" "$(int_get_phase "$rd" "$kM")" "merged"
+
   # ---- pending(승인X·지적X) → 대기(rc=20), 로컬 review 미호출 ----
   local kPd="pd-ppp0"
   forge_review sha-PD pending > "$RV/110.review"
@@ -864,6 +895,17 @@ rl_selftest() {
     "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$GBLK" rl_review_fetch_gh 206 2>/dev/null | grep -c '^blocked: 1')" "1"
   chk "#600 스레드 없는 pending 은 blocked 미표면화" \
     "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_REVIEWS="$MARK_OLD2" SC_THREADS="$GEMPTY" rl_review_fetch_gh 207 2>/dev/null | grep -c '^blocked: 1')" "0"
+  # #627: `*-bot` 접미 머신유저(예: courtesy-bot)도 신뢰봇 — GitHub App 이 아닌 실리뷰봇 계정 관례.
+  #   미인식이면 blocked=0·reviewed=0 으로 approve 가 합성돼 승인 가림(#493)이 무력화된다.
+  local MARK_CB="courtesy-bot\t<!-- claude-formal-review head_sha=$GH verdict=comment -->\n"
+  local CBBLK; CBBLK="$(thr false "courtesy-bot" "$GH" "**[blocking/90] 실봇 차단 지적**")"
+  chk "#627 courtesy-bot 미해결 스레드+approve → changes(approve 합성 금지)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_REVIEWS="$MARK_CB" SC_THREADS="$CBBLK" rvg)" "changes"
+  chk "#627 courtesy-bot 마커승인 → approve" \
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_REVIEWS="courtesy-bot\t<!-- claude-formal-review head_sha=$GH verdict=approve -->\n" SC_THREADS="$GEMPTY" rvg)" "approve"
+  # 배제 방향: `-bot` 접미가 아닌 계정(abbot)은 여전히 비신뢰 — 차단 게이트에 잡히지 않는다.
+  chk "#627 비접미 계정(abbot) 스레드 → 차단 안 함(approve 유지)" \
+    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$(thr false "abbot" "$GH" "**[blocking/90] 위조**")" rvg)" "approve"
   unset -f gh
 
   # ---- force 미사용 (mock_git force 보면 exit99; 여기 도달했으면 미사용) ----

--- a/plugins/autopilot/lib/forge/lib/review-loop.sh
+++ b/plugins/autopilot/lib/forge/lib/review-loop.sh
@@ -51,9 +51,26 @@ set -uo pipefail
 
 REVIEW_ROUNDS_MAX="${REVIEW_ROUNDS_MAX:-3}"
 # 신뢰봇 로그인 판별(세 게이트 공용: 승인 마커·현재-head 재리뷰 증거·미해결 스레드 차단).
-#   `-bot$`: GitHub App 이 아닌 머신유저 리뷰봇 계정의 접미 관례(예: courtesy-bot) — #627.
-#   접미 앵커라 임의 계정 오포섭을 최소화한다. 저장소별 커스텀은 env override 로.
-REVIEW_BOT_LOGIN_RE="${REVIEW_BOT_LOGIN_RE:-(\[bot\]$|-bot$|claude|github-actions)}"
+#   기본값은 플랫폼이 보장하는 식별자만 둔다 — 접미 관례(`-bot$` 등)를 기본 신뢰하면 저장소가
+#   제어하지 않는 임의 GitHub 계정이 로그인만으로 승격돼 승인 마커 위조가 가능하다(#627 리뷰).
+#   GitHub App 이 아닌 머신유저 리뷰봇(예: courtesy-bot)은 저장소 관리 allowlist
+#   (`<repo>/.autopilot/review-bot-logins`, 한 줄당 로그인 정확일치, `#` 주석 허용) 또는
+#   REVIEW_BOT_LOGIN_RE env override 로 명시 등록한다.
+rl_default_bot_re() {
+  local base='(\[bot\]$|claude|github-actions)' root f logins
+  root="$(${GIT_CMD:-git} rev-parse --show-toplevel 2>/dev/null)" || root=""
+  f="$root/.autopilot/review-bot-logins"
+  if [[ -n "$root" && -f "$f" ]]; then
+    logins="$(grep -Ev '^[[:space:]]*(#|$)' "$f" 2>/dev/null \
+      | sed -E 's/[^A-Za-z0-9_-]//g' | grep -v '^$' | paste -sd'|' -)"
+    if [[ -n "$logins" ]]; then
+      printf '(^(%s)$|\[bot\]$|claude|github-actions)' "$logins"
+      return 0
+    fi
+  fi
+  printf '%s' "$base"
+}
+REVIEW_BOT_LOGIN_RE="${REVIEW_BOT_LOGIN_RE:-$(rl_default_bot_re)}"
 
 REVIEW_FETCH_CMD="${REVIEW_FETCH_CMD:-rl_review_fetch_gh}"
 REVIEW_PRODUCE_CMD="${REVIEW_PRODUCE_CMD:-rl_produce_review_skill}"
@@ -895,18 +912,34 @@ rl_selftest() {
     "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$GBLK" rl_review_fetch_gh 206 2>/dev/null | grep -c '^blocked: 1')" "1"
   chk "#600 스레드 없는 pending 은 blocked 미표면화" \
     "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_REVIEWS="$MARK_OLD2" SC_THREADS="$GEMPTY" rl_review_fetch_gh 207 2>/dev/null | grep -c '^blocked: 1')" "0"
-  # #627: `*-bot` 접미 머신유저(예: courtesy-bot)도 신뢰봇 — GitHub App 이 아닌 실리뷰봇 계정 관례.
+  # #627: 머신유저 리뷰봇(예: courtesy-bot)은 allowlist/env 로 명시 등록됐을 때만 신뢰된다.
   #   미인식이면 blocked=0·reviewed=0 으로 approve 가 합성돼 승인 가림(#493)이 무력화된다.
+  local ALLOW_RE='(^(courtesy-bot)$|\[bot\]$|claude|github-actions)'
   local MARK_CB="courtesy-bot\t<!-- claude-formal-review head_sha=$GH verdict=comment -->\n"
   local CBBLK; CBBLK="$(thr false "courtesy-bot" "$GH" "**[blocking/90] 실봇 차단 지적**")"
-  chk "#627 courtesy-bot 미해결 스레드+approve → changes(approve 합성 금지)" \
-    "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_REVIEWS="$MARK_CB" SC_THREADS="$CBBLK" rvg)" "changes"
-  chk "#627 courtesy-bot 마커승인 → approve" \
-    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_REVIEWS="courtesy-bot\t<!-- claude-formal-review head_sha=$GH verdict=approve -->\n" SC_THREADS="$GEMPTY" rvg)" "approve"
-  # 배제 방향: `-bot` 접미가 아닌 계정(abbot)은 여전히 비신뢰 — 차단 게이트에 잡히지 않는다.
-  chk "#627 비접미 계정(abbot) 스레드 → 차단 안 함(approve 유지)" \
+  chk "#627 allowlist 등록 courtesy-bot 미해결 스레드+approve → changes(approve 합성 금지)" \
+    "$(REVIEW_BOT_LOGIN_RE="$ALLOW_RE" SC_DECISION=APPROVED SC_HEAD="$GH" SC_REVIEWS="$MARK_CB" SC_THREADS="$CBBLK" rvg)" "changes"
+  chk "#627 allowlist 등록 courtesy-bot 마커승인 → approve" \
+    "$(REVIEW_BOT_LOGIN_RE="$ALLOW_RE" SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_REVIEWS="courtesy-bot\t<!-- claude-formal-review head_sha=$GH verdict=approve -->\n" SC_THREADS="$GEMPTY" rvg)" "approve"
+  # 배제 방향(보안): 기본값은 임의 계정을 신뢰하지 않는다 — `*-bot` 접미(evil-bot)든 아니든(abbot),
+  #   allowlist/env 등록 없이는 승인 마커 위조·차단 게이트 진입이 불가하다(#627 리뷰).
+  chk "#627 기본값: 미등록 evil-bot 마커승인 → 승인 합성 안 함(pending)" \
+    "$(SC_DECISION=REVIEW_REQUIRED SC_HEAD="$GH" SC_REVIEWS="evil-bot\t<!-- claude-formal-review head_sha=$GH verdict=approve -->\n" SC_THREADS="$GEMPTY" rvg)" "pending"
+  chk "#627 기본값: 미등록 계정(abbot) 스레드 → 차단 안 함(approve 유지)" \
     "$(SC_DECISION=APPROVED SC_HEAD="$GH" SC_THREADS="$(thr false "abbot" "$GH" "**[blocking/90] 위조**")" rvg)" "approve"
   unset -f gh
+
+  # ---- #627: allowlist 로더 — 저장소 관리 파일에서 정확일치 RE 를 만든다 ----
+  local ALD; ALD="$(mktemp -d)"
+  mkdir -p "$ALD/.autopilot"
+  printf '# comment\n\ncourtesy-bot\nother bot!\n' > "$ALD/.autopilot/review-bot-logins"
+  fake_root() { echo "$ALD"; }
+  chk "#627 allowlist 로더: 주석·빈 줄 제외, 특수문자 제거, 정확일치 앵커" \
+    "$(GIT_CMD=fake_root rl_default_bot_re)" '(^(courtesy-bot|otherbot)$|\[bot\]$|claude|github-actions)'
+  rm -f "$ALD/.autopilot/review-bot-logins"
+  chk "#627 allowlist 부재 → 플랫폼 보장 기본값" \
+    "$(GIT_CMD=fake_root rl_default_bot_re)" '(\[bot\]$|claude|github-actions)'
+  unset -f fake_root; rm -rf "$ALD"
 
   # ---- force 미사용 (mock_git force 보면 exit99; 여기 도달했으면 미사용) ----
   [[ -s "$PUSHLOG" ]] && ok "재작업 라운드 실제 push 수행" || bad "재작업 라운드 실제 push 수행"


### PR DESCRIPTION
## 요약

forge review-loop 의 신뢰봇 게이트가 저장소의 실제 리뷰봇을 인식하지 못해 생기는 두 결함의 수정: (1) 신뢰봇 판별이 실리뷰봇 로그인을 커버하도록 하고, (2) 같은-head 분기에서 approve 판정이 재전이 없이 무한 대기하는 경로를 유한 종착(approved 재전이 또는 에스컬레이션)으로 바꾼다.

## 작업 내용

run 627 완료 — forge review-loop 신뢰봇 게이트 두 결함 수정 (fix:root e473062, 0.64.3)

1. REVIEW_BOT_LOGIN_RE 기본값에 `-bot$` 접미 관례 추가 — courtesy-bot 등 머신유저
   리뷰봇이 세 게이트(승인마커·재리뷰 증거·미해결 스레드 차단)에 인식. blocking
   스레드 존재 시 approve 합성 금지(#493 보존). 배제 방향(비접미 계정 비신뢰)도 검증.
2. 같은-head approve/approve + phase=review 강등(머지 게이트 차단 후 재진입) 조합을
   approved 재전이(rc=30)로 유한 종착 — rc=20 무한 대기 제거. approved 정상 멱등·
   merged/merging 비역행 보존.

검증: review-loop selftest ALL PASS(0 exit, RED 선행 확인), merge/integration/state-io
selftest 0 exit — 기존 가드(#493/#549/#571/#600, 상한·무진전·핑퐁) 회귀 없음.
버전: plugin.json 0.64.2→0.64.3, marketplace.json stale 0.63.5 동기화, CHANGELOG 갱신.

후속 관찰(scope 밖): 신뢰봇 판별 이원화 — review-loop `REVIEW_BOT_LOGIN_RE`(정규식) vs
merge.sh/execute-task.sh `REVIEW_BOT_LOGINS_RE`(courtesy-bot 리터럴). courtesy-bot 은
세 곳 커버되나 새 `-bot$` 계정 등장 시 비대칭 — 단일 출처화 별도 태스크 후보.
