### PR TITLE
🤖 [자동 리뷰] create-task 스킬 벤더 독립화 — CLAUDE_PLUGIN_ROOT 폴백·도구명 중립화

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,7 +25,7 @@
       "name": "autopilot",
       "source": "./plugins/autopilot",
       "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
-      "version": "0.64.3",
+      "version": "0.64.5",
       "category": "automation",
       "tags": [
         "autonomous",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 ### 변경(호환)
 - **공유 session-conventions 해체 — 규범을 각 SKILL.md에 용어 특화 인라인 (run 604)** — `skills/shared/session-conventions.md`를 제거하고 규범 5영역(호출 규약·세션 파일 규율·디스패치 공통 규범·중앙 리서치 공통 규범·공통 안전 경계)을 brainstorm(세션 파일, `.brainstorm/<session-id>.md`)·roundtable(회의 파일, `.roundtable/<meeting-id>.md`) 각 SKILL.md 본문에 각 스킬 용어로 자체 정의. `../shared/` 참조·위임 문구 제거(스킬 자기완결). 규범 의미·강도 불변.
 
+## autopilot 0.64.5
+
+### 변경(호환)
+- **create-task 스킬 벤더 독립화 — CLAUDE_PLUGIN_ROOT 폴백·도구명 중립화 (#634)** — SKILL.md 본문의 `${CLAUDE_PLUGIN_ROOT}` 경로 참조 3곳(어댑터·persist-backend-config.sh·scope-coverage-check.sh)을 env 폴백 형태(`${CLAUDE_PLUGIN_ROOT:-$SKILL_DIR/../..}`, `$SKILL_DIR` = 스킬 문서 위치 디렉토리)로 교체하고, 본문 산문의 Claude 전용 도구명(`TodoWrite`·`AskUserQuestion`)을 벤더 중립 기능 서술 + 기능 부재 폴백(간결한 직접 질문 등)으로 대체. frontmatter `allowed-tools`는 유지(타 런타임은 무시). 절차·워크플로 의미 불변. marketplace.json의 stale autopilot 버전(0.64.3)·머지 중 소실된 0.64.4 CHANGELOG 섹션도 복구.
+
+## autopilot 0.64.4
+
+### 버그 수정
+- **라벨 설정 실패 사유를 라벨 부재로 오귀속(권한 거부 은폐) (#629)** — github 백엔드 `be_set_status`가 gh stderr를 버리고 실패를 "라벨 존재 필요" 고정 문구로 단정해 권한 거부·네트워크 오류 등 실제 원인이 은폐되던 문제 수정. `github.sh`가 원본 stderr를 보존해 진단에 포함한다(성공 시 무진단 유지). 회귀 가드: `lib/task-backend/tests/test-github-status-fail.sh`.
+
 ## autopilot 0.64.3
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.64.4",
+  "version": "0.64.5",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/skills/create-task/SKILL.md
+++ b/plugins/autopilot/skills/create-task/SKILL.md
@@ -29,12 +29,17 @@ allowed-tools:
 ## 백엔드 어댑터
 
 ```
-ADAPTER="${CLAUDE_PLUGIN_ROOT}/lib/task-backend/adapter.sh"
+# SKILL_DIR = 이 스킬 문서(SKILL.md)가 위치한 디렉토리 (런타임이 스킬 로드 시 제공)
+ADAPTER="${CLAUDE_PLUGIN_ROOT:-$SKILL_DIR/../..}/lib/task-backend/adapter.sh"
 bash "$ADAPTER" <verb> [args]
 ```
 
+경로 해석: `CLAUDE_PLUGIN_ROOT`가 정의된 런타임(Claude Code)에서는 그 값을 쓰고, 없으면 이 스킬
+문서가 위치한 디렉토리 기준 상대 경로로 해석한다(플러그인 루트 = 스킬 디렉토리의 두 단계 상위).
+
 동사·상태 집합·태스크 본문 구조의 단일 출처는 `task-backend/contract.md`다. 백엔드 미설정 시
-`bash "$ADAPTER" init --backend <filesystem|github-project|beads>`를 안내한다(선택은 `AskUserQuestion`).
+`bash "$ADAPTER" init --backend <filesystem|github-project|beads>`를 안내한다(선택은 현재 런타임의
+구조화된 사용자 질문 기능으로 받고, 없으면 간결한 직접 질문으로 폴백한다).
 
 ### 백엔드 선택 SoT 영속화
 
@@ -42,7 +47,7 @@ bash "$ADAPTER" <verb> [args]
 헬퍼를 실행해 이 SoT를 **메인 브랜치까지 영속화**한다(새 체크아웃·CI·다른 세션에서 동일 백엔드 보장):
 
 ```
-bash "${CLAUDE_PLUGIN_ROOT}/skills/create-task/references/persist-backend-config.sh"
+bash "${CLAUDE_PLUGIN_ROOT:-$SKILL_DIR/../..}/skills/create-task/references/persist-backend-config.sh"
 ```
 
 헬퍼는 멱등이며 config 파일 **단독** 변경만 커밋한다 — origin 있으면 config-only 브랜치 push → PR →
@@ -55,7 +60,9 @@ auto-merge, 없으면 로컬 메인 merge. `.autopilot/` 는 워치 디렉토리
 
 ## 워크플로
 
-호출 시 단계를 TodoWrite로 등록한다. 결정·승인은 `AskUserQuestion`으로 받는다(자유 텍스트 질문 종결구 금지).
+호출 시 단계를 현재 런타임의 체크리스트(todo) 기능으로 등록한다(없으면 응답 내 인라인 목록으로 단계를
+추적한다). 결정·승인은 현재 런타임의 구조화된 사용자 질문 기능으로 받는다(자유 텍스트 질문 종결구 금지;
+기능이 없으면 간결한 직접 질문으로 폴백한다).
 
 1. **입력 수신·경로 분기** — 작성자(`feature`/`fix`)가 넘긴 **완성 태스크 본문**(제목 + frontmatter-first 스펙:
    scope frontmatter·무엇을 만들 것인가·완료 조건(EARS) 등)을 입력으로 받는다. 본문 작성·인터뷰·분해는 하지
@@ -68,20 +75,21 @@ auto-merge, 없으면 로컬 메인 merge. `.autopilot/` 는 워치 디렉토리
      `bash "$ADAPTER" get_task --task-id <task-id>`로 그 id가 **실존 태스크로 해석되는지** 확인한다. 해석
      성공이면 재개, 해석 실패(유효 task-id 형식이 아니거나 없는 id)면 첫 줄을 자연어 제목으로 보고 **신규
      등록으로 처리**한다(전체 입력 = `<제목>\n\n<본문>`).
-2. **백엔드 준비** — 백엔드 미설정이면 `adapter init`(선택은 `AskUserQuestion`) 후 위 「백엔드 선택 SoT
-   영속화」 헬퍼를 실행해 config를 메인까지 영속화한다(멱등).
+2. **백엔드 준비** — 백엔드 미설정이면 `adapter init`(선택은 현재 런타임의 구조화된 사용자 질문 기능,
+   없으면 간결한 직접 질문) 후 위 「백엔드 선택 SoT 영속화」 헬퍼를 실행해 config를 메인까지 영속화한다(멱등).
 3. **scope-coverage 검증** — 등록 전에 scope-coverage 검증을 수행한다. 본문 frontmatter의
    `scope.include`에서 소스 경로를 읽어, 그 소스를 덮는 **기존** 테스트 경로가 scope.include에 함께 있는지
    확인한다. 소스→테스트 매핑은 **컨슈밍 프로젝트가 `.autopilot/scope-coverage-map.json`으로 공급**하며,
    그 설정 스키마의 단일 출처는 `references/scope-coverage-map.md`다. 설정이 없는 프로젝트에서는 검사가
    경고 없이 통과한다:
    ```
-   CHECKER="${CLAUDE_PLUGIN_ROOT}/skills/create-task/references/scope-coverage-check.sh"
+   CHECKER="${CLAUDE_PLUGIN_ROOT:-$SKILL_DIR/../..}/skills/create-task/references/scope-coverage-check.sh"
    echo "<본문>" | bash "$CHECKER"
    ```
    누락이 있으면 `SCOPE_COVERAGE_WARNING` 과 누락 경로 목록을 출력한다. **등록을 막지 않는다** — 경고를
-   작성자에게 보고하고 다음 단계로 진행한다. 인터랙티브 맥락에서는 `AskUserQuestion`으로 scope.include에
-   추가할지 확인할 수 있다. 스크립트는 항상 0 exit이므로 경고 유무와 관계없이 다음 단계로 진행된다.
+   작성자에게 보고하고 다음 단계로 진행한다. 인터랙티브 맥락에서는 현재 런타임의 구조화된 사용자 질문
+   기능(없으면 간결한 직접 질문)으로 scope.include에 추가할지 확인할 수 있다. 스크립트는 항상 0 exit이므로
+   경고 유무와 관계없이 다음 단계로 진행된다.
 4. **등록** — 받은 본문을 그대로 등록한다(`create_task`의 초기 상태는 `backlog`다). 작성자가 의존 관계를
    넘겼으면 `--depends-on`으로 함께 전달한다:
    ```

--- a/tests/autopilot/test-create-task-status-transition.sh
+++ b/tests/autopilot/test-create-task-status-transition.sh
@@ -86,4 +86,40 @@ echo "$DESC" | grep -qE '(feature.*fix).*(먼저|아니)' \
 ok "description: 배제 조항 존재"
 
 echo ""
+echo "=== TEST 10: 본문 CLAUDE_PLUGIN_ROOT 참조는 전부 env 폴백 형태 (벤더 독립) ==="
+FM="$(awk 'NR==1{next} /^---$/{exit} {print}' "$SKILL_MD")"
+# 폴백 없는 단독 확장 형태 ${CLAUDE_PLUGIN_ROOT} (\":-\" 폴백 미포함)만 결함 — 폴백 규칙을 설명하는 산문 언급은 허용
+bare="$(echo "$BODY" | grep -nF '${CLAUDE_PLUGIN_ROOT}' || true)"
+[[ -z "$bare" ]] \
+  || fail "본문에 폴백 없는 단독 \${CLAUDE_PLUGIN_ROOT} 참조 잔존: $bare"
+echo "$BODY" | grep -q 'CLAUDE_PLUGIN_ROOT:-' \
+  || fail "본문에 CLAUDE_PLUGIN_ROOT env 폴백 형태 참조가 하나도 없음 (경로 해석 서술 소실)"
+ok "본문 CLAUDE_PLUGIN_ROOT: 전부 폴백 형태"
+
+echo ""
+echo "=== TEST 11: 본문 산문에 Claude 전용 도구명 부재 (벤더 중립) ==="
+hits="$(echo "$BODY" | grep -nE 'TodoWrite|AskUserQuestion' || true)"
+[[ -z "$hits" ]] \
+  || fail "본문 산문에 Claude 전용 도구명 잔존: $hits"
+ok "본문 산문: TodoWrite/AskUserQuestion 부재"
+
+echo ""
+echo "=== TEST 12: 벤더 중립 기능 서술 + 기능 부재 폴백 존재 ==="
+echo "$BODY" | grep -q '구조화된 사용자 질문' \
+  || fail "본문에 '구조화된 사용자 질문' 기능 서술 없음"
+echo "$BODY" | grep -qE '체크리스트|todo' \
+  || fail "본문에 체크리스트(todo) 기능 서술 없음"
+echo "$BODY" | grep -qE '직접 질문' \
+  || fail "본문에 기능 부재 런타임 폴백(직접 질문) 서술 없음"
+ok "벤더 중립 기능 서술 + 폴백 존재"
+
+echo ""
+echo "=== TEST 13: frontmatter allowed-tools 유지 (AskUserQuestion 항목 보존) ==="
+echo "$FM" | grep -q 'AskUserQuestion' \
+  || fail "frontmatter에서 AskUserQuestion 항목이 제거됨 (유지 대상)"
+echo "$FM" | grep -q 'allowed-tools' \
+  || fail "frontmatter allowed-tools 블록 소실"
+ok "frontmatter allowed-tools 유지"
+
+echo ""
 echo "=== 모든 create-task 등록-후 상태 전이 조건부화 테스트 통과 ==="


### PR DESCRIPTION
## 요약


`create-task` 스킬 문서(SKILL.md)를 특정 에이전트 런타임(Claude Code)에 묶이지 않게 고친다.
스킬 본문이 Claude Code 전용 환경 변수·도구명에 의존하지 않고, 어떤 에이전트 런타임에서
로드돼도 같은 절차를 수행할 수 있어야 한다. 세 가지 벤더 의존을 제거한다:

1. **경로 해석** — `${CLAUDE_PLUGIN_ROOT}` 참조 3곳(백엔드 어댑터 경로,
   persist-backend-config.sh 경로, scope-coverage-check.sh 경로)을 env 폴백 형태로 교체:
   `CLAUDE_PLUGIN_ROOT`가 정의돼 있으면 그 값을 쓰고, 없으면 이 스킬 문서(SKILL.md)가
   위치한 디렉토리 기준 상대 경로로 해석한다(스킬 베이스 디렉토리는 런타임이 스킬 로드 시
   제공하는 공통 관례). 예:
   `ADAPTER="${CLAUDE_PLUGIN_ROOT:-<스킬 베이스 디렉토리>/../..}/lib/task-backend/adapter.sh"`
2. **도구명 중립화** — 본문의 Claude 전용 도구명을 벤더 중립 기능 서술로 대체한다:
   `TodoWrite` → "현재 런타임의 체크리스트(todo) 기능", `AskUserQuestion` → "현재 런타임의
   구조화된 사용자 질문 기능". 각 서술에는 기능 부재 런타임의 폴백(간결한 직접 질문 등)을
   한 줄로 덧붙인다.
3. **frontmatter는 유지** — `allowed-tools` 등 frontmatter의 Claude 확장 키는 그대로 둔다
   (타 런타임은 무시하므로 이미 벤더-허용적; 제거하면 Claude에서 권한 프롬프트 증가).
   frontmatter 내 `AskUserQuestion` 도구 항목도 유지 대상이다 — 중립화는 **본문 산문**에만
   적용한다.

## 작업 내용

create-task 스킬 벤더 독립화 완료 (commit 31ac132, autopilot 0.64.5).

- SKILL.md 본문 `${CLAUDE_PLUGIN_ROOT}` 3곳(adapter·persist-backend-config.sh·scope-coverage-check.sh) → env 폴백 형태 `${CLAUDE_PLUGIN_ROOT:-$SKILL_DIR/../..}` + 해석 규칙 산문.
- 본문 산문 TodoWrite·AskUserQuestion → 벤더 중립 기능 서술("체크리스트(todo) 기능"·"구조화된 사용자 질문 기능") + 기능 부재 폴백 각 1줄.
- frontmatter allowed-tools 불변.
- 버전 표면: plugin.json 0.64.4→0.64.5, marketplace.json stale 0.64.3 동기화, CHANGELOG 0.64.5 + 머지 중 소실된 0.64.4 섹션 복구.
- 회귀 가드: test-create-task-status-transition.sh TEST 10–13 (RED 확인 후 GREEN). sweep 두 테스트 fresh 0 exit.
- 4-Level Verifier·Self-Review·적대 렌즈(비자명 변경) 통과. 잔여 관찰: contract.md의 `$CODEX_PLUGIN_ROOT` 관용구와 분기 — 후속 태스크 후보(비차단). test-loop-sh.sh는 base부터 실패(pre-existing, scope 밖).
