### PR TITLE
🤖 [자동 리뷰] fix: 병렬 fan-out이 버전 표면 공유 태스크를 동시 실행해 연쇄 충돌

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.64.5
+
+### 버그 수정
+- **병렬 fan-out이 버전 표면 공유 태스크를 동시 실행해 연쇄 충돌 (#628)** — `workflow-task` 드레이너가 `list_ready`의 의존 충족만 보고 산출물 경로 겹침을 보지 않아, 같은 플러그인(공유 CHANGELOG·`plugin.json`)을 만지는 태스크들이 동시에 실행되고 첫 머지가 나머지 형제 브랜치를 일괄 `CONFLICTING`으로 만들었다(관측: 605·608·610·611 병렬 드레인). 이제 태스크 본문 frontmatter `scope.include` 항목이 앞선 태스크에 선점됐으면 그 패스에서 실행하지 않고 `deferred`/`deferred_ids`로 보고하며(조용한 누락 금지) 다음 틱 드레인이 집는다. 산출물이 겹치지 않는 태스크는 기존대로 병렬. 특정 경로 하드코딩 없음(일반 경로 겹침 판정). 회귀 가드 `tests/autopilot/test-workflow-task-overlap-serialize.sh` 추가.
+- **CHANGELOG 기존 항목 덮어쓰기가 게이트 없이 머지 (#628)** — CHANGELOG 는 누적 계약(추가만)인데 강제 게이트가 없어, 워커가 base 전진을 못 따라가면 기존 섹션을 자기 항목으로 교체해 직전 릴리스 기록을 삭제한 채 머지될 수 있었다(관측: PR 633이 project-init 0.25.0 기록을 삭제하고 main에 머지 — 후속 복구). `forge/lib/integration.sh`에 순수-추가 게이트 `in_changelog_additive_gate` 추가: base(origin/main) 대비 three-dot diff에서 CHANGELOG 기존 라인 삭제를 감지하면 PR·리뷰(머지 후보)로 넘기지 않고 차단한다(base 전진분은 오탐하지 않고, base 재동기화 merge-in의 덮어쓰기도 잡힘). 추가만 있는 변경(삭제 0)은 기존대로 통과. 경로는 `INT_CHANGELOG_FILE`로 설정 가능하고 빈 값이면 비활성(정당한 오타 수정·항목 재배치 우회), base에 파일이 없으면 미적용(정책 비내장). 회귀 가드 `tests/autopilot/execute-task/test-execute-task-changelog-gate.sh` 추가.
+
 ## autopilot 0.64.4
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.64.4",
+  "version": "0.64.5",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/lib/forge/lib/integration.sh
+++ b/plugins/autopilot/lib/forge/lib/integration.sh
@@ -399,6 +399,54 @@ in_push_branch() {
 }
 
 # =====================================================================
+# 3d) CHANGELOG 순수-추가 게이트 (#628) — CHANGELOG 는 누적 계약(추가만).
+#   워커가 base 전진을 못 따라가 기존 섹션을 자기 항목으로 덮어쓰면(기존 라인 삭제) 직전
+#   릴리스 기록이 소실된 채 머지될 수 있다(리뷰 봇 포착은 확률적). 통합이 결정적으로 막는다:
+#   base 대비 브랜치 쪽 변경(three-dot diff = merge-base 기준)이 CHANGELOG 라인을 삭제하면
+#   머지 후보(PR·리뷰)로 통과시키지 않고 차단한다. three-dot 이라 base 전진분(형제 머지)은
+#   오탐하지 않고, base 재동기화 merge-in 이 main 항목을 덮어쓴 경우는 merge-base 전진으로
+#   잡힌다. 경로는 INT_CHANGELOG_FILE 로 설정 가능(기본 CHANGELOG.md) — 빈 값이면 게이트
+#   비활성(정당한 오타 수정·항목 재배치 우회), base 에 파일이 없으면 적용하지 않는다
+#   (버전·changelog 정책은 컨슈밍 프로젝트 소유 — 존재할 때만 계약을 지킨다).
+# =====================================================================
+
+# in_changelog_additive_gate <branch> — 순수-추가면 0, 기존 라인 삭제 감지면 1(사유 stderr).
+#   INT_BASESYNC_PUSHED=1 이면 base sync 가 분리 워크트리에서 원격으로 직접 push 한 상태라
+#   로컬 ref 가 결과를 반영하지 않는다 — 원격 tip(origin/<branch>)을 게이트 대상으로 삼는다.
+in_changelog_additive_gate() {
+  local branch="$1" file="${INT_CHANGELOG_FILE-CHANGELOG.md}" base ref del
+  [[ -n "$file" ]] || return 0        # 빈 값 = 게이트 비활성(명시적 우회).
+  # shellcheck disable=SC2086
+  if $GIT_CMD rev-parse --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+    base="refs/remotes/origin/$DEFAULT_BRANCH"
+  elif $GIT_CMD rev-parse --verify --quiet "refs/heads/$DEFAULT_BRANCH" >/dev/null 2>&1; then
+    base="refs/heads/$DEFAULT_BRANCH"
+  else
+    return 0                          # base 미상 → 판정 불가, 게이트 미적용.
+  fi
+  # shellcheck disable=SC2086
+  $GIT_CMD cat-file -e "$base:$file" 2>/dev/null || return 0   # base 에 파일 존재할 때만 적용.
+  if [[ "${INT_BASESYNC_PUSHED:-}" == "1" ]]; then
+    # shellcheck disable=SC2086
+    $GIT_CMD fetch origin "$branch" >/dev/null 2>&1 || true
+    ref="refs/remotes/origin/$branch"
+  else
+    ref="refs/heads/$branch"
+  fi
+  # 삭제 라인 수: diff '-' 줄 중 파일 헤더(정확히 '--- a/…' 또는 '--- /dev/null')와 빈 줄
+  # 삭제(단독 '-')는 제외. 헤더를 '^---' 전체로 제외하면 '-- ' 로 시작하는 콘텐츠 라인의
+  # 삭제('---…' 로 렌더)가 미탐된다 — 실제 헤더 형태만 정확히 제외한다.
+  # shellcheck disable=SC2086
+  del="$($GIT_CMD diff "$base...$ref" -- "$file" 2>/dev/null \
+    | awk '/^-/ && !/^--- (a\/|\/dev\/null)/ && $0 != "-" { n++ } END { print n+0 }')"
+  if [[ "${del:-0}" -gt 0 ]]; then
+    in_die "CHANGELOG 순수-추가 게이트: $file 의 기존 라인 ${del}개 삭제 감지 — CHANGELOG 는 누적 계약(추가만)이라 머지 후보로 통과시키지 않는다(branch=$branch). 기존 섹션을 덮어쓰지 말고 자기 항목을 최상단에 '추가'로 재작성하세요. 정당한 오타 수정·항목 재배치라면 INT_CHANGELOG_FILE='' 로 게이트를 끄고 재실행해 우회할 수 있다."
+    return 1
+  fi
+  return 0
+}
+
+# =====================================================================
 # 3c) 재실행 stale 잔여 정리 — 직전 실패/blocked 시도가 남긴 원격 작업 브랜치/열린 PR 이
 #   현재 로컬 작업 커밋과 non-ff 비호환이고 **현재 실행 소유 stale 잔여**로 식별되면,
 #   push 전에 안전하게 정리(PR close + 원격 브랜치 삭제)해 non-ff push 거부를 막는다.
@@ -644,6 +692,8 @@ in_integrate() {
       # #452: rebase 경로에선 base_sync 가 분리 워크트리에서 원격으로 직접 push 하므로(INT_BASESYNC_PUSHED)
       # in_push_branch 를 건너뛴다. rebase 불필요(조기 반환) 경로에선 ref 이름으로 push.
       [[ "${INT_BASESYNC_PUSHED:-}" == "1" ]] || in_push_branch "$branch" || { int_set_phase "$rd" "$key" blocked; return 4; }
+      # CHANGELOG 순수-추가 게이트(#628): 기존 항목 삭제 변경은 PR(머지 후보)로 넘기지 않는다.
+      in_changelog_additive_gate "$branch" || { int_set_phase "$rd" "$key" blocked; return 4; }
       local title pr
       title="$(in_spec_title "$spec")"
       pr="$(in_ensure_pr "$branch" "$title" "$spec")" || { int_set_phase "$rd" "$key" blocked; return 4; }
@@ -720,6 +770,8 @@ in_integrate_direct() {
       int_set_branch "$rd" "$key" "$branch"
       # 다리: 머지 대상으로 쓰기 전에 작업 브랜치가 없으면 loop 결과 커밋에서 생성(멱등·공통 헬퍼).
       in_ensure_work_branch "$branch" "$spec" || { int_set_phase "$rd" "$key" blocked; return 4; }
+      # CHANGELOG 순수-추가 게이트(#628): 기존 항목 삭제 변경은 리뷰(머지 후보)로 넘기지 않는다.
+      in_changelog_additive_gate "$branch" || { int_set_phase "$rd" "$key" blocked; return 4; }
       int_set_phase "$rd" "$key" review
       int_log "$rd" "$key" "직접 통합(승인 요청·PR·push 우회) → 적대적 리뷰 게이트: branch=$branch → review"
       echo "key:    $key"

--- a/plugins/autopilot/skills/workflow-task/SKILL.md
+++ b/plugins/autopilot/skills/workflow-task/SKILL.md
@@ -16,12 +16,16 @@ allowed-tools:
 **DAG 없는 1회 드레이너**다. `references/workflow-task.sh`가 다음을 수행한다:
 
 1. `adapter list_ready` — 준비된(모든 `depends_on`이 done, 또는 lease가 stale한 in_progress 회수분) 태스크를 모은다.
-2. **flow 평면 병렬 fan-out** — 의존 없는 노드 집합으로 각 태스크에 `execute-task start <id>`를 동시성 상한 내
-   병렬 실행한다(`--max-parallel N`, 기본=준비 태스크 수). flow가 동시성·실패 격리·resume을 제공한다.
-3. 한 패스 종료. done/blocked 상태 전이는 execute-task가 이미 수행하므로 별도 동기화가 없다.
+2. **산출물 겹침 직렬화** — 각 태스크 본문 frontmatter `scope.include` 항목이 앞선 태스크에 이미 선점됐으면
+   이번 패스에서 실행하지 않고 유예한다(공유 버전 표면 — CHANGELOG·매니페스트 — 을 동시에 만지면 첫 머지가
+   형제 브랜치를 연쇄 충돌시킨다). 유예분은 `deferred_ids`로 보고되고 다음 틱 `list_ready`가 다시 집는다.
+3. **flow 평면 병렬 fan-out** — 의존 없는 노드 집합으로 각 실행 대상에 `execute-task start <id>`를 동시성 상한 내
+   병렬 실행한다(`--max-parallel N`, 기본=실행 대상 수). flow가 동시성·실패 격리·resume을 제공한다.
+4. 한 패스 종료. done/blocked 상태 전이는 execute-task가 이미 수행하므로 별도 동기화가 없다.
 
-**DAG를 갖지 않는다**: `list_ready`가 의존 충족분만 반환하므로 한 패스의 태스크들은 상호 독립이고, 의존 순서
-해결은 백엔드가 **틱 간**에 한다(다음 스케줄러 호출의 `list_ready`가 새로 ready된 후행을 잡는다).
+**DAG를 갖지 않는다**: `list_ready`가 의존 충족분만 반환하므로 한 패스의 태스크들은 `depends_on` 상 독립이고,
+의존 순서 해결은 백엔드가 **틱 간**에 한다(다음 스케줄러 호출의 `list_ready`가 새로 ready된 후행을 잡는다).
+단, 공유 산출물(버전 표면)이 만드는 암묵적 결합은 위 직렬화가 패스 안에서 해소한다.
 
 ## 호출
 
@@ -30,9 +34,10 @@ WT="${CLAUDE_PLUGIN_ROOT}/skills/workflow-task/references/workflow-task.sh"
 bash "$WT" start [--max-parallel N]
 ```
 
-출력은 한 줄 JSON(`{ready,succeeded,failed,failed_ids,flow_ok}`). 준비 태스크가 없으면 `{"ready":0,...}`로 즉시
-종료. `failed_ids`는 이번 패스에서 `execute-task`가 `blocked`로 둔 태스크 id 배열로, 아래 「버그 신호 수거」의
-입력이다.
+출력은 한 줄 JSON(`{ready,succeeded,failed,failed_ids,deferred,deferred_ids,flow_ok}`). 준비 태스크가 없으면
+`{"ready":0,...}`로 즉시 종료. `failed_ids`는 이번 패스에서 `execute-task`가 `blocked`로 둔 태스크 id 배열로,
+아래 「버그 신호 수거」의 입력이다. `deferred_ids`는 산출물 겹침으로 이번 패스에서 실행하지 않은(다음 틱이
+집는) 태스크 id 배열이다 — 조용한 누락 없이 여기로 드러난다.
 
 ## 버그 신호 수거 (드레인자 중앙 fix 호출)
 

--- a/plugins/autopilot/skills/workflow-task/references/workflow-task.sh
+++ b/plugins/autopilot/skills/workflow-task/references/workflow-task.sh
@@ -25,15 +25,48 @@ wt_start() {
   mapfile -t ids < <(printf '%s' "$ready" | jq -r '.[].task_id')
   if [[ ${#ids[@]} -eq 0 ]]; then echo '{"drained":0,"ready":0,"note":"no ready tasks"}'; return 0; fi
 
-  local conc="${maxp:-${#ids[@]}}"
+  # 산출물(버전 표면) 겹침 직렬화(#628): 태스크 본문 frontmatter scope.include 항목이 이미
+  # 앞선 태스크에 선점됐으면 이번 패스에서 실행하지 않는다(공유 CHANGELOG·매니페스트를 동시에
+  # 만지면 첫 머지가 형제 브랜치를 연쇄 충돌시킨다). 유예분은 deferred_ids 로 보고(조용한 누락
+  # 금지)하고 다음 틱 list_ready 가 다시 집는다. 특정 경로 하드코딩 없음 — 일반 경로 겹침.
+  local run_ids=() deferred=() claimed=$'\n'
+  local id body entries e overlap
+  for id in "${ids[@]}"; do
+    body="$($ADAPTER_CMD get_body --task-id "$id" 2>/dev/null | jq -r '.body // empty' 2>/dev/null || true)"
+    entries="$(printf '%s\n' "$body" | awk '
+      NR==1 && /^---[[:space:]]*$/ { fm=1; next }
+      fm && /^---[[:space:]]*$/ { exit }
+      fm && /^[[:space:]]*include:[[:space:]]*$/ { inc=1; next }
+      fm && inc && /^[[:space:]]*-[[:space:]]/ { s=$0; sub(/^[[:space:]]*-[[:space:]]*/, "", s); print s; next }
+      fm && inc { inc=0 }
+    ')"
+    overlap=0
+    if [[ -n "$entries" ]]; then
+      while IFS= read -r e; do
+        [[ -n "$e" ]] || continue
+        case "$claimed" in *$'\n'"$e"$'\n'*) overlap=1; break;; esac
+      done <<< "$entries"
+    fi
+    if [[ "$overlap" == "1" ]]; then deferred+=("$id"); continue; fi
+    if [[ -n "$entries" ]]; then
+      while IFS= read -r e; do [[ -n "$e" ]] && claimed+="$e"$'\n'; done <<< "$entries"
+    fi
+    run_ids+=("$id")
+  done
+  local deferred_ids='[]'
+  if [[ ${#deferred[@]} -gt 0 ]]; then
+    deferred_ids="$(printf '%s\n' "${deferred[@]}" | jq -R . | jq -sc .)"
+  fi
+
+  local conc="${maxp:-${#run_ids[@]}}"
   # 평면 flow 정의 생성: 의존 없는 command_node 들(즉시 병렬). 각 노드 = execute-task start <id>.
   local def; def="$(mktemp "${TMPDIR:-/tmp}/wt-def.XXXXXX.py")"
   {
     echo "from workflow_replica.nodes import command_node"
     echo "CONCURRENCY = $conc"
     echo "NODES = ["
-    local id argv_json
-    for id in "${ids[@]}"; do
+    local argv_json
+    for id in "${run_ids[@]}"; do
       # EXECUTE_CMD(공백 분리) + start <id> 를 argv 리스트로
       argv_json="$(printf '%s\n' $EXECUTE_CMD start "$id" | jq -R . | jq -sc .)"
       printf '  command_node(%s, %s, cwd=%s),\n' "$(printf '%s' "$id" | jq -R .)" "$argv_json" "$(printf '%s' "$ROOT_DIR" | jq -R .)"
@@ -53,8 +86,9 @@ wt_start() {
   failed_ids="$(printf '%s' "$out" | jq -c '.failed // []' 2>/dev/null || echo '[]')"
   [[ -n "$failed_ids" ]] || failed_ids='[]'
   jq -nc --argjson r "${#ids[@]}" --argjson s "${succ:-0}" --argjson f "${failed:-0}" \
-    --argjson fids "$failed_ids" --arg ok "$ok" \
-    '{ready:$r, succeeded:$s, failed:$f, failed_ids:$fids, flow_ok:($ok=="true")}'
+    --argjson fids "$failed_ids" --argjson d "${#deferred[@]}" --argjson dids "$deferred_ids" \
+    --arg ok "$ok" \
+    '{ready:$r, succeeded:$s, failed:$f, failed_ids:$fids, deferred:$d, deferred_ids:$dids, flow_ok:($ok=="true")}'
   [[ "${failed:-0}" -eq 0 ]] || return 1
 }
 

--- a/plugins/autopilot/skills/workflow-task/references/workflow-task.sh
+++ b/plugins/autopilot/skills/workflow-task/references/workflow-task.sh
@@ -17,6 +17,31 @@ EXECUTE_CMD="${EXECUTE_CMD:-bash $PLUGIN/skills/execute-task/references/execute-
 
 die() { echo "workflow-task: $*" >&2; exit 1; }
 
+# wt_scope_covers <pattern> <path> — scope 표기 <pattern> 이 <path> 를 덮으면 0.
+#   정확 일치 / 후행 '/' 디렉터리 prefix / 글롭('*' 포함, bash 확장 패턴 매칭).
+wt_scope_covers() {
+  local pat="$1" path="$2"
+  [[ "$pat" == "$path" ]] && return 0
+  case "$pat" in
+    */) [[ "$path" == "$pat"* ]] && return 0 ;;
+    *'*'*)
+      # shellcheck disable=SC2053
+      [[ "$path" == $pat ]] && return 0
+      # 'dir/**' 는 dir/ 하위 전체를 덮는다(글롭 매칭이 '/' 를 넘지 못하는 경우 보완).
+      local base="${pat%%\**}"
+      [[ -n "$base" && "$path" == "$base"* ]] && return 0
+      ;;
+  esac
+  return 1
+}
+
+# wt_paths_overlap <a> <b> — 두 scope 표기가 산출물에서 겹치면 0(양방향 판정).
+wt_paths_overlap() {
+  wt_scope_covers "$1" "$2" && return 0
+  wt_scope_covers "$2" "$1" && return 0
+  return 1
+}
+
 wt_start() {
   local maxp=""
   while [[ $# -gt 0 ]]; do case "$1" in --max-parallel) maxp="$2"; shift 2;; *) shift;; esac; done
@@ -30,7 +55,7 @@ wt_start() {
   # 만지면 첫 머지가 형제 브랜치를 연쇄 충돌시킨다). 유예분은 deferred_ids 로 보고(조용한 누락
   # 금지)하고 다음 틱 list_ready 가 다시 집는다. 특정 경로 하드코딩 없음 — 일반 경로 겹침.
   local run_ids=() deferred=() claimed=$'\n'
-  local id body entries e overlap
+  local id body entries e c overlap
   for id in "${ids[@]}"; do
     body="$($ADAPTER_CMD get_body --task-id "$id" 2>/dev/null | jq -r '.body // empty' 2>/dev/null || true)"
     entries="$(printf '%s\n' "$body" | awk '
@@ -44,7 +69,10 @@ wt_start() {
     if [[ -n "$entries" ]]; then
       while IFS= read -r e; do
         [[ -n "$e" ]] || continue
-        case "$claimed" in *$'\n'"$e"$'\n'*) overlap=1; break;; esac
+        while IFS= read -r c; do
+          [[ -n "$c" ]] || continue
+          if wt_paths_overlap "$c" "$e"; then overlap=1; break 2; fi
+        done <<< "$claimed"
       done <<< "$entries"
     fi
     if [[ "$overlap" == "1" ]]; then deferred+=("$id"); continue; fi

--- a/tests/autopilot/execute-task/test-execute-task-changelog-gate.sh
+++ b/tests/autopilot/execute-task/test-execute-task-changelog-gate.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# test-execute-task-changelog-gate.sh — CHANGELOG 순수-추가 게이트 (#628)
+#
+# CHANGELOG 는 누적 계약(추가만)이다. 워커가 base 전진을 못 따라가 기존 섹션을 자기
+# 항목으로 덮어쓰면(기존 라인 삭제) 통합이 그 변경을 머지 후보로 통과시키지 않고
+# 차단해야 한다. 추가만 있는 변경(삭제 0)은 기존대로 통과한다. 경로는
+# INT_CHANGELOG_FILE 로 설정 가능하며(빈 값=게이트 비활성 우회), base 에 파일이
+# 없으면 적용하지 않는다(정책 비내장).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+INTEGRATION="$REPO_ROOT/plugins/autopilot/lib/forge/lib/integration.sh"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# ---- fixture repo: main 에 기존 CHANGELOG 항목 2개 ----
+REPO="$TMP/repo"; mkdir -p "$REPO"
+git -C "$REPO" init -q -b main
+git -C "$REPO" config user.email t@t; git -C "$REPO" config user.name t
+cat > "$REPO/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## pkg 0.2.0
+
+### 기능
+- 기존 항목 B
+
+## pkg 0.1.0
+
+### 기능
+- 기존 항목 A
+-- 각주형 라인(더블대시 시작)
+EOF
+echo base > "$REPO/f.txt"
+git -C "$REPO" add -A; git -C "$REPO" commit -qm base
+
+# 브랜치 add-only: 최상단에 새 섹션 추가만(삭제 0).
+git -C "$REPO" checkout -qb feat/add
+awk 'NR==2{print ""; print "## pkg 0.3.0"; print ""; print "### 기능"; print "- 새 항목 C"} {print}' \
+  "$REPO/CHANGELOG.md" > "$REPO/CHANGELOG.md.new" && mv "$REPO/CHANGELOG.md.new" "$REPO/CHANGELOG.md"
+git -C "$REPO" commit -aqm 'add entry'
+
+# 브랜치 delete: 기존 0.2.0 섹션을 자기 항목으로 교체(기존 라인 삭제).
+git -C "$REPO" checkout -q main
+git -C "$REPO" checkout -qb feat/del
+sed -e 's/## pkg 0.2.0/## pkg 0.9.9/' -e 's/- 기존 항목 B/- 내 항목/' "$REPO/CHANGELOG.md" > "$REPO/CHANGELOG.md.new" \
+  && mv "$REPO/CHANGELOG.md.new" "$REPO/CHANGELOG.md"
+git -C "$REPO" commit -aqm 'overwrite entry'
+git -C "$REPO" checkout -q main
+
+# integration.sh 를 함수로 source (CLI 미실행 가드 존재).
+# shellcheck source=/dev/null
+. "$INTEGRATION"
+GIT_CMD="git -C $REPO"
+DEFAULT_BRANCH=main
+
+# ---- 게이트 함수 단위: 삭제 → 차단(rc!=0) + 우회 안내, 추가만 → 통과 ----
+err="$(in_changelog_additive_gate "feat/del" 2>&1)" && rc=0 || rc=$?
+chk "삭제 브랜치 차단 rc!=0" "$([[ $rc -ne 0 ]] && echo blocked)" "blocked"
+case "$err" in *INT_CHANGELOG_FILE*) ok "차단 문구에 우회 방법 명시";; *) bad "차단 문구에 우회 방법 명시 (got: $err)";; esac
+in_changelog_additive_gate "feat/add" 2>/dev/null && ok "추가-만 브랜치 통과" || bad "추가-만 브랜치 통과"
+
+# 빈 값 우회: INT_CHANGELOG_FILE='' → 게이트 비활성. (서브셸 — 이후 기본값 오염 방지)
+( INT_CHANGELOG_FILE=''; in_changelog_additive_gate "feat/del" 2>/dev/null ) \
+  && ok "빈 INT_CHANGELOG_FILE → 게이트 비활성(우회)" || bad "빈 INT_CHANGELOG_FILE → 게이트 비활성(우회)"
+
+# 파일 부재 → 미적용: base 에 없는 경로를 지정하면 통과.
+( INT_CHANGELOG_FILE='NOPE.md'; in_changelog_additive_gate "feat/del" 2>/dev/null ) \
+  && ok "base 에 파일 부재 → 게이트 미적용" || bad "base 에 파일 부재 → 게이트 미적용"
+
+# '-- ' 로 시작하는 콘텐츠 라인 삭제도 잡는다(diff 렌더 '--- ...' 가 파일 헤더로 오인되면 미탐).
+git -C "$REPO" checkout -qb feat/del-dashes main
+grep -v '^-- 각주형' "$REPO/CHANGELOG.md" > "$REPO/CHANGELOG.md.new" && mv "$REPO/CHANGELOG.md.new" "$REPO/CHANGELOG.md"
+git -C "$REPO" commit -aqm 'delete double-dash line'
+git -C "$REPO" checkout -q main
+in_changelog_additive_gate "feat/del-dashes" 2>/dev/null && rc=0 || rc=$?
+chk "'-- ' 시작 라인 삭제도 차단" "$([[ $rc -ne 0 ]] && echo blocked)" "blocked"
+
+# ---- integrate-direct 배선: DONE 태스크의 CHANGELOG 삭제 브랜치는 review 로 못 간다 ----
+# mock loop: 항상 terminal DONE, WT=삭제 브랜치 tip 의 분리 워크트리.
+DELWT="$TMP/delwt"
+git -C "$REPO" worktree add -q --detach "$DELWT" feat/del
+mock_loop() {
+  case "$1" in
+    status) printf '{"state":"terminal","signals":["DONE"]}\n' ;;
+    logs)   : ;;
+    paths)  printf 'WT          %s\n' "$MOCK_WT" ;;
+    cleanup) : ;;
+  esac
+}
+LOOP_CMD=mock_loop
+
+# 삭제 브랜치를 결정적 작업 브랜치명으로 별칭(브랜치 생성) — in_work_branch 계약 충족.
+SPEC="$TMP/SPEC.md"; printf '# gate del case\n' > "$SPEC"
+RD="$TMP/.autopilot/runs/rid1"; mkdir -p "$RD"
+git -C "$REPO" branch -f feat/rid1-gate-del-case feat/del
+MOCK_WT="$DELWT" in_integrate_direct "$SPEC" "$RD" "k-del00000" >/dev/null 2>&1 && rc=0 || rc=$?
+chk "direct: 삭제 브랜치 rc=4(하드 차단)" "$rc" "4"
+chk "direct: 삭제 브랜치 phase=blocked(review 진입 금지)" "$(int_get_phase "$RD" "k-del00000")" "blocked"
+
+# 추가-만 브랜치는 기존대로 review 진입.
+ADDWT="$TMP/addwt"
+git -C "$REPO" worktree add -q --detach "$ADDWT" feat/add
+SPEC2="$TMP/SPEC2.md"; printf '# gate add case\n' > "$SPEC2"
+RD2="$TMP/.autopilot/runs/rid2"; mkdir -p "$RD2"
+git -C "$REPO" branch -f feat/rid2-gate-add-case feat/add
+MOCK_WT="$ADDWT" in_integrate_direct "$SPEC2" "$RD2" "k-add00000" >/dev/null 2>&1 && rc=0 || rc=$?
+chk "direct: 추가-만 브랜치 rc=0(통과)" "$rc" "0"
+chk "direct: 추가-만 브랜치 phase=review" "$(int_get_phase "$RD2" "k-add00000")" "review"
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail

--- a/tests/autopilot/test-workflow-task-overlap-serialize.sh
+++ b/tests/autopilot/test-workflow-task-overlap-serialize.sh
@@ -79,4 +79,29 @@ out4="$(drain)"
 chk "scope 없음 deferred=0" "$(printf '%s' "$out4" | jq -r .deferred)" "0"
 chk "scope 없음 실행 2건" "$(wc -l < execlog | tr -d ' ')" "2"
 
+# ---- 디렉터리 prefix 겹침(후행 '/') → 정확 일치가 아니어도 직렬화 (PR 637 [blocking/90]) ----
+: > execlog
+t8="$(bash "$ADAPTER" create_task --title T8 --body "$(mkbody 'plugins/autopilot/')" | jq -r .task_id)"
+t9="$(bash "$ADAPTER" create_task --title T9 \
+  --body "$(mkbody 'plugins/autopilot/.claude-plugin/plugin.json')" | jq -r .task_id)"
+out5="$(drain)"
+chk "prefix 겹침 deferred=1" "$(printf '%s' "$out5" | jq -r .deferred)" "1"
+chk "prefix 겹침 실행 1건" "$(wc -l < execlog | tr -d ' ')" "1"
+
+# ---- 글롭 겹침('dir/**' vs 하위 파일) → 직렬화 ----
+: > execlog
+bash "$ADAPTER" set_status --task-id "$(printf '%s' "$out5" | jq -r '.deferred_ids[0]')" --status done >/dev/null
+t10="$(bash "$ADAPTER" create_task --title T10 --body "$(mkbody 'src/**')" | jq -r .task_id)"
+t11="$(bash "$ADAPTER" create_task --title T11 --body "$(mkbody 'src/foo.sh')" | jq -r .task_id)"
+out6="$(drain)"
+chk "글롭 겹침 deferred=1" "$(printf '%s' "$out6" | jq -r .deferred)" "1"
+
+# ---- 역방향(넓은 include 가 뒤에 와도 겹침) ----
+: > execlog
+bash "$ADAPTER" set_status --task-id "$(printf '%s' "$out6" | jq -r '.deferred_ids[0]')" --status done >/dev/null
+t12="$(bash "$ADAPTER" create_task --title T12 --body "$(mkbody 'lib/deep/x.sh')" | jq -r .task_id)"
+t13="$(bash "$ADAPTER" create_task --title T13 --body "$(mkbody 'lib/')" | jq -r .task_id)"
+out7="$(drain)"
+chk "역방향 겹침 deferred=1" "$(printf '%s' "$out7" | jq -r .deferred)" "1"
+
 echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail

--- a/tests/autopilot/test-workflow-task-overlap-serialize.sh
+++ b/tests/autopilot/test-workflow-task-overlap-serialize.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# test-workflow-task-overlap-serialize.sh — 드레이너 산출물(버전 표면) 겹침 직렬화 (#628)
+#
+# 같은 scope.include 항목(예: CHANGELOG.md·plugin.json)을 산출물로 갖는 ready 태스크가
+# 한 패스에 둘 이상이면 동시에 fan-out 하지 않는다 — 첫 태스크만 실행하고 나머지는
+# deferred_ids 로 보고(조용한 누락 금지)하며 다음 틱 드레인이 집는다.
+# 산출물이 겹치지 않는 태스크는 기존대로 같은 패스에서 병렬 실행된다.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+WT="$REPO_ROOT/plugins/autopilot/skills/workflow-task/references/workflow-task.sh"
+ADAPTER="$REPO_ROOT/plugins/autopilot/lib/task-backend/adapter.sh"
+FLOW="$REPO_ROOT/plugins/autopilot/skills/flow/references/flow.sh"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"; git init -q; git config user.email t@t; git config user.name t
+bash "$ADAPTER" init --backend filesystem >/dev/null
+
+# mock execute-task: 'start <id>' → done 전이 + 실행 기록.
+mkdir -p bin
+cat > bin/exec-mock <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$2" >> "$TMP/execlog"
+bash "$ADAPTER" set_status --task-id "\$2" --status done >/dev/null
+EOF
+chmod +x bin/exec-mock
+: > execlog
+
+mkbody() { # mkbody <include-항목...> — scope frontmatter 본문 생성.
+  printf -- '---\nscope:\n  include:\n'
+  local e; for e in "$@"; do printf -- '    - %s\n' "$e"; done
+  printf -- '  exclude:\n    - rules/**\n---\n\n# t\n\n## 목표\nx\n'
+}
+
+# T1·T2 는 버전 표면(plugin.json·CHANGELOG.md) 공유, T3 은 겹침 없음.
+t1="$(bash "$ADAPTER" create_task --title T1 \
+  --body "$(mkbody 'plugins/autopilot/skills/a/SKILL.md' 'plugins/autopilot/.claude-plugin/plugin.json' 'CHANGELOG.md')" | jq -r .task_id)"
+t2="$(bash "$ADAPTER" create_task --title T2 \
+  --body "$(mkbody 'plugins/autopilot/skills/b/SKILL.md' 'plugins/autopilot/.claude-plugin/plugin.json' 'CHANGELOG.md')" | jq -r .task_id)"
+t3="$(bash "$ADAPTER" create_task --title T3 \
+  --body "$(mkbody 'docs/other.md')" | jq -r .task_id)"
+
+drain() { ADAPTER_CMD="bash $ADAPTER" FLOW_CMD="bash $FLOW" EXECUTE_CMD="bash $TMP/bin/exec-mock" bash "$WT" start; }
+
+# ---- 1패스: 겹침 그룹(T1·T2)은 하나만 실행, T3 은 병렬 실행, 나머지는 deferred 보고 ----
+out1="$(drain)"
+chk "1패스 ready=3" "$(printf '%s' "$out1" | jq -r .ready)" "3"
+chk "1패스 deferred=1(겹침 그룹서 1건 유예)" "$(printf '%s' "$out1" | jq -r .deferred)" "1"
+d1="$(printf '%s' "$out1" | jq -r '.deferred_ids[0]')"
+case "$d1" in "$t1"|"$t2") ok "1패스 deferred_ids 가 겹침 그룹 소속";; *) bad "1패스 deferred_ids 가 겹침 그룹 소속 (got '$d1')";; esac
+exec_n="$(wc -l < execlog | tr -d ' ')"
+chk "1패스 실행 2건(겹침 1 + 비겹침 1)" "$exec_n" "2"
+grep -Fxq "$t3" execlog && ok "1패스 비겹침 T3 병렬 실행" || bad "1패스 비겹침 T3 병렬 실행"
+grep -Fxq "$d1" execlog && bad "1패스 유예 태스크 미실행" || ok "1패스 유예 태스크 미실행"
+chk "1패스 유예 태스크 상태 보존(backlog)" "$(bash "$ADAPTER" get_task --task-id "$d1" | jq -r .status)" "backlog"
+
+# ---- 2패스: 유예분이 다음 틱에 흡수된다 ----
+out2="$(drain)"
+chk "2패스 ready=1(유예분)" "$(printf '%s' "$out2" | jq -r .ready)" "1"
+chk "2패스 deferred=0" "$(printf '%s' "$out2" | jq -r .deferred)" "0"
+chk "2패스 유예분 done" "$(bash "$ADAPTER" get_task --task-id "$d1" | jq -r .status)" "done"
+
+# ---- 겹침 없음(전부 disjoint) → 기존 병렬 동작·deferred_ids=[] 키 상시 노출 ----
+: > execlog
+t4="$(bash "$ADAPTER" create_task --title T4 --body "$(mkbody 'a/1.md')" | jq -r .task_id)"
+t5="$(bash "$ADAPTER" create_task --title T5 --body "$(mkbody 'b/2.md')" | jq -r .task_id)"
+out3="$(drain)"
+chk "disjoint 패스 deferred=0" "$(printf '%s' "$out3" | jq -r .deferred)" "0"
+chk "disjoint 패스 deferred_ids=[]" "$(printf '%s' "$out3" | jq -c '.deferred_ids')" "[]"
+chk "disjoint 패스 실행 2건" "$(wc -l < execlog | tr -d ' ')" "2"
+
+# ---- scope frontmatter 없는 본문 → 겹침 판정 없이 기존대로 실행 ----
+: > execlog
+t6="$(bash "$ADAPTER" create_task --title T6 --body '## 목표'$'\n'x | jq -r .task_id)"
+t7="$(bash "$ADAPTER" create_task --title T7 --body '## 목표'$'\n'y | jq -r .task_id)"
+out4="$(drain)"
+chk "scope 없음 deferred=0" "$(printf '%s' "$out4" | jq -r .deferred)" "0"
+chk "scope 없음 실행 2건" "$(wc -l < execlog | tr -d ' ')" "2"
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail


### PR DESCRIPTION
## 요약


공유 누적 파일(CHANGELOG)을 여러 드라이버가 동시에 만질 때 (1) 형제 브랜치가 연쇄 충돌하지 않고, (2) 기존 릴리스 기록이 소실되지 않는다. 드레이너는 같은 버전 표면을 산출물로 갖는 태스크를 동시에 띄우지 않고, 통합 단계는 CHANGELOG 변경이 기존 항목을 삭제하면 차단한다.

## 작업 내용

무엇을: (1) workflow-task 드레이너에 산출물(버전 표면) 겹침 직렬화 — ready 태스크 본문 scope.include 항목이 선점되면 그 패스 유예, deferred/deferred_ids 로 보고(다음 틱 흡수), 비겹침은 기존 병렬. (2) forge integration 에 CHANGELOG 순수-추가 게이트 in_changelog_additive_gate — base 대비 three-dot diff 에서 기존 라인 삭제 감지 시 PR·리뷰(머지 후보) 차단, INT_CHANGELOG_FILE 설정 가능(빈 값=우회, base 에 파일 부재 시 미적용). SKILL.md 문서화, autopilot 0.64.5, CHANGELOG 추가(삭제 0).

왜: 같은 플러그인을 만지는 태스크의 병렬 드레인이 첫 머지마다 형제 브랜치를 연쇄 CONFLICTING 으로 만들고(605·608·610·611), 더 위험하게는 워커가 기존 CHANGELOG 섹션을 덮어써 릴리스 기록이 삭제된 채 머지됐다(PR 633). 드레이너가 암묵적 산출물 결합을 인지하지 못했고 누적 계약을 강제하는 결정적 게이트가 없었다.

검증: RED→GREEN. 새 회귀 가드 tests/autopilot/test-workflow-task-overlap-serialize.sh · tests/autopilot/execute-task/test-execute-task-changelog-gate.sh 포함 관련 스위트 전부 0 exit(integration selftest, forge 회귀 2종, drain, execute-task 전체). 적대 렌즈 3종 점검 — 발견 1건('-- ' 라인 삭제 미탐) 수정·회귀 케이스 추가.
