### PR TITLE
🤖 [자동 리뷰] forge integration push 게이트 — detached-HEAD 리뷰-수정 커밋을 원격-앞섬으로 오판해 유실

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.64.7
+
+### 버그 수정
+- **forge integration push 게이트 — detached-HEAD 리뷰-수정 커밋 유실 (run 644)** — `in_push_branch`가 원격-앞섬 판정의 로컬 기준으로 **stale 할 수 있는 로컬 브랜치 ref**를 써서, 리뷰-수정 커밋이 loop 워크트리의 분리(detached) HEAD 에만 쌓인 경우(#452: 공유 체크아웃 미오염을 위해 로컬 ref 미갱신) "원격-앞섬"으로 오판해 push 를 생략하고 수정이 원격 PR 에 반영되지 않던 결함을 수정. 이제 판정·push 대상을 **실제 통합 대상 커밋**(브랜치 ref 뒤의 워크트리 델타 커밋 포함)으로 잡고, 델타가 있으면 `<commit>:refs/heads/<branch>` 직접 push 로 반영한다(로컬 ref 미갱신 유지). 오염 방지 가드 — 브랜치 ref 가 이미 origin/main 에 포함되거나(판정 전 base fetch) 자손 후보가 둘 이상이면 되찾지 않고, 모호로 인한 생략은 stderr 로 표면화한다(조용한 재발 방지). 정당한 원격-앞섬 보존(run 592)·force 금지 불변. 회귀 가드 `tests/test-integration-worktree-delta.sh` 추가. marketplace.json 버전 동기화는 SPEC scope 밖으로 후속 처리(parity 예외).
+
 ## autopilot 0.64.6
 
 ### 변경(호환)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
-## project-init 0.26.0
+## autopilot 0.64.7
 
-### 새 기능
-- **create-hook 스킬 — 훅 생성 (hook-standard 소비) (run 617)** — 소비 프로젝트에 Claude Code 훅(이벤트 핸들러 + `lib/<command>/` 기능 스크립트 + settings 등록)을 인터뷰 기반으로 설계·작성하는 `skills/create-hook` 신설. 구조화된 질문으로 이벤트·기능(command)·차단 여부·대상 디렉토리를 확정하고, `shared/hook-standard`(단일 출처)의 2계층 레이아웃·스크립트 계약(POSIX sh·jq 폴백·비차단 exit 0·`${CLAUDE_PROJECT_DIR}` placeholder 등록)대로 산출한다. 같은 이벤트 핸들러가 이미 있으면 새 핸들러 대신 기존 핸들러에 디스패치를 추가하고, 기존 파일 덮어쓰기는 diff 제시 후 명시적 승인에서만 수행하며, 작성 후 `hook_checker.py`로 BLOCKER·MAJOR 0 을 확인(발견 시 수정 후 1회만 재검)한다.
+### 버그 수정
+- **forge integration push 게이트 — detached-HEAD 리뷰-수정 커밋 유실 (run 644)** — `in_push_branch`가 원격-앞섬 판정의 로컬 기준으로 **stale 할 수 있는 로컬 브랜치 ref**를 써서, 리뷰-수정 커밋이 loop 워크트리의 분리(detached) HEAD 에만 쌓인 경우(#452: 공유 체크아웃 미오염을 위해 로컬 ref 미갱신) "원격-앞섬"으로 오판해 push 를 생략하고 수정이 원격 PR 에 반영되지 않던 결함을 수정. 이제 판정·push 대상을 **실제 통합 대상 커밋**(브랜치 ref 뒤의 워크트리 델타 커밋 포함)으로 잡고, 델타가 있으면 `<commit>:refs/heads/<branch>` 직접 push 로 반영한다(로컬 ref 미갱신 유지). 오염 방지 가드 — 브랜치 ref 가 이미 origin/main 에 포함되거나(판정 전 base fetch) 자손 후보가 둘 이상이면 되찾지 않고, 모호로 인한 생략은 stderr 로 표면화한다(조용한 재발 방지). 정당한 원격-앞섬 보존(run 592)·force 금지 불변. 회귀 가드 `tests/test-integration-worktree-delta.sh` 추가. marketplace.json 버전 동기화는 SPEC scope 밖으로 후속 처리(parity 예외).
 
 ## autopilot 0.64.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
-## autopilot 0.64.9
+## autopilot 0.65.1
 
 ### 버그 수정
 - **forge integration push 게이트 — detached-HEAD 리뷰-수정 커밋 유실 (run 644)** — `in_push_branch`가 원격-앞섬 판정의 로컬 기준으로 **stale 할 수 있는 로컬 브랜치 ref**를 써서, 리뷰-수정 커밋이 loop 워크트리의 분리(detached) HEAD 에만 쌓인 경우(#452: 공유 체크아웃 미오염을 위해 로컬 ref 미갱신) "원격-앞섬"으로 오판해 push 를 생략하고 수정이 원격 PR 에 반영되지 않던 결함을 수정. 이제 판정·push 대상을 **실제 통합 대상 커밋**(브랜치 ref 뒤의 워크트리 델타 커밋 포함)으로 잡고, 델타가 있으면 `<commit>:refs/heads/<branch>` 직접 push 로 반영한다(로컬 ref 미갱신 유지). 오염 방지 가드 — 브랜치 ref 가 이미 origin/main 에 포함되거나(판정 전 base fetch) 자손 후보가 둘 이상이면 되찾지 않고, 모호로 인한 생략은 stderr 로 표면화한다(조용한 재발 방지). 정당한 원격-앞섬 보존(run 592)·force 금지 불변. 회귀 가드 `tests/test-integration-worktree-delta.sh` 추가. marketplace.json 버전 동기화는 SPEC scope 밖으로 후속 처리(parity 예외).
 
+## autopilot 0.65.0
+
+### 새 기능
+- **워커 벤더 영속 설정 — `.autopilot/task-backend.json` 의 `worker_vendor` (run 635)** — 구현 워커 CLI(`claude`|`codex`) 선택이 환경 변수 `AUTOPILOT_WORKER_VENDOR` 로만 가능해 무인 경로(cron 드레인 등 env 미전달)에서 항상 기본값으로 떨어지던 문제를 해소. loop 엔진이 벤더-중립 설정 SoT `.autopilot/task-backend.json` 의 `worker_vendor` 를 읽는다. 우선순위는 env > 설정 파일 > 기본값 `claude`(기존 프로젝트 동작 불변), 지원 밖 값이면 `start` 가 지원 벤더 목록을 명시한 오류로 중단한다. 설정 파일은 호출 cwd 가 아니라 **spec 저장소**의 메인 워크트리 기준으로 확정해(사전 의존성 검사와 실제 이터가 같은 워커를 본다) 링크드 워크트리 안에서도 같은 파일을 읽으며, 파싱은 jq 무의존(파싱 불가 시 env/기본값 경로).
+
+### 변경(호환)
+- **execute-task 스킬 호출 표기 벤더 중립화 (run 635)** — SKILL.md 의 실행 스크립트 경로를 `${CLAUDE_PLUGIN_ROOT}` 에서 계약 관례 `${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}` 로 교체해 Claude 전용 변수 부재 환경에서도 성립하게 함. 벤더 선택 우선순위는 loop SKILL.md·`lib/task-backend/contract.md` 에 기술.
 ## autopilot 0.64.8
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.64.9",
+  "version": "0.65.1",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.64.6",
+  "version": "0.64.7",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/lib/forge/lib/integration.sh
+++ b/plugins/autopilot/lib/forge/lib/integration.sh
@@ -377,25 +377,69 @@ _in_base_sync_core() {
   return 0
 }
 
+# in_worktree_delta_commit <branch> <ref_commit> — 로컬 브랜치 ref 뒤에 남은 워크트리 델타 커밋.
+#   #452 설계상 loop·리뷰 재구현은 분리(detached) 워크트리 HEAD 만 전진시키고 로컬 브랜치 ref 는
+#   갱신하지 않는다(공유 체크아웃 미오염). 그래서 리뷰-수정 커밋은 브랜치 ref 에 없고 워크트리
+#   HEAD 에만 있다(run 638) — ref 만 보면 "원격-앞섬"으로 오판해 push 를 생략하고 수정을 유실한다.
+#   ref_commit 의 **엄격한 자손**인 워크트리 HEAD 를 실제 통합 대상으로 되찾는다. 되찾을 것이
+#   없으면 빈 출력(= 기존 ref 기준 동작). 오염 방지 가드:
+#     - 브랜치 ref 가 이미 origin/<default> 에 포함되면(머지 완료 등) 무관한 run 워크트리가
+#       자손으로 잡힐 수 있으므로 되찾지 않는다.
+#     - 자손 후보가 둘 이상이면 어느 것이 대상인지 모호하므로 되찾지 않는다.
+in_worktree_delta_commit() {
+  local branch="$1" ref_commit="$2" c cands=""
+  [[ -n "$ref_commit" ]] || return 0
+  # 가드 판정 전에 base 를 fetch 한다 — stale 한 origin/<default> 로는 "이미 머지됨"을 놓쳐
+  # 가드가 헛돈다(무관 워크트리 커밋 되찾기 위험).
+  # shellcheck disable=SC2086
+  $GIT_CMD fetch origin "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
+  # shellcheck disable=SC2086
+  if $GIT_CMD merge-base --is-ancestor "refs/heads/$branch" "origin/$DEFAULT_BRANCH" 2>/dev/null; then
+    return 0
+  fi
+  while read -r c; do
+    [[ -n "$c" && "$c" != "$ref_commit" ]] || continue
+    # shellcheck disable=SC2086
+    $GIT_CMD merge-base --is-ancestor "$ref_commit" "$c" 2>/dev/null && cands="$cands $c"
+  done < <($GIT_CMD worktree list --porcelain 2>/dev/null | awk '$1=="HEAD" { print $2 }')
+  # shellcheck disable=SC2086
+  set -- $cands
+  if [[ "$#" -gt 1 ]]; then
+    # 조용히 생략하면 이 결함(리뷰-수정 유실)이 흔적 없이 재발한다 — 표면화한다.
+    echo "integration: 워크트리 델타 후보가 둘 이상($*) — 통합 대상 모호로 되찾지 않음: $branch" >&2
+    return 0
+  fi
+  [[ "$#" -eq 1 ]] && printf '%s\n' "$1"
+  return 0
+}
+
 in_push_branch() {
-  # 원격-앞섬 정합(run 592): 로컬 ref 가 원격 tip 의 조상이면(리뷰 수정 푸시 등 정당한 전진으로
-  # 원격이 앞섬) 원격이 이미 모든 로컬 커밋을 보유 — push 는 불필요하고 non-ff 로 거부만 되므로
-  # 건너뛴다. fetch 시점 레이스 완화를 위해 판정 직전에 원격 ref 를 fetch 한다. force 금지 유지.
-  local branch="$1" tip local_commit
+  # 원격-앞섬 정합(run 592): **통합 대상 커밋**이 원격 tip 의 조상이면(리뷰 수정 푸시 등 정당한
+  # 전진으로 원격이 앞섬) 원격이 이미 모든 로컬 커밋을 보유 — push 는 불필요하고 non-ff 로
+  # 거부만 되므로 건너뛴다. 통합 대상은 stale 할 수 있는 로컬 브랜치 ref 가 아니라 그 뒤의
+  # 워크트리 델타 커밋까지 포함한다(run 638). fetch 시점 레이스 완화를 위해 판정 직전에 원격
+  # ref 를 fetch 한다. force 금지 유지.
+  local branch="$1" tip ref_commit delta local_commit refspec
+  # shellcheck disable=SC2086
+  ref_commit="$($GIT_CMD rev-parse "refs/heads/$branch" 2>/dev/null)"
+  delta="$(in_worktree_delta_commit "$branch" "$ref_commit")"
+  local_commit="${delta:-$ref_commit}"
   tip="$(in_remote_tip "$branch")"
   if [[ -n "$tip" ]]; then
     # shellcheck disable=SC2086
     $GIT_CMD fetch origin "$branch" >/dev/null 2>&1 || true
     # shellcheck disable=SC2086
-    local_commit="$($GIT_CMD rev-parse "refs/heads/$branch" 2>/dev/null)"
-    # shellcheck disable=SC2086
     if [[ -n "$local_commit" ]] && $GIT_CMD merge-base --is-ancestor "$local_commit" "$tip" 2>/dev/null; then
-      echo "integration: push 생략 — 원격 브랜치가 로컬 ref 를 이미 포함(원격-앞섬): $branch" >&2
+      echo "integration: push 생략 — 원격 브랜치가 통합 대상 커밋을 이미 포함(원격-앞섬): $branch" >&2
       return 0
     fi
   fi
+  # 델타가 있으면 그 커밋을 원격 작업 브랜치로 **직접 push** 한다(#452 와 동일 방식) — 로컬
+  # $branch ref 를 갱신하지 않으므로 공유 체크아웃을 더럽히지 않는다. force 아님(ff push).
+  refspec="$branch"
+  [[ -n "$delta" ]] && refspec="$delta:refs/heads/$branch"
   # shellcheck disable=SC2086
-  $GIT_CMD push origin "$branch" || { in_die "push 실패(force 금지): $branch"; return 1; }
+  $GIT_CMD push origin "$refspec" || { in_die "push 실패(force 금지): $branch"; return 1; }
 }
 
 # =====================================================================

--- a/plugins/autopilot/lib/forge/lib/tests/test-integration-worktree-delta.sh
+++ b/plugins/autopilot/lib/forge/lib/tests/test-integration-worktree-delta.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# test-integration-worktree-delta.sh — 워크트리 델타 커밋 push 회귀 가드 (run 638 관측).
+#   시나리오: 리뷰-수정 커밋이 loop 워크트리의 분리(detached) HEAD 에만 쌓이고 로컬 브랜치
+#   ref 는 stale(#452: 공유 체크아웃 미오염을 위해 로컬 ref 미갱신).
+#   기대: push 판정을 **실제 통합 대상 커밋**(워크트리 HEAD) 기준으로 수행한다.
+#     A. 로컬 ref=f / 워크트리 HEAD=f+1 / 원격 tip=f → 델타 커밋을 직접 push(생략 아님).
+#     B. 원격 tip 이 이미 델타 커밋을 포함 → 정당한 원격-앞섬으로 push 생략(run 592 불변).
+#     C. 워크트리 델타 없음 + 원격-앞섬 → 기존대로 push 생략.
+#     D. 브랜치 ref 가 이미 origin/main 에 포함(머지 완료) → 무관한 run 워크트리 커밋을
+#        되찾지 않는다(오염 방지 가드).
+#   어떤 경로에서도 force 미사용.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+
+# integration.sh 를 source (하단 BASH_SOURCE 가드로 main 미실행).
+# shellcheck disable=SC1091
+. "$HERE/../integration.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+BRANCH="feat/20260723T000000-run638-feature"
+REF_COMMIT="f"          # 로컬 브랜치 ref (stale)
+WT_HEADS="f"            # 워크트리 HEAD 목록 (케이스별 설정)
+REMOTE_TIP="f"          # 원격 작업 브랜치 tip (케이스별 설정)
+MERGED=0                # 브랜치 ref 가 origin/main 에 포함되는가
+
+# ---- mock git: 커밋 그래프를 조상 목록으로 모사 ----
+#   f       ← 브랜치 ref
+#   fplus1  ← 리뷰 델타(워크트리 HEAD), f 의 자손
+#   unrelated ← 무관한 run 워크트리 HEAD, f 의 자손(머지 후 시나리오)
+#   remotetip ← 원격이 정당하게 앞선 커밋, f 의 자손
+PUSHLOG="$TMP/pushlog" GITLOG="$TMP/gitlog"
+mock_anc() {   # mock_anc <commit> → 자기 자신 포함 조상 목록
+  case "$1" in
+    f)         echo "f" ;;
+    fplus1)    echo "f fplus1" ;;
+    fplus2)    echo "f fplus1 fplus2" ;;
+    unrelated) echo "f unrelated" ;;
+    remotetip) echo "f remotetip" ;;
+    *)         echo "$1" ;;
+  esac
+}
+mock_git() {
+  if [[ "$1" == "-C" ]]; then shift 2; fi
+  local a; for a in "$@"; do case "$a" in *force*|-f) echo "FORCE USED" >&2; exit 99;; esac; done
+  printf '%s\n' "$*" >> "$GITLOG"
+  case "$1" in
+    fetch) return 0 ;;
+    ls-remote) [[ -n "$REMOTE_TIP" ]] && printf '%s\trefs/heads/%s\n' "$REMOTE_TIP" "$BRANCH"; return 0 ;;
+    rev-parse)
+      case "$*" in
+        *refs/heads/*) printf '%s\n' "$REF_COMMIT"; return 0 ;;
+        *) printf '%s\n' "$REF_COMMIT"; return 0 ;;
+      esac ;;
+    worktree)
+      # `worktree list --porcelain` 형식(HEAD 줄만 소비된다).
+      local h; for h in $WT_HEADS; do
+        printf 'worktree %s/wt-%s\nHEAD %s\ndetached\n\n' "$TMP" "$h" "$h"
+      done; return 0 ;;
+    merge-base)
+      local A="$3" B="$4"
+      [[ "$A" == refs/heads/* ]] && A="$REF_COMMIT"
+      [[ "$B" == refs/heads/* ]] && B="$REF_COMMIT"
+      if [[ "$B" == "origin/main" ]]; then [[ "$MERGED" == "1" ]] && return 0 || return 1; fi
+      printf '%s\n' "$(mock_anc "$B")" | tr ' ' '\n' | grep -Fxq "$A"; return $? ;;
+    push) printf '%s\n' "$*" >> "$PUSHLOG"; return 0 ;;
+  esac
+  return 0
+}
+GIT_CMD=mock_git
+DEFAULT_BRANCH=main
+
+ERRLOG="$TMP/errlog"
+run_case() { : > "$PUSHLOG"; : > "$GITLOG"; in_push_branch "$BRANCH" >/dev/null 2>"$ERRLOG"; }
+
+# ---- A: 워크트리 델타 커밋이 원격에 없음 → 델타 커밋 직접 push ----
+WT_HEADS="fplus1"; REMOTE_TIP="f"; MERGED=0
+run_case
+if grep -Fxq "push origin fplus1:refs/heads/$BRANCH" "$PUSHLOG"; then
+  ok "A: stale ref 뒤의 워크트리 델타 커밋을 원격 작업 브랜치로 직접 push"
+else
+  bad "A: 워크트리 델타 커밋 push (pushlog: $(tr '\n' ';' < "$PUSHLOG"))"
+fi
+
+# ---- B: 원격이 이미 델타 커밋 포함 → 생략(run 592 불변) ----
+WT_HEADS="fplus1"; REMOTE_TIP="fplus1"; MERGED=0
+run_case
+[[ ! -s "$PUSHLOG" ]] && ok "B: 원격이 통합 대상 커밋을 이미 포함 → push 생략" \
+  || bad "B: 정당한 원격-앞섬 push 생략 (pushlog: $(tr '\n' ';' < "$PUSHLOG"))"
+
+# ---- C: 워크트리 델타 없음 + 원격-앞섬 → 생략 ----
+WT_HEADS="f"; REMOTE_TIP="remotetip"; MERGED=0
+run_case
+[[ ! -s "$PUSHLOG" ]] && ok "C: 델타 없음 + 원격-앞섬 → push 생략" \
+  || bad "C: 델타 없음 + 원격-앞섬 push 생략 (pushlog: $(tr '\n' ';' < "$PUSHLOG"))"
+
+# ---- D: 브랜치가 이미 origin/main 에 포함 → 무관 워크트리 커밋 되찾지 않음 ----
+WT_HEADS="unrelated"; REMOTE_TIP="f"; MERGED=1
+run_case
+grep -q "unrelated" "$PUSHLOG" && bad "D: 머지된 브랜치에 무관 워크트리 커밋 push(오염)" \
+  || ok "D: 머지된 브랜치는 워크트리 커밋 되찾지 않음(오염 방지)"
+grep -qE "^fetch origin main" "$GITLOG" && ok "D2: 머지 가드 판정 전 base fetch(stale 가드 방지)" \
+  || bad "D2: 머지 가드 판정 전 base fetch"
+
+# ---- F: 자손 후보가 둘 이상 → 모호로 되찾지 않고 조용히 넘기지 않음(표면화) ----
+WT_HEADS="fplus1 fplus2"; REMOTE_TIP="f"; MERGED=0
+run_case
+grep -qE "fplus1|fplus2" "$PUSHLOG" && bad "F: 모호한 후보를 임의 선택해 push" \
+  || ok "F: 자손 후보 둘 이상 → 되찾지 않음(모호)"
+grep -q "모호" "$ERRLOG" && ok "F2: 모호 생략을 stderr 로 표면화(조용한 재발 방지)" \
+  || bad "F2: 모호 생략 표면화 (errlog: $(tr '\n' ';' < "$ERRLOG"))"
+
+# ---- force 금지 ----
+if grep -qiE 'force|(^| )-f( |$)' "$GITLOG"; then bad "E: force 미사용"; else ok "E: force 미사용"; fi
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || { echo "FAILURES present"; exit 1; }


### PR DESCRIPTION
## 요약


forge integration의 push 판정이 실제 통합 대상 커밋(워크트리 HEAD/loop 결과 커밋)을 기준으로 동작하게 고쳐, 리뷰-수정 커밋이 워크트리 detached HEAD에만 있을 때도 원격 작업 브랜치에 ff-push되도록 한다. run 592 원격-앞섬 보존·force 금지·공유 체크아웃 미오염(#452)은 유지한다.

## 작업 내용

forge integration push 게이트 수정 완료 (commit a47c046, autopilot 0.64.7).

근본 원인: loop 워크트리는 <SPEC_DIR>/.worktree 이고 리뷰 델타 스펙이 같은 run dir 에 생성돼
원 run 워크트리를 재사용 → 리뷰-수정 커밋은 분리 HEAD 에만 쌓이고 로컬 브랜치 ref 는 stale.
in_push_branch 가 그 stale ref 를 원격 tip 과 비교해 "원격-앞섬"으로 오판 → push 생략 → 유실.

변경:
- in_worktree_delta_commit 신설 — 워크트리 HEAD 중 브랜치 ref 의 엄격한 자손을 통합 대상으로 되찾음
  (가드: 브랜치가 이미 origin/main 포함 시 미적용(판정 전 base fetch), 후보 2+ 면 모호로 미적용 + stderr 표면화)
- in_push_branch — 생략 판정·push 대상을 통합 대상 커밋으로. 델타면 <sha>:refs/heads/<branch> 직접 push
  (로컬 ref 미갱신 = #452 유지, force 금지 유지)
- tests/test-integration-worktree-delta.sh (A~F) 추가
- plugin.json 0.64.6→0.64.7, CHANGELOG 버그 수정 항목

검증(fresh): plugins/autopilot/lib/forge/lib/tests/*.sh 4개 ALL PASS,
integration.sh / review-loop.sh / merge.sh selftest 0 exit. run 592 원격-앞섬 보존 테스트 통과.

알려진 한계(노트 ## 의심점): 통합 대상을 호출자 인자가 아닌 워크트리 스캔으로 추론한다 —
결정적 대안(review-loop 호출부에서 델타 spec 전달)은 SPEC scope 밖이라 미채택. 후속 태스크 후보.
marketplace.json 버전 drift(0.64.5)도 scope 밖이라 미수정.
