### PR TITLE
🤖 [자동 리뷰] base 재동기화 자율 해소가 CHANGELOG 누적 항목을 삭제 — 파일-단위 한쪽 채택

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 이 저장소의 **사용자 가시(behavior-changing) 변경**을 기록합니다. 버전의 단일 출처(SoT)는 각 플러그인의 `plugin.json`이며(`rules/engineering/versioning.md`), 본 파일은 변경이 머지될 때마다 누적합니다. 분류: 새 기능 / 변경(호환) / 변경(깨짐) / 버그 수정 / 보안.
 
+## autopilot 0.65.2
+
+### 버그 수정
+- **base 재동기화 자율 해소가 CHANGELOG 누적 항목을 삭제 (run 648)** — open-PR base 재동기화의 충돌 자율 해소가 충돌 파일을 **파일 단위 한쪽 채택**(`checkout --ours/--theirs`)으로 닫아, 누적(추가-전용) 계약 파일에선 전략과 무관하게 다른 쪽 섹션이 통째로 삭제된 채 커밋·push 되던 결함을 수정(run 635 관측: main 의 `## autopilot 0.64.8` 섹션 소실 후 순수-추가 게이트가 사후 차단 → 자력 회복 불가). 이제 누적 계약 파일(판별 표면은 순수-추가 게이트와 동일한 `INT_CHANGELOG_FILE`, 기본 `CHANGELOG.md`)은 **union 병합으로 양쪽 항목을 모두 보존**해 해소하고, 그 결과가 base 쪽 라인을 하나라도 잃으면 커밋·push 없이 merge/rebase 를 중단하고 사유를 남긴다. merge-in·rebase 두 경로 모두 적용. 일반 충돌 파일의 전략(`FORGE_CONFLICT_STRATEGY`)과 게이트 비활성(`INT_CHANGELOG_FILE=''`) 동작은 그대로(후방 호환), force 미사용 불변. 회귀 가드 `plugins/autopilot/lib/forge/lib/tests/test-integration-changelog-union.sh` 추가.
+
 ## autopilot 0.65.1
 
 ### 버그 수정

--- a/plugins/autopilot/.claude-plugin/plugin.json
+++ b/plugins/autopilot/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "autopilot",
-  "version": "0.65.1",
+  "version": "0.65.2",
   "description": "자율 수행 루프(랄프 루프) 운영 인터페이스. 태스크 중심 파이프라인 — feature가 기능 의도를 명확화 인터뷰로 태스크 본문(=SPEC)으로 작성하고 fix가 버그·증상·실패 신호를 정적 분석으로 진단해 본문(진단 섹션 포함)을 무인 작성(feature의 정적분석 짝), 등록 프리미티브 create-task가 그 본문을 태스크 백엔드(filesystem/github-project/beads)에 등록(본문=SPEC, 등록-후 상태 전이 소유), execute-task로 단일 태스크 전체 생애(구현→리뷰→머지→done, origin 호스트별 PR/MR/로컬), workflow-task로 준비된 태스크를 무인 자동 실행하는 DAG 없는 1회 드레인(드레인자가 버그·실패 신호를 감지하면 중앙에서 fix 호출→다음 틱 흡수). 재사용 엔진 — loop으로 스펙 파일 기반 로컬 자율 실행, review로 변경을 다관점 리뷰해 머신리더블 판정·재작업 브리프 생산, forge로 origin 호스트(GitHub/GitLab/로컬)별 통합·리뷰·머지 추상화(가용이면 PR 적대 리뷰→서버사이드 머지, 미가용이면 로컬 적대 리뷰→ff-only 직접 머지), flow로 내장 dynamic Workflow 미가용 시 Python 표준 라이브러리만으로 임의 depends_on DAG를 스트리밍 fan-out·동시성 상한·실패 이행 격리·저널 resume으로 구동. 플러그인 자기완결(프로젝트 rules 비의존), 검증된 엔진(loop/forge/flow)은 런타임 재사용.",
   "author": {
     "name": "예의상",

--- a/plugins/autopilot/lib/forge/lib/integration.sh
+++ b/plugins/autopilot/lib/forge/lib/integration.sh
@@ -189,6 +189,43 @@ in_ensure_work_branch() {
 #   진행한다(거짓 green 방지). 충돌 해소가 없었으면 비어 있음.
 INT_AUTORESOLVE_FLAG=""
 
+# in_accumulating_file <path> — 누적(추가-전용) 계약 파일이면 0. 판별 표면은 순수-추가
+#   게이트와 동일(INT_CHANGELOG_FILE, 기본 CHANGELOG.md; 빈 값이면 비활성 → 일반 파일 취급).
+in_accumulating_file() {
+  local file="${INT_CHANGELOG_FILE-CHANGELOG.md}"
+  [[ -n "$file" && "$1" == "$file" ]]
+}
+
+# in_union_resolve <path> <base-stage> — 누적 계약 파일 충돌을 **양쪽 보존**(union)으로 해소.
+#   한쪽 채택(checkout --ours/--theirs)은 누적 파일에선 곧 다른 쪽 항목의 삭제라, 전략과
+#   무관하게 손실이 난다(run 635). union 병합으로 양쪽 항목을 모두 남기고, 그 결과가 base
+#   쪽 라인을 하나라도 잃으면 실패(1)로 보고해 호출자가 커밋·push 전에 중단하게 한다.
+#   <base-stage>: base(origin/main) 쪽 인덱스 스테이지 — merge-in 은 3(theirs), rebase 는 2(ours).
+in_union_resolve() {
+  local f="$1" base_stage="$2" d top side rc=0
+  # shellcheck disable=SC2086
+  top="$($GIT_CMD rev-parse --show-toplevel 2>/dev/null)" || return 1
+  [[ -n "$top" ]] || return 1
+  d="$(mktemp -d)"
+  # 공통 조상(stage 1)은 add/add 충돌이면 없을 수 있다 — 빈 파일로 대체.
+  # shellcheck disable=SC2086
+  $GIT_CMD show ":1:$f" > "$d/base" 2>/dev/null || : > "$d/base"
+  # shellcheck disable=SC2086
+  $GIT_CMD show ":2:$f" > "$d/ours" 2>/dev/null || rc=1
+  # shellcheck disable=SC2086
+  $GIT_CMD show ":3:$f" > "$d/theirs" 2>/dev/null || rc=1
+  if [[ "$rc" == 0 ]]; then
+    # shellcheck disable=SC2086
+    $GIT_CMD merge-file -p --union "$d/ours" "$d/base" "$d/theirs" > "$d/merged" 2>/dev/null || rc=1
+    side="$d/theirs"; [[ "$base_stage" == "2" ]] && side="$d/ours"
+    # base 쪽에 있던 라인이 결과에서 사라졌으면 손실 — 순수-추가 계약을 만족하지 못한다.
+    [[ "$(diff "$side" "$d/merged" | grep -c '^<')" == "0" ]] || rc=1
+  fi
+  [[ "$rc" == 0 ]] && cp "$d/merged" "$top/$f"
+  rm -rf "$d"
+  return "$rc"
+}
+
 # in_autoresolve_rebase <branch> — 진행 중(충돌 정지) rebase 를 자율 해결.
 #   파일별: FORGE_CONFLICT_STRATEGY (기본 incoming=재적용 중 작업 커밋 쪽 --theirs,
 #   base=새 베이스 쪽 --ours) + 비결정 표시. plugin.json 버전 충돌도 일반 충돌로 처리한다
@@ -201,6 +238,17 @@ in_autoresolve_rebase() {
   [[ -n "$unmerged" ]] || { $GIT_CMD rebase --abort 2>/dev/null || true; return 1; }
   while IFS= read -r f; do
     [[ -n "$f" ]] || continue
+    if in_accumulating_file "$f"; then
+      # rebase 에선 --ours=새 베이스 쪽(stage 2) — 그쪽 라인을 잃지 않아야 한다.
+      if ! in_union_resolve "$f" 2; then
+        echo "autoresolve: 누적 계약 파일 양쪽 보존 해소 실패 — 손실 결과를 만들지 않고 중단(rebase abort): $f" >&2
+        $GIT_CMD rebase --abort 2>/dev/null || true; return 1
+      fi
+      resolved_general=1
+      # shellcheck disable=SC2086
+      $GIT_CMD add -- "$f" 2>/dev/null || true
+      continue
+    fi
     # shellcheck disable=SC2086
     case "${FORGE_CONFLICT_STRATEGY:-incoming}" in
       base) $GIT_CMD checkout --ours   -- "$f" 2>/dev/null || true ;;
@@ -234,6 +282,17 @@ in_autoresolve_merge() {
   [[ -n "$unmerged" ]] || { $GIT_CMD merge --abort 2>/dev/null || true; return 1; }
   while IFS= read -r f; do
     [[ -n "$f" ]] || continue
+    if in_accumulating_file "$f"; then
+      # merge-in 에선 --theirs=새 베이스(origin/main) 쪽(stage 3) — 그쪽 라인을 잃지 않아야 한다.
+      if ! in_union_resolve "$f" 3; then
+        echo "autoresolve: 누적 계약 파일 양쪽 보존 해소 실패 — 손실 결과를 만들지 않고 중단(merge abort): $f" >&2
+        $GIT_CMD merge --abort 2>/dev/null || true; return 1
+      fi
+      resolved_general=1
+      # shellcheck disable=SC2086
+      $GIT_CMD add -- "$f" 2>/dev/null || true
+      continue
+    fi
     # shellcheck disable=SC2086
     case "${FORGE_CONFLICT_STRATEGY:-incoming}" in
       base) $GIT_CMD checkout --theirs -- "$f" 2>/dev/null || true ;;

--- a/plugins/autopilot/lib/forge/lib/tests/test-integration-changelog-union.sh
+++ b/plugins/autopilot/lib/forge/lib/tests/test-integration-changelog-union.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# test-integration-changelog-union.sh — 재동기화 자율 해소의 누적 계약 파일 양쪽 보존 (run 648).
+#   시나리오: PR 이 열린 동안 base(main)가 CHANGELOG 최상단에 새 섹션을 추가해 재동기화
+#   merge-in/rebase 가 충돌. 기존 구현은 파일 단위 한쪽 채택(checkout --ours/--theirs)이라
+#   다른 쪽 섹션을 통째로 삭제한 결과를 만들었다(run 635 관측).
+#   기대: 누적 계약 파일(INT_CHANGELOG_FILE, 기본 CHANGELOG.md)은 union 병합으로 양쪽 항목을
+#   모두 보존하고, 그 결과가 base 쪽 라인을 하나라도 잃으면 커밋 전에 중단(rc!=0)한다.
+#   일반 충돌 파일과 게이트 비활성(빈 값)은 기존 전략 동작 그대로(후방 호환).
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fail=0; ok(){ echo "PASS  $1"; }; bad(){ echo "FAIL  $1"; fail=1; }
+chk(){ [[ "$2" == "$3" ]] && ok "$1" || bad "$1 (want '$3' got '$2')"; }
+
+# shellcheck disable=SC1091
+. "$HERE/../integration.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+DEFAULT_BRANCH=main
+BRANCH=feat/x
+
+# mk_repo <dir> [drop-old]  — main 에 CHANGELOG 기존 섹션, 브랜치·main 이 각각 최상단에 섹션 추가.
+#   drop-old=1 이면 브랜치가 기존 섹션 라인을 함께 삭제한다(양쪽 보존 불가 = 손실 시나리오).
+mk_repo() {
+  local r="$1" drop="${2:-0}"
+  mkdir -p "$r"; git -C "$r" init -q -b main
+  git -C "$r" config user.email t@t; git -C "$r" config user.name t
+  cat > "$r/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## pkg 0.1.0
+
+### 버그 수정
+- 기존 항목 A
+- 기존 항목 A2
+- 기존 항목 A3
+- 기존 항목 A4
+EOF
+  echo base > "$r/f.txt"
+  git -C "$r" add -A; git -C "$r" commit -qm base
+
+  git -C "$r" checkout -qb "$BRANCH"
+  awk 'NR==2{print ""; print "## pkg 0.2.0"; print ""; print "### 기능"; print "- 브랜치 항목 B"} {print}' \
+    "$r/CHANGELOG.md" > "$r/c.new"
+  if [[ "$drop" == "1" ]]; then grep -v '^- 기존 항목 A4$' "$r/c.new" > "$r/c2" && mv "$r/c2" "$r/c.new"; fi
+  mv "$r/c.new" "$r/CHANGELOG.md"
+  echo branch > "$r/f.txt"
+  git -C "$r" commit -aqm 'branch entry'
+
+  git -C "$r" checkout -q main
+  awk 'NR==2{print ""; print "## pkg 0.3.0"; print ""; print "### 기능"; print "- main 항목 C"} {print}' \
+    "$r/CHANGELOG.md" > "$r/c.new" && mv "$r/c.new" "$r/CHANGELOG.md"
+  echo mainside > "$r/f.txt"
+  git -C "$r" commit -aqm 'main entry'
+  git -C "$r" checkout -q "$BRANCH"
+}
+
+# main 쪽 CHANGELOG 라인 중 결과 파일에서 사라진 라인 수.
+lost_lines() {
+  local r="$1"
+  git -C "$r" show "main:CHANGELOG.md" > "$r/.mainver"
+  diff "$r/.mainver" "$r/CHANGELOG.md" | grep -c '^<' || true
+}
+
+# ---- 케이스 1: merge-in 재동기화 — 양쪽 보존 ----
+R="$TMP/merge"; mk_repo "$R"
+GIT_CMD="git -C $R"
+git -C "$R" merge --no-commit --no-ff main >/dev/null 2>&1
+rc=0; in_autoresolve_merge "$BRANCH" >/dev/null 2>&1 || rc=$?
+chk "1: merge-in 자율 해소 rc=0" "$rc" "0"
+grep -q '브랜치 항목 B' "$R/CHANGELOG.md" && ok "2: 브랜치 섹션 보존" || bad "2: 브랜치 섹션 보존"
+grep -q 'main 항목 C' "$R/CHANGELOG.md" && ok "3: base(main) 섹션 보존" || bad "3: base(main) 섹션 보존"
+grep -q '<<<<<<<\|>>>>>>>' "$R/CHANGELOG.md" && bad "4: 충돌 마커 없음" || ok "4: 충돌 마커 없음"
+chk "5: base 대비 삭제 라인 0" "$(lost_lines "$R")" "0"
+chk "6: 충돌 미해소 파일 없음" "$(git -C "$R" diff --name-only --diff-filter=U | wc -l | tr -d ' ')" "0"
+chk "7: 일반 파일은 기존 전략(incoming=--ours=브랜치 쪽) 유지" "$(cat "$R/f.txt")" "branch"
+
+# ---- 케이스 2: 양쪽 보존 실패(손실) → 커밋 전 중단 ----
+R2="$TMP/lossy"; mk_repo "$R2" 1
+GIT_CMD="git -C $R2"
+git -C "$R2" merge --no-commit --no-ff main >/dev/null 2>&1
+err="$(in_autoresolve_merge "$BRANCH" 2>&1)" && rc=0 || rc=$?
+[[ "$rc" -ne 0 ]] && ok "8: 손실 해소는 실패(rc!=0) — 커밋·push 없음" || bad "8: 손실 해소는 실패(rc!=0)"
+[[ -n "$err" ]] && ok "9: 중단 사유 출력" || bad "9: 중단 사유 출력"
+[[ -e "$R2/.git/MERGE_HEAD" ]] && bad "10: 머지 중단(abort)됨" || ok "10: 머지 중단(abort)됨"
+
+# ---- 케이스 3: 게이트 비활성(INT_CHANGELOG_FILE='') → 기존 동작 유지 ----
+R3="$TMP/off"; mk_repo "$R3"
+GIT_CMD="git -C $R3"
+git -C "$R3" merge --no-commit --no-ff main >/dev/null 2>&1
+rc=0; ( INT_CHANGELOG_FILE=''; GIT_CMD="git -C $R3"; in_autoresolve_merge "$BRANCH" >/dev/null 2>&1 ) || rc=$?
+chk "11: 게이트 비활성 rc=0" "$rc" "0"
+grep -q 'main 항목 C' "$R3/CHANGELOG.md" && bad "12: 비활성 시 기존 한쪽 채택 동작 유지" || ok "12: 비활성 시 기존 한쪽 채택 동작 유지"
+
+# ---- 케이스 4: rebase 경로도 같은 보존 ----
+R4="$TMP/rebase"; mk_repo "$R4"
+GIT_CMD="git -C $R4"
+git -C "$R4" rebase main >/dev/null 2>&1
+rc=0; in_autoresolve_rebase "$BRANCH" >/dev/null 2>&1 || rc=$?
+chk "13: rebase 자율 해소 rc=0" "$rc" "0"
+grep -q '브랜치 항목 B' "$R4/CHANGELOG.md" && ok "14: rebase — 브랜치 섹션 보존" || bad "14: rebase — 브랜치 섹션 보존"
+grep -q 'main 항목 C' "$R4/CHANGELOG.md" && ok "15: rebase — base 섹션 보존" || bad "15: rebase — base 섹션 보존"
+chk "16: rebase — base 대비 삭제 라인 0" "$(lost_lines "$R4")" "0"
+
+echo "----"; [[ $fail -eq 0 ]] && echo "ALL PASS" || { echo "FAILURES present"; exit 1; }


### PR DESCRIPTION
## 작업 내용

base 재동기화 자율 해소의 누적 계약 파일(CHANGELOG) 손실 수정 완료 — 커밋 38f9f6f (0.65.2).

수정:
- `in_accumulating_file` / `in_union_resolve` 추가 (integration.sh). 누적 계약 파일 판별은
  순수-추가 게이트와 동일한 설정 표면 `INT_CHANGELOG_FILE`(기본 CHANGELOG.md) 재사용.
- `in_autoresolve_merge`(stage 3 = origin/main) / `in_autoresolve_rebase`(stage 2 = 새 베이스)
  두 경로 모두 누적 계약 파일을 `git merge-file --union` 으로 양쪽 보존 해소.
- 결과가 base 쪽 라인을 하나라도 잃으면 rc!=0 → merge/rebase abort + 사유 stderr,
  커밋·push 없음.
- 일반 충돌 파일은 기존 `FORGE_CONFLICT_STRATEGY` 경로 그대로(후방 호환), 게이트 비활성
  (`INT_CHANGELOG_FILE=''`)이면 기존 한쪽 채택 유지. force 미사용 불변.

완료 조건 대응:
1 양쪽 보존 해소 — 가드 2·3·14·15
2 push 전 base 대비 삭제 0 — 가드 5·16
3 보존 실패 시 커밋·push 없이 중단 + 사유 — 가드 8·9·10
4 일반 충돌 파일 후방 호환 — 가드 7
5 게이트 비활성 시 기존 동작 — 가드 11·12
6 회귀 가드 `plugins/autopilot/lib/forge/lib/tests/test-integration-changelog-union.sh` (16/16 PASS)
7 plugin.json 0.65.2 + CHANGELOG 최상단 항목

검증(fresh): 스윕 17/17 PASS
(plugins/autopilot/lib/forge/lib/tests/ 5건 + tests/autopilot/execute-task/ 12건), exit 0.
