### PR TITLE
fix:root: codex-review PR head fetch 누락 복구 + 불완전 verdict 가시 댓글

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1047,6 +1047,55 @@ jobs:
               event = 'COMMENT';
             }
 
+            // 불완전 verdict(needs_context/unavailable) 청크 때문에 승인이 막혔는데
+            // 게시할 inline finding 도 없으면, formal review 는 마커만 남아 사용자에게
+            // 아무 설명이 없다. skip-reason 댓글과 같은 방식으로 사유·모델이 요청한
+            // 추가 컨텍스트를 issue 댓글로 upsert 해 가시화한다(formal review 제출과
+            // 멱등 마커 의미론은 그대로 유지).
+            if (!canApprove && inlineFindings.length === 0 && !allReviewed) {
+              const reviewerName = /^codex/.test(prefix) ? 'Codex' : 'Claude';
+              const incompleteMarker = `<!-- ${prefix}-incomplete -->`;
+              const incomplete = reviewedResults.filter((r) =>
+                r.verdict !== 'approve' && r.verdict !== 'comment');
+              const incompleteVerdicts = [...new Set(incomplete.map((r) => r.verdict))];
+              const reasons = [...new Set(incomplete
+                .map((r) => String(r.automation_safety?.reason || r.eligibility?.reason || '').trim())
+                .filter(Boolean))];
+              const requestedFiles = [...new Set(incomplete
+                .flatMap((r) => (r.context_requests || []).flatMap((c) => c.files || [])))];
+              const incompleteLines = [
+                `🤖 **${reviewerName} 리뷰** — 리뷰가 불완전하게 끝났습니다 (verdict: ${incompleteVerdicts.join(', ')})`,
+                '',
+                reasons.length ? reasons.join('\n\n')
+                  : '모델이 최종 판정에 필요한 컨텍스트를 확보하지 못했습니다.',
+              ];
+              if (requestedFiles.length > 0) {
+                incompleteLines.push('', '모델이 요청한 추가 컨텍스트:',
+                  ...requestedFiles.map((f) => `- \`${f}\``));
+              }
+              incompleteLines.push('', `<sub>head: \`${head_sha}\`</sub>`, incompleteMarker);
+              const incompleteBody = incompleteLines.join('\n');
+              try {
+                const comments = await github.paginate(github.rest.issues.listComments,
+                  { owner, repo, issue_number: pull_number, per_page: 100 });
+                // 작성자 검증: skip-reason 댓글과 동일 — 우리 토큰 신원(botLogin)의
+                // 댓글만 upsert 대상으로 본다(위조 차단).
+                const existing = comments.find((c) =>
+                  c.user?.login === botLogin && (c.body || '').includes(incompleteMarker));
+                if (existing) {
+                  await github.rest.issues.updateComment(
+                    { owner, repo, comment_id: existing.id, body: incompleteBody });
+                  core.info(`Updated incomplete-review comment (${existing.id}).`);
+                } else {
+                  await github.rest.issues.createComment(
+                    { owner, repo, issue_number: pull_number, body: incompleteBody });
+                  core.info('Created incomplete-review comment.');
+                }
+              } catch (e) {
+                core.warning(`Incomplete-review comment upsert failed: ${e.message}`);
+              }
+            }
+
             // Review body — built from the ACTUAL submit event, not the intended
             // one. Only an APPROVE submission carries the single "승인되었습니다." line;
             // every other submission (including the APPROVE→COMMENT degradation when

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -455,6 +455,17 @@ jobs:
         with:
           name: codex-review-prep
 
+      # follow-up context 해석은 git cat-file/show 를 PR_HEAD_SHA 기준으로 실행한다.
+      # 위 checkout 은 base ref 만 받으므로 PR head 커밋 객체를 별도로 fetch 하지
+      # 않으면 모든 context_requests 가 조용히 실패해 2차 리뷰가 영영 스킵된다.
+      - name: Fetch PR head for follow-up context
+        if: ${{ needs.prep.outputs.pr_number != '' }}
+        env:
+          PR_NUMBER: ${{ needs.prep.outputs.pr_number }}
+        run: |
+          git fetch --no-tags --depth=1 origin \
+            "+refs/pull/$PR_NUMBER/head:refs/remotes/pull/$PR_NUMBER/head"
+
       - name: Bootstrap Codex auth.json
         # ChatGPT account authentication: write the CODEX_AUTH_JSON secret into a
         # dedicated codex-home directory as auth.json (chmod 600) and expose ONLY
@@ -897,6 +908,55 @@ jobs:
               event = 'APPROVE';
             } else {
               event = 'COMMENT';
+            }
+
+            // 불완전 verdict(needs_context/unavailable) 청크 때문에 승인이 막혔는데
+            // 게시할 inline finding 도 없으면, formal review 는 마커만 남아 사용자에게
+            // 아무 설명이 없다. skip-reason 댓글과 같은 방식으로 사유·모델이 요청한
+            // 추가 컨텍스트를 issue 댓글로 upsert 해 가시화한다(formal review 제출과
+            // 멱등 마커 의미론은 그대로 유지).
+            if (!canApprove && inlineFindings.length === 0 && !allReviewed) {
+              const reviewerName = /^codex/.test(prefix) ? 'Codex' : 'Claude';
+              const incompleteMarker = `<!-- ${prefix}-incomplete -->`;
+              const incomplete = reviewedResults.filter((r) =>
+                r.verdict !== 'approve' && r.verdict !== 'comment');
+              const incompleteVerdicts = [...new Set(incomplete.map((r) => r.verdict))];
+              const reasons = [...new Set(incomplete
+                .map((r) => String(r.automation_safety?.reason || r.eligibility?.reason || '').trim())
+                .filter(Boolean))];
+              const requestedFiles = [...new Set(incomplete
+                .flatMap((r) => (r.context_requests || []).flatMap((c) => c.files || [])))];
+              const incompleteLines = [
+                `🤖 **${reviewerName} 리뷰** — 리뷰가 불완전하게 끝났습니다 (verdict: ${incompleteVerdicts.join(', ')})`,
+                '',
+                reasons.length ? reasons.join('\n\n')
+                  : '모델이 최종 판정에 필요한 컨텍스트를 확보하지 못했습니다.',
+              ];
+              if (requestedFiles.length > 0) {
+                incompleteLines.push('', '모델이 요청한 추가 컨텍스트:',
+                  ...requestedFiles.map((f) => `- \`${f}\``));
+              }
+              incompleteLines.push('', `<sub>head: \`${head_sha}\`</sub>`, incompleteMarker);
+              const incompleteBody = incompleteLines.join('\n');
+              try {
+                const comments = await github.paginate(github.rest.issues.listComments,
+                  { owner, repo, issue_number: pull_number, per_page: 100 });
+                // 작성자 검증: skip-reason 댓글과 동일 — 우리 토큰 신원(botLogin)의
+                // 댓글만 upsert 대상으로 본다(위조 차단).
+                const existing = comments.find((c) =>
+                  c.user?.login === botLogin && (c.body || '').includes(incompleteMarker));
+                if (existing) {
+                  await github.rest.issues.updateComment(
+                    { owner, repo, comment_id: existing.id, body: incompleteBody });
+                  core.info(`Updated incomplete-review comment (${existing.id}).`);
+                } else {
+                  await github.rest.issues.createComment(
+                    { owner, repo, issue_number: pull_number, body: incompleteBody });
+                  core.info('Created incomplete-review comment.');
+                }
+              } catch (e) {
+                core.warning(`Incomplete-review comment upsert failed: ${e.message}`);
+              }
             }
 
             // Review body — built from the ACTUAL submit event, not the intended


### PR DESCRIPTION
## 의도
PR #654에서 Codex 리뷰가 `verdict=needs_context`, findings 0건으로 끝나고 숨은 마커만 담긴 빈 COMMENT 리뷰를 게시했다. 근본 원인 수정 + 재발 시 침묵하지 않게 한다.

## 원인
1. **follow-up 2차 리뷰 고장** — codex-review.yml review job은 base ref만 checkout(`fetch-depth: 1`). follow-up 스텝이 `git cat-file -t \"$PR_HEAD_SHA:파일\"`로 context_requests를 해석하는데 PR head 커밋 객체가 로컬에 없어 전부 조용히 실패(`2>/dev/null`) → `has_extra_context=false` → 2차 리뷰 스킵 → needs_context가 최종 verdict로 잔류. claude-review.yml은 4d5aa90에서 fetch 스텝을 받았으나 codex 쪽은 누락.
2. **불완전 verdict의 침묵** — merge 집계에서 needs_context는 COMMENT로 폴스루하고 body는 마커만. `automation_safety.reason`·`context_requests`는 버려짐. skip-reason 댓글은 전 청크 eligibility≠reviewed일 때만 발동해 `eligibility=reviewed + verdict=needs_context` 조합이 빠져나감.

## 범위
- `codex-review.yml`: review job에 `Fetch PR head for follow-up context` 스텝 추가 (claude-review.yml 기존 패턴 포트, `pr_number` 빈값 가드 — 976d14a와 동일 취지)
- `codex-review.yml`·`claude-review.yml` merge job: 조건 `!canApprove && inlineFindings 0 && !allReviewed`일 때 청크별 불완전 verdict·사유·요청 컨텍스트 파일 목록을 issue 댓글로 upsert (`<!-- prefix-incomplete -->` 마커, skip-reason 댓글과 동일한 botLogin 작성자 검증). formal review 제출·inline-only 정책·멱등 마커 의미론 불변.
- glob 형태 context_requests 미해석은 이번 범위 밖 (알려진 한계로 유지)

## 검증
- YAML 파스 양쪽 OK, 내장 github-script 블록 3개씩 `node --check` 통과
- 워크플로는 trusted base(main)에서 실행되므로 이 PR 안에서는 새 코드가 돌지 않음 — 머지 후 다음 PR에서 확인: fetch 스텝 실행 여부, needs_context 시 `Run Codex follow-up review`가 skipped→실행으로 바뀌는지, 불완전 종료 시 `-incomplete` 댓글 게시 여부

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013e4zzs1hugprLsQvcoCtWr