### PR TITLE
fix(review): 증분 diff 머지-유입 감지 + CJK-aware 토큰 추정

### DIFF
--- a/.github/scripts/pr-review-chunking.js
+++ b/.github/scripts/pr-review-chunking.js
@@ -33,10 +33,16 @@ const LIMITS = Object.freeze({
   maxOutputTokens: 16000,
 });
 
-// 추정 입력 토큰 = 문자수 / 4 (올림). 토크나이저 부재 휴리스틱.
+// 추정 입력 토큰 = CJK/한글 문자 1자당 ~1토큰 + 나머지 문자수/4 (올림).
+// chars/4 단일 휴리스틱은 한국어 텍스트를 ~4배 과소평가해, 토큰 밀도 높은
+// diff(한국어 CHANGELOG·문서)가 청크링 임계(maxDiffBeforeChunking) 아래로
+// 잘못 통과 → 리뷰 잡이 읽을 수 없는 크기의 단일 청크가 되는 결함이 있었다.
+// 전각 라틴/구두점(U+FF00-FFEF)은 의도적으로 제외 — CJK 가중이 부적절.
+const CJK_RE = /[ᄀ-ᇿ㄰-㆏가-힣぀-ヿ一-鿿]/g;
 function estimateTokens(text) {
   if (typeof text !== 'string' || text.length === 0) return 0;
-  return Math.ceil(text.length / 4);
+  const cjkCount = (text.match(CJK_RE) || []).length;
+  return Math.ceil(cjkCount + (text.length - cjkCount) / 4);
 }
 
 // 저우선 파일 분류. 'low' | 'normal'.

--- a/.github/scripts/pr-review-chunking.test.js
+++ b/.github/scripts/pr-review-chunking.test.js
@@ -46,6 +46,13 @@ test('estimateTokens tolerates non-string', () => {
   assert.strictEqual(M.estimateTokens(undefined), 0);
 });
 
+test('estimateTokens weights CJK/Hangul chars ~1 token each (ASCII stays chars/4)', () => {
+  assert.strictEqual(M.estimateTokens('가나다라'), 4);      // 한글 4자 → 4 (chars/4 였다면 1)
+  assert.strictEqual(M.estimateTokens('가나다라abcd'), 5);  // 한글 4 + ASCII 4자(=1)
+  assert.strictEqual(M.estimateTokens('日本語テスト'), 6);   // 한자·가나도 CJK 가중
+  assert.strictEqual(M.estimateTokens('Ａｐｐｌｅ'), 2);     // 전각 라틴은 CJK 가중 제외: ceil(5/4)
+});
+
 // ---- classifyFilePriority ----
 
 test('classify: doc-only is low priority', () => {

--- a/.github/scripts/pr-review-context.sh
+++ b/.github/scripts/pr-review-context.sh
@@ -103,6 +103,33 @@ collect_review_threads() {
 collect_review_threads > "$REVIEW_OUTPUT_DIR/review-threads.json" 2>/dev/null \
   || echo '[]' > "$REVIEW_OUTPUT_DIR/review-threads.json"
 
+# Merge-influx guard — when a base-sync merge commit landed inside the incremental
+# range (incremental_base..HEAD), the two-dot diff below would carry the ENTIRE
+# base delta, not just the PR's own changes. That inflated diff can exceed what a
+# review run can read, the review then skips, the success-gated marker never posts,
+# and the base never advances — a self-perpetuating skip loop. Detect the influx
+# and fall back to the PR-own merge-base so the diff is bounded by the PR's size.
+# Incremental mode switches to the existing full branch (gh pr diff — equivalent
+# to a merge-base two-dot diff); thread mode keeps its path scope and only swaps
+# the base. A merge commit authored inside the PR itself also triggers this —
+# over-falling-back to the PR-own diff is safe. The label must stay shell-word
+# safe: context-mode.env is `source`d by the workflows.
+mode_label="$mode"
+if [[ ( "$mode" == "incremental" || "$mode" == "thread" ) && -n "$incremental_base" ]]; then
+  if git rev-list --merges "${incremental_base}..${PR_HEAD_SHA}" 2>/dev/null | grep -q .; then
+    merge_fallback_base="$(git merge-base "${PR_BASE_SHA:-$incremental_base}" "$PR_HEAD_SHA" 2>/dev/null || true)"
+    if [[ -n "$merge_fallback_base" ]]; then
+      incremental_base="$merge_fallback_base"
+      if [[ "$mode" == "incremental" ]]; then
+        mode="full"
+        mode_label="full-merge-fallback"
+      else
+        mode_label="thread-merge-fallback"
+      fi
+    fi
+  fi
+fi
+
 case "$mode" in
   incremental)
     git diff --patch "$incremental_base" "$PR_HEAD_SHA" > "$REVIEW_OUTPUT_DIR/diff.patch" || {
@@ -143,6 +170,6 @@ gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --patch \
   || cp "$REVIEW_OUTPUT_DIR/diff.patch" "$REVIEW_OUTPUT_DIR/anchor.patch"
 
 {
-  printf 'REVIEW_CONTEXT_MODE=%s\n' "$mode"
+  printf 'REVIEW_CONTEXT_MODE=%s\n' "$mode_label"
   printf 'REVIEW_INCREMENTAL_BASE=%s\n' "$incremental_base"
 } > "$REVIEW_OUTPUT_DIR/context-mode.env"

--- a/tests/review-context/test-pr-review-context.sh
+++ b/tests/review-context/test-pr-review-context.sh
@@ -14,7 +14,13 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
 mkdir -p "$tmp/bin"
-cat > "$tmp/bin/gh" <<'GH'
+
+# gh 스텁 — 마커 기반 증분 base 해석(reviews API) 때문에 synchronize 블록마다
+# "마지막 성공 리뷰 마커의 head_sha"가 달라야 해서 블록별로 재생성한다.
+# 마커 SHA 는 resolver(pr-review-incremental-base.js)가 hex 만 통과시키므로
+# 반드시 hex 문자열이어야 한다.
+write_gh_stub() { # $1 = formal-review 마커의 head_sha (hex)
+  sed "s/__MARKER_SHA__/$1/" > "$tmp/bin/gh" <<'GH'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
@@ -30,26 +36,56 @@ case "$*" in
   'api repos/owner/repo/pulls/12/comments')
     printf '[{"id":2,"path":"src/thread.js","line":9,"body":"old inline"}]\n'
     ;;
+  'api repos/owner/repo/pulls/12/reviews --paginate')
+    printf '[{"user":{"login":"github-actions[bot]","type":"Bot"},"submitted_at":"2026-01-01T00:00:00Z","body":"<!-- claude-formal-review head_sha=__MARKER_SHA__ verdict=approve -->"}]\n'
+    ;;
   *)
     echo "unexpected gh call: $*" >&2
     exit 2
     ;;
 esac
 GH
-chmod +x "$tmp/bin/gh"
+  chmod +x "$tmp/bin/gh"
+}
+write_gh_stub beefa123
 
 cat > "$tmp/bin/git" <<'GIT'
 #!/usr/bin/env bash
 set -euo pipefail
 case "$*" in
-  'diff --patch before123 head456')
+  'diff --patch beefa123 head456')
     printf 'diff --git a/src/inc.js b/src/inc.js\n+incremental\n'
     ;;
-  'diff --patch missing123 head456')
+  'diff --patch deadb123 head456')
     exit 1
     ;;
   'diff --patch base000 head456 -- src/thread.js')
     printf 'diff --git a/src/thread.js b/src/thread.js\n+thread\n'
+    ;;
+  'diff --patch mergebaseM2 head456 -- src/thread.js')
+    printf 'diff --git a/src/thread.js b/src/thread.js\n+thread-fallback\n'
+    ;;
+  'merge-base --is-ancestor beefa123 head456' \
+  | 'merge-base --is-ancestor deadb123 head456' \
+  | 'merge-base --is-ancestor cafeb001 head456')
+    exit 0
+    ;;
+  'rev-list --merges beefa123..head456' \
+  | 'rev-list --merges deadb123..head456' \
+  | 'rev-list --merges base000..head456')
+    : # 머지 커밋 없음 — 빈 출력
+    ;;
+  'rev-list --merges cafeb001..head456')
+    printf 'mergecommit1\n'
+    ;;
+  'rev-list --merges baseM2..head456')
+    printf 'mergecommit2\n'
+    ;;
+  'merge-base base000 head456')
+    printf 'mergebaseM1\n'
+    ;;
+  'merge-base baseM2 head456')
+    printf 'mergebaseM2\n'
     ;;
   *)
     echo "unexpected git call: $*" >&2
@@ -69,13 +105,15 @@ GITHUB_REPOSITORY=owner/repo \
 PR_NUMBER=12 \
 PR_BASE_SHA=base000 \
 PR_HEAD_SHA=head456 \
+REVIEW_MARKER_PREFIX=claude-formal-review \
+REVIEW_BOT_LOGINS='github-actions[bot]' \
 REVIEW_OUTPUT_DIR="$out" \
 "$SCRIPT"
 
 grep -q '^REVIEW_CONTEXT_MODE=incremental$' "$out/context-mode.env" \
   || fail "synchronize event should use incremental mode"
 grep -q '+incremental' "$out/diff.patch" \
-  || fail "incremental mode should use before..head diff"
+  || fail "incremental mode should use marker..head diff"
 ok "synchronize event uses incremental diff"
 
 # Regression: anchor.patch must be the canonical PR-vs-base diff (gh pr diff,
@@ -92,20 +130,50 @@ ok "incremental mode anchor.patch = canonical PR-vs-base diff (createReview-safe
 
 out="$tmp/incremental-fallback-out"
 mkdir -p "$out"
+write_gh_stub deadb123
 GITHUB_EVENT_NAME=pull_request \
 GITHUB_EVENT_PATH="$FIXTURES/synchronize-missing-before-event.json" \
 GITHUB_REPOSITORY=owner/repo \
 PR_NUMBER=12 \
 PR_BASE_SHA=base000 \
 PR_HEAD_SHA=head456 \
+REVIEW_MARKER_PREFIX=claude-formal-review \
+REVIEW_BOT_LOGINS='github-actions[bot]' \
 REVIEW_OUTPUT_DIR="$out" \
 "$SCRIPT"
 
 grep -q '^REVIEW_CONTEXT_MODE=incremental$' "$out/context-mode.env" \
-  || fail "synchronize event with missing before should still use incremental mode"
+  || fail "synchronize event with unreachable diff should still use incremental mode"
 grep -q '+full' "$out/diff.patch" \
   || fail "incremental diff failure should fallback to gh pr diff"
 ok "incremental diff failure falls back to full PR diff"
+
+# Regression (merge-influx): a base-sync merge commit inside the incremental
+# range must NOT be diffed two-dot (it would drag the whole base delta into
+# diff.patch → oversized input → review skip → marker never posts → the base
+# never advances). The script must detect it and fall back to the canonical
+# PR-vs-base diff, labelling the mode so the header stays truthful.
+out="$tmp/merge-fallback-out"
+mkdir -p "$out"
+write_gh_stub cafeb001
+GITHUB_EVENT_NAME=pull_request \
+GITHUB_EVENT_PATH="$FIXTURES/synchronize-event.json" \
+GITHUB_REPOSITORY=owner/repo \
+PR_NUMBER=12 \
+PR_BASE_SHA=base000 \
+PR_HEAD_SHA=head456 \
+REVIEW_MARKER_PREFIX=claude-formal-review \
+REVIEW_BOT_LOGINS='github-actions[bot]' \
+REVIEW_OUTPUT_DIR="$out" \
+"$SCRIPT"
+
+grep -q '^REVIEW_CONTEXT_MODE=full-merge-fallback$' "$out/context-mode.env" \
+  || fail "merge commit in incremental range should switch to full-merge-fallback"
+grep -q '+full' "$out/diff.patch" \
+  || fail "merge-fallback diff.patch should be the canonical PR-vs-base diff"
+grep -q '+incremental' "$out/diff.patch" \
+  && fail "merge-fallback diff.patch must not contain the polluted incremental range"
+ok "merge commit influx falls back to canonical PR-vs-base diff"
 
 out="$tmp/thread-out"
 mkdir -p "$out"
@@ -123,6 +191,28 @@ grep -q '^REVIEW_CONTEXT_MODE=thread$' "$out/context-mode.env" \
 grep -q '"path": "src/thread.js"' "$out/thread.json" \
   || fail "thread mode should persist target thread metadata"
 ok "thread reply event uses thread context"
+
+# Regression (thread merge-influx): thread mode keeps its path scope on merge
+# influx — only the diff base swaps to the PR-own merge-base. An unscoped full
+# diff would bury the reply context under unrelated files.
+out="$tmp/thread-merge-fallback-out"
+mkdir -p "$out"
+GITHUB_EVENT_NAME=pull_request_review_comment \
+GITHUB_EVENT_PATH="$FIXTURES/thread-reply-event.json" \
+GITHUB_REPOSITORY=owner/repo \
+PR_NUMBER=12 \
+PR_BASE_SHA=baseM2 \
+PR_HEAD_SHA=head456 \
+REVIEW_OUTPUT_DIR="$out" \
+"$SCRIPT"
+
+grep -q '^REVIEW_CONTEXT_MODE=thread-merge-fallback$' "$out/context-mode.env" \
+  || fail "thread mode with merge influx should be labelled thread-merge-fallback"
+grep -q '"path": "src/thread.js"' "$out/thread.json" \
+  || fail "thread merge-fallback should keep target thread metadata"
+grep -q '+thread-fallback' "$out/diff.patch" \
+  || fail "thread merge-fallback diff should stay path-scoped on the swapped base"
+ok "thread merge influx swaps base only, keeping path scope"
 
 out="$tmp/full-out"
 mkdir -p "$out"


### PR DESCRIPTION
## 문제

PR #607에서 관측된 리뷰 영구 스킵 루프:

1. 마지막 성공 리뷰 이후 base 동기화 **merge 커밋**이 PR 브랜치에 들어오면, 증분 리뷰 diff(two-dot `git diff <마지막 성공 리뷰 head> <현재 head>`)에 base 델타 전체가 유입 — 실측 PR 고유 diff 15.5KB vs 오염된 증분 diff 178KB.
2. `estimateTokens = chars/4` 휴리스틱이 한국어를 ~4배 과소평가(실제 ~100k 토큰 → 추정 ~44k) → 청크링 임계(80k) 미발동 → 읽을 수 없는 단일 청크.
3. 리뷰 잡이 입력 완독 실패 → 리뷰 스킵 → 성공 게이트 마커 미게시 → 증분 기준점 영구 정체 → **매 런 동일 재발**.

## 수정

- **pr-review-context.sh** — 증분 범위에 merge 커밋 감지(`rev-list --merges`) 시 diff 기준을 PR 고유 merge-base로 폴백. incremental은 기존 full 분기(`gh pr diff`) 재사용(수학적 동치), thread는 path 스코프 유지·base만 교체. 모드 라벨(`full-merge-fallback`/`thread-merge-fallback`)은 `source` 안전한 하이픈 형태.
- **pr-review-chunking.js** — `estimateTokens` CJK-aware(한글·CJK 1자 ~1토큰, 전각 라틴 제외). 순수 ASCII는 기존과 동일(무회귀). 두 스크립트 모두 claude·codex 리뷰 워크플로 공유라 양쪽 동시 적용.
- **테스트** — `test-pr-review-context.sh`는 b3a99a0(마커 기반 base 해석) 이후 깨져 있었음 — 마커 경로에 맞게 복구(hex 마커 SHA, reviews API·`merge-base --is-ancestor` 스텁, 블록별 gh 스텁 재생성)하고 머지-유입 폴백 회귀 2종 추가. chunking 테스트에 CJK 가중 케이스 추가.

## 검증

- `bash tests/review-context/test-pr-review-context.sh` → ALL CHECKS PASSED (7 케이스)
- `node .github/scripts/pr-review-chunking.test.js` → ALL 34 CHECKS PASSED
- `node .github/scripts/pr-review-incremental-base.test.js` → ALL 16 CHECKS PASSED (무회귀)
- shellcheck: 신규 지적 0 (잔여 SC2016 info는 기존 라인)
- 실측: `estimateTokens('가'.repeat(50000))` = 50000 (기존 12500)

머지 후 `.github/scripts/dispatch-rereview.sh 607`로 PR #607 재리뷰 트리거 예정 — base(main) 신뢰 체크아웃에서 스크립트가 실행되므로 이미 열린 PR에도 즉시 적용됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCW6t945spup6BcshFWAEd