### PR TITLE
🤖 [자동 리뷰] fix: 재실행이 이전 시도 잔재(원격 브랜치·워크트리 등록)를 정리하지 않아 자력 회복 불가

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.64.8
+
+### 버그 수정
+- **재실행이 이전 시도 잔재를 정리하지 않아 자력 회복 불가 (#630)** — 브랜치명·워크트리 경로가 태스크 id 에서 결정적으로 파생되므로 이전 시도의 잔재가 남으면 재실행이 반드시 같은 자리에서 실패했고, 실패 문구만으로는 무엇을 치울지 알 수 없어 무한 반복됐다. (1) `execute-task` 가 loop 진입 전에 run-dir 워크트리 **등록**이 stale(디렉터리 부재)인지 보고 `git worktree prune` 으로 정리한 뒤 진행한다(`fatal: ... is a missing but already registered worktree` 회귀 해소, 살아 있는 워크트리는 미훼손). (2) `forge/lib/integration.sh` 는 자동 정리하지 못한 non-ff 원격 작업 브랜치(열린 PR 없음 = 소유 확증 불가)를 '최초 통합' 으로 오인해 push 하고 "push 실패" 한 줄로 끝내는 대신, 확인·삭제·재실행 명령을 담은 사유로 push 전에 차단한다. force 덮어쓰기·소유 미확증 원격 자동 삭제는 도입하지 않았고, 잔재가 없으면 기존 재실행 동작 그대로다. 회귀 가드 `tests/autopilot/execute-task/test-execute-task-stale-residue.sh` 추가 + `integration.sh selftest` AC#630 케이스.
+
 ## autopilot 0.64.7
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.64.7",
+  "version": "0.64.8",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/lib/forge/lib/integration.sh
+++ b/plugins/autopilot/lib/forge/lib/integration.sh
@@ -518,6 +518,24 @@ in_clear_stale_residue() {
   return 0
 }
 
+# in_stale_remote_guard <branch> — 자동 정리 불가한 stale 원격 작업 브랜치를 push 전에 차단(#630).
+#   in_clear_stale_residue 가 정리하지 못한 잔재(열린 PR 없음 = 소유 확증 불가)가 non-ff 로 남아
+#   있으면, base sync 는 이를 '최초 통합(원격 미존재)'으로 오인해 push 하고 "push 실패" 한 줄로만
+#   끝난다 — 무엇을 어떻게 치울지 알 수 없어 재실행이 같은 자리에서 무한 반복된다. 여기서 정리
+#   방법을 담은 사유로 즉시 차단한다. force 재배치·소유 미확증 원격 자동 삭제는 하지 않는다.
+#   열린 PR 이 있는 경로는 기존 재동기화(in_resync_open_pr)가 처리하므로 건드리지 않는다.
+in_stale_remote_guard() {
+  local branch="$1" local_commit
+  [[ -n "$branch" ]] || return 0
+  # shellcheck disable=SC2086
+  local_commit="$($GIT_CMD rev-parse "refs/heads/$branch" 2>/dev/null)"
+  [[ -n "$local_commit" ]] || return 0
+  in_remote_ff_incompatible "$branch" "$local_commit" || return 0   # 원격부재/ff호환 → 기존 동작.
+  [[ -z "$(in_existing_open_pr "$branch")" ]] || return 0           # 열린 PR → 재동기화 경로 소관.
+  in_die "stale 원격 작업 브랜치: origin/$branch 가 이번 결과 커밋($local_commit)과 non-fast-forward 라 force 없이 push 할 수 없다(force 금지). 열린 PR 이 없어 소유를 확증할 수 없으므로 자동 삭제하지 않는다. 정리: (1) 'git fetch origin $branch && git log --oneline origin/$branch' 로 보존할 커밋이 없는지 확인, (2) 'git push origin --delete $branch' 로 원격 브랜치 삭제, (3) execute-task start 로 재실행."
+  return 1
+}
+
 # =====================================================================
 # 3b) 실패/터미널 경로 조건부 워크트리 정리 — "보존되면 정리, 아니면 보존"(비대칭).
 #   머지 성공 경로는 merge.sh 가 무조건 정리(머지=대상 브랜치에 보존)한다. 여기서는 실패/비완료
@@ -687,6 +705,8 @@ in_integrate() {
       # 재실행 안전: 직전 실패/blocked 가 남긴 non-ff·autopilot-소유 stale 원격 브랜치/PR 을
       # push 전에 정리(force 금지·미소유 보존) — non-ff push 거부를 막는다.
       in_clear_stale_residue "$branch"
+      # 정리하지 못한 non-ff 잔재는 push 전에 정리 방법을 담은 사유로 차단(#630) — 재실행 무한 반복 방지.
+      in_stale_remote_guard "$branch" || { int_set_phase "$rd" "$key" blocked; return 4; }
       int_log "$rd" "$key" "base sync → push → PR (branch=$branch)"
       in_base_sync   "$branch" || { int_set_phase "$rd" "$key" blocked; return 4; }
       # #452: rebase 경로에선 base_sync 가 분리 워크트리에서 원격으로 직접 push 하므로(INT_BASESYNC_PUSHED)
@@ -1002,6 +1022,23 @@ in_selftest() {
     MOCK_REMOTE_FF=0 in_integrate "$spec" "$rd" "$kSE" >/dev/null
   grep -q -- '--delete' "$PUSHLOG" && bad "AC#462 외부 소유 동명 브랜치 삭제(오삭제)" || ok "AC#462 외부 소유 동명 브랜치 미삭제"
   [[ ! -s "$PRCLOSELOG" ]] && ok "AC#462 외부 소유 PR 미close" || bad "AC#462 외부 소유 PR 미close"
+  : > "$REMOTE_BRANCHES"
+
+  # ---- AC(#630): 자동 정리 불가한 stale 원격 작업 브랜치(열린 PR 없음 = 소유 확증 불가)는
+  #   '최초 통합'으로 오인해 non-ff push 로 실패하는 대신, push 전에 정리 방법을 담은 사유로 차단한다.
+  #   force 덮어쓰기·소유 미확증 원격 자동 삭제는 하지 않는다. ----
+  local kSR="x-sr33dddd"; : > "$PUSHLOG"; : > "$PRLOG"; : > "$PRCLOSELOG"; : > "$BRANCHES"; : > "$GITLOG"
+  st_done > "$LP/SPEC.md.json"; : > "$LP/SPEC.md.logs"
+  printf '%s\n' "$wbST" > "$REMOTE_BRANCHES"
+  err="$(MOCK_EXISTING_PR="" MOCK_REMOTE_FF=0 in_integrate "$spec" "$rd" "$kSR" 2>&1 >/dev/null)"; rc=$?
+  chk "AC#630 정리 불가 stale 원격 → rc=4(차단)" "$rc" "4"
+  chk "AC#630 phase=blocked" "$(int_get_phase "$rd" "$kSR")" "blocked"
+  case "$err" in
+    *"git push origin --delete $wbST"*) ok "AC#630 차단 사유에 정리 방법(명령) 포함";;
+    *) bad "AC#630 차단 사유에 정리 방법(명령) 포함 (got: $err)";;
+  esac
+  [[ ! -s "$PUSHLOG" ]] && ok "AC#630 차단 시 push 미수행(force 금지)" || bad "AC#630 차단 시 push 미수행(force 금지)"
+  [[ ! -s "$PRCLOSELOG" ]] && ok "AC#630 소유 미확증 원격 자동 삭제·PR close 안 함" || bad "AC#630 소유 미확증 자동 삭제 안 함"
   : > "$REMOTE_BRANCHES"
 
   # ---- AC9: spec-gap BLOCKED → push·PR 없이 blocked-spec-gap ----

--- a/plugins/autopilot/skills/execute-task/references/execute-task.sh
+++ b/plugins/autopilot/skills/execute-task/references/execute-task.sh
@@ -56,6 +56,22 @@ et_cleanup_dirs() {
   for d in "$@"; do rm -rf "$d" 2>/dev/null || true; done
 }
 
+# et_prune_stale_worktree <run_dir> — 이전 시도가 남긴 stale 워크트리 '등록' 정리(#630).
+#   run-dir 를 디렉터리 삭제로만 치우면 git 의 워크트리 등록은 남고, 다음 실행의 worktree add 가
+#   "missing but already registered worktree" 로 반드시 실패한다(브랜치명·경로가 태스크 id 에서
+#   결정적이라 재실행이 같은 자리에서 무한 반복). 등록만 남고 디렉터리가 없을 때만 **그 경로
+#   하나를** 정리한다 — 전역 prune 은 병렬 드레인(workflow-task fan-out)에서 다른 태스크가 막
+#   등록하고 디렉터리를 만들기 전인 워크트리까지 지울 수 있으므로 쓰지 않는다. 디렉터리가 살아
+#   있으면 건드리지 않는다(worktree remove 는 살아 있는 워크트리를 실제로 지우므로 이 가드가 필수).
+et_prune_stale_worktree() {
+  local wt="$1/.worktree"
+  git -C "$ROOT_DIR" worktree list --porcelain 2>/dev/null \
+    | grep -Fxq "worktree $wt" || return 0
+  [[ -d "$wt" ]] && return 0
+  echo "execute-task: stale 워크트리 등록 정리 — $wt" >&2
+  git -C "$ROOT_DIR" worktree remove "$wt" >/dev/null 2>&1 || true
+}
+
 # et_approval_gh <pr> — PR 호스팅 리뷰가 승인 상태면 0, 아니면 1.
 #   승인 신호 두 가지(merge.sh mg_approval_gh / review-loop rl_review_fetch_gh 와 동일 컨벤션):
 #     (a) 공식 APPROVE 리뷰 → reviewDecision==APPROVED.
@@ -163,6 +179,9 @@ et_start() {
   local run_dir="$ROOT_DIR/.autopilot/runs/$id"
   local reentry=0
   [[ -f "$run_dir/review_entered" ]] && reentry=1
+
+  # 재실행 잔재: 이전 시도의 stale 워크트리 등록을 정리하고 진행(#630). loop 의 worktree add 보다 앞선다.
+  et_prune_stale_worktree "$run_dir"
 
   # reclaim: 죽은 워커 잔재 정리(최초 실행/loop-단계 재진입). forge-단계 재진입(reentry=1)은 loop 가
   #   이미 DONE 이라 회수할 워커가 없고, 완료된 .worktree 를 forge integrate 가 loop 결과(HEAD)로 읽으므로

--- a/tests/autopilot/execute-task/test-execute-task-stale-residue.sh
+++ b/tests/autopilot/execute-task/test-execute-task-stale-residue.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# test-execute-task-stale-residue.sh — 재실행이 이전 시도의 stale 워크트리 '등록'을 정리하고 진행하는지(#630).
+#   (a) run-dir 디렉터리만 삭제돼 git 워크트리 등록이 stale 로 남은 상태에서 재실행하면,
+#       그 등록을 정리해 loop 의 worktree add 가 성공한다("missing but already registered" 회귀 가드).
+#   (b) 잔재가 없으면 기존 동작 그대로(정리 로그 없이 loop.start 진행).
+#   (c) 워크트리 디렉터리가 살아 있으면 건드리지 않는다(오정리로 작업 유실 방지).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ET="$HERE/../../../plugins/autopilot/skills/execute-task/references/execute-task.sh"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"; git init -q; git config user.email t@t; git config user.name t
+echo tracked > tracked.txt; git add tracked.txt; git commit -q -m init
+
+mkdir -p bin wd; touch wd/dummy.md
+
+# mock loop: start 에서 **실제** worktree add 를 수행한다(재현 대상이 loop 의 add 실패이므로).
+#   성공/실패를 LOOP_CALL_LOG 에 남겨 정리 여부를 관찰한다.
+cat > bin/loop << 'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  start)
+    # 실제 loop 처럼 materialize 된 run-dir(=워크트리 부모) 아래에 워크트리를 만든다.
+    # 부모가 존재해야 git 이 stale 등록을 "missing but already registered" 로 판정한다.
+    # 잔재 정리 단계가 살아 있는 워크트리를 지웠는지 관찰(loop 진입 시점 = 정리 직후).
+    [[ -f "$MOCK_WT/tracked.txt" ]] && echo "keep-ok" >> "${LOOP_CALL_LOG:-/dev/null}"
+    mkdir -p "$(dirname "$MOCK_WT")"
+    if git -C "$MOCK_ROOT" worktree add --detach -q "$MOCK_WT" HEAD 2>/dev/null; then
+      echo "add-ok" >> "${LOOP_CALL_LOG:-/dev/null}"
+    else
+      echo "add-fail" >> "${LOOP_CALL_LOG:-/dev/null}"
+    fi
+    exit 0;;
+  cleanup) exit 0;;
+  status) printf '{"state":"terminal","signals":["DONE"]}\n';;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/loop
+
+cat > bin/forge << 'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  integrate) echo "branch: feat/x"; echo "pr: 7"; exit 0;;
+  review) exit 20;;
+  merge) exit 0;;
+  *) exit 0;;
+esac
+EOF
+chmod +x bin/forge
+
+cat > bin/adapter_mock << 'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  materialize) printf '{"spec_path":"%s/dummy.md"}\n' "${MOCK_WD:-.}";;
+  claim)       printf '{"task_id":"X","claimed":true}\n';;
+  *)           printf '{"task_id":"X"}\n';;
+esac
+EOF
+chmod +x bin/adapter_mock
+
+run_mock() {
+  ADAPTER_CMD="bash $TMP/bin/adapter_mock" LOOP_CMD="bash $TMP/bin/loop" FORGE_CMD="bash $TMP/bin/forge" \
+  HEARTBEAT_INTERVAL=999 APPROVAL_CHECK_CMD=true BLOCKING_CHECK_CMD=true SLEEP_CMD=: \
+  MOCK_ROOT="$TMP" MOCK_WD="$TMP/wd" \
+  bash "$ET" "$@"
+}
+
+registered() {  # <path> — git 워크트리 등록 목록에 있으면 0.
+  git worktree list --porcelain 2>/dev/null | grep -Fxq "worktree $1"
+}
+
+# --- (a) stale 등록(디렉터리 부재) → 정리 후 진행 ---
+wt_a="$TMP/.autopilot/runs/Xa/.worktree"
+git worktree add --detach -q "$wt_a" HEAD
+rm -rf "$TMP/.autopilot/runs/Xa"
+registered "$wt_a" && ok "(a) 사전조건: stale 워크트리 등록 존재" || bad "(a) 사전조건: stale 워크트리 등록 존재"
+log_a="$TMP/loop_a.log"; : > "$log_a"
+LOOP_CALL_LOG="$log_a" MOCK_WT="$wt_a" run_mock start Xa >/dev/null 2>&1 || true
+grep -qx "add-ok" "$log_a" \
+  && ok "(a) stale 등록 정리 후 worktree add 성공(재실행 자력 회복)" \
+  || bad "(a) stale 등록 정리 후 worktree add 성공(재실행 자력 회복)"
+
+# --- (b) 잔재 없음 → 기존 동작 유지 ---
+wt_b="$TMP/.autopilot/runs/Xb/.worktree"
+log_b="$TMP/loop_b.log"; : > "$log_b"
+LOOP_CALL_LOG="$log_b" MOCK_WT="$wt_b" run_mock start Xb >/dev/null 2>&1 || true
+grep -qx "add-ok" "$log_b" && ok "(b) 잔재 없음 → 기존 동작 유지(add 성공)" || bad "(b) 잔재 없음 → 기존 동작 유지(add 성공)"
+
+# --- (c) 살아 있는 워크트리는 미훼손 ---
+#   등록 존재 여부만 보면 loop 의 재-add 가 흔적을 덮어 항상 통과한다(무의미 단언).
+#   워크트리 안의 작업 파일이 정리 단계 직후(loop 진입 시점)에도 남아 있는지로 관찰한다
+#   (done 경로의 run-dir 정리는 의도된 기능이라 실행 후 관찰은 불가).
+wt_c="$TMP/.autopilot/runs/Xc/.worktree"
+git worktree add --detach -q "$wt_c" HEAD
+log_c="$TMP/loop_c.log"; : > "$log_c"
+LOOP_CALL_LOG="$log_c" MOCK_WT="$wt_c" run_mock start Xc >/dev/null 2>&1 || true
+grep -qx "keep-ok" "$log_c" \
+  && ok "(c) 살아 있는 워크트리 보존(작업 내용 미훼손)" \
+  || bad "(c) 살아 있는 워크트리 보존(작업 내용 미훼손)"
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || echo "FAILURES present"; exit $fail


### PR DESCRIPTION
## 요약


태스크를 재실행할 때 이전 시도가 남긴 아티팩트(원격 브랜치, 등록된 워크트리)를 감지해 정리하거나, 정리 방법을 담은 사유로 즉시 차단한다. 사람이 여러 곳을 손으로 치우기 전까지 자력 회복이 불가능한 상태가 없어야 한다.

## 작업 내용

run 630 완료 — 재실행 잔재 자력 회복.

- execute-task.sh: stale 워크트리 '등록'(디렉터리 부재)만 경로 한정으로 정리(git worktree remove)한 뒤 진행. 살아 있는 워크트리·다른 태스크 워크트리 미훼손(전역 prune 미사용).
- integration.sh: 자동 정리 불가한 non-ff 원격 작업 브랜치(열린 PR 없음)를 push 전에 차단하고 사유에 확인·삭제·재실행 명령을 담는다(in_stale_remote_guard).
- force 미도입, 원격 자동 삭제 미도입, 잔재 없으면 기존 동작 유지.
- 회귀 가드: tests/autopilot/execute-task/test-execute-task-stale-residue.sh (a·b·c, mutation 으로 실효성 확인) + integration.sh selftest AC#630.
- 버전 표면: plugin.json 0.64.8, CHANGELOG 순수-추가.

fresh verify: 위 두 스위트 0 exit, execute-task 테스트 12개 + forge 테스트 전부 통과.
