### PR TITLE
🤖 [자동 리뷰] fix: 재진입이 충돌 브랜치를 재통합하지 않아 blocked 무한 루프

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
-## project-init 0.25.0
+## autopilot 0.64.3
 
-### 새 기능
-- **소비 프로젝트 훅 구조 표준 + 결정적 검사기 신설 (run 616)** — `shared/hook-standard/` 추가. `standard.md`가 소비 프로젝트 `.claude/hooks/`의 2계층 레이아웃(직속=이벤트명 kebab-case 핸들러, `lib/<command>/`=기능별 디렉터리)·역할 분리(핸들러는 디스패처, 로직은 lib)·스크립트 계약(POSIX sh·jq 우선 sed 폴백·비차단 exit 0·차단 exit 2·실행권한·`${CLAUDE_PROJECT_DIR}` 등록)을 단일 출처로 정의하고, 검사기 판정 10항목과 모델 판정 5항목을 분리된 절로 둔다. `hook_checker.py`(Python3 표준 라이브러리 전용)가 레이아웃·파일명·실행권한·셔뱅·settings↔핸들러 정합·lib 구조를 판정해 항목별 severity+evidence JSON을 stdout으로 내며, 결함이 있어도 평가 성공이면 exit 0. `checker-invocation.md`가 호출 계약(절대경로 고정·실행 형식·결과 해석)을 정의하고, `tests/`가 통과·위반 5종 픽스처로 판정을 검증한다. 후속 `create-hook`·`repair-hook` 스킬이 공유할 기준선(`shared/rubric`이 create-skill·repair-skill에 하는 역할과 대칭).
+### 버그 수정
+- **재실행이 충돌 브랜치를 재통합하지 않아 blocked 무한 루프 (#626)** — blocked 태스크 재실행(open PR 존재) 시 base sync가 무조건 조기 반환해 충돌이 남은 채 리뷰 승인만 폴링하다 상한 초과로 다시 blocked되던 문제 수정. `forge/lib/integration.sh` base sync가 open PR 브랜치의 충돌을 감지하면 `origin/main`을 원격 tip에 merge-in(history 미재작성, non-force)으로 자율 해소해 갱신된 head를 직접 push하고, 무충돌이면 기존 동작(재작성·push 없음)을 유지한다. 재통합 실패 시 리뷰 폴링에 들어가지 않고 integrate 단계에서 즉시 차단된다. 회귀 가드: `tests/autopilot/execute-task/test-execute-task-reentry-conflict-resync.sh`.
 
 ## thinktank 1.0.2
 

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.64.2",
+  "version": "0.64.3",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/lib/forge/lib/integration.sh
+++ b/plugins/autopilot/lib/forge/lib/integration.sh
@@ -212,6 +212,75 @@ in_autoresolve_rebase() {
   return 0
 }
 
+# in_autoresolve_merge <branch> — 진행 중(충돌 정지) merge-in 을 자율 해결(open PR 재동기화 전용).
+#   in_autoresolve_rebase 와 같은 전략 축이나 방향이 반대: merge-in 에선 --ours=작업 브랜치 쪽,
+#   --theirs=새 베이스(origin/main) 쪽. incoming(기본)=작업 커밋 쪽 --ours, base=--theirs.
+#   비결정 표시(INT_AUTORESOLVE_FLAG)는 rebase 경로와 동일 계약. 커밋은 호출자 책임.
+#   닫지 못하면 merge --abort 후 1. force 미사용.
+in_autoresolve_merge() {
+  local branch="$1" f resolved_general=0 unmerged
+  # shellcheck disable=SC2086
+  unmerged="$($GIT_CMD diff --name-only --diff-filter=U 2>/dev/null)"
+  [[ -n "$unmerged" ]] || { $GIT_CMD merge --abort 2>/dev/null || true; return 1; }
+  while IFS= read -r f; do
+    [[ -n "$f" ]] || continue
+    # shellcheck disable=SC2086
+    case "${FORGE_CONFLICT_STRATEGY:-incoming}" in
+      base) $GIT_CMD checkout --theirs -- "$f" 2>/dev/null || true ;;
+      *)    $GIT_CMD checkout --ours   -- "$f" 2>/dev/null || true ;;
+    esac
+    resolved_general=1
+    # shellcheck disable=SC2086
+    $GIT_CMD add -- "$f" 2>/dev/null || true
+  done <<< "$unmerged"
+  # shellcheck disable=SC2086
+  if [[ -n "$($GIT_CMD diff --name-only --diff-filter=U 2>/dev/null)" ]]; then
+    $GIT_CMD merge --abort 2>/dev/null || true; return 1
+  fi
+  [[ "$resolved_general" == "1" ]] && INT_AUTORESOLVE_FLAG="needs-verify"
+  printf 'autoresolve: open-PR base 재동기화 merge-in 자율 해결 (branch=%s general=%s flag=%s)\n' \
+    "$branch" "$resolved_general" "${INT_AUTORESOLVE_FLAG:-deterministic}" >&2
+  return 0
+}
+
+# in_resync_open_pr <branch> — open PR 재실행 경로의 base 정합(#626). 분리 워크트리 안에서 호출됨.
+#   원격 tip(리뷰 수정 푸시로 로컬 ref 보다 앞설 수 있음) 기준으로 origin/main merge-in 을 시도:
+#     클린(충돌 없음) → 병합을 버리고 기존 동작 유지(재작성·push 없음 — 머지 단계 ff 게이트가 정합).
+#     충돌           → 전략 자율 해소로 머지 커밋 생성 후 원격 작업 브랜치로 직접 push(non-force,
+#                      merge-in 은 원격 tip 위에 커밋을 얹으므로 fast-forward push 성립).
+#     해소 불가       → 병합 중단 후 1 — integrate 가 즉시 차단(리뷰 폴링 진입 전, 상한 미소진).
+in_resync_open_pr() {
+  local branch="$1" tip
+  # shellcheck disable=SC2086
+  $GIT_CMD fetch origin "$branch" >/dev/null 2>&1 || true
+  # shellcheck disable=SC2086
+  tip="$($GIT_CMD rev-parse --verify --quiet "refs/remotes/origin/$branch" 2>/dev/null)" || tip=""
+  # shellcheck disable=SC2086
+  [[ -n "$tip" ]] || tip="$($GIT_CMD rev-parse "refs/heads/$branch" 2>/dev/null)"
+  [[ -n "$tip" ]] || { in_die "open PR 재동기화: 브랜치 tip 확인 실패: $branch"; return 1; }
+  # 분리 HEAD 를 원격 tip 으로 이동(워크트리는 이미 detached — reset 은 브랜치 ref 를 건드리지 않음).
+  # shellcheck disable=SC2086
+  $GIT_CMD reset --hard "$tip" >/dev/null 2>&1 \
+    || { in_die "open PR 재동기화: tip 이동 실패: $branch"; return 1; }
+  # shellcheck disable=SC2086
+  if $GIT_CMD merge --no-commit --no-ff "origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+    # 충돌 없음 — 기존 동작 보존: 재작성·push 없이 반환(정합은 머지 단계 ff-only 게이트가 강제).
+    $GIT_CMD merge --abort >/dev/null 2>&1 || true
+    return 0
+  fi
+  in_autoresolve_merge "$branch" \
+    || { in_die "open PR 재동기화 충돌 자율 해소 실패 — 사람 위임(force 금지): $branch ← origin/$DEFAULT_BRANCH"; return 1; }
+  # shellcheck disable=SC2086
+  $GIT_CMD commit -m "merge: origin/$DEFAULT_BRANCH into $branch — base 재동기화(충돌 자율 해소)" >/dev/null 2>&1 \
+    || { $GIT_CMD merge --abort >/dev/null 2>&1 || true
+         in_die "open PR 재동기화 머지 커밋 실패: $branch"; return 1; }
+  # shellcheck disable=SC2086
+  $GIT_CMD push origin "HEAD:refs/heads/$branch" >/dev/null 2>&1 \
+    || { in_die "open PR 재동기화 push 실패(force 금지): $branch"; return 1; }
+  INT_BASESYNC_PUSHED=1
+  return 0
+}
+
 # in_base_sync <branch> — 작업 브랜치를 origin/main 으로 정합(필요 시 rebase)한다.
 #   #452: rebase 를 공유 체크아웃에서 수행하면 (성공 시에도) 공유 체크아웃이 작업 브랜치로 남고,
 #   병렬 실행 시 서로의 브랜치를 덮어쓰는 경쟁이 생긴다. 그래서 **전용 분리(detached) 임시 워크트리**를
@@ -260,10 +329,13 @@ _in_base_sync_core() {
     return 0
   fi
   # base 가 전진했고 원격 브랜치(open PR)가 이미 있으면, rebase 재작성은 SHA 를 바꿔 force 없는
-  # push 를 non-fast-forward 로 실패시킨다. 재작성하지 않고 그대로 둔다 — base 정합은 머지 단계의
-  # ff-only 게이트(그쪽도 자율 재동기화)가 강제한다.
+  # push 를 non-fast-forward 로 실패시킨다. 충돌이 없으면 재작성하지 않고 그대로 둔다 — base 정합은
+  # 머지 단계의 ff-only 게이트(그쪽도 자율 재동기화)가 강제한다. 단, **충돌**이면 그대로 두면 리뷰가
+  # 영영 승인 불가(재실행 무한 루프, #626) — rebase 대신 origin/main 을 merge-in(history 미재작성
+  # → non-force push, rules/version-control/git.md)해 해소 후 직접 push 한다.
   if [[ -n "$(in_existing_open_pr "$branch")" ]]; then
-    return 0
+    in_resync_open_pr "$branch"
+    return $?
   fi
   # 최초 통합(원격 브랜치 미존재): rebase 후 push(ff-safe). 충돌은 자율 해결하고, 해결 도중
   # 타겟이 또 전진하면(레이스) 갱신된 origin/main 으로 유한 횟수 재rebase 한다(non-force).

--- a/tests/autopilot/execute-task/test-execute-task-reentry-conflict-resync.sh
+++ b/tests/autopilot/execute-task/test-execute-task-reentry-conflict-resync.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# test-execute-task-reentry-conflict-resync.sh — 재실행(open PR 존재) base sync 의 충돌 재통합 (#626 회귀 가드).
+#   재진입은 forge integrate 를 재실행하고 integrate 는 리뷰 폴링 **전에** in_base_sync 를 탄다.
+#   따라서 in_base_sync 가 open PR 충돌 브랜치를 재통합하면 "리뷰 폴링 전 재통합" 계약이 성립한다.
+#   (a) 충돌: open PR + origin/main 충돌 전진 → origin/main merge-in 자율 해소 후 원격 작업
+#       브랜치로 직접 push(INT_BASESYNC_PUSHED=1). non-force: 기존 원격 tip 은 새 tip 의 조상 보존.
+#   (b) 무충돌: open PR + origin/main 클린 전진 → 기존 동작 유지(재작성·push 없음, rc0).
+#   (c) 재통합 실패(push 거부): rc≠0 즉시 실패 — integrate 가 차단하므로 리뷰 폴링 상한 미소진
+#       (driver 의 integrate-실패 즉시 blocked 는 test-execute-task-blocked-category.sh 가 가드).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEG="$HERE/../../../plugins/autopilot/lib/forge/lib/integration.sh"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+# mock forge: 모든 브랜치에 open PR #42 존재.
+cat > "$TMP/bin/forge" << 'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "pr" && "${2:-}" == "list" ]] && echo "42"
+exit 0
+EOF
+chmod +x "$TMP/bin/forge"
+
+# ---- fixture: bare origin + 로컬 repo, 공통 조상 C0 에서 세 작업 브랜치 + main 충돌 전진 ----
+git init -q --bare "$TMP/origin.git"
+git init -q "$TMP/repo"
+cd "$TMP/repo"
+git config user.email t@t; git config user.name t
+git remote add origin "$TMP/origin.git"   # 절대 경로(분리 워크트리에서도 해석)
+printf 'base\n' > c.txt; printf 'base\n' > d.txt
+git add .; git commit -qm C0
+git push -q origin HEAD:main
+C0="$(git rev-parse HEAD)"
+
+git checkout -qb feat/9-x "$C0"; printf 'work\n' > c.txt;  git commit -qam work-x;  git push -q origin feat/9-x
+git checkout -qb feat/9-y "$C0"; printf 'y\n'    > e.txt;  git add e.txt; git commit -qm work-y; git push -q origin feat/9-y
+git checkout -qb feat/9-z "$C0"; printf 'work\n' > c.txt;  git commit -qam work-z;  git push -q origin feat/9-z
+
+# main 전진: c.txt 를 바꿔 x·z 와 충돌, y 와는 무충돌.
+git checkout -q --detach "$C0"; printf 'main2\n' > c.txt; git commit -qam main2
+git push -q origin HEAD:main
+git fetch -q origin
+
+# integration.sh 를 소싱(함수만 노출) — 주입 변수로 mock 연결.
+GIT_CMD=git DEFAULT_BRANCH=main FORGE_CMD="$TMP/bin/forge" LOOP_CMD=/bin/true
+# shellcheck source=/dev/null
+. "$INTEG"
+
+# ---- (a) 충돌 브랜치: merge-in 재통합 + 직접 push ----
+tip1="$(git ls-remote origin refs/heads/feat/9-x | awk '{print $1}')"
+rc=0; in_base_sync feat/9-x >/dev/null 2>&1 || rc=$?
+tip2="$(git ls-remote origin refs/heads/feat/9-x | awk '{print $1}')"
+git fetch -q origin
+[[ "$rc" == 0 ]] && ok "a: rc=0" || bad "a: rc=0 (got $rc)"
+[[ "$tip2" != "$tip1" ]] && ok "a: 원격 tip 갱신(재통합 push)" || bad "a: 원격 tip 갱신(재통합 push)"
+[[ "${INT_BASESYNC_PUSHED:-}" == "1" ]] && ok "a: INT_BASESYNC_PUSHED=1" || bad "a: INT_BASESYNC_PUSHED=1"
+git merge-base --is-ancestor origin/main "$tip2" 2>/dev/null \
+  && ok "a: origin/main 이 새 tip 의 조상(충돌 해소)" || bad "a: origin/main 이 새 tip 의 조상(충돌 해소)"
+git merge-base --is-ancestor "$tip1" "$tip2" 2>/dev/null \
+  && ok "a: 기존 tip 보존(non-force merge-in)" || bad "a: 기존 tip 보존(non-force merge-in)"
+[[ "$(git show "$tip2:c.txt" 2>/dev/null)" == "work" ]] \
+  && ok "a: 충돌 파일 작업 쪽 해소(incoming 기본)" || bad "a: 충돌 파일 작업 쪽 해소(incoming 기본)"
+[[ "${INT_AUTORESOLVE_FLAG:-}" == "needs-verify" ]] \
+  && ok "a: 비결정 표시(needs-verify)" || bad "a: 비결정 표시(needs-verify)"
+
+# ---- (b) 무충돌 브랜치: 기존 동작 유지(재작성·push 없음) ----
+tipy1="$(git ls-remote origin refs/heads/feat/9-y | awk '{print $1}')"
+rc=0; in_base_sync feat/9-y >/dev/null 2>&1 || rc=$?
+tipy2="$(git ls-remote origin refs/heads/feat/9-y | awk '{print $1}')"
+[[ "$rc" == 0 ]] && ok "b: rc=0" || bad "b: rc=0 (got $rc)"
+[[ "$tipy2" == "$tipy1" ]] && ok "b: 원격 tip 불변(무충돌 → 기존 동작)" || bad "b: 원격 tip 불변(무충돌 → 기존 동작)"
+[[ -z "${INT_BASESYNC_PUSHED:-}" ]] && ok "b: INT_BASESYNC_PUSHED 미설정" || bad "b: INT_BASESYNC_PUSHED 미설정"
+
+# ---- (c) 재통합 push 거부: 즉시 실패(rc≠0) ----
+mkdir -p "$TMP/origin.git/hooks"
+printf '#!/bin/sh\nexit 1\n' > "$TMP/origin.git/hooks/pre-receive"
+chmod +x "$TMP/origin.git/hooks/pre-receive"
+rc=0; in_base_sync feat/9-z >/dev/null 2>&1 || rc=$?
+[[ "$rc" != 0 ]] && ok "c: 재통합 실패 시 rc≠0(즉시 차단 경로)" || bad "c: 재통합 실패 시 rc≠0(즉시 차단 경로)"
+
+echo "----"
+[[ $fail -eq 0 ]] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES present"; exit 1; }


### PR DESCRIPTION
## 요약


blocked 태스크를 재실행할 때, 작업 브랜치가 베이스와 충돌 상태면 재통합(base sync)을 거쳐 충돌을 해소한 뒤 리뷰로 넘어간다. 충돌이 남은 채로 리뷰 승인만 기다리다 상한 초과로 다시 blocked되는 무한 루프가 없어야 한다.

## 작업 내용

재진입 base sync 의 open-PR 충돌 브랜치 재통합 구현 완료 (0.64.3, commit 28a53eb).

무엇을·왜:
- integration.sh `_in_base_sync_core` 의 open-PR 무조건 조기 반환이 근본 원인 — 재실행이
  CONFLICTING PR head 를 갱신하지 못한 채 리뷰 승인만 폴링하다 상한 초과로 blocked 무한 루프.
- `in_resync_open_pr` 신설: 원격 tip 기준 origin/main merge --no-commit 판정 — 클린이면 기존
  동작 유지(무 push), 충돌이면 `in_autoresolve_merge`(incoming=--ours/base=--theirs) 자율 해소
  후 merge-in 커밋을 원격 작업 브랜치로 직접 push(non-force ff, rules/version-control/git.md).
- 해소·push 실패는 integrate 단계 즉시 차단 — 리뷰 폴링 상한 미소진.
- execute-task.sh 무변경(재진입이 이미 integrate → base sync 경유, 폴링 전).

검증: RED→GREEN 회귀 가드 tests/autopilot/execute-task/test-execute-task-reentry-conflict-resync.sh
(충돌 재통합 push·non-force 보존·무충돌 불변·push 거부 즉시 실패) + execute-task 테스트 10종 +
integration/merge selftest + forge-routing 전부 0 exit. 적대 렌즈 3종 점검 — --no-verify 비일관
발견 수정, 레이스 무재시도는 자가 회복(멱등)으로 수용·기록.

버전 표면: plugin.json 0.64.3 + CHANGELOG autopilot 0.64.3 버그 수정 항목.
