### PR TITLE
🤖 [자동 리뷰] fix: 라벨 설정 실패 사유를 라벨 부재로 오귀속(권한 거부 은폐)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.64.4
+
+### 버그 수정
+- **라벨 설정 실패 사유를 라벨 부재로 오귀속(권한 거부 은폐) (#629)** — github 백엔드 `be_set_status`가 gh stderr를 버리고 실패를 "라벨 존재 필요" 고정 문구로 단정해 권한 거부·네트워크 오류 등 실제 원인이 은폐되던 문제 수정. `github.sh`가 원본 stderr를 보존해 진단에 포함한다(성공 시 무진단 유지). 회귀 가드: `lib/task-backend/tests/test-github-status-fail.sh`.
+
 ## autopilot 0.64.3
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.64.3",
+  "version": "0.64.4",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/lib/task-backend/github.sh
+++ b/plugins/autopilot/lib/task-backend/github.sh
@@ -92,7 +92,9 @@ be_set_status() {
   local id s; id="$(_argval --task-id "$@")"; s="$(_argval --status "$@")"
   local old; old="$(gh_status_label "$id")"
   [[ -n "$old" ]] && gh issue edit "$id" $(gh_repo_args) --remove-label "status:$old" >/dev/null 2>&1 || true
-  gh issue edit "$id" $(gh_repo_args) --add-label "status:$s" >/dev/null 2>&1 || tb_die "라벨 status:$s 설정 실패(라벨 존재 필요)"
+  # 실패 원인(권한 거부·라벨 부재·네트워크)을 오귀속하지 않도록 원본 stderr 를 보존해 전달한다.
+  local err
+  err="$(gh issue edit "$id" $(gh_repo_args) --add-label "status:$s" 2>&1 >/dev/null)" || tb_die "라벨 status:$s 설정 실패: $err"
   if [[ "$s" == "in_progress" ]]; then gh_set_lease "$id" "$(tb_now_epoch)" "$(_argval --owner "$@")"; fi
   # review 진입 시각을 lease 에 기록(owner="review"). heartbeat 없는 forge 단계의 crash 감지에 사용.
   if [[ "$s" == "review" ]]; then gh_set_lease "$id" "$(tb_now_epoch)" "review"; fi

--- a/plugins/autopilot/lib/task-backend/tests/test-github-status-fail.sh
+++ b/plugins/autopilot/lib/task-backend/tests/test-github-status-fail.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# test-github-status-fail.sh — set_status 라벨 설정 실패 시 원본 stderr 가 진단에 보존되는지 검증(github).
+# 회귀 가드: 권한 거부 등 실제 원인이 "라벨 존재 필요" 고정 문구로 오귀속되지 않아야 한다.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+A="$HERE/../adapter.sh"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"; git init -q; git config user.email t@t; git config user.name t
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+
+# gh 스텁: --add-label 편집만 권한 거부로 실패, 나머지는 성공(무출력).
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+GH_FAIL_MODE="${GH_FAIL_MODE:-perm}"
+for a in "$@"; do
+  if [[ "$a" == "--add-label" && "$GH_FAIL_MODE" == "perm" ]]; then
+    echo "GraphQL: someuser does not have the correct permissions to execute AddLabelsToLabelable (addLabelsToLabelable)" >&2
+    exit 1
+  fi
+done
+exit 0
+EOF
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+
+bash "$A" init --backend github-project --github-owner o --github-repo r >/dev/null
+
+# 실패 경로: 권한 거부 → 원본 메시지 보존, "라벨 존재 필요" 단정 없음, 비0 exit
+set +e
+err="$(bash "$A" set_status --task-id 42 --status in_progress 2>&1 >/dev/null)"
+rc=$?
+set -e
+[[ $rc -ne 0 ]] && ok "실패 시 비0 exit" || bad "실패 시 비0 exit (rc=$rc)"
+[[ "$err" == *"does not have the correct permissions"* ]] \
+  && ok "원본 stderr 보존" || bad "원본 stderr 보존 (got '$err')"
+[[ "$err" != *"라벨 존재 필요"* ]] \
+  && ok "라벨 부재 오귀속 없음" || bad "라벨 부재 오귀속 없음 (got '$err')"
+
+# 성공 경로: 진단 무출력
+set +e
+err2="$(GH_FAIL_MODE=none bash "$A" set_status --task-id 42 --status backlog 2>&1 >/dev/null)"
+rc2=$?
+set -e
+[[ $rc2 -eq 0 && -z "$err2" ]] && ok "성공 시 무진단" || bad "성공 시 무진단 (rc=$rc2, got '$err2')"
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail


### PR DESCRIPTION
## 요약


상태 라벨 설정이 실패했을 때 진단 문구가 실제 실패 원인을 반영한다. 라벨이 실제로 없을 때만 라벨 부재를 말하고, 권한 거부·네트워크 오류 등 다른 원인은 그 원인을 그대로 드러낸다.

## 작업 내용

run 629 완료 — github be_set_status 라벨 설정 실패 오귀속 해소.

- github.sh: gh stderr 캡처해 tb_die 진단에 원본 실패 메시지 포함(고정 "라벨 존재 필요" 문구 제거). 성공 시 무진단 유지.
- 회귀 가드: lib/task-backend/tests/test-github-status-fail.sh — gh 스텁으로 권한 거부 재현, 원본 보존·오귀속 없음·성공 무진단 4 assert.
- fresh verify: tests 3종 + adapter selftest 전부 exit 0.
- 버전 0.64.3→0.64.4 (plugin.json SoT), CHANGELOG 항목 추가.
- commit: d704177 fix:root
