### PR TITLE
🤖 [자동 리뷰] execute-task 벤더 독립화 — 플러그인 루트 표기 중립화 + 워커 벤더 영속 설정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.65.0
+
+### 새 기능
+- **워커 벤더 영속 설정 — `.autopilot/task-backend.json` 의 `worker_vendor` (run 635)** — 구현 워커 CLI(`claude`|`codex`) 선택이 환경 변수 `AUTOPILOT_WORKER_VENDOR` 로만 가능해 무인 경로(cron 드레인 등 env 미전달)에서 항상 기본값으로 떨어지던 문제를 해소. loop 엔진이 벤더-중립 설정 SoT `.autopilot/task-backend.json` 의 `worker_vendor` 를 읽는다. 우선순위는 env > 설정 파일 > 기본값 `claude`(기존 프로젝트 동작 불변), 지원 밖 값이면 `start` 가 지원 벤더 목록을 명시한 오류로 중단한다. 설정 파일은 메인 워크트리 기준으로 확정해 링크드 워크트리 안에서도 같은 파일을 읽으며, 파싱은 jq 무의존(파싱 불가 시 env/기본값 경로).
+
+### 변경(호환)
+- **execute-task 스킬 호출 표기 벤더 중립화 (run 635)** — SKILL.md 의 실행 스크립트 경로를 `${CLAUDE_PLUGIN_ROOT}` 에서 계약 관례 `${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}` 로 교체해 Claude 전용 변수 부재 환경에서도 성립하게 함. 벤더 선택 우선순위는 loop SKILL.md·`lib/task-backend/contract.md` 에 기술.
+
 ## autopilot 0.64.6
 
 ### 변경(호환)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
-## project-init 0.26.0
+## autopilot 0.65.0
 
 ### 새 기능
-- **create-hook 스킬 — 훅 생성 (hook-standard 소비) (run 617)** — 소비 프로젝트에 Claude Code 훅(이벤트 핸들러 + `lib/<command>/` 기능 스크립트 + settings 등록)을 인터뷰 기반으로 설계·작성하는 `skills/create-hook` 신설. 구조화된 질문으로 이벤트·기능(command)·차단 여부·대상 디렉토리를 확정하고, `shared/hook-standard`(단일 출처)의 2계층 레이아웃·스크립트 계약(POSIX sh·jq 폴백·비차단 exit 0·`${CLAUDE_PROJECT_DIR}` placeholder 등록)대로 산출한다. 같은 이벤트 핸들러가 이미 있으면 새 핸들러 대신 기존 핸들러에 디스패치를 추가하고, 기존 파일 덮어쓰기는 diff 제시 후 명시적 승인에서만 수행하며, 작성 후 `hook_checker.py`로 BLOCKER·MAJOR 0 을 확인(발견 시 수정 후 1회만 재검)한다.
+- **워커 벤더 영속 설정 — `.autopilot/task-backend.json` 의 `worker_vendor` (run 635)** — 구현 워커 CLI(`claude`|`codex`) 선택이 환경 변수 `AUTOPILOT_WORKER_VENDOR` 로만 가능해 무인 경로(cron 드레인 등 env 미전달)에서 항상 기본값으로 떨어지던 문제를 해소. loop 엔진이 벤더-중립 설정 SoT `.autopilot/task-backend.json` 의 `worker_vendor` 를 읽는다. 우선순위는 env > 설정 파일 > 기본값 `claude`(기존 프로젝트 동작 불변), 지원 밖 값이면 `start` 가 지원 벤더 목록을 명시한 오류로 중단한다. 설정 파일은 메인 워크트리 기준으로 확정해 링크드 워크트리 안에서도 같은 파일을 읽으며, 파싱은 jq 무의존(파싱 불가 시 env/기본값 경로).
+
+### 변경(호환)
+- **execute-task 스킬 호출 표기 벤더 중립화 (run 635)** — SKILL.md 의 실행 스크립트 경로를 `${CLAUDE_PLUGIN_ROOT}` 에서 계약 관례 `${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}` 로 교체해 Claude 전용 변수 부재 환경에서도 성립하게 함. 벤더 선택 우선순위는 loop SKILL.md·`lib/task-backend/contract.md` 에 기술.
 
 ## autopilot 0.64.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## autopilot 0.65.0
 
 ### 새 기능
-- **워커 벤더 영속 설정 — `.autopilot/task-backend.json` 의 `worker_vendor` (run 635)** — 구현 워커 CLI(`claude`|`codex`) 선택이 환경 변수 `AUTOPILOT_WORKER_VENDOR` 로만 가능해 무인 경로(cron 드레인 등 env 미전달)에서 항상 기본값으로 떨어지던 문제를 해소. loop 엔진이 벤더-중립 설정 SoT `.autopilot/task-backend.json` 의 `worker_vendor` 를 읽는다. 우선순위는 env > 설정 파일 > 기본값 `claude`(기존 프로젝트 동작 불변), 지원 밖 값이면 `start` 가 지원 벤더 목록을 명시한 오류로 중단한다. 설정 파일은 메인 워크트리 기준으로 확정해 링크드 워크트리 안에서도 같은 파일을 읽으며, 파싱은 jq 무의존(파싱 불가 시 env/기본값 경로).
+- **워커 벤더 영속 설정 — `.autopilot/task-backend.json` 의 `worker_vendor` (run 635)** — 구현 워커 CLI(`claude`|`codex`) 선택이 환경 변수 `AUTOPILOT_WORKER_VENDOR` 로만 가능해 무인 경로(cron 드레인 등 env 미전달)에서 항상 기본값으로 떨어지던 문제를 해소. loop 엔진이 벤더-중립 설정 SoT `.autopilot/task-backend.json` 의 `worker_vendor` 를 읽는다. 우선순위는 env > 설정 파일 > 기본값 `claude`(기존 프로젝트 동작 불변), 지원 밖 값이면 `start` 가 지원 벤더 목록을 명시한 오류로 중단한다. 설정 파일은 호출 cwd 가 아니라 **spec 저장소**의 메인 워크트리 기준으로 확정해(사전 의존성 검사와 실제 이터가 같은 워커를 본다) 링크드 워크트리 안에서도 같은 파일을 읽으며, 파싱은 jq 무의존(파싱 불가 시 env/기본값 경로).
 
 ### 변경(호환)
 - **execute-task 스킬 호출 표기 벤더 중립화 (run 635)** — SKILL.md 의 실행 스크립트 경로를 `${CLAUDE_PLUGIN_ROOT}` 에서 계약 관례 `${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}` 로 교체해 Claude 전용 변수 부재 환경에서도 성립하게 함. 벤더 선택 우선순위는 loop SKILL.md·`lib/task-backend/contract.md` 에 기술.

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.64.6",
+  "version": "0.65.0",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/lib/task-backend/contract.md
+++ b/plugins/autopilot/lib/task-backend/contract.md
@@ -25,13 +25,15 @@ bash <plugin>/lib/task-backend/adapter.sh <verb> [args...]
   "github_owner": "<owner>",
   "github_repo": "<repo>",
   "lease_ttl_seconds": 300,
-  "heartbeat_interval_seconds": 60
+  "heartbeat_interval_seconds": 60,
+  "worker_vendor": "claude | codex"
 }
 ```
 
 - `backend` 필수. 나머지는 백엔드별 선택.
 - config 부재 시 어댑터는 `init` 안내 후 비-0 exit(조용한 폴백 없음).
 - `lease_ttl_seconds` 기본 300, `heartbeat_interval_seconds` 기본 60(ttl보다 작아야 함).
+- `worker_vendor` 선택 — 구현 워커 CLI. 어댑터가 아니라 **loop 엔진**이 읽는다(같은 파일을 공유하는 프로젝트 단위 벤더-중립 설정). 우선순위는 환경 변수 `AUTOPILOT_WORKER_VENDOR` > 이 필드 > 기본값 `claude`이며, 지원 밖 값이면 loop `start`가 지원 벤더 목록을 명시한 오류로 중단한다. env는 무인 경로(cron·드레인)에서 유실되므로 프로젝트 고정 선택은 이 필드에 둔다.
 
 ## 상태 집합 (플러그인 자체 정의)
 

--- a/plugins/autopilot/lib/task-backend/contract.md
+++ b/plugins/autopilot/lib/task-backend/contract.md
@@ -33,7 +33,7 @@ bash <plugin>/lib/task-backend/adapter.sh <verb> [args...]
 - `backend` 필수. 나머지는 백엔드별 선택.
 - config 부재 시 어댑터는 `init` 안내 후 비-0 exit(조용한 폴백 없음).
 - `lease_ttl_seconds` 기본 300, `heartbeat_interval_seconds` 기본 60(ttl보다 작아야 함).
-- `worker_vendor` 선택 — 구현 워커 CLI. 어댑터가 아니라 **loop 엔진**이 읽는다(같은 파일을 공유하는 프로젝트 단위 벤더-중립 설정). 우선순위는 환경 변수 `AUTOPILOT_WORKER_VENDOR` > 이 필드 > 기본값 `claude`이며, 지원 밖 값이면 loop `start`가 지원 벤더 목록을 명시한 오류로 중단한다. env는 무인 경로(cron·드레인)에서 유실되므로 프로젝트 고정 선택은 이 필드에 둔다.
+- `worker_vendor` 선택 — 구현 워커 CLI. 어댑터가 아니라 **loop 엔진**이 읽는다(같은 파일을 공유하는 프로젝트 단위 벤더-중립 설정). 읽는 파일은 호출 cwd 가 아니라 **spec 저장소**의 메인 워크트리 기준으로 확정한다. 우선순위는 환경 변수 `AUTOPILOT_WORKER_VENDOR` > 이 필드 > 기본값 `claude`이며, 지원 밖 값이면 loop `start`가 지원 벤더 목록을 명시한 오류로 중단한다. env는 무인 경로(cron·드레인)에서 유실되므로 프로젝트 고정 선택은 이 필드에 둔다.
 
 ## 상태 집합 (플러그인 자체 정의)
 

--- a/plugins/autopilot/skills/execute-task/SKILL.md
+++ b/plugins/autopilot/skills/execute-task/SKILL.md
@@ -30,7 +30,7 @@ allowed-tools:
 ## 호출
 
 ```
-EXEC="${CLAUDE_PLUGIN_ROOT}/skills/execute-task/references/execute-task.sh"
+EXEC="${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}/skills/execute-task/references/execute-task.sh"
 bash "$EXEC" start <task-id> [--stop-at review]   # ← run_in_background: true 필수 (아래 참고)
 bash "$EXEC" status|stop|logs <task-id>
 ```

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -61,6 +61,16 @@ driver 동작: 검증 → lock 획득 → 작업 공간 준비(헌법을 `CLAUDE
 
 driver 인터페이스의 self-emit 단일 출처: `loop.sh env`(환경 변수) · `loop.sh gates`(객관 게이트) · `loop.sh paths <spec>`(계산된 경로) · `loop.sh deps`(의존성 + 설치 상태). 지침은 본문에 중복 열거하지 않고 이 subcommand 를 가리킨다.
 
+## 워커 벤더 선택
+
+구현 워커 CLI(`claude`|`codex`)는 다음 우선순위로 정해진다:
+
+1. 환경 변수 `AUTOPILOT_WORKER_VENDOR`
+2. 벤더-중립 설정 `.autopilot/task-backend.json` 의 `worker_vendor`(메인 워크트리 기준 — 링크드 워크트리 안에서도 같은 파일)
+3. 기본값 `claude`
+
+env 는 무인 경로(cron·드레인)에서 유실되므로 프로젝트 고정 선택은 설정 파일에 둔다. 지원 밖 값이면 `start` 가 지원 벤더 목록을 명시한 오류로 중단한다(조용한 폴백 없음). 필드 정의는 `lib/task-backend/contract.md`.
+
 ## Scope 경로 표기 (표기 관례 단일 출처)
 
 SPEC frontmatter 의 경로 필드(`scope.include`·`scope.exclude`·`test_sweep_paths`)가 수용하는 표기와 매칭 의미론의 단일 출처다. driver(`loop.sh`)의 scope 게이트가 이 관례로 변경 파일을 판정한다.

--- a/plugins/autopilot/skills/loop/SKILL.md
+++ b/plugins/autopilot/skills/loop/SKILL.md
@@ -66,7 +66,7 @@ driver 인터페이스의 self-emit 단일 출처: `loop.sh env`(환경 변수) 
 구현 워커 CLI(`claude`|`codex`)는 다음 우선순위로 정해진다:
 
 1. 환경 변수 `AUTOPILOT_WORKER_VENDOR`
-2. 벤더-중립 설정 `.autopilot/task-backend.json` 의 `worker_vendor`(메인 워크트리 기준 — 링크드 워크트리 안에서도 같은 파일)
+2. 벤더-중립 설정 `.autopilot/task-backend.json` 의 `worker_vendor`(**spec 저장소**의 메인 워크트리 기준 — 호출 cwd 와 무관하고, 링크드 워크트리 안에서도 같은 파일)
 3. 기본값 `claude`
 
 env 는 무인 경로(cron·드레인)에서 유실되므로 프로젝트 고정 선택은 설정 파일에 둔다. 지원 밖 값이면 `start` 가 지원 벤더 목록을 명시한 오류로 중단한다(조용한 폴백 없음). 필드 정의는 `lib/task-backend/contract.md`.

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -44,10 +44,13 @@ require_tool() {
 # 메인 워크트리 루트 — 링크드 워크트리 안에서 --show-toplevel 은 워크트리 루트를
 # 반환하므로, worktree list --porcelain 첫 항목(항상 메인 워크트리)을 우선한다.
 # 구버전 git(< 2.7)·git 미설치는 --show-toplevel 으로 폴백.
+# 기준점은 SPEC_DIR(정체성) — loop 은 spec 절대 경로로 어느 cwd 에서든 실행되므로
+# 호출 cwd 기준으로 풀면 다른 저장소의 설정을 읽는다. SPEC_DIR 미확정(compute_paths
+# 이전·cmd_deps 등 spec 없는 경로)일 때만 cwd 기준.
 main_repo_root() {
-  local root
-  root="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10); exit}')" || true
-  [[ -n "$root" ]] || root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  local from="${SPEC_DIR:-.}" root
+  root="$(git -C "$from" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10); exit}')" || true
+  [[ -n "$root" ]] || root="$(git -C "$from" rev-parse --show-toplevel 2>/dev/null || pwd)"
   printf '%s' "$root"
 }
 
@@ -723,9 +726,6 @@ cmd_start() {
   local input="$1"; shift || true
   [[ -z "$input" ]] && die "사용: $0 start <spec-path> [--max-iterations N] [--wall-clock-minutes N]"
   [[ -f "$input" ]] || die "스펙 파일을 찾을 수 없음: $input"
-  # 게이트(yq)·worker CLI는 start에서만 필요 — 여기서 검사.
-  require_tool yq
-  require_tool "$(worker_executable)"
 
   local max_iterations_override="" wall_clock_minutes_override="" base_ref_override=""
   while [[ $# -gt 0 ]]; do
@@ -742,6 +742,13 @@ cmd_start() {
   BASE_REF="${base_ref_override:-${AUTOPILOT_BASE_REF:-}}"
 
   compute_paths "$input"
+
+  # 게이트(yq)·worker CLI는 start에서만 필요 — 여기서 검사. compute_paths 뒤에 두는
+  # 이유: 워커 벤더 설정은 호출 cwd 가 아니라 spec 저장소 기준으로 해석해야 하고
+  # (main_repo_root 가 SPEC_DIR 을 기준점으로 쓴다), 그래야 사전 검사와 실제 이터가
+  # 같은 워커를 본다.
+  require_tool yq
+  require_tool "$(worker_executable)"
 
   # 스펙 내용 검증은 하지 않는다 — 특정 스펙 작성 도구의 규약(마커·placeholder)에
   # 비결합. 스펙 강화 필요 여부는 워커가 signals/ 에 차단 신호로 표현하고, 호출자가

--- a/plugins/autopilot/skills/loop/references/loop.sh
+++ b/plugins/autopilot/skills/loop/references/loop.sh
@@ -18,7 +18,8 @@
 #   WALL_CLOCK_MINUTES     시계 캡 (기본: 120)
 #   AUTOPILOT_BASE_REF     워크트리 base ref 주입 (미지정 시 fetch 한
 #                          origin/<default-branch>; --base-ref 가 우선)
-#   AUTOPILOT_WORKER_VENDOR  worker CLI 선택 (기본: claude; claude|codex)
+#   AUTOPILOT_WORKER_VENDOR  worker CLI 선택 (claude|codex). 우선순위:
+#                          env > .autopilot/task-backend.json 의 worker_vendor > claude
 #   AUTOPILOT_WORKER_FAIL_STREAK_LIMIT  worker 비정상 exit 연속 허용 (기본: 3)
 
 set -euo pipefail
@@ -40,8 +41,34 @@ require_tool() {
   command -v "$1" >/dev/null 2>&1 || die "'$1' 명령이 필요합니다."
 }
 
+# 메인 워크트리 루트 — 링크드 워크트리 안에서 --show-toplevel 은 워크트리 루트를
+# 반환하므로, worktree list --porcelain 첫 항목(항상 메인 워크트리)을 우선한다.
+# 구버전 git(< 2.7)·git 미설치는 --show-toplevel 으로 폴백.
+main_repo_root() {
+  local root
+  root="$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10); exit}')" || true
+  [[ -n "$root" ]] || root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+  printf '%s' "$root"
+}
+
+# .autopilot/task-backend.json 의 worker_vendor (벤더-중립 설정 SoT).
+# loop 엔진은 jq 무의존 — awk 로 문자열 필드만 뽑고, 파싱 불가면 빈 값(=폴백).
+config_worker_vendor() {
+  local cfg; cfg="$(main_repo_root)/.autopilot/task-backend.json"
+  [[ -f "$cfg" ]] || return 0
+  awk 'match($0, /"worker_vendor"[[:space:]]*:[[:space:]]*"[^"]*"/) {
+         s = substr($0, RSTART, RLENGTH)
+         sub(/^"worker_vendor"[[:space:]]*:[[:space:]]*"/, "", s)
+         sub(/"$/, "", s)
+         print s; exit
+       }' "$cfg" 2>/dev/null || true
+}
+
+# 우선순위: env AUTOPILOT_WORKER_VENDOR > 설정 파일 worker_vendor > 기본값 claude.
 worker_vendor() {
-  printf '%s' "${AUTOPILOT_WORKER_VENDOR:-claude}"
+  local v="${AUTOPILOT_WORKER_VENDOR:-}"
+  [[ -n "$v" ]] || v="$(config_worker_vendor)"
+  printf '%s' "${v:-claude}"
 }
 
 worker_executable() {
@@ -1045,6 +1072,8 @@ start 동작을 조정하는 환경 변수:
   MAX_ITERATIONS             기본 30      이터 상한 (--max-iterations 로 override)
   WALL_CLOCK_MINUTES         기본 120     시간 상한 (--wall-clock-minutes 로 override)
   AUTOPILOT_WORKER_VENDOR              기본 claude  worker CLI (claude|codex)
+                                                  우선순위: env > .autopilot/task-backend.json
+                                                  의 worker_vendor > claude
   AUTOPILOT_WORKER_FAIL_STREAK_LIMIT  기본 3       worker 비정상 exit 연속 허용 횟수
 EOF
 }

--- a/tests/autopilot/test-worker-vendor-config.sh
+++ b/tests/autopilot/test-worker-vendor-config.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# test-worker-vendor-config.sh — loop 엔진 워커 벤더 해석 회귀 가드 (run 635)
+#
+# 워커 CLI(claude|codex) 선택이 환경변수 AUTOPILOT_WORKER_VENDOR로만 가능하면
+# 무인 경로(cron 드레인, env 미전달)에서 항상 기본값으로 떨어진다. 벤더 중립 설정
+# SoT인 .autopilot/task-backend.json의 worker_vendor를 loop 엔진이 읽어야 한다.
+#
+# 우선순위 계약: env > .autopilot/task-backend.json > 기본값 claude.
+# 미지원 값은 지원 벤더 목록을 명시한 오류로 중단(조용한 진행 금지).
+#
+# loop.sh는 디스패처가 BASH_SOURCE 가드 뒤에 있어 source 시 함수만 노출된다
+# (test-loop-sh.sh TEST 11/12 패턴 재사용).
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+LOOP_SH="$REPO_ROOT/plugins/autopilot/skills/loop/references/loop.sh"
+[[ -f "$LOOP_SH" ]] || { echo "FAIL: loop.sh 부재: $LOOP_SH"; exit 1; }
+
+WORK_DIR="$(mktemp -d)"
+# shellcheck disable=SC2064  # trap-set 시점 값으로 고정 의도
+trap "rm -rf $WORK_DIR" EXIT
+
+# 격리된 가짜 프로젝트 (실제 저장소의 .autopilot/ 를 읽지 않게)
+PROJECT="$WORK_DIR/project"
+mkdir -p "$PROJECT/.autopilot"
+cd "$PROJECT"
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ok()   { echo "OK: $*"; }
+
+write_config() {  # $1 = worker_vendor 값 ("" 이면 필드 없음)
+  if [[ -z "${1:-}" ]]; then
+    printf '{\n  "backend": "filesystem"\n}\n' > "$PROJECT/.autopilot/task-backend.json"
+  else
+    printf '{\n  "backend": "filesystem",\n  "worker_vendor": "%s"\n}\n' "$1" \
+      > "$PROJECT/.autopilot/task-backend.json"
+  fi
+}
+
+# loop.sh 를 source 해 worker_vendor 를 평가한다. env 는 호출자가 지정.
+eval_vendor() {  # $1 = AUTOPILOT_WORKER_VENDOR 값("" 이면 미설정)
+  (
+    cd "$PROJECT"
+    if [[ -n "${1:-}" ]]; then export AUTOPILOT_WORKER_VENDOR="$1"; else unset AUTOPILOT_WORKER_VENDOR; fi
+    source "$LOOP_SH"
+    worker_vendor
+  )
+}
+
+echo "=== T1: 설정 파일 worker_vendor 채택 (env 없음) ==="
+write_config codex
+got="$(eval_vendor "")"
+[[ "$got" == "codex" ]] || fail "T1: 설정 파일 값 미채택. got='$got' want='codex'"
+ok "설정 파일 worker_vendor=codex 채택"
+
+echo "=== T2: env 가 설정 파일보다 우선 ==="
+write_config codex
+got="$(eval_vendor "claude")"
+[[ "$got" == "claude" ]] || fail "T2: env override 실패. got='$got' want='claude'"
+ok "env AUTOPILOT_WORKER_VENDOR 우선"
+
+echo "=== T3: 설정 필드·env 모두 없음 → 기본값 claude (후방 호환) ==="
+write_config ""
+got="$(eval_vendor "")"
+[[ "$got" == "claude" ]] || fail "T3: 기본값 회귀. got='$got' want='claude'"
+rm -f "$PROJECT/.autopilot/task-backend.json"
+got="$(eval_vendor "")"
+[[ "$got" == "claude" ]] || fail "T3: config 파일 부재 시 기본값 회귀. got='$got' want='claude'"
+ok "기본값 claude 유지"
+
+echo "=== T4: 미지원 벤더 값은 지원 목록 명시 오류로 중단 ==="
+write_config bogusvendor
+set +e
+out=$( { cd "$PROJECT"; unset AUTOPILOT_WORKER_VENDOR; source "$LOOP_SH"; worker_executable; } 2>&1 )
+rc=$?
+set -e
+[[ $rc -ne 0 ]] || fail "T4: 미지원 벤더인데 0 exit (조용한 진행). out='$out'"
+echo "$out" | grep -q "bogusvendor" || fail "T4: 오류에 문제 값 미포함. out='$out'"
+echo "$out" | grep -q "claude" && echo "$out" | grep -q "codex" \
+  || fail "T4: 오류에 지원 벤더 목록(claude, codex) 미포함. out='$out'"
+ok "미지원 값 거부 + 지원 목록 명시"
+
+echo "=== T5: 링크드 워크트리 안에서도 메인 워크트리 설정을 읽음 ==="
+# 설정은 커밋하지 않는다 — 링크드 워크트리에는 파일이 없어야 메인 루트 확정을 실제로 검증한다.
+write_config codex
+echo placeholder > "$PROJECT/README.md"
+git -C "$PROJECT" add README.md
+git -C "$PROJECT" commit -qm init
+LINKED="$WORK_DIR/linked"
+git -C "$PROJECT" worktree add -q --detach "$LINKED" >/dev/null 2>&1
+got="$(
+  cd "$LINKED"
+  unset AUTOPILOT_WORKER_VENDOR
+  source "$LOOP_SH"
+  worker_vendor
+)"
+[[ "$got" == "codex" ]] || fail "T5: 링크드 워크트리에서 메인 설정 미해석. got='$got' want='codex'"
+ok "링크드 워크트리에서도 메인 워크트리 설정 해석"
+
+echo "ALL PASS"

--- a/tests/autopilot/test-worker-vendor-config.sh
+++ b/tests/autopilot/test-worker-vendor-config.sh
@@ -100,4 +100,39 @@ got="$(
 [[ "$got" == "codex" ]] || fail "T5: 링크드 워크트리에서 메인 설정 미해석. got='$got' want='codex'"
 ok "링크드 워크트리에서도 메인 워크트리 설정 해석"
 
+echo "=== T6: start 사전 검사가 spec 저장소 설정을 읽음 (호출 cwd 아님) ==="
+# loop 은 spec 절대 경로로 어느 cwd 에서든 실행된다. 사전 의존성 검사가 호출 cwd 의
+# 설정을 읽으면, 실제 이터(=spec 저장소 워크트리에서 실행)와 다른 워커를 요구해
+# 시작 전에 잘못 실패한다. spec 저장소=codex, 호출 cwd=설정 없음으로 분리 검증.
+write_config codex
+printf -- '---\nscope:\n  include:\n    - README.md\n---\n\n# t\n' > "$PROJECT/spec.md"
+
+OTHER="$WORK_DIR/other"
+mkdir -p "$OTHER"
+git -C "$OTHER" init -q
+
+# claude·codex 가 실제 PATH 에 있으면 require_tool 이 통과해 루프가 시작되므로,
+# 사전 검사에 필요한 도구만 담은 최소 PATH 로 격리한다(둘 다 부재 → 어느 쪽을
+# 요구하는지가 오류 메시지로 관측된다).
+STUB="$WORK_DIR/stub"
+mkdir -p "$STUB"
+for t in bash git awk dirname basename; do
+  p="$(command -v "$t")" || fail "T6: 전제 도구 부재: $t"
+  ln -sf "$p" "$STUB/$t"
+done
+printf '#!/bin/sh\nexit 0\n' > "$STUB/yq"; chmod +x "$STUB/yq"
+
+set +e
+out=$(
+  cd "$OTHER"
+  unset AUTOPILOT_WORKER_VENDOR
+  PATH="$STUB" "$STUB/bash" "$LOOP_SH" start "$PROJECT/spec.md" 2>&1
+)
+rc=$?
+set -e
+[[ $rc -ne 0 ]] || fail "T6: 워커 CLI 부재인데 0 exit. out='$out'"
+echo "$out" | grep -q "codex" \
+  || fail "T6: 사전 검사가 spec 저장소 설정(codex) 대신 호출 cwd 기준으로 판정. out='$out'"
+ok "start 사전 검사가 spec 저장소 기준으로 워커 벤더 해석"
+
 echo "ALL PASS"


### PR DESCRIPTION
## 요약


execute-task 실행 경로의 벤더 종속 두 지점을 중립화한다.

1. **호출 표기 중립화** — execute-task 스킬의 호출 안내가 Claude 전용 환경변수만
   가정하지 않고, 플러그인 계약(contract.md)의 벤더 중립 관례와 같은 표기로 플러그인
   루트를 해석하도록 한다.
2. **워커 벤더 영속 선택** — 구현 워커 CLI(claude|codex) 선택이 현재 환경변수
   `AUTOPILOT_WORKER_VENDOR`로만 가능해 무인 경로(cron 드레인, env 미전달)에서 항상
   기본값(claude)으로 떨어진다. 벤더 중립 설정 SoT인 `.autopilot/task-backend.json`에
   `worker_vendor` 필드를 추가하고 loop 엔진이 이를 읽어 워커를 고르게 한다.

## 작업 내용

execute-task 벤더 독립화 — 완료 (commit 870238e, autopilot 0.65.0)

## 충족한 완료 조건

1. config `worker_vendor` + env 없음 → loop 엔진이 설정 파일 벤더 선택 (loop.sh `worker_vendor()`).
2. env `AUTOPILOT_WORKER_VENDOR` 가 설정 파일보다 우선.
3. 둘 다 없으면 기본값 claude (후방 호환).
4. 미지원 값은 지원 목록(claude, codex) 명시 오류로 중단 — `worker_executable()` die,
   `cmd_start` 의 `require_tool "$(worker_executable)"` 에서 발동.
5. execute-task SKILL.md 호출 표기 `${CLAUDE_PLUGIN_ROOT:-$CODEX_PLUGIN_ROOT}`.
6. 우선순위 규칙 문서화 — loop SKILL.md `## 워커 벤더 선택`, lib/task-backend/contract.md
   `worker_vendor` 필드, loop.sh 헤더·`cmd_env`.
7. 회귀 테스트 tests/autopilot/test-worker-vendor-config.sh (env 우선·설정 파일·기본값·
   미지원 값 거부·링크드 워크트리 해석) — ALL PASS.
8. plugin.json 0.64.6 → 0.65.0, CHANGELOG 항목 추가.

## 검증

- test-worker-vendor-config.sh: 0 exit (commit 후 fresh 재실행).
- tests/autopilot/execute-task/*.sh (10개), plugins/autopilot/lib/task-backend/tests/*.sh (3개): 전부 0 exit.
- tests/autopilot/test-loop-sh.sh: TEST 11에서 실패하나 **BASE_SHA(0f6b10e) 원본 loop.sh 로도
  동일 지점 동일 실패 — 본 변경의 회귀 아님(사전 존재)**. 격리 재현 시 rc=0이라 이 컨테이너의
  상시 claude 프로세스가 orphan 가드 판정을 오염시키는 환경 의존으로 보인다. SPEC 범위 밖이라
  손대지 않았다(테스트 약화 금지). 후속 태스크 후보.

## 미해결

- .claude-plugin/marketplace.json 의 autopilot 버전(0.64.5)은 SPEC scope 밖 — parity 예외로
  보류, 사유·해소 계획을 commit 메시지에 기록. 후속 동기화 필요.
